### PR TITLE
stop using raw nsatz, field_algebra, common_denominator

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -28,6 +28,7 @@ src/CompleteEdwardsCurve/Pre.v
 src/Encoding/EncodingTheorems.v
 src/Encoding/ModularWordEncodingPre.v
 src/Encoding/ModularWordEncodingTheorems.v
+src/Encoding/PointEncodingPre.v
 src/Experiments/DerivationsOptionRectLetInEncoding.v
 src/Experiments/EdDSARefinement.v
 src/Experiments/GenericFieldPow.v
@@ -54,8 +55,8 @@ src/Spec/ModularWordEncoding.v
 src/Spec/WeierstrassCurve.v
 src/Specific/GF1305.v
 src/Specific/GF25519.v
-src/Tactics/Nsatz.v
 src/Tactics/VerdiTactics.v
+src/Tactics/Algebra_syntax/Nsatz.v
 src/Util/CaseUtil.v
 src/Util/Decidable.v
 src/Util/IterAssocOp.v

--- a/src/Algebra.v
+++ b/src/Algebra.v
@@ -1,9 +1,10 @@
 Require Import Coq.Classes.Morphisms. Require Coq.Setoids.Setoid.
-Require Import Crypto.Util.Tactics Crypto.Tactics.Nsatz.
+Require Import Crypto.Util.Tactics.
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.Notations.
 Require Coq.Numbers.Natural.Peano.NPeano.
 Local Close Scope nat_scope. Local Close Scope type_scope. Local Close Scope core_scope.
+Require Crypto.Tactics.Algebra_syntax.Nsatz.
 
 Module Import ModuloCoq8485.
   Import NPeano Nat.
@@ -637,6 +638,11 @@ Module Field.
   End Homomorphism.
 End Field.
 
+(** Tactics *)
+
+Ltac nsatz := Algebra_syntax.Nsatz.nsatz; dropRingSyntax.
+Ltac nsatz_contradict := Algebra_syntax.Nsatz.nsatz_contradict; dropRingSyntax.
+
 (*** Tactics for manipulating field equations *)
 Require Import Coq.setoid_ring.Field_tac.
 
@@ -981,7 +987,7 @@ Ltac neq01 :=
 Ltac conservative_field_algebra :=
   intros;
   conservative_common_denominator_all;
-  try (nsatz; dropRingSyntax);
+  try nsatz;
   repeat (apply conj);
   try solve
       [neq01
@@ -991,7 +997,7 @@ Ltac conservative_field_algebra :=
 Ltac field_algebra :=
   intros;
   common_denominator_all;
-  try (nsatz; dropRingSyntax);
+  try nsatz;
   repeat (apply conj);
   try solve
       [neq01

--- a/src/Algebra.v
+++ b/src/Algebra.v
@@ -668,7 +668,7 @@ Ltac field_nonzero_mul_split :=
            => apply IntegralDomain.mul_nonzero_nonzero_iff in H; destruct H
          end.
 
-Ltac common_denominator :=
+Ltac field_simplify_eq_if_div :=
   let fld := guess_field in
   lazymatch type of fld with
     field (div:=?div) =>
@@ -679,7 +679,7 @@ Ltac common_denominator :=
   end.
 
 (** We jump through some hoops to ensure that the side-conditions come late *)
-Ltac common_denominator_in_cycled_side_condition_order H :=
+Ltac field_simplify_eq_if_div_in_cycled_side_condition_order H :=
   let fld := guess_field in
   lazymatch type of fld with
     field (div:=?div) =>
@@ -689,14 +689,10 @@ Ltac common_denominator_in_cycled_side_condition_order H :=
     end
   end.
 
-Ltac common_denominator_in H :=
+Ltac field_simplify_eq_if_div_in H :=
   side_conditions_before_to_side_conditions_after
-    common_denominator_in_cycled_side_condition_order
+    field_simplify_eq_if_div_in_cycled_side_condition_order
     H.
-
-Ltac common_denominator_all :=
-  common_denominator;
-  repeat match goal with [H: _ |- _ _ _ ] => progress common_denominator_in H end.
 
 (** Now we have more conservative versions that don't simplify non-division structure. *)
 Ltac deduplicate_nonfraction_pieces mul :=
@@ -789,7 +785,7 @@ Ltac conservative_common_denominator_in H :=
   lazymatch type of H with
   | appcontext[div]
     => set_nonfraction_pieces_in H;
-       common_denominator_in H;
+       field_simplify_eq_if_div_in H;
        [
        | default_conservative_common_denominator_nonzero_tac.. ];
        repeat match goal with H := _ |- _ => subst H end
@@ -805,7 +801,7 @@ Ltac conservative_common_denominator :=
   lazymatch goal with
   | |- appcontext[div]
     => set_nonfraction_pieces;
-       common_denominator;
+       field_simplify_eq_if_div;
        [
        | default_conservative_common_denominator_nonzero_tac.. ];
        repeat match goal with H := _ |- _ => subst H end

--- a/src/Algebra.v
+++ b/src/Algebra.v
@@ -984,26 +984,6 @@ Ltac neq01 :=
       |apply one_neq_zero
       |apply Group.opp_one_neq_zero].
 
-Ltac conservative_field_algebra :=
-  intros;
-  conservative_common_denominator_all;
-  try nsatz;
-  repeat (apply conj);
-  try solve
-      [neq01
-      |trivial
-      |apply Ring.opp_nonzero_nonzero;trivial].
-
-Ltac field_algebra :=
-  intros;
-  common_denominator_all;
-  try nsatz;
-  repeat (apply conj);
-  try solve
-      [neq01
-      |trivial
-      |apply Ring.opp_nonzero_nonzero;trivial].
-
 Ltac combine_field_inequalities_step :=
   match goal with
   | [ H : not (?R ?x ?zero), H' : not (?R ?x' ?zero) |- _ ]
@@ -1184,10 +1164,10 @@ Section Example.
   Add Field _ExampleField : (Field.field_theory_for_stdlib_tactic (T:=F)).
 
   Example _example_nsatz x y : 1+1 <> 0 -> x + y = 0 -> x - y = 0 -> x = 0.
-  Proof. field_algebra. Qed.
+  Proof. intros. nsatz. Qed.
 
   Example _example_field_nsatz x y z : y <> 0 -> x/y = z -> z*y + y = x + y.
-  Proof. intros; subst; field_algebra. Qed.
+  Proof. intros. super_nsatz. Qed.
 
   Example _example_nonzero_nsatz_contradict x y : x * y = 1 -> not (x = 0).
   Proof. intros. intro. nsatz_contradict. Qed.

--- a/src/Algebra.v
+++ b/src/Algebra.v
@@ -771,11 +771,11 @@ Ltac set_nonfraction_pieces :=
          ltac:(fun T' => change T');
        deduplicate_nonfraction_pieces mul
   end.
-Ltac default_conservative_common_denominator_nonzero_tac :=
+Ltac default_common_denominator_nonzero_tac :=
   repeat apply conj;
   try first [ assumption
             | intro; field_nonzero_mul_split; tauto ].
-Ltac conservative_common_denominator_in H :=
+Ltac common_denominator_in H :=
   idtac;
   let fld := guess_field in
   let div := lazymatch type of fld with
@@ -787,11 +787,11 @@ Ltac conservative_common_denominator_in H :=
     => set_nonfraction_pieces_in H;
        field_simplify_eq_if_div_in H;
        [
-       | default_conservative_common_denominator_nonzero_tac.. ];
+       | default_common_denominator_nonzero_tac.. ];
        repeat match goal with H := _ |- _ => subst H end
   | ?T => fail 0 "no division in" H ":" T
   end.
-Ltac conservative_common_denominator :=
+Ltac common_denominator :=
   idtac;
   let fld := guess_field in
   let div := lazymatch type of fld with
@@ -803,12 +803,12 @@ Ltac conservative_common_denominator :=
     => set_nonfraction_pieces;
        field_simplify_eq_if_div;
        [
-       | default_conservative_common_denominator_nonzero_tac.. ];
+       | default_common_denominator_nonzero_tac.. ];
        repeat match goal with H := _ |- _ => subst H end
   | |- ?G
     => fail 0 "no division in goal" G
   end.
-Ltac conservative_common_denominator_inequality_in H :=
+Ltac common_denominator_inequality_in H :=
   let HT := type of H in
   lazymatch HT with
   | not (?R _ _) => idtac
@@ -823,8 +823,8 @@ Ltac conservative_common_denominator_inequality_in H :=
   cut (not HT'); subst HT';
   [ intro H; clear H'
   | let H'' := fresh in
-    intro H''; apply H'; conservative_common_denominator; [ eexact H'' | .. ] ].
-Ltac conservative_common_denominator_inequality :=
+    intro H''; apply H'; common_denominator; [ eexact H'' | .. ] ].
+Ltac common_denominator_inequality :=
   let G := get_goal in
   lazymatch G with
   | not (?R _ _) => idtac
@@ -838,37 +838,37 @@ Ltac conservative_common_denominator_inequality :=
   assert (H' : not HT'); subst HT';
   [
   | let HG := fresh in
-    intros HG; apply H'; conservative_common_denominator_in HG; [ eexact HG | .. ] ].
+    intros HG; apply H'; common_denominator_in HG; [ eexact HG | .. ] ].
 
-Ltac conservative_common_denominator_hyps :=
+Ltac common_denominator_hyps :=
   try match goal with
       | [H: _ |- _ ]
-        => progress conservative_common_denominator_in H;
-           [ conservative_common_denominator_hyps
+        => progress common_denominator_in H;
+           [ common_denominator_hyps
            | .. ]
       end.
 
-Ltac conservative_common_denominator_inequality_hyps :=
+Ltac common_denominator_inequality_hyps :=
   try match goal with
       | [H: _ |- _ ]
-        => progress conservative_common_denominator_inequality_in H;
-           [ conservative_common_denominator_inequality_hyps
+        => progress common_denominator_inequality_in H;
+           [ common_denominator_inequality_hyps
            | .. ]
       end.
 
-Ltac conservative_common_denominator_all :=
-  try conservative_common_denominator;
-  [ try conservative_common_denominator_hyps
+Ltac common_denominator_all :=
+  try common_denominator;
+  [ try common_denominator_hyps
   | .. ].
 
-Ltac conservative_common_denominator_inequality_all :=
-  try conservative_common_denominator_inequality;
-  [ try conservative_common_denominator_inequality_hyps
+Ltac common_denominator_inequality_all :=
+  try common_denominator_inequality;
+  [ try common_denominator_inequality_hyps
   | .. ].
 
-Ltac conservative_common_denominator_equality_inequality_all :=
-  conservative_common_denominator_all;
-  [ conservative_common_denominator_inequality_all
+Ltac common_denominator_equality_inequality_all :=
+  common_denominator_all;
+  [ common_denominator_inequality_all
   | .. ].
 
 Inductive field_simplify_done {T} : T -> Type :=
@@ -1042,7 +1042,7 @@ Ltac super_nsatz_internal nsatz_alternative :=
   prensatz_contradict;
   (* Each goal left over by [prensatz_contradict] is separate (and
      there might not be any), so we handle them all separately *)
-  [ try conservative_common_denominator_equality_inequality_all;
+  [ try common_denominator_equality_inequality_all;
     [ try nsatz_inequality_to_equality;
       try first [ nsatz;
                   (* [nstaz] might leave over side-conditions; we handle them if they are inequalities *)

--- a/src/CompleteEdwardsCurve/CompleteEdwardsCurveTheorems.v
+++ b/src/CompleteEdwardsCurve/CompleteEdwardsCurveTheorems.v
@@ -6,8 +6,7 @@ Require Import Coq.Logic.Eqdep_dec.
 Require Import Crypto.Tactics.VerdiTactics.
 Require Import Coq.Classes.Morphisms.
 Require Import Relation_Definitions.
-Require Import Crypto.Util.Tuple.
-Require Import Crypto.Util.Notations.
+Require Import Crypto.Util.Tuple Crypto.Util.Notations Crypto.Util.Tactics.
 
 Module E.
   Import Group ScalarMult Ring Field CompleteEdwardsCurve.E.
@@ -37,49 +36,75 @@ Module E.
                destruct p as [[x y] pf]
              end.
 
-    Local Obligation Tactic := intros; destruct_points; simpl; field_algebra.
+    Local Obligation Tactic := intros; destruct_points; simpl; super_nsatz.
     Program Definition opp (P:point) : point :=
       exist _ (let '(x, y) := coordinates P in (Fopp x, y) ) _.
 
+    (* all nonzero-denominator goals here require proofs that are not
+    trivially implied by field axioms. Posing all such proofs at once
+    and then solving the nonzero-denominator goal using [super_nsatz]
+    is too slow because the context contains many assumed nonzero
+    expressions and the product of all of them is a very large
+    polynomial. However, we never need to use more than one
+    nonzero-ness assumption for a given nonzero-denominator goal, so
+    we can try them separately one-by-one. *)
+
+    Ltac apply_field_nonzero H :=
+      match goal with |- not (Feq _ 0) => idtac | _ => fail "not a nonzero goal" end;
+      try solve [exact H];
+      let Hx := fresh "H" in
+      intro Hx;
+      apply H;
+      try conservative_common_denominator;
+      [rewrite <-Hx; ring | ..].
+      
     Ltac bash_step :=
+      let addCompletePlus := constr:(edwardsAddCompletePlus(char_gt_2:=char_gt_2)(d_nonsquare:=nonsquare_d)(a_square:=square_a)(a_nonzero:=nonzero_a)) in
+      let addCompleteMinus := constr:(edwardsAddCompleteMinus(char_gt_2:=char_gt_2)(d_nonsquare:=nonsquare_d)(a_square:=square_a)(a_nonzero:=nonzero_a)) in
+      let addOnCurve := constr:(unifiedAdd'_onCurve(char_gt_2:=char_gt_2)(d_nonsquare:=nonsquare_d)(a_square:=square_a)(a_nonzero:=nonzero_a)) in
       match goal with
       | |- _ => progress intros
       | [H: _ /\ _ |- _ ] => destruct H
+      | [H: ?a = ?b |- _ ] => is_var a; is_var b; repeat rewrite <-H in *; clear H b (* fast path *)
       | |- _ => progress destruct_points
       | |- _ => progress cbv [fst snd coordinates proj1_sig eq fieldwise fieldwise' add zero opp] in *
       | |- _ => split
-      | |- Feq _ _ => field_algebra
+      | [H:Feq (a*_^2+_^2) (1 + d*_^2*_^2) |- _ <> 0]
+        => apply_field_nonzero (addCompletePlus _ _ _ _ H H) ||
+           apply_field_nonzero (addCompleteMinus _ _ _ _ H H)
+      | [A:Feq (a*_^2+_^2) (1 + d*_^2*_^2),
+           B:Feq (a*_^2+_^2) (1 + d*_^2*_^2) |- _ <> 0]
+        => apply_field_nonzero (addCompletePlus _ _ _ _ A B) ||
+           apply_field_nonzero (addCompleteMinus _ _ _ _ A B)
+      | [A:Feq (a*_^2+_^2) (1 + d*_^2*_^2),
+           B:Feq (a*_^2+_^2) (1 + d*_^2*_^2),
+             C:Feq (a*_^2+_^2) (1 + d*_^2*_^2) |- _ <> 0]
+        => apply_field_nonzero (addCompleteMinus _ _ _ _ A (addOnCurve (_, _) (_, _) B C)) ||
+           apply_field_nonzero (addCompletePlus _ _ _ _ A (addOnCurve (_, _) (_, _) B C))
+      | |- ?x <> 0 => let H := fresh "H" in assert (x = 1) as H by ring; rewrite H; exact one_neq_zero
+      | |- Feq _ _ => progress conservative_common_denominator
+      | |- Feq _ _ => nsatz
+      | |- _ => exact _ (* typeclass instances *)
       end.
 
     Ltac bash := repeat bash_step.
 
-    Global Instance Proper_add : Proper (eq==>eq==>eq) add.
-    Proof. bash.
-           pose proof edwardsAddCompletePlus(char_gt_2:=char_gt_2)(d_nonsquare:=nonsquare_d)(a_square:=square_a)(a_nonzero:=nonzero_a) as Hxy.
-           specialize (Hxy _ _ _ _ pfx pfy).
-           pose proof (edwardsAddCompletePlus(char_gt_2:=char_gt_2)(d_nonsquare:=nonsquare_d)(a_square:=square_a)(a_nonzero:=nonzero_a) _ _ _ _ pfx pfy).
-    Qed.
+    Global Instance Proper_add : Proper (eq==>eq==>eq) add. Proof. bash. Qed.
     Global Instance Proper_opp : Proper (eq==>eq) opp. Proof. bash. Qed.
     Global Instance Proper_coordinates : Proper (eq==>fieldwise (n:=2) Feq) coordinates. Proof. bash. Qed.
-
     Global Instance edwards_acurve_abelian_group : abelian_group (eq:=eq)(op:=add)(id:=zero)(inv:=opp).
     Proof.
       bash.
-      (* TODO: port denominator-nonzero proofs for associativity *)
-      match goal with | |- _ <> 0 => admit end.
-      match goal with | |- _ <> 0 => admit end.
-      match goal with | |- _ <> 0 => admit end.
-      match goal with | |- _ <> 0 => admit end.
-    Admitted.
+    Qed.
 
     Global Instance Proper_mul : Proper (Logic.eq==>eq==>eq) mul.
     Proof.
-      intros n m Hnm P Q HPQ. rewrite <-Hnm; clear Hnm m.
-      induction n; simpl; rewrite ?IHn, ?HPQ; reflexivity.
+      intros n n'; repeat intro; subst n'.
+      induction n; (reflexivity || eapply Proper_add; eauto).
     Qed.
 
     Global Instance mul_is_scalarmult : @is_scalarmult point eq add zero mul.
-    Proof. split; intros; reflexivity || typeclasses eauto. Qed.
+    Proof. unfold mul; split; intros; (reflexivity || exact _). Qed.
 
     Section PointCompression.
       Local Notation "x ^ 2" := (x*x).
@@ -89,12 +114,13 @@ Module E.
       Proof.
         intros ? eq_zero.
         destruct square_a as [sqrt_a sqrt_a_id]; rewrite <- sqrt_a_id in eq_zero.
-        destruct (eq_dec y 0); [apply nonzero_a|apply nonsquare_d with (sqrt_a/y)]; field_algebra.
+        destruct (eq_dec y 0); [apply nonzero_a | apply nonsquare_d with (sqrt_a/y)]; super_nsatz.
       Qed.
 
       Lemma solve_correct : forall x y, onCurve (x, y) <-> (x^2 = solve_for_x2 y).
       Proof.
-        unfold solve_for_x2; simpl; split; intros; field_algebra; auto using a_d_y2_nonzero.
+        unfold solve_for_x2; simpl; split; intros;
+          (conservative_common_denominator_all; [nsatz | auto using a_d_y2_nonzero]).
       Qed.
     End PointCompression.
   End CompleteEdwardsCurveTheorems.

--- a/src/CompleteEdwardsCurve/CompleteEdwardsCurveTheorems.v
+++ b/src/CompleteEdwardsCurve/CompleteEdwardsCurveTheorems.v
@@ -55,7 +55,7 @@ Module E.
       let Hx := fresh "H" in
       intro Hx;
       apply H;
-      try conservative_common_denominator;
+      try common_denominator;
       [rewrite <-Hx; ring | ..].
       
     Ltac bash_step :=
@@ -82,7 +82,7 @@ Module E.
         => apply_field_nonzero (addCompleteMinus _ _ _ _ A (addOnCurve (_, _) (_, _) B C)) ||
            apply_field_nonzero (addCompletePlus _ _ _ _ A (addOnCurve (_, _) (_, _) B C))
       | |- ?x <> 0 => let H := fresh "H" in assert (x = 1) as H by ring; rewrite H; exact one_neq_zero
-      | |- Feq _ _ => progress conservative_common_denominator
+      | |- Feq _ _ => progress common_denominator
       | |- Feq _ _ => nsatz
       | |- _ => exact _ (* typeclass instances *)
       end.
@@ -120,7 +120,7 @@ Module E.
       Lemma solve_correct : forall x y, onCurve (x, y) <-> (x^2 = solve_for_x2 y).
       Proof.
         unfold solve_for_x2; simpl; split; intros;
-          (conservative_common_denominator_all; [nsatz | auto using a_d_y2_nonzero]).
+          (common_denominator_all; [nsatz | auto using a_d_y2_nonzero]).
       Qed.
     End PointCompression.
   End CompleteEdwardsCurveTheorems.

--- a/src/CompleteEdwardsCurve/CompleteEdwardsCurveTheorems.v
+++ b/src/CompleteEdwardsCurve/CompleteEdwardsCurveTheorems.v
@@ -1,6 +1,6 @@
 Require Export Crypto.Spec.CompleteEdwardsCurve.
 
-Require Import Crypto.Algebra Crypto.Tactics.Nsatz.
+Require Import Crypto.Algebra Crypto.Algebra.
 Require Import Crypto.CompleteEdwardsCurve.Pre.
 Require Import Coq.Logic.Eqdep_dec.
 Require Import Crypto.Tactics.VerdiTactics.

--- a/src/CompleteEdwardsCurve/ExtendedCoordinates.v
+++ b/src/CompleteEdwardsCurve/ExtendedCoordinates.v
@@ -1,6 +1,6 @@
 Require Export Crypto.Spec.CompleteEdwardsCurve.
 
-Require Import Crypto.Algebra Crypto.Tactics.Nsatz.
+Require Import Crypto.Algebra Crypto.Algebra.
 Require Import Crypto.CompleteEdwardsCurve.Pre Crypto.CompleteEdwardsCurve.CompleteEdwardsCurveTheorems.
 Require Import Coq.Logic.Eqdep_dec.
 Require Import Crypto.Tactics.VerdiTactics.

--- a/src/CompleteEdwardsCurve/ExtendedCoordinates.v
+++ b/src/CompleteEdwardsCurve/ExtendedCoordinates.v
@@ -33,6 +33,7 @@ Module Extended.
     Create HintDb bash discriminated.
     Local Hint Unfold E.eq fst snd fieldwise fieldwise' coordinates E.coordinates proj1_sig Pre.onCurve : bash.
     Ltac bash :=
+      pose proof E.char_gt_2;
       repeat match goal with
              | |- Proper _ _ => intro
              | _ => progress intros
@@ -43,15 +44,11 @@ Module Extended.
              | |- _ /\ _ => split
              | _ => solve [neq01]
              | _ => solve [eauto]
-             | _ => solve [intuition]
+             | _ => solve [intuition eauto]
              | _ => solve [etransitivity; eauto]
-             | |- Feq _ _ => field_algebra
-             | |- _ <> 0 => apply mul_nonzero_nonzero
-             | [ H : _ <> 0 |- _ <> 0 ] =>
-               intro; apply H;
-               field_algebra;
-               solve [ apply Ring.opp_nonzero_nonzero, E.char_gt_2
-                     | apply E.char_gt_2]
+             | |- _*_ <> 0 => apply mul_nonzero_nonzero
+             | [H: _ |- _ ] => solve [intro; apply H; super_nsatz]
+             | |- Feq _ _ => super_nsatz
              end.
 
     Obligation Tactic := bash.
@@ -63,8 +60,7 @@ Module Extended.
       (let '(X,Y,Z,T) := coordinates P in ((X/Z), (Y/Z))) _.
 
     Definition eq (P Q:point) := E.eq (to_twisted P) (to_twisted Q).
-    Global Instance DecidableRel_eq : Decidable.DecidableRel eq.
-    Proof. typeclasses eauto. Qed.
+    Global Instance DecidableRel_eq : Decidable.DecidableRel eq := _.
 
     Local Hint Unfold from_twisted to_twisted eq : bash.
 

--- a/src/CompleteEdwardsCurve/Pre.v
+++ b/src/CompleteEdwardsCurve/Pre.v
@@ -50,24 +50,25 @@ Section Pre.
         => apply d_nonsquare with (sqrt_d:= (f (sqrt_a * x1) (d * x1 * x2 * y1 * y2 * y1))
                                            /(f (sqrt_a * x2) y2   *   x1 * y1           ))
       | _ => apply a_nonzero
-      end; field_algebra; auto using Ring.opp_nonzero_nonzero; nsatz_contradict.
+      end; super_nsatz.
   Qed.
 
   Lemma edwardsAddCompletePlus x1 y1 x2 y2 :
     onCurve (x1, y1) -> onCurve (x2, y2) -> (1 + d*x1*x2*y1*y2) <> 0.
-  Proof. intros H1 H2 ?. apply (edwardsAddComplete' _ _ _ _ H1 H2); field_algebra. Qed.
+  Proof. intros H1 H2 ?. apply (edwardsAddComplete' _ _ _ _ H1 H2); super_nsatz. Qed.
 
   Lemma edwardsAddCompleteMinus x1 y1 x2 y2 :
     onCurve (x1, y1) -> onCurve (x2, y2) -> (1 - d*x1*x2*y1*y2) <> 0.
-  Proof. intros H1 H2 ?. apply (edwardsAddComplete' _ _ _ _ H1 H2); field_algebra. Qed.
+  Proof. intros H1 H2 ?. apply (edwardsAddComplete' _ _ _ _ H1 H2); super_nsatz. Qed.
 
-  Lemma zeroOnCurve : onCurve (0, 1). Proof. simpl. field_algebra. Qed.
+  Lemma zeroOnCurve : onCurve (0, 1). Proof. simpl. super_nsatz. Qed.
 
   Lemma unifiedAdd'_onCurve : forall P1 P2,
     onCurve P1 -> onCurve P2 -> onCurve (unifiedAdd' P1 P2).
   Proof.
-    unfold onCurve, unifiedAdd'; intros [x1 y1] [x2 y2] H1 H2.
-    field_algebra; auto using edwardsAddCompleteMinus, edwardsAddCompletePlus.
+    unfold onCurve, unifiedAdd'; intros [x1 y1] [x2 y2] ? ?.
+    conservative_common_denominator; [ | auto using edwardsAddCompleteMinus, edwardsAddCompletePlus..].
+    nsatz.
   Qed.
 End Pre.
 

--- a/src/CompleteEdwardsCurve/Pre.v
+++ b/src/CompleteEdwardsCurve/Pre.v
@@ -67,7 +67,7 @@ Section Pre.
     onCurve P1 -> onCurve P2 -> onCurve (unifiedAdd' P1 P2).
   Proof.
     unfold onCurve, unifiedAdd'; intros [x1 y1] [x2 y2] ? ?.
-    conservative_common_denominator; [ | auto using edwardsAddCompleteMinus, edwardsAddCompletePlus..].
+    common_denominator; [ | auto using edwardsAddCompleteMinus, edwardsAddCompletePlus..].
     nsatz.
   Qed.
 End Pre.

--- a/src/CompleteEdwardsCurve/Pre.v
+++ b/src/CompleteEdwardsCurve/Pre.v
@@ -1,5 +1,5 @@
 Require Import Coq.Classes.Morphisms. Require Coq.Setoids.Setoid.
-Require Import Crypto.Algebra Crypto.Tactics.Nsatz.
+Require Import Crypto.Algebra Crypto.Algebra.
 Require Import Crypto.Util.Notations.
 
 Generalizable All Variables.

--- a/src/Encoding/PointEncodingPre.v
+++ b/src/Encoding/PointEncodingPre.v
@@ -7,7 +7,7 @@ Require Import Bedrock.Word.
 Require Import Crypto.Encoding.ModularWordEncodingTheorems.
 Require Import Crypto.Tactics.VerdiTactics.
 Require Import Crypto.Util.ZUtil.
-Require Import Crypto.Algebra Crypto.Nsatz.
+Require Import Crypto.Algebra.
 
 Require Import Crypto.Spec.Encoding Crypto.Spec.ModularWordEncoding Crypto.Spec.ModularArithmetic.
 
@@ -241,13 +241,13 @@ Section PointEncodingPre.
       eauto using inversion_option_coordinates_eq, solve_onCurve, solve_opp_onCurve.
   Qed.
 
-  Definition point_dec' w p : option E.point :=
+  Definition point_dec' w p : option point :=
     match (option_coordinates_eq_dec  (point_dec_coordinates w) (Some p)) with
       | left EQ => Some (exist _ p (point_dec_coordinates_onCurve w p EQ))
       | right _ => None (* this case is never reached *)
     end.
 
-  Definition point_dec (w : word (S sz)) : option E.point :=
+  Definition point_dec (w : word (S sz)) : option point :=
     match point_dec_coordinates w with
     | Some p => point_dec' w p
     | None => None

--- a/src/Spec/CompleteEdwardsCurve.v
+++ b/src/Spec/CompleteEdwardsCurve.v
@@ -29,8 +29,9 @@ Module E.
     Definition coordinates (P:point) : (F*F) := proj1_sig P.
 
     (** The following points are indeed on the curve -- see [CompleteEdwardsCurve.Pre] for proof *)
-    Local Obligation Tactic := intros; apply Pre.zeroOnCurve
-      || apply (Pre.unifiedAdd'_onCurve (char_gt_2:=char_gt_2) (d_nonsquare:=nonsquare_d)
+    Local Obligation Tactic := intros;
+      apply (Pre.zeroOnCurve(a_nonzero:=nonzero_a)(char_gt_2:=char_gt_2)) ||
+      apply (Pre.unifiedAdd'_onCurve (char_gt_2:=char_gt_2) (d_nonsquare:=nonsquare_d)
          (a_nonzero:=nonzero_a) (a_square:=square_a) _ _ (proj2_sig _) (proj2_sig _)).
 
     Program Definition zero : point := (0, 1).

--- a/src/Tactics/Algebra_syntax/Nsatz.v
+++ b/src/Tactics/Algebra_syntax/Nsatz.v
@@ -121,11 +121,14 @@ Ltac nsatz_sugar_power sugar power :=
   let domain := nsatz_guess_domain in
   nsatz_domain_sugar_power domain sugar power.
 
-Tactic Notation "nsatz" constr(n) :=
-  let nn := (eval compute in (BinNat.N.of_nat n)) in
-  nsatz_sugar_power BinInt.Z0 nn.
+Ltac nsatz_power power :=
+  let power_N := (eval compute in (BinNat.N.of_nat power)) in
+  nsatz_sugar_power BinInt.Z0 power_N.
 
-Tactic Notation "nsatz" := nsatz 1%nat || nsatz 2%nat || nsatz 3%nat || nsatz 4%nat || nsatz 5%nat.
+Ltac nsatz := nsatz_power 1%nat || nsatz_power 2%nat || nsatz_power 3%nat || nsatz_power 4%nat || nsatz_power 5%nat.
+
+Tactic Notation "nsatz" := nsatz.
+Tactic Notation "nsatz" constr(n) := nsatz_power n.
 
 (** If the goal is of the form [?x <> ?y] and assuming [?x = ?y]
     contradicts any hypothesis of the form [?x' <> ?y'], we turn this

--- a/src/Util/Tactics.v
+++ b/src/Util/Tactics.v
@@ -7,6 +7,9 @@ Tactic Notation "test" tactic3(tac) :=
 (** [not tac] is equivalent to [fail tac "succeeds"] if [tac] succeeds, and is equivalent to [idtac] if [tac] fails *)
 Tactic Notation "not" tactic3(tac) := try ((test tac); fail 1 tac "succeeds").
 
+Ltac get_goal :=
+  match goal with |- ?G => G end.
+
 (** find the head of the given expression *)
 Ltac head expr :=
   match expr with

--- a/src/WeierstrassCurve/Pre.v
+++ b/src/WeierstrassCurve/Pre.v
@@ -51,7 +51,6 @@ Section Pre.
     onCurve P1 -> onCurve P2 -> onCurve (unifiedAdd' P1 P2).
   Proof.
     unfold onCurve, unifiedAdd'; intros [[x1 y1]|] [[x2 y2]|] H1 H2;
-      break_match; trivial; setoid_subst_rel eq; only_two_square_roots;
-        field_algebra; nsatz_contradict.
+      break_match; trivial; setoid_subst_rel eq; only_two_square_roots; super_nsatz.
   Qed.
 End Pre.

--- a/src/WeierstrassCurve/Pre.v
+++ b/src/WeierstrassCurve/Pre.v
@@ -1,5 +1,5 @@
 Require Import Coq.Classes.Morphisms. Require Coq.Setoids.Setoid.
-Require Import Crypto.Algebra Crypto.Tactics.Nsatz.
+Require Import Crypto.Algebra.
 Require Import Crypto.Util.Tactics.
 Require Import Crypto.Util.Notations.
 


### PR DESCRIPTION
Supersedes #16; closes #10; closes #15.

Several replacements were made in separate commits:
- `nsatz` was redefined in `Algebra.v` as `nsatz; dropRingSyntax`, other files were changed to import that instead
- uses of `field_algebra` were replaced with `super_nsatz`, `nsatz` and `conservative_common_denominator` as appropriate.
- `common_denominator` family tactics were replaced with `conservative_common_denominator` family tactics
- `common_denominator` tactics were renamed to `field_simplify_if_div`
- `conservative_common_denominator` tactics were renamed to `common_denominator`

In some cases, `super_nsatz` is a too big hammer: when the goal contains many hypotheses of the form `?x <> 0` then `super_nsatz` takes a long time, but `intro; apply; rewrite; ring` wins quickly. This speedup was successfully applied to make the CompleteEdwardsCurveTheorems associativity proof feasible.