### PR TITLE
update licensing information for #5

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,16 @@
+# This is the official list of fiat-crypto authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as one of
+#     Organization's name
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+# See CONTRIBUTORS for the meaning of multiple email addresses.
+
+# Please keep the list sorted.
+
+Andres Erbsen <andreser@mit.edu>
+Google Inc.
+Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>
+Massachusetts Institute of Technology

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,9 +20,6 @@
 
 # Please keep the list sorted.
 
-## This file allows joining different accounts of a single person.
-## Cf for instance: git shortlog -nse. More details via: man git shortlog
-
 Adam Chlipala <adamc@csail.mit.edu> <adam@chlipala.net>
 Andres Erbsen <andreser@mit.edu>
 Daniel Ziegler <dmz@mit.edu>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,31 @@
+# This is the official list of people have contributed code to the
+# fiat-crypto repository.
+#
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, Google employees are listed here
+# but not in AUTHORS, because Google holds the copyright.
+#
+# When adding J Random Contributor's name to this file,
+# either J's name or J's organization's name should be
+# added to the AUTHORS file, depending on who holds the copyright.
+#
+# Names should be added to this file like so:
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+#
+# An entry with multiple email addresses specifies that the
+# first address should be used in the submit logs and
+# that the other addresses should be recognized as the
+# same person.
+
+# Please keep the list sorted.
+
+## This file allows joining different accounts of a single person.
+## Cf for instance: git shortlog -nse. More details via: man git shortlog
+
+Adam Chlipala <adamc@csail.mit.edu> <adam@chlipala.net>
+Andres Erbsen <andreser@mit.edu>
+Daniel Ziegler <dmz@mit.edu>
+Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>
+Jason Gross <jgross@mit.edu> <jagro@google.com> <jasongross9@gmail.com>
+Robert Sloan <rsloan@mit.edu> <varomodt@gmail.com> <rsloan@sumologic.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Programming Languages and Verification Group at MIT CSAIL
+Copyright (c) 2015-2016 the fiat-crypto authors (see the AUTHORS file).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #5.

I added licensing information according to the same pattern that I previously used for `dename` at MIT, G and Y. Old commits were incorporated such that everybody is listed in `CONTRIBUTORS` and individuals were assumed hold copyright for the contributions they submitted while not employed at the relevant institutions.