### PR TITLE
Make [base] and [log_cap] notations

### DIFF
--- a/src/ModularArithmetic/ExtendedBaseVector.v
+++ b/src/ModularArithmetic/ExtendedBaseVector.v
@@ -9,6 +9,7 @@ Local Open Scope Z_scope.
 
 Section ExtendedBaseVector.
   Context `{prm : PseudoMersenneBaseParams}.
+  Local Notation base := (Pow2Base.base_from_limb_widths limb_widths).
 
   (* This section defines a new BaseVector that has double the length of the BaseVector
   * used to construct [params]. The coefficients of the new vector are as follows:
@@ -159,4 +160,3 @@ Section ExtendedBaseVector.
     unfold ext_base; rewrite app_length; rewrite map_length; auto.
   Qed.
 End ExtendedBaseVector.
-

--- a/src/ModularArithmetic/ModularBaseSystem.v
+++ b/src/ModularArithmetic/ModularBaseSystem.v
@@ -4,7 +4,6 @@ Require Import Crypto.Util.ListUtil Crypto.Util.CaseUtil Crypto.Util.ZUtil.
 Require Import Crypto.ModularArithmetic.PrimeFieldTheorems.
 Require Import Crypto.BaseSystem.
 Require Import Crypto.ModularArithmetic.PseudoMersenneBaseParams.
-Require Import Crypto.ModularArithmetic.PseudoMersenneBaseParamProofs.
 Require Import Crypto.ModularArithmetic.ExtendedBaseVector.
 Require Import Crypto.Tactics.VerdiTactics.
 Require Import Crypto.Util.Notations.
@@ -13,6 +12,7 @@ Local Open Scope Z_scope.
 
 Section PseudoMersenneBase.
   Context `{prm :PseudoMersenneBaseParams}.
+  Local Notation base := (base_from_limb_widths limb_widths).
 
   Definition decode (us : digits) : F modulus := ZToField (BaseSystem.decode base us).
 
@@ -39,22 +39,20 @@ End PseudoMersenneBase.
 
 Section CarryBasePow2.
   Context `{prm :PseudoMersenneBaseParams}.
-
-  Definition log_cap i := nth_default 0 limb_widths i.
+  Local Notation base := (base_from_limb_widths limb_widths).
+  Local Notation log_cap i := (nth_default 0 limb_widths i).
 
   Definition add_to_nth n (x:Z) xs :=
     set_nth n (x + nth_default 0 xs n) xs.
 
-  Definition pow2_mod n i := Z.land n (Z.ones i).
-
   Definition carry_simple i := fun us =>
     let di := nth_default 0 us      i in
-    let us' := set_nth i (pow2_mod di (log_cap i)) us in
+    let us' := set_nth i (Z.pow2_mod di (log_cap i)) us in
     add_to_nth (S i) (   (Z.shiftr di (log_cap i))) us'.
 
   Definition carry_and_reduce i := fun us =>
     let di := nth_default 0 us      i in
-    let us' := set_nth i (pow2_mod di (log_cap i)) us in
+    let us' := set_nth i (Z.pow2_mod di (log_cap i)) us in
     add_to_nth   0  (c * (Z.shiftr di (log_cap i))) us'.
 
   Definition carry i : digits -> digits :=
@@ -80,6 +78,8 @@ End CarryBasePow2.
 
 Section Canonicalization.
   Context `{prm :PseudoMersenneBaseParams}.
+  Local Notation base := (base_from_limb_widths limb_widths).
+  Local Notation log_cap i := (nth_default 0 limb_widths i).
 
   (* compute at compile time *)
   Definition max_ones := Z.ones (fold_right Z.max 0 limb_widths).

--- a/src/ModularArithmetic/ModularBaseSystemInterface.v
+++ b/src/ModularArithmetic/ModularBaseSystemInterface.v
@@ -13,8 +13,9 @@ Generalizable All Variables.
 Section s.
   Context `{prm:PseudoMersenneBaseParams m} {sc : SubtractionCoefficient m prm}.
   Context {k_ c_} (pfk : k = k_) (pfc:c = c_).
+  Local Notation base := (Pow2Base.base_from_limb_widths limb_widths).
 
-  Definition fe := tuple Z (length PseudoMersenneBaseParamProofs.base).
+  Definition fe := tuple Z (length base).
 
   Definition mul  (x y:fe) : fe :=
     carry_mul_opt_cps k_ c_ (from_list_default 0%Z (length base))

--- a/src/ModularArithmetic/Pow2Base.v
+++ b/src/ModularArithmetic/Pow2Base.v
@@ -14,14 +14,13 @@ Section Pow2Base.
     | w :: lw => 1 :: map (Z.mul (two_p w)) (base_from_limb_widths lw)
     end.
 
-  Local Notation "{base}" := (base_from_limb_widths limb_widths).
-
+  Local Notation base := (base_from_limb_widths limb_widths).
 
   Definition bounded us := forall i, 0 <= nth_default 0 us i < 2 ^ w[i].
 
   Definition upper_bound := 2 ^ (sum_firstn limb_widths (length limb_widths)).
 
-  Fixpoint decode_bitwise' us i acc := 
+  Fixpoint decode_bitwise' us i acc :=
     match i with
     | O => acc
     | S i' => decode_bitwise' us i' (Z.lor (nth_default 0 us i') (Z.shiftl acc w[i']))

--- a/src/ModularArithmetic/PseudoMersenneBaseParamProofs.v
+++ b/src/ModularArithmetic/PseudoMersenneBaseParamProofs.v
@@ -23,11 +23,11 @@ Section PseudoMersenneBaseParamProofs.
     apply sum_firstn_limb_widths_nonneg; auto.
   Qed. Hint Resolve k_nonneg.
 
-  Definition base := base_from_limb_widths limb_widths.
+  Local Notation base := (base_from_limb_widths limb_widths).
 
   Lemma base_length : length base = length limb_widths.
   Proof.
-    unfold base; auto using base_from_limb_widths_length.
+    auto using base_from_limb_widths_length.
   Qed.
 
   Lemma base_matches_modulus: forall i j,
@@ -43,18 +43,18 @@ Section PseudoMersenneBaseParamProofs.
     subst r.
     assert (i + j - length base < length base)%nat by omega.
     rewrite Z.mul_div_eq by (apply Z.gt_lt_iff; apply Z.mul_pos_pos;
-      [ | subst b; unfold base; rewrite nth_default_base; try assumption ];
+      [ | subst b; rewrite nth_default_base; try assumption ];
       zero_bounds; auto using sum_firstn_limb_widths_nonneg, limb_widths_nonneg).
     rewrite (Zminus_0_l_reverse (b i * b j)) at 1.
     f_equal.
     subst b.
-    unfold base; repeat rewrite nth_default_base by auto.
+    repeat rewrite nth_default_base by auto.
     do 2 rewrite <- Z.pow_add_r by auto using sum_firstn_limb_widths_nonneg.
     symmetry.
     apply Z.mod_same_pow.
     split.
     + apply Z.add_nonneg_nonneg; auto using sum_firstn_limb_widths_nonneg.
-    + rewrite base_length, base_from_limb_widths_length in * by auto.
+    + rewrite base_length in * by auto.
       apply limb_widths_match_modulus; auto.
   Qed.
 
@@ -71,7 +71,7 @@ Section PseudoMersenneBaseParamProofs.
 
    Lemma b0_1 : forall x : Z, nth_default x base 0 = 1.
    Proof.
-     unfold base; case_eq limb_widths; intros; [pose proof limb_widths_nonnil; congruence | reflexivity].
+     case_eq limb_widths; intros; [pose proof limb_widths_nonnil; congruence | reflexivity].
    Qed.
 
    Lemma base_good : forall i j : nat,
@@ -81,7 +81,6 @@ Section PseudoMersenneBaseParamProofs.
                 b i * b j = r * b (i + j)%nat.
    Proof.
      intros; subst b r.
-     unfold base in *.
      repeat rewrite nth_default_base by (omega || auto).
      rewrite (Z.mul_comm _ (2 ^ (sum_firstn limb_widths (i+j)))).
      rewrite Z.mul_div_eq by (apply Z.gt_lt_iff; zero_bounds;


### PR DESCRIPTION
Also use [ZUtil.Z.pow2_mod].  Making `base` a notation lets us remove the dependency of
ModularBaseSystem on ModularArithmetic.PseudoMersenneBaseParamProofs.

This is a small part of reorganizing and factoring ModularBaseSystem for
use with Barrett reduction.