### PR TITLE
Refactor ModularArithmetic into Zmod, expand Decidable

### DIFF
--- a/src/Algebra.v
+++ b/src/Algebra.v
@@ -365,12 +365,14 @@ Module ScalarMult.
 
     Global Instance Proper_scalarmult_ref : Proper (Logic.eq==>eq==>eq) scalarmult_ref.
     Proof.
-      repeat intro; subst.
-      match goal with [n:nat |- _ ] => induction n; simpl @scalarmult_ref; [reflexivity|] end.
-      repeat match goal with [H:_ |- _ ] => rewrite H end; reflexivity.
+      repeat intro; subst; 
+        match goal with [n:nat |- _ ] =>
+                        solve [induction n; simpl scalarmult_ref; rewrite_hyp ?*; reflexivity]
+        end.
     Qed.
 
     Lemma scalarmult_ext : forall n P, mul n P = scalarmult_ref n P.
+    Proof.
       induction n; simpl @scalarmult_ref; intros; rewrite <-?IHn; (apply scalarmult_0_l || apply scalarmult_S_l).
     Qed.
 

--- a/src/CompleteEdwardsCurve/CompleteEdwardsCurveTheorems.v
+++ b/src/CompleteEdwardsCurve/CompleteEdwardsCurveTheorems.v
@@ -1,6 +1,6 @@
 Require Export Crypto.Spec.CompleteEdwardsCurve.
 
-Require Import Crypto.Algebra Crypto.Algebra.
+Require Import Crypto.Algebra Crypto.Algebra Crypto.Util.Decidable.
 Require Import Crypto.CompleteEdwardsCurve.Pre.
 Require Import Coq.Logic.Eqdep_dec.
 Require Import Crypto.Tactics.VerdiTactics.
@@ -115,7 +115,7 @@ Module E.
       Proof.
         intros ? eq_zero.
         destruct square_a as [sqrt_a sqrt_a_id]; rewrite <- sqrt_a_id in eq_zero.
-        destruct (eq_dec y 0); [apply nonzero_a | apply nonsquare_d with (sqrt_a/y)]; super_nsatz.
+        destruct (dec (y=0)); [apply nonzero_a | apply nonsquare_d with (sqrt_a/y)]; super_nsatz.
       Qed.
 
       Lemma solve_correct : forall x y, onCurve (x, y) <-> (x^2 = solve_for_x2 y).

--- a/src/CompleteEdwardsCurve/Pre.v
+++ b/src/CompleteEdwardsCurve/Pre.v
@@ -1,6 +1,6 @@
 Require Import Coq.Classes.Morphisms. Require Coq.Setoids.Setoid.
 Require Import Crypto.Algebra Crypto.Algebra.
-Require Import Crypto.Util.Notations.
+Require Import Crypto.Util.Notations Crypto.Util.Decidable.
 
 Generalizable All Variables.
 Section Pre.
@@ -44,7 +44,7 @@ Section Pre.
     (d*x1*x2*y1*y2)^2 <> 1.
   Proof.
     unfold onCurve, not; use_sqrt_a; intros.
-    destruct (eq_dec (sqrt_a*x2 + y2) 0); destruct (eq_dec (sqrt_a*x2 - y2) 0);
+    destruct (dec ((sqrt_a*x2 + y2) = 0)); destruct (dec ((sqrt_a*x2 - y2) = 0));
       lazymatch goal with
       | [H: not (eq (?f (sqrt_a * x2)  y2) 0) |- _ ]
         => apply d_nonsquare with (sqrt_d:= (f (sqrt_a * x1) (d * x1 * x2 * y1 * y2 * y1))

--- a/src/Encoding/ModularWordEncodingPre.v
+++ b/src/Encoding/ModularWordEncodingPre.v
@@ -16,18 +16,18 @@ Section ModularWordEncodingPre.
   Let Fm_dec (x_ : word sz) : option (F m) :=
     let z := Z.of_N (wordToN (x_)) in
     if Z_lt_dec z m
-      then Some (ZToField z)
+      then Some (ZToField _ z)
       else None
   .
 
   Lemma Fm_encoding_valid : forall x, Fm_dec (Fm_enc x) = Some x.
   Proof.
     unfold Fm_dec, Fm_enc; intros.
-    pose proof (FieldToZ_range x m_pos).
+    pose proof (Zmod.FieldToZ_range x m_pos).
     rewrite wordToN_NToWord_idempotent by (apply bound_check_nat_N;
      assert (Z.to_nat x < Z.to_nat m) by (apply Z2Nat.inj_lt; omega); omega).
     rewrite Z2N.id by omega.
-    rewrite ZToField_idempotent.
+    rewrite Zmod.ZToField_FieldToZ.
     break_if; auto; omega.
   Qed.
 
@@ -36,7 +36,7 @@ Section ModularWordEncodingPre.
     unfold Fm_dec, Fm_enc; intros ? ? dec_Some.
     break_if; [ | congruence ].
     inversion dec_Some.
-    rewrite FieldToZ_ZToField.
+    rewrite Zmod.FieldToZ_ZToField.
     rewrite Z.mod_small by (pose proof (N2Z.is_nonneg (wordToN w)); try omega).
     rewrite N2Z.id.
     apply NToWord_wordToN.

--- a/src/Encoding/ModularWordEncodingPre.v
+++ b/src/Encoding/ModularWordEncodingPre.v
@@ -11,23 +11,23 @@ Local Open Scope nat_scope.
 Section ModularWordEncodingPre.
   Context {m : Z} {sz : nat} {m_pos : (0 < m)%Z} {bound_check : Z.to_nat m < 2 ^ sz}.
 
-  Let Fm_enc (x : F m) : word sz := NToWord sz (Z.to_N (FieldToZ x)).
+  Let Fm_enc (x : F m) : word sz := NToWord sz (Z.to_N (F.to_Z x)).
 
   Let Fm_dec (x_ : word sz) : option (F m) :=
     let z := Z.of_N (wordToN (x_)) in
     if Z_lt_dec z m
-      then Some (ZToField _ z)
+      then Some (F.of_Z m z)
       else None
   .
 
   Lemma Fm_encoding_valid : forall x, Fm_dec (Fm_enc x) = Some x.
   Proof.
     unfold Fm_dec, Fm_enc; intros.
-    pose proof (Zmod.FieldToZ_range x m_pos).
+    pose proof (F.to_Z_range x m_pos).
     rewrite wordToN_NToWord_idempotent by (apply bound_check_nat_N;
-     assert (Z.to_nat x < Z.to_nat m) by (apply Z2Nat.inj_lt; omega); omega).
+     assert (Z.to_nat (F.to_Z x) < Z.to_nat m) by (apply Z2Nat.inj_lt; omega); omega).
     rewrite Z2N.id by omega.
-    rewrite Zmod.ZToField_FieldToZ.
+    rewrite F.of_Z_to_Z.
     break_if; auto; omega.
   Qed.
 
@@ -36,7 +36,7 @@ Section ModularWordEncodingPre.
     unfold Fm_dec, Fm_enc; intros ? ? dec_Some.
     break_if; [ | congruence ].
     inversion dec_Some.
-    rewrite Zmod.FieldToZ_ZToField.
+    rewrite F.to_Z_of_Z.
     rewrite Z.mod_small by (pose proof (N2Z.is_nonneg (wordToN w)); try omega).
     rewrite N2Z.id.
     apply NToWord_wordToN.

--- a/src/Encoding/ModularWordEncodingTheorems.v
+++ b/src/Encoding/ModularWordEncodingTheorems.v
@@ -3,7 +3,7 @@ Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Crypto.CompleteEdwardsCurve.CompleteEdwardsCurveTheorems.
 Require Import Crypto.ModularArithmetic.PrimeFieldTheorems Crypto.ModularArithmetic.ModularArithmeticTheorems.
 Require Import Bedrock.Word.
-Require Import Crypto.Tactics.VerdiTactics.
+Require Import Crypto.Tactics.VerdiTactics Crypto.Util.Tactics.
 Require Import Crypto.Spec.Encoding.
 Require Import Crypto.Util.ZUtil.
 Require Import Crypto.Spec.ModularWordEncoding.
@@ -24,7 +24,7 @@ Section SignBit.
       assert (m < 1)%Z by (apply Z2Nat.inj_lt; try omega; assumption).
       omega.
     + assert (0 < m)%Z as m_pos by (pose proof prime_ge_2 m prime_m; omega).
-      pose proof (FieldToZ_range x m_pos).
+      pose proof (Zmod.FieldToZ_range x m_pos).
       destruct (FieldToZ x); auto.
       - destruct p; auto.
       - pose proof (Pos2Z.neg_is_neg p); omega.
@@ -35,20 +35,13 @@ Section SignBit.
     rewrite sign_bit_parity; auto.
   Qed.
 
-  Lemma sign_bit_opp : forall (x : F m), x <> 0 -> negb (@sign_bit m sz x) = @sign_bit m sz (opp x).
-  Proof.
-    intros.
-    pose proof sign_bit_zero as sign_zero.
-    rewrite !sign_bit_parity in *.
-    pose proof (F_opp_spec x) as opp_spec_x.
-    apply F_eq in opp_spec_x.
-    rewrite FieldToZ_add in opp_spec_x.
-    rewrite <-opp_spec_x, Z.odd_mod in sign_zero by (pose proof prime_ge_2 m prime_m; omega).
-    replace (Z.odd m) with true in sign_zero by (destruct (Z.prime_odd_or_2 m prime_m); auto || omega).
-    rewrite Z.odd_add, F_FieldToZ_add_opp, Z.div_same, Bool.xorb_true_r in sign_zero by assumption || omega.
-    apply Bool.xorb_eq.
-    rewrite <-Bool.negb_xorb_l.
-    assumption.
-  Qed.
+  Lemma odd_m : Z.odd m = true. Admitted.
 
+  Lemma sign_bit_opp (x : F m) (Hnz:x <> 0) : negb (@sign_bit m sz x) = @sign_bit m sz (opp x).
+  Proof.
+    pose proof Zmod.FieldToZ_nonzero_range x Hnz; specialize_by omega.
+    rewrite !sign_bit_parity, Zmod.FieldToZ_opp, Z_mod_nz_opp_full,
+      Zmod_small, Z.odd_sub, odd_m, (Bool.xorb_true_l (Z.odd x)) by
+       (omega || rewrite Zmod_small by omega; auto using Zmod.FieldToZ_nonzero); trivial.
+  Qed.
 End SignBit.

--- a/src/Encoding/ModularWordEncodingTheorems.v
+++ b/src/Encoding/ModularWordEncodingTheorems.v
@@ -6,6 +6,7 @@ Require Import Bedrock.Word.
 Require Import Crypto.Tactics.VerdiTactics Crypto.Util.Tactics.
 Require Import Crypto.Spec.Encoding.
 Require Import Crypto.Util.ZUtil.
+Require Import Crypto.Util.FixCoqMistakes.
 Require Import Crypto.Spec.ModularWordEncoding.
 
 
@@ -35,13 +36,11 @@ Section SignBit.
     rewrite sign_bit_parity; auto.
   Qed.
 
-  Lemma odd_m : Z.odd m = true. Admitted.
-
   Lemma sign_bit_opp (x : F m) (Hnz:x <> 0) : negb (@sign_bit m sz x) = @sign_bit m sz (opp x).
   Proof.
     pose proof Zmod.FieldToZ_nonzero_range x Hnz; specialize_by omega.
-    rewrite !sign_bit_parity, Zmod.FieldToZ_opp, Z_mod_nz_opp_full,
-      Zmod_small, Z.odd_sub, odd_m, (Bool.xorb_true_l (Z.odd x)) by
-       (omega || rewrite Zmod_small by omega; auto using Zmod.FieldToZ_nonzero); trivial.
+    rewrite !sign_bit_parity, Zmod.FieldToZ_opp, Z_mod_nz_opp_full, Zmod_small,
+      Z.odd_sub, (NumTheoryUtil.p_odd m), (Bool.xorb_true_l (Z.odd x));
+      try eapply Zrel_prime_neq_mod_0, rel_prime_le_prime; intuition omega.
   Qed.
 End SignBit.

--- a/src/Encoding/ModularWordEncodingTheorems.v
+++ b/src/Encoding/ModularWordEncodingTheorems.v
@@ -15,18 +15,18 @@ Local Open Scope F_scope.
 Section SignBit.
   Context {m : Z} {prime_m : prime m} {two_lt_m : (2 < m)%Z} {sz : nat} {bound_check : (Z.to_nat m < 2 ^ sz)%nat}.
 
-  Lemma sign_bit_parity : forall x, @sign_bit m sz x = Z.odd x.
+  Lemma sign_bit_parity : forall x, @sign_bit m sz x = Z.odd (F.to_Z x).
   Proof.
     unfold sign_bit, Fm_enc; intros.
-    pose proof (shatter_word (NToWord sz (Z.to_N x))) as shatter.
+    pose proof (shatter_word (NToWord sz (Z.to_N (F.to_Z x)))) as shatter.
     case_eq sz; intros; subst; rewrite shatter.
     + pose proof (prime_ge_2 m prime_m).
       simpl in bound_check.
       assert (m < 1)%Z by (apply Z2Nat.inj_lt; try omega; assumption).
       omega.
     + assert (0 < m)%Z as m_pos by (pose proof prime_ge_2 m prime_m; omega).
-      pose proof (Zmod.FieldToZ_range x m_pos).
-      destruct (FieldToZ x); auto.
+      pose proof (F.to_Z_range x m_pos).
+      destruct (F.to_Z x); auto.
       - destruct p; auto.
       - pose proof (Pos2Z.neg_is_neg p); omega.
    Qed.
@@ -36,11 +36,11 @@ Section SignBit.
     rewrite sign_bit_parity; auto.
   Qed.
 
-  Lemma sign_bit_opp (x : F m) (Hnz:x <> 0) : negb (@sign_bit m sz x) = @sign_bit m sz (opp x).
+  Lemma sign_bit_opp (x : F m) (Hnz:x <> 0) : negb (@sign_bit m sz x) = @sign_bit m sz (F.opp x).
   Proof.
-    pose proof Zmod.FieldToZ_nonzero_range x Hnz; specialize_by omega.
-    rewrite !sign_bit_parity, Zmod.FieldToZ_opp, Z_mod_nz_opp_full, Zmod_small,
-      Z.odd_sub, (NumTheoryUtil.p_odd m), (Bool.xorb_true_l (Z.odd x));
+    pose proof F.to_Z_nonzero_range x Hnz; specialize_by omega.
+    rewrite !sign_bit_parity, F.to_Z_opp, Z_mod_nz_opp_full, Zmod_small,
+      Z.odd_sub, (NumTheoryUtil.p_odd m), (Bool.xorb_true_l (Z.odd (F.to_Z x)));
       try eapply Zrel_prime_neq_mod_0, rel_prime_le_prime; intuition omega.
   Qed.
 End SignBit.

--- a/src/Experiments/DerivationsOptionRectLetInEncoding.v
+++ b/src/Experiments/DerivationsOptionRectLetInEncoding.v
@@ -267,7 +267,7 @@ Lemma unfoldDiv : forall {m} (x y:F m), (x/y = x * inv y)%F. Proof. unfold div. 
 Definition FieldToN {m} (x:F m) := Z.to_N (FieldToZ x).
 Lemma FieldToN_correct {m} (x:F m) : FieldToN (m:=m) x = Z.to_N (FieldToZ x). reflexivity. Qed.
 
-Definition natToField {m} x : F m := ZToField (Z.of_nat x).
+Definition natToField {m} x : F m := ZToField _ (Z.of_nat x).
 Definition FieldToNat {m} (x:F m) : nat := Z.to_nat (FieldToZ x).
 
 Section with_unqualified_modulo2.
@@ -275,11 +275,6 @@ Import NPeano Nat.
 Local Infix "mod" := modulo : nat_scope.
 Lemma FieldToNat_natToField {m} : m <> 0 -> forall x, x mod m = FieldToNat (natToField (m:=Z.of_nat m) x).
   unfold natToField, FieldToNat; intros.
-  rewrite (FieldToZ_ZToField), <-mod_Zmod, Nat2Z.id; trivial.
+  rewrite (Zmod.FieldToZ_ZToField), <-mod_Zmod, Nat2Z.id; trivial.
 Qed.
 End with_unqualified_modulo2.
-
-Lemma F_eqb_iff {q} : forall x y : F q, F_eqb x y = true <-> x = y.
-Proof.
-  split; eauto using F_eqb_eq, F_eqb_complete.
-Qed.

--- a/src/Experiments/DerivationsOptionRectLetInEncoding.v
+++ b/src/Experiments/DerivationsOptionRectLetInEncoding.v
@@ -261,20 +261,3 @@ Proof.
     eapply decode_failed_neq_encoding in Hdec.
     destruct (B_eqb P_ (enc Q)) eqn:Heq; [rewrite B_eqb_iff in Heq; eauto | trivial]. }
 Qed.
-
-Lemma unfoldDiv : forall {m} (x y:F m), (x/y = x * inv y)%F. Proof. unfold div. congruence. Qed.
-
-Definition FieldToN {m} (x:F m) := Z.to_N (FieldToZ x).
-Lemma FieldToN_correct {m} (x:F m) : FieldToN (m:=m) x = Z.to_N (FieldToZ x). reflexivity. Qed.
-
-Definition natToField {m} x : F m := ZToField _ (Z.of_nat x).
-Definition FieldToNat {m} (x:F m) : nat := Z.to_nat (FieldToZ x).
-
-Section with_unqualified_modulo2.
-Import NPeano Nat.
-Local Infix "mod" := modulo : nat_scope.
-Lemma FieldToNat_natToField {m} : m <> 0 -> forall x, x mod m = FieldToNat (natToField (m:=Z.of_nat m) x).
-  unfold natToField, FieldToNat; intros.
-  rewrite (Zmod.FieldToZ_ZToField), <-mod_Zmod, Nat2Z.id; trivial.
-Qed.
-End with_unqualified_modulo2.

--- a/src/Experiments/SpecEd25519.v
+++ b/src/Experiments/SpecEd25519.v
@@ -12,7 +12,7 @@ Require Import Coq.Logic.Decidable Crypto.Util.Decidable.
 Require Import Coq.omega.Omega.
 
 (* TODO: move to PrimeFieldTheorems *)
-Lemma minus1_is_square {q} :  prime q -> (q mod 4)%Z = 1%Z -> (exists y, y*y  = opp (ZToField q 1))%F.
+Lemma minus1_is_square {q} : prime q -> (q mod 4)%Z = 1%Z -> (exists y, y*y = opp (ZToField q 1))%F.
   intros; pose proof prime_ge_2 q _.
   rewrite Zmod.square_iff.
   destruct (minus1_square_1mod4 q) as [b b_id]; trivial; exists b.
@@ -30,16 +30,6 @@ Lemma nonzero_a : a <> 0%F. Proof. vm_decide_no_check. Qed.
 Lemma square_a : exists b, (b*b=a)%F.
 Proof. pose (@Zmod.Decidable_square q _ two_lt_q a); vm_decide_no_check. Qed.
 Definition d : F q := (opp (ZToField _ 121665) / (ZToField _ 121666))%F.
-
-(* TODO: move to Decidable *)
-Lemma not_not P {d:Decidable P} : not (not P) <-> P.
-Proof. destruct (dec P); intuition. Qed.
-  
-Global Instance dec_ex_forall_not T (P:T->Prop) {d:Decidable (exists b, P b)} : Decidable (forall b, ~ P b).
-Proof.
-  destruct (dec (~ exists b, P b)) as [Hd|Hd]; [left|right];
-    [abstract eauto | abstract (rewrite not_not in Hd by eauto; destruct Hd; eauto) ].
-Defined.
 
 Lemma nonsquare_d : forall x, (x*x <> d)%F.
 Proof. pose (@Zmod.Decidable_square q _ two_lt_q d). vm_decide_no_check. Qed.

--- a/src/Experiments/SpecEd25519.v
+++ b/src/Experiments/SpecEd25519.v
@@ -8,44 +8,43 @@ Require Import Crypto.ModularArithmetic.PrimeFieldTheorems Crypto.ModularArithme
 Require Import Crypto.Util.NatUtil Crypto.Util.ZUtil Crypto.Util.WordUtil Crypto.Util.NumTheoryUtil.
 Require Import Bedrock.Word.
 Require Import Crypto.Tactics.VerdiTactics.
-Require Import Coq.Logic.Decidable.
+Require Import Coq.Logic.Decidable Crypto.Util.Decidable.
 Require Import Coq.omega.Omega.
 
 (* TODO: move to PrimeFieldTheorems *)
-Lemma minus1_is_square {q} :  prime q -> (q mod 4)%Z = 1%Z -> isSquare (opp 1 : F q)%F.
+Lemma minus1_is_square {q} :  prime q -> (q mod 4)%Z = 1%Z -> (exists y, y*y  = opp (ZToField q 1))%F.
   intros; pose proof prime_ge_2 q _.
-  apply square_Zmod_F.
-  destruct (minus1_square_1mod4 q) as [b b_id]; trivial.
-  exists b; rewrite b_id.
-  rewrite opp_ZToField, !FieldToZ_ZToField, !Z.mod_small; omega.
-Qed.
-
-Lemma euler_criterion_nonsquare {q} (prime_q:prime q) (two_lt_q:(2<q)%Z) (d:F q) : 
-  ((d =? 0)%Z || (Pre.powmod q d (Z.to_N (q / 2)) =? 1)%Z)%bool = false -> 
-   forall x : F q, (x ^ 2)%F <> d.
-Proof.
-  pose proof @euler_criterion_if q prime_q d two_lt_q;
-    break_if; intros; try discriminate; eauto.
+  rewrite Zmod.square_iff.
+  destruct (minus1_square_1mod4 q) as [b b_id]; trivial; exists b.
+  rewrite b_id, Zmod.FieldToZ_opp, Zmod.FieldToZ_ZToField, Z.mod_opp_l_nz, !Zmod_small;
+    (repeat (omega || rewrite Zmod_small)).
 Qed.
 
 Definition q : Z := (2 ^ 255 - 19)%Z.
 Global Instance prime_q : prime q. Admitted.
 Lemma two_lt_q : (2 < q)%Z. Proof. reflexivity. Qed.
-Lemma char_gt_2 : (1 + 1 <> (0:F q))%F. Proof. rewrite F_eq; compute; discriminate. Qed.
+Lemma char_gt_2 : (1 + 1 <> (0:F q))%F. vm_decide_no_check. Qed.
 
 Definition a : F q := opp 1%F.
-Lemma nonzero_a : a <> 0%F. Proof. rewrite F_eq; compute; discriminate. Qed.
+Lemma nonzero_a : a <> 0%F. Proof. vm_decide_no_check. Qed.
 Lemma square_a : exists b, (b*b=a)%F.
-Proof. setoid_rewrite <-F_pow_2_r. apply (minus1_is_square _); reflexivity. Qed.
+Proof. pose (@Zmod.Decidable_square q _ two_lt_q a); vm_decide_no_check. Qed.
+Definition d : F q := (opp (ZToField _ 121665) / (ZToField _ 121666))%F.
 
-Definition d : F q := (opp (ZToField 121665) / (ZToField 121666))%F.
-Lemma nonsquare_d : forall x, (x*x <> d)%F.
+(* TODO: move to Decidable *)
+Lemma not_not P {d:Decidable P} : not (not P) <-> P.
+Proof. destruct (dec P); intuition. Qed.
+  
+Global Instance dec_ex_forall_not T (P:T->Prop) {d:Decidable (exists b, P b)} : Decidable (forall b, ~ P b).
 Proof.
-  intros; rewrite <-F_pow_2_r.
-  apply (euler_criterion_nonsquare prime_q two_lt_q); vm_cast_no_check (eq_refl false).
-Qed. (* 3s *)
+  destruct (dec (~ exists b, P b)) as [Hd|Hd]; [left|right];
+    [abstract eauto | abstract (rewrite not_not in Hd by eauto; destruct Hd; eauto) ].
+Defined.
 
-Instance curve25519params : @E.twisted_edwards_params (F q) eq (ZToField 0) (ZToField 1) add mul a d :=
+Lemma nonsquare_d : forall x, (x*x <> d)%F.
+Proof. pose (@Zmod.Decidable_square q _ two_lt_q d). vm_decide_no_check. Qed.
+
+Instance curve25519params : @E.twisted_edwards_params (F q) eq 0%F 1%F add mul a d :=
   {
     nonzero_a := nonzero_a;
     char_gt_2 := char_gt_2;
@@ -112,10 +111,10 @@ Definition FlEncoding : canonical encoding of F (Z.of_nat l) as word b :=
 Lemma q_5mod8 : (q mod 8 = 5)%Z. cbv; reflexivity. Qed.
 
 Lemma sqrt_minus1_valid : ((@ZToField q 2 ^ Z.to_N (q / 4)) ^ 2 = opp 1)%F.
-Proof. apply F_eq; vm_compute; reflexivity. Qed.
+Proof. vm_decide_no_check. Qed.
 
-Local Notation point := (@E.point (F q) eq (ZToField 1) add mul a d).
-Local Notation zero := (E.zero(H:=field_modulo)).
+Local Notation point := (@E.point (F q) eq 1%F add mul a d).
+Local Notation zero := (E.zero(H:=Zmod.field_modulo q)).
 Local Notation add := (E.add(H0:=curve25519params)).
 Local Infix "*" := (E.mul(H0:=curve25519params)).
 Axiom H : forall n : nat, word n -> word (b + b).

--- a/src/Experiments/SpecEd25519.v
+++ b/src/Experiments/SpecEd25519.v
@@ -12,11 +12,11 @@ Require Import Coq.Logic.Decidable Crypto.Util.Decidable.
 Require Import Coq.omega.Omega.
 
 (* TODO: move to PrimeFieldTheorems *)
-Lemma minus1_is_square {q} : prime q -> (q mod 4)%Z = 1%Z -> (exists y, y*y = opp (ZToField q 1))%F.
+Lemma minus1_is_square {q} : prime q -> (q mod 4)%Z = 1%Z -> (exists y, y*y = F.opp (F.of_Z q 1))%F.
   intros; pose proof prime_ge_2 q _.
-  rewrite Zmod.square_iff.
+  rewrite F.square_iff.
   destruct (minus1_square_1mod4 q) as [b b_id]; trivial; exists b.
-  rewrite b_id, Zmod.FieldToZ_opp, Zmod.FieldToZ_ZToField, Z.mod_opp_l_nz, !Zmod_small;
+  rewrite b_id, F.to_Z_opp, F.to_Z_of_Z, Z.mod_opp_l_nz, !Zmod_small;
     (repeat (omega || rewrite Zmod_small)).
 Qed.
 
@@ -25,16 +25,16 @@ Global Instance prime_q : prime q. Admitted.
 Lemma two_lt_q : (2 < q)%Z. Proof. reflexivity. Qed.
 Lemma char_gt_2 : (1 + 1 <> (0:F q))%F. vm_decide_no_check. Qed.
 
-Definition a : F q := opp 1%F.
+Definition a : F q := F.opp 1%F.
 Lemma nonzero_a : a <> 0%F. Proof. vm_decide_no_check. Qed.
 Lemma square_a : exists b, (b*b=a)%F.
-Proof. pose (@Zmod.Decidable_square q _ two_lt_q a); vm_decide_no_check. Qed.
-Definition d : F q := (opp (ZToField _ 121665) / (ZToField _ 121666))%F.
+Proof. pose (@F.Decidable_square q _ two_lt_q a); vm_decide_no_check. Qed.
+Definition d : F q := (F.opp (F.of_Z _ 121665) / (F.of_Z _ 121666))%F.
 
 Lemma nonsquare_d : forall x, (x*x <> d)%F.
-Proof. pose (@Zmod.Decidable_square q _ two_lt_q d). vm_decide_no_check. Qed.
+Proof. pose (@F.Decidable_square q _ two_lt_q d). vm_decide_no_check. Qed.
 
-Instance curve25519params : @E.twisted_edwards_params (F q) eq 0%F 1%F add mul a d :=
+Instance curve25519params : @E.twisted_edwards_params (F q) eq 0%F 1%F F.add F.mul a d :=
   {
     nonzero_a := nonzero_a;
     char_gt_2 := char_gt_2;
@@ -100,11 +100,11 @@ Definition FlEncoding : canonical encoding of F (Z.of_nat l) as word b :=
 
 Lemma q_5mod8 : (q mod 8 = 5)%Z. cbv; reflexivity. Qed.
 
-Lemma sqrt_minus1_valid : ((@ZToField q 2 ^ Z.to_N (q / 4)) ^ 2 = opp 1)%F.
+Lemma sqrt_minus1_valid : ((F.of_Z q 2 ^ Z.to_N (q / 4)) ^ 2 = F.opp 1)%F.
 Proof. vm_decide_no_check. Qed.
 
-Local Notation point := (@E.point (F q) eq 1%F add mul a d).
-Local Notation zero := (E.zero(H:=Zmod.field_modulo q)).
+Local Notation point := (@E.point (F q) eq 1%F F.add F.mul a d).
+Local Notation zero := (E.zero(H:=F.field_modulo q)).
 Local Notation add := (E.add(H0:=curve25519params)).
 Local Infix "*" := (E.mul(H0:=curve25519params)).
 Axiom H : forall n : nat, word n -> word (b + b).

--- a/src/ModularArithmetic/ModularArithmeticTheorems.v
+++ b/src/ModularArithmetic/ModularArithmeticTheorems.v
@@ -2,54 +2,20 @@ Require Import Coq.omega.Omega.
 Require Import Crypto.Spec.ModularArithmetic.
 Require Import Crypto.ModularArithmetic.Pre.
 
-Require Import Coq.Logic.Eqdep_dec.
-Require Import Crypto.Tactics.VerdiTactics.
 Require Import Coq.ZArith.BinInt Coq.ZArith.Zdiv Coq.ZArith.Znumtheory Coq.NArith.NArith. (* import Zdiv before Znumtheory *)
 Require Import Coq.Classes.Morphisms Coq.Setoids.Setoid.
-Require Export Coq.setoid_ring.Ring_theory Coq.setoid_ring.Field_theory Coq.setoid_ring.Field_tac.
-Require Export Crypto.Util.IterAssocOp.
+Require Export Coq.setoid_ring.Ring_theory Coq.setoid_ring.Ring_tac.
 
+Require Import Crypto.Algebra Crypto.Util.Decidable.
 Require Export Crypto.Util.FixCoqMistakes.
-
-Section ModularArithmeticPreliminaries.
-  Context {m:Z}.
-  Let ZToFm := ZToField : BinNums.Z -> F m. Hint Unfold ZToFm. Local Coercion ZToFm : Z >-> F.
-
-  Theorem F_eq: forall (x y : F m), x = y <-> FieldToZ x = FieldToZ y.
-  Proof.
-    destruct x, y; intuition; simpl in *; try congruence.
-    subst_max.
-    f_equal.
-    eapply UIP_dec, Z.eq_dec.
-  Qed.
-
-  Lemma F_pow_spec : forall (a:F m),
-      pow a 0%N = 1%F /\ forall x, pow a (1 + x)%N = mul a (pow a x).
-  Proof.
-    intros a.
-    pose (@pow_with_spec m) as H.
-    change (@pow m) with (proj1_sig H).
-    destruct H; eauto.
-  Qed.
-End ModularArithmeticPreliminaries.
 
 (* Fails iff the input term does some arithmetic with mod'd values. *)
 Ltac notFancy E :=
-match E with
-| - (_ mod _) => idtac
-| context[_ mod _] => fail 1
-| _ => idtac
-end.
-
-Lemma Zplus_neg : forall n m, n + -m = n - m.
-Proof.
-  auto.
-Qed.
-
-Lemma Zmod_eq : forall a b n, a = b -> a mod n = b mod n.
-Proof.
-  intros; rewrite H; trivial.
-Qed.
+  match E with
+  | - (_ mod _) => idtac
+  | context[_ mod _] => fail 1
+  | _ => idtac
+  end.
 
 (* Remove redundant [mod] operations from the conclusion. *)
 Ltac demod :=
@@ -68,680 +34,325 @@ Ltac demod :=
            notFancy y; rewrite (Zmult_mod_idemp_r y)
          | [ |- context[(?x mod _) mod _] ] =>
            notFancy x; rewrite (Zmod_mod x)
-         | _ => rewrite Zplus_neg in * || rewrite Z.sub_diag in *
          end.
 
-(* Remove exists under equals: we do this a lot *)
-Ltac eq_remove_proofs := lazymatch goal with
-| [ |- @eq (F _) ?a ?b ] =>
-    assert (Q := F_eq a b);
-    simpl in *; apply Q; clear Q
-end.
-
-(** TODO FIXME(from jgross): This tactic is way too powerful for
-    arcane reasons.  It should not be using so many databases with
-    [intuition]. *)
-Ltac Fdefn :=
+Ltac unwrap_F :=
   intros;
   repeat match goal with [ x : F _ |- _ ] => destruct x end;
-  try eq_remove_proofs;
-  demod;
-  rewrite ?Z.mul_1_l;
-  intuition auto with zarith lia relations typeclass_instances; demod; try solve [ f_equal; intuition auto with zarith lia relations typeclass_instances ].
+  lazy iota beta delta [add sub mul opp FieldToZ ZToField proj1_sig] in *;
+  try apply eqsig_eq;
+  demod.
 
-Local Open Scope F_scope.
+Global Instance eq_dec {m} : DecidableRel (@eq (F m)). exact _. Defined.
 
-Section FEquality.
-  Context {m:Z}.
+Global Instance commutative_ring_modulo m
+  : @Algebra.commutative_ring (F m) Logic.eq 0%F 1%F opp add sub mul.
+Proof.
+  repeat (split || intro); unwrap_F;
+    autorewrite with zsimplify; solve [ exact _ | auto with zarith | congruence].
+Qed.
 
-  (** Equality **)
-  Definition F_eqb (x y : F m) : bool :=  Z.eqb x y.
 
-  Lemma F_eqb_eq x y : F_eqb x y = true -> x = y.
-  Proof.
-    unfold F_eqb; Fdefn; apply Z.eqb_eq; trivial.
-  Qed.
+Module Zmod.
+  Lemma pow_spec {m} a : pow a 0%N = 1%F :> F m /\ forall x, pow a (1 + x)%N = mul a (pow a x).
+  Proof. change (@pow m) with (proj1_sig (@pow_with_spec m)); destruct (@pow_with_spec m); eauto. Qed.
 
-  Lemma F_eqb_complete : forall x y: F m, x = y -> F_eqb x y = true.
-  Proof.
-    intros; subst; apply Z.eqb_refl.
-  Qed.
+  Section FandZ.
+    Context {m:Z}.
+    Local Open Scope F_scope.
 
-  Lemma F_eqb_refl : forall x, F_eqb x x = true.
-  Proof.
-    intros; apply F_eqb_complete; trivial.
-  Qed.
+    Theorem eq_FieldToZ_iff (x y : F m) : x = y <-> FieldToZ x = FieldToZ y.
+    Proof. destruct x, y; intuition; simpl in *; try apply (eqsig_eq _ _); congruence. Qed.
 
-  Lemma F_eqb_neq x y : F_eqb x y = false -> x <> y.
-  Proof.
-    intuition; subst y.
-    pose proof (F_eqb_refl x).
-    congruence.
-  Qed.
+    Lemma eq_ZToField_iff : forall x y : Z, x mod m = y mod m <-> ZToField m x = ZToField m y.
+    Proof. split; unwrap_F; congruence. Qed.
 
-  Lemma F_eqb_neq_complete x y : x <> y -> F_eqb x y = false.
-  Proof.
-    intros.
-    case_eq (F_eqb x y); intros; trivial.
-    pose proof (F_eqb_eq x y); intuition.
-  Qed.
+    
+    Lemma FieldToZ_ZToField : forall z, FieldToZ (@ZToField m z) = z mod m.
+    Proof. unwrap_F; trivial. Qed.
 
-  Lemma F_eq_dec : forall x y : F m, {x = y} + {x <> y}.
-  Proof.
-    intros; case_eq (F_eqb x y); [left|right]; auto using F_eqb_eq, F_eqb_neq.
-  Qed.
+    Lemma ZToField_FieldToZ x : ZToField m (FieldToZ x) = x :> F m.
+    Proof. unwrap_F; congruence. Qed.
 
-  Lemma if_F_eq_dec_if_F_eqb : forall {T} x y (a b:T), (if F_eq_dec x y then a else b) = (if F_eqb x y then a else b).
-  Proof.
-    intros; intuition; break_if.
-    - rewrite F_eqb_complete; trivial.
-    - rewrite F_eqb_neq_complete; trivial.
-  Defined.
-End FEquality.
+    
+    Lemma ZToField_mod : forall x, ZToField m x = ZToField m (x mod m).
+    Proof. unwrap_F; trivial. Qed.
 
-Section FandZ.
-  Context {m:Z}.
+    Lemma mod_FieldToZ : forall (x:F m),  FieldToZ x mod m = FieldToZ x.
+    Proof. unwrap_F. congruence. Qed.
 
-  Lemma ZToField_small_nonzero : forall z, (0 < z < m)%Z -> ZToField z <> (0:F m).
-  Proof.
-    intuition; find_inversion; rewrite ?Z.mod_0_l, ?Z.mod_small in *; intuition auto with zarith.
-  Qed.
+    Lemma FieldToZ_0 : FieldToZ (0:F m) = 0%Z.
+    Proof. unwrap_F. apply Zmod_0_l. Qed.
 
-  Require Crypto.Algebra.
-  Global Instance commutative_ring_modulo : @Algebra.commutative_ring (F m) Logic.eq (ZToField 0) (ZToField 1) opp add sub mul.
-  Proof.
-    repeat split; Fdefn; try apply F_eq_dec.
-    { rewrite Z.add_0_r. auto. }
-    { rewrite Z.mul_1_r. auto. }
-  Qed.
+    Lemma ZToField_small_nonzero z : (0 < z < m)%Z -> ZToField m z <> 0.
+    Proof. intros Hrange Hnz. inversion Hnz. rewrite Zmod_small, Zmod_0_l in *; omega. Qed.
 
-  Lemma F_opp_spec : forall (a:F m), add a (opp a) = 0.
-    Fdefn.
-  Qed.
+    Lemma FieldToZ_nonzero (x:F m) : x <> 0 -> FieldToZ x <> 0%Z.
+    Proof. intros Hnz Hz. rewrite <- Hz, ZToField_FieldToZ in Hnz; auto. Qed.
 
-  Lemma ZToField_0 : @ZToField m 0 = 0.
-  Proof.
-    Fdefn.
-  Qed.
+    Lemma FieldToZ_range (x : F m) : 0 < m -> 0 <= x < m.
+    Proof. intros. rewrite <- mod_FieldToZ. apply Z.mod_pos_bound. trivial. Qed.
 
-  Lemma FieldToZ_ZToField : forall z, FieldToZ (@ZToField m z) = z mod m.
-  Proof.
-    Fdefn.
-  Qed.
+    Lemma FieldToZ_nonzero_range (x : F m) : (x <> 0) -> 0 < m -> (1 <= x < m)%Z.
+    Proof.
+      unfold not; intros Hnz Hlt.
+      rewrite eq_FieldToZ_iff, FieldToZ_0 in Hnz; pose proof (FieldToZ_range x Hlt).
+      omega.
+    Qed.
 
-  Lemma mod_FieldToZ : forall x,  (@FieldToZ m x) mod m = FieldToZ x.
-  Proof.
-    Fdefn.
-  Qed.
+    Lemma ZToField_add : forall (x y : Z),
+        ZToField m (x + y) = ZToField m x + ZToField m y.
+    Proof. unwrap_F; trivial. Qed.
 
-  (** ZToField distributes over operations **)
-  Lemma ZToField_add : forall (x y : Z),
-      @ZToField m (x + y) = ZToField x + ZToField y.
-  Proof.
-    Fdefn.
-  Qed.
+    Lemma FieldToZ_add : forall x y : F m,
+        FieldToZ (x + y) = ((FieldToZ x + FieldToZ y) mod m)%Z.
+    Proof. unwrap_F; trivial. Qed.
 
-  Lemma FieldToZ_add : forall x y : F m,
-      FieldToZ (x + y) = ((FieldToZ x + FieldToZ y) mod m)%Z.
-  Proof.
-    Fdefn.
-  Qed.
+    Lemma ZToField_mul x y : ZToField m (x * y) = ZToField _ x * ZToField _ y :> F m.
+    Proof. unwrap_F. trivial. Qed.
 
-  Lemma FieldToZ_mul : forall x y : F m,
-      FieldToZ (x * y) = ((FieldToZ x * FieldToZ y) mod m)%Z.
-  Proof.
-    Fdefn.
-  Qed.
+    Lemma FieldToZ_mul : forall x y : F m,
+        FieldToZ (x * y) = ((FieldToZ x * FieldToZ y) mod m)%Z.
+    Proof. unwrap_F; trivial. Qed.
+    
+    Lemma ZToField_sub x y : ZToField _ (x - y) = ZToField _ x - ZToField _ y :> F m.
+    Proof. unwrap_F. trivial. Qed.
 
-  Lemma FieldToZ_pow_Zpow_mod : forall (x : F m) n,
-    (FieldToZ x ^ Z.of_N n mod m = FieldToZ (x ^ n)%F)%Z.
-  Proof.
-    intros.
-    induction n using N.peano_ind;
-      destruct (F_pow_spec x) as [pow_0 pow_succ] . {
-      rewrite pow_0.
-      rewrite Z.pow_0_r; auto.
-    } {
-      rewrite N2Z.inj_succ.
-      rewrite Z.pow_succ_r by apply N2Z.is_nonneg.
-      rewrite <- N.add_1_l.
-      rewrite pow_succ.
-      rewrite <- Zmult_mod_idemp_r.
-      rewrite IHn.
-      apply FieldToZ_mul.
-    }
-  Qed.
+    Lemma FieldToZ_opp : forall x, FieldToZ (@opp m x) = -x mod m.
+    Proof. unwrap_F; trivial. Qed.
 
-  Lemma FieldToZ_pow_efficient : forall (x : F m) n, FieldToZ (x^n) = powmod m (FieldToZ x) n.
-  Proof.
-    intros.
-    rewrite powmod_Zpow_mod.
-    rewrite <-FieldToZ_pow_Zpow_mod.
-    reflexivity.
-  Qed.
+    Lemma ZToField_pow x n : ZToField _ x ^ n = ZToField _ (x ^ (Z.of_N n) mod m) :> F m.
+    Proof.
+      intros.
+      induction n using N.peano_ind;
+        destruct (pow_spec (@ZToField m x)) as [pow_0 pow_succ] . {
+        rewrite pow_0.
+        unwrap_F; trivial.
+      } {
+        rewrite N2Z.inj_succ.
+        rewrite Z.pow_succ_r by apply N2Z.is_nonneg.
+        rewrite <- N.add_1_l.
+        rewrite pow_succ.
+        rewrite IHn.
+        unwrap_F; trivial.
+      }
+    Qed.
 
-  Lemma pow_nat_iter_op_correct: forall (x:F m) n, (@nat_iter_op _ mul 1) (N.to_nat n) x = x^n.
-  Proof.
-    induction n using N.peano_ind;
-      destruct (F_pow_spec x) as [pow_0 pow_succ];
-      rewrite ?N2Nat.inj_succ, ?pow_0, <-?N.add_1_l, ?pow_succ;
-      simpl; congruence.
-  Qed.
+    Lemma FieldToZ_pow : forall (x : F m) n,
+        FieldToZ (x ^ n)%F = (FieldToZ x ^ Z.of_N n mod m)%Z.
+    Proof.
+      intros.
+      symmetry.
+      induction n using N.peano_ind;
+        destruct (pow_spec x) as [pow_0 pow_succ] . {
+        rewrite pow_0, Z.pow_0_r; auto.
+      } {
+        rewrite N2Z.inj_succ.
+        rewrite Z.pow_succ_r by apply N2Z.is_nonneg.
+        rewrite <- N.add_1_l.
+        rewrite pow_succ.
+        rewrite <- Zmult_mod_idemp_r.
+        rewrite IHn.
+        apply FieldToZ_mul.
+      }
+    Qed.
 
-  Lemma mod_plus_zero_subproof a b : 0 mod m = (a + b) mod m ->
-                                     b mod m =  (- a)  mod m.
-  Proof.
-    rewrite <-Z.sub_0_l; intros.
-    replace (0-a)%Z with (b-(a + b))%Z by omega.
-    rewrite Zminus_mod.
-    rewrite <- H.
-    rewrite Zmod_0_l.
-    replace (b mod m - 0)%Z with (b mod m) by omega.
-    rewrite Zmod_mod.
-    reflexivity.
-  Qed.
+    Lemma square_iff (x:F m) :
+      (exists y : F m, y * y = x) <-> (exists y : Z, y * y mod m = x)%Z.
+    Proof.
+      setoid_rewrite eq_FieldToZ_iff; setoid_rewrite FieldToZ_mul; split; intro H; destruct H as [x' H].
+      - eauto.
+      - exists (ZToField _ x'); rewrite !FieldToZ_ZToField; demod; auto.
+    Qed.
 
-  Lemma FieldToZ_opp' : forall x, FieldToZ (@opp m x) mod m = -x mod m.
-  Proof.
-    intros.
-    pose proof (FieldToZ_add x (opp x)) as H.
-    rewrite F_opp_spec, FieldToZ_ZToField in H.
-    auto using mod_plus_zero_subproof.
-  Qed.
+    (* TODO: move to ZUtil *)
+    Lemma sub_intersperse_modulus : forall x y, ((x - y) mod m = (x + (m - y)) mod m)%Z.
+    Proof.
+      intros.
+      replace (x + (m - y))%Z with (m+(x-y))%Z by omega.
+      rewrite Zplus_mod.
+      rewrite Z_mod_same_full; simpl Z.add.
+      rewrite Zmod_mod.
+      reflexivity.
+    Qed.
+  End FandZ.
 
-  Lemma FieldToZ_opp : forall x, FieldToZ (@opp m x) = -x mod m.
-  Proof.
-    intros.
-    pose proof (FieldToZ_opp' x) as H; rewrite mod_FieldToZ in H; trivial.
-  Qed.
+  Section RingTacticGadgets.
+    Context (m:Z).
 
-  Lemma sub_intersperse_modulus : forall x y, ((x - y) mod m = (x + (m - y)) mod m)%Z.
-  Proof.
-    intros.
-    replace (x + (m - y))%Z with (m+(x-y))%Z by omega.
-    rewrite Zplus_mod.
-    rewrite Z_mod_same_full; simpl Z.add.
-    rewrite Zmod_mod.
-    reflexivity.
-  Qed.
+    Definition ring_theory : ring_theory 0%F 1%F (@add m) (@mul m) (@sub m) (@opp m) eq
+      := Algebra.Ring.ring_theory_for_stdlib_tactic.
 
-  (* Compatibility between inject and subtraction *)
-  Lemma ZToField_sub : forall (x y : Z),
-      @ZToField m (x - y) = ZToField x - ZToField y.
-  Proof.
-    Fdefn.
-  Qed.
+    Lemma pow_pow_N (x : F m) : forall (n : N), (x ^ id n)%F = pow_N 1%F mul x n.
+    Proof.
+      destruct (pow_spec x) as [HO HS]; intros.
+      destruct n; auto; unfold id.
+      rewrite Pre.N_pos_1plus at 1.
+      rewrite HS.
+      simpl.
+      induction p using Pos.peano_ind.
+      - simpl. rewrite HO. apply Algebra.right_identity.
+      - rewrite (@pow_pos_succ (F m) (@mul m) eq _ _ associative x).
+        rewrite <-IHp, Pos.pred_N_succ, Pre.N_pos_1plus, HS.
+        trivial.
+    Qed.
 
-  (* Compatibility between inject and multiplication *)
-  Lemma ZToField_mul : forall (x y : Z),
-      @ZToField m (x * y) = ZToField x * ZToField y.
-  Proof.
-    Fdefn.
-  Qed.
+    Lemma power_theory : power_theory 1%F (@mul m) eq id (@pow m).
+    Proof. split; apply pow_pow_N. Qed.
 
-  (* Compatibility between inject and GFtoZ *)
-  Lemma ZToField_idempotent : forall (x : F m), ZToField x = x.
-  Proof.
-    Fdefn.
-  Qed.
-  Definition ZToField_FieldToZ := ZToField_idempotent. (* alias *)
+    (***** Division Theory *****)
+    Definition quotrem(a b: F m): F m * F m :=
+      let '(q, r) := (Z.quotrem a b) in (ZToField _ q , ZToField _ r).
+    Lemma Fdiv_theory : div_theory eq (@add m) (@mul m) (@id _) quotrem.
+    Proof.
+      constructor; intros; unfold quotrem, id.
 
-  (* Compatibility between inject and mod *)
-  Lemma ZToField_mod : forall x, @ZToField m x = ZToField (x mod m).
-  Proof.
-    Fdefn.
-  Qed.
+      replace (Z.quotrem a b) with (Z.quot a b, Z.rem a b) by
+          try (unfold Z.quot, Z.rem; rewrite <- surjective_pairing; trivial).
 
-  (* Compatibility between inject and pow *)
-  Lemma ZToField_pow : forall x n,
-    @ZToField m x ^ n = ZToField (x ^ (Z.of_N n) mod m).
-  Proof.
-    intros.
-    induction n using N.peano_ind;
-      destruct (F_pow_spec (@ZToField m x)) as [pow_0 pow_succ] . {
-      rewrite pow_0.
-      Fdefn.
-    } {
-      rewrite N2Z.inj_succ.
-      rewrite Z.pow_succ_r by apply N2Z.is_nonneg.
-      rewrite <- N.add_1_l.
-      rewrite pow_succ.
-      rewrite IHn.
-      Fdefn.
-    }
-  Qed.
+      unwrap_F; rewrite <-Z.quot_rem'; trivial.
+    Qed.
 
-  Lemma ZToField_eqmod : forall x y : Z, x mod m = y mod m -> ZToField x = @ZToField m y.
-    Fdefn.
-  Qed.
+    Lemma Z_mod_opp_equiv : forall x y m,  x  mod m = (-y) mod m ->
+                                           (-x) mod m =   y  mod m.
+    Proof.
+      intros.
+      rewrite <-Z.sub_0_l.
+      rewrite Zminus_mod. rewrite H.
+      rewrite ?Zminus_mod_idemp_l, ?Zminus_mod_idemp_r; f_equal.
+      destruct y; auto.
+    Qed.
 
-  Lemma FieldToZ_nonzero:
-    forall x0 : F m, x0 <> 0 -> FieldToZ x0 <> 0%Z.
-  Proof.
-    intros x0 Hnz Hz.
-    rewrite <- Hz, ZToField_FieldToZ in Hnz; auto.
-  Qed.
+    Lemma Z_opp_opp : forall x : Z, (-(-x)) = x.
+      destruct x; auto.
+    Qed.
 
-End FandZ.
+    Lemma Z_mod_opp : forall x m, (- x) mod m = (- (x mod m)) mod m.
+      intros.
+      apply Z_mod_opp_equiv.
+      rewrite Z_opp_opp.
+      demod; auto.
+    Qed.
 
-Section RingModuloPre.
-  Context {m:Z}.
-  Let ZToFm := ZToField : Z -> F m. Hint Unfold ZToFm. Local Coercion ZToFm : Z >-> F.
-  (* Substitution to prove all Compats *)
-  Ltac compat := repeat intro; subst; trivial.
+    (* Define a "ring morphism" between GF and Z, i.e. an equivalence
+     * between 'inject (ZFunction (X))' and 'GFFunction (inject (X))'.
+     *
+     * Doing this allows the [ring] tactic to do coefficient
+     * manipulations in Z rather than F, because we know it's equivalent
+     * to inject the result afterward. *)
+    Lemma ring_morph: ring_morph 0%F 1%F (@add m) (@mul m) (@sub m) (@opp m) eq
+                                 0%Z 1%Z Z.add    Z.mul    Z.sub    Z.opp  Z.eqb  (@ZToField m).
+    Proof. split; intros; unwrap_F; solve [ auto | rewrite (proj1 (Z.eqb_eq x y)); trivial]. Qed.
 
-  Instance Fplus_compat : Proper (eq==>eq==>eq) (@add m).
-  Proof.
-    compat.
-  Qed.
-
-  Instance Fminus_compat : Proper (eq==>eq==>eq) (@sub m).
-  Proof.
-    compat.
-  Qed.
-
-  Instance Fmult_compat : Proper (eq==>eq==>eq) (@mul m).
-  Proof.
-    compat.
-  Qed.
-
-  Instance Fopp_compat : Proper (eq==>eq) (@opp m).
-  Proof.
-    compat.
-  Qed.
-
-  Instance Finv_compat : Proper (eq==>eq) (@inv m).
-  Proof.
-    compat.
-  Qed.
-
-  Instance Fdiv_compat : Proper (eq==>eq==>eq) (@div m).
-  Proof.
-    compat.
-  Qed.
-
-  (***** Ring Theory *****)
-  Definition Fring_theory : ring_theory 0%F 1%F (@add m) (@mul m) (@sub m) (@opp m) eq.
-  Proof.
-    constructor; Fdefn.
-  Qed.
-
-  Lemma F_mul_1_r:
-    forall x : F m, x * 1 = x.
-  Proof.
-    Fdefn; rewrite Z.mul_1_r; auto.
-  Qed.
-
-  Lemma F_mul_assoc:
-    forall x y z : F m, x * (y * z) = x * y * z.
-  Proof.
-    Fdefn.
-  Qed.
-
-  Lemma F_pow_pow_N (x : F m) : forall (n : N), (x ^ id n)%F = pow_N 1%F mul x n.
-  Proof.
-    destruct (F_pow_spec x) as [HO HS]; intros.
-    destruct n; auto; unfold id.
-    rewrite Pre.N_pos_1plus at 1.
-    rewrite HS.
-    simpl.
-    induction p using Pos.peano_ind.
-    - simpl. rewrite HO; apply F_mul_1_r.
-    - rewrite (@pow_pos_succ (F m) (@mul m) eq _ _ F_mul_assoc x).
-      rewrite <-IHp, Pos.pred_N_succ, Pre.N_pos_1plus, HS.
-      f_equal.
-  Qed.
-
-  (***** Power theory *****)
-  Lemma Fpower_theory : power_theory 1%F (@mul m) eq id (@pow m).
-  Proof.
-    constructor; apply F_pow_pow_N.
-  Qed.
-
-  (***** Division Theory *****)
-  Definition Fquotrem(a b: F m): F m * F m :=
-    let '(q, r) := (Z.quotrem a b) in (q : F m, r : F m).
-  Lemma Fdiv_theory : div_theory eq (@add m) (@mul m) (@id _) Fquotrem.
-  Proof.
-    constructor; intros; unfold Fquotrem, id.
-
-    replace (Z.quotrem a b) with (Z.quot a b, Z.rem a b) by
-      try (unfold Z.quot, Z.rem; rewrite <- surjective_pairing; trivial).
-
-    Fdefn; rewrite <-Z.quot_rem'; trivial.
-  Qed.
-
-  Lemma Z_mul_mod_modulus_r : forall x m, ((x*m) mod m = 0)%Z.
-    intros.
-    rewrite Zmult_mod, Z_mod_same_full.
-    rewrite Z.mul_0_r, Zmod_0_l.
-    reflexivity.
-  Qed.
-
-  Lemma Z_mod_opp_equiv : forall x y m,  x  mod m = (-y) mod m ->
-                                       (-x) mod m =   y  mod m.
-  Proof.
-    intros.
-    rewrite <-Z.sub_0_l.
-    rewrite Zminus_mod. rewrite H.
-    rewrite ?Zminus_mod_idemp_l, ?Zminus_mod_idemp_r; f_equal.
-    destruct y; auto.
-  Qed.
-
-  Lemma Z_opp_opp : forall x : Z, (-(-x)) = x.
-    destruct x; auto.
-  Qed.
-
-  Lemma Z_mod_opp : forall x m, (- x) mod m = (- (x mod m)) mod m.
-    intros.
-    apply Z_mod_opp_equiv.
-    rewrite Z_opp_opp.
-    demod; auto.
-  Qed.
-
-  (* Define a "ring morphism" between GF and Z, i.e. an equivalence
-   * between 'inject (ZFunction (X))' and 'GFFunction (inject (X))'.
-   *
-   * Doing this allows us to do our coefficient manipulations in Z
-   * rather than GF, because we know it's equivalent to inject the
-   * result afterward.
-   *)
-  Lemma Fring_morph:
-      ring_morph 0%F 1%F (@add m) (@mul m) (@sub m) (@opp m) eq
-                 0%Z 1%Z Z.add    Z.mul    Z.sub    Z.opp  Z.eqb
-                 (@ZToField m).
-  Proof.
-    constructor; intros; try Fdefn; unfold id;
-      try (apply gf_eq; simpl; intuition).
-    - apply Z_mod_opp_equiv; rewrite Z_opp_opp, Zmod_mod; reflexivity.
-    - rewrite (proj1 (Z.eqb_eq x y)); trivial.
-  Qed.
-
-  (* Redefine our division theory under the ring morphism *)
-  Lemma Fmorph_div_theory:
+    (* Redefine our division theory under the ring morphism *)
+    Lemma morph_div_theory:
       div_theory eq Zplus Zmult (@ZToField m) Z.quotrem.
-  Proof.
-    constructor; intros; intuition.
-    replace (Z.quotrem a b) with (Z.quot a b, Z.rem a b);
-      try (unfold Z.quot, Z.rem; rewrite <- surjective_pairing; trivial).
+    Proof.
+      split; intros.
+      replace (Z.quotrem a b) with (Z.quot a b, Z.rem a b);
+        try (unfold Z.quot, Z.rem; rewrite <- surjective_pairing; trivial).
+      unwrap_F; rewrite <- (Z.quot_rem' a b); trivial.
+    Qed.
 
-    eq_remove_proofs; demod;
-      rewrite <- (Z.quot_rem' a b);
-      destruct a; simpl; trivial.
-  Qed.
+  End RingTacticGadgets.
 
-  Lemma ZToField_1 : @ZToField m 1 = 1.
-  Proof.
-    Fdefn.
-  Qed.
-End RingModuloPre.
+  Ltac is_constant t := match t with @ZToField _ ?x => x | _ => NotConstant end.
+  Ltac is_pow_constant t := Ncst t.
 
-Ltac Fconstant t := match t with @ZToField _ ?x => x | _ => NotConstant end.
-Ltac Fexp_tac t := Ncst t.
-Ltac Fpreprocess := rewrite <-?ZToField_0, ?ZToField_1.
-Ltac Fpostprocess := repeat split;
-  repeat match goal with [ |- context[exist ?a ?b (Pre.Z_mod_mod ?x ?q)] ] =>
-    change (exist a b (Pre.Z_mod_mod x q)) with (@ZToField q x%Z) end;
-  rewrite ?ZToField_0, ?ZToField_1.
+  Module Type Modulus. Parameter modulus : Z. End Modulus.
 
-Module Type Modulus.
-  Parameter modulus : Z.
-End Modulus.
+  (* Example of how to instantiate the ring tactic *)
+  Module RingModulo (Export M : Modulus).
+    Add Ring _theory : (ring_theory modulus)
+                         (morphism (ring_morph modulus),
+                          constants [is_constant],
+                          div (morph_div_theory modulus),
+                          power_tac (power_theory modulus) [is_pow_constant]).
 
-(* Example of how to instantiate the ring tactic *)
-Module RingModulo (Export M : Modulus).
-  Definition ring_theory_modulo := @Fring_theory modulus.
-  Definition ring_morph_modulo := @Fring_morph modulus.
-  Definition morph_div_theory_modulo := @Fmorph_div_theory modulus.
-  Definition power_theory_modulo := @Fpower_theory modulus.
+    Example ring_modulo_example : forall x y z, x*z + z*y = z*(x+y).
+    Proof. intros. ring. Qed.
+  End RingModulo.
 
-  Add Ring GFring_Z : ring_theory_modulo
-    (morphism ring_morph_modulo,
-     constants [Fconstant],
-     div morph_div_theory_modulo,
-     power_tac power_theory_modulo [Fexp_tac]).
-End RingModulo.
+  Section VariousModulo.
+    Context {m:Z}.
+    Local Open Scope F_scope.
 
-Section VariousModulo.
-  Context {m:Z}.
+    Add Ring _theory : (ring_theory m)
+                         (morphism (ring_morph m),
+                          constants [is_constant],
+                          div (morph_div_theory m),
+                          power_tac (power_theory m) [is_pow_constant]).
 
-  Add Ring GFring_Z : (@Fring_theory m)
-    (morphism (@Fring_morph m),
-     constants [Fconstant],
-     div (@Fmorph_div_theory m),
-     power_tac (@Fpower_theory m) [Fexp_tac]).
+    Lemma mul_nonzero_l : forall a b : F m, a*b <> 0 -> a <> 0.
+    Proof. intros a b Hnz Hz. rewrite Hz in Hnz; apply Hnz; ring. Qed.
 
-  Lemma F_mul_0_l : forall x : F m, 0 * x = 0.
-  Proof.
-    intros; ring.
-  Qed.
+    Lemma mul_nonzero_r : forall a b : F m, a*b <> 0 -> b <> 0.
+    Proof. intros a b Hnz Hz. rewrite Hz in Hnz; apply Hnz; ring. Qed.
+  End VariousModulo.
 
-  Lemma F_mul_0_r : forall x : F m, x * 0 = 0.
-  Proof.
-    intros; ring.
-  Qed.
+  Section Pow.
+    Context {m:Z}.
+    Add Ring _theory' : (ring_theory m)
+                          (morphism (ring_morph m),
+                           constants [is_constant],
+                           div (morph_div_theory m),
+                           power_tac (power_theory m) [is_pow_constant]).
+    Local Open Scope F_scope.
 
-  Lemma F_mul_nonzero_l : forall a b : F m, a*b <> 0 -> a <> 0.
-    intros; intuition; subst.
-    assert (0 * b = 0) by ring; intuition.
-  Qed.
+    Import Algebra.ScalarMult.
+    Global Instance pow_is_scalarmult
+      : is_scalarmult (G:=F m) (eq:=eq) (add:=mul) (zero:=1%F) (mul := fun n x => x ^ (N.of_nat n)).
+    Proof.
+      split; intros; rewrite ?Nat2N.inj_succ, <-?N.add_1_l;
+        match goal with
+        | [x:F m |- _ ] => solve [destruct (@pow_spec m P); auto]
+        | |- Proper _ _ => solve_proper
+        end.
+    Qed.
 
-  Lemma F_mul_nonzero_r : forall a b : F m, a*b <> 0 -> b <> 0.
-    intros; intuition; subst.
-    assert (a * 0 = 0) by ring; intuition.
-  Qed.
+    (* TODO: move this somewhere? *)
+    Create HintDb nat2N discriminated.
+    Hint Rewrite Nat2N.inj_iff
+         (eq_refl _ : (0%N = N.of_nat 0))
+         (eq_refl _ : (1%N = N.of_nat 1))
+         (eq_refl _ : (2%N = N.of_nat 2))
+         (eq_refl _ : (3%N = N.of_nat 3))
+      : nat2N.
+    Hint Rewrite <- Nat2N.inj_double Nat2N.inj_succ_double Nat2N.inj_succ
+         Nat2N.inj_add Nat2N.inj_mul Nat2N.inj_sub Nat2N.inj_pred
+         Nat2N.inj_div2 Nat2N.inj_max Nat2N.inj_min Nat2N.id
+      : nat2N.
 
-  Lemma F_pow_distr_mul : forall (x y:F m) z, (0 <= z)%N ->
-    (x ^ z) * (y ^ z) = (x * y) ^ z.
-  Proof.
-    intros.
-    replace z with (Z.to_N (Z.of_N z)) by apply N2Z.id.
-    apply natlike_ind with (x := Z.of_N z); simpl; [ ring | |
-      replace 0%Z with (Z.of_N 0%N) by auto; apply N2Z.inj_le; auto].
-    intros z' z'_nonneg IHz'.
-    rewrite Z2N.inj_succ by auto.
-    rewrite <-N.add_1_l.
-    rewrite !(proj2 (@F_pow_spec m _) _).
-    rewrite <- IHz'.
-    ring.
-  Qed.
+    Ltac pow_to_scalarmult_ref :=
+      repeat (autorewrite with nat2N;
+              match goal with
+              | |- context [ (_^?n)%F ] =>
+                rewrite <-(N2Nat.id n); generalize (N.to_nat n); clear n;
+                let m := fresh n in intro m
+              | |- context [ (_^N.of_nat ?n)%F ] =>
+                let rw := constr:(scalarmult_ext(zero:=ZToField m 1) n) in
+                setoid_rewrite rw (* rewriting moduloa reduction *)
+              end).
 
-  Lemma F_opp_0 : opp (0 : F m) = 0%F.
-  Proof.
-    intros; ring.
-  Qed.
+    Lemma pow_0_r (x:F m) : x^0 = 1.
+    Proof. pow_to_scalarmult_ref. apply scalarmult_0_l. Qed.
 
-  Lemma F_opp_swap : forall x y : F m, opp x = y <-> x = opp y.
-  Proof.
-    split; intro; subst; ring.
-  Qed.
+    Lemma pow_add_r (x:F m) (a b:N) : x^(a+b) = x^a * x^b.
+    Proof. pow_to_scalarmult_ref; apply scalarmult_add_l. Qed.
 
-  Lemma F_opp_involutive : forall x : F m, opp (opp x) = x.
-  Proof.
-    intros; ring.
-  Qed.
+    Lemma pow_0_l (n:N) : n <> 0%N -> 0^n = 0 :> F m.
+    Proof. pow_to_scalarmult_ref; destruct n; simpl; intros; [congruence|ring]. Qed.
 
-  Lemma F_square_opp : forall x : F m, (opp x ^ 2 = x ^ 2)%F.
-  Proof.
-    intros; ring.
-  Qed.
+    Lemma pow_pow_l (x:F m) (a b:N) : (x^a)^b = x^(a*b).
+    Proof. pow_to_scalarmult_ref. apply scalarmult_assoc. Qed.
 
-  Lemma F_mul_opp_r : forall x y : F m, (x * opp y = opp (x * y))%F.
-    intros; ring.
-  Qed.
+    Lemma pow_1_r (x:F m) : x^1 = x.
+    Proof. pow_to_scalarmult_ref; simpl; ring. Qed.
 
-  Lemma F_mul_opp_l : forall x y : F m, (opp x * y = opp (x * y))%F.
-    intros; ring.
-  Qed.
+    Lemma pow_2_r (x:F m) : x^2 = x*x.
+    Proof. pow_to_scalarmult_ref; simpl; ring. Qed.
 
-  Lemma F_mul_opp_both : forall x y : F m, (opp x * opp y = x * y)%F.
-    intros; ring.
-  Qed.
-
-  Lemma F_add_0_r : forall x : F m, (x + 0)%F = x.
-  Proof.
-    intros; ring.
-  Qed.
-
-  Lemma F_add_0_l : forall x : F m, (0 + x)%F = x.
-  Proof.
-    intros; ring.
-  Qed.
-
-  Lemma F_add_reg_r : forall x y z : F m, y + x = z + x -> y = z.
-  Proof.
-    intros ? ? ? A.
-    replace y with (y + x - x) by ring.
-    rewrite A; ring.
-  Qed.
-
-  Lemma F_add_reg_l : forall x y z : F m, x + y = x + z -> y = z.
-  Proof.
-    intros ? ? ? A.
-    replace y with (x + y - x) by ring.
-    rewrite A; ring.
-  Qed.
-
-  Lemma F_sub_0_r : forall x : F m, (x - 0)%F = x.
-  Proof.
-    intros; ring.
-  Qed.
-
-  Lemma F_sub_0_l : forall x : F m, (0 - x)%F = opp x.
-  Proof.
-    intros; ring.
-  Qed.
-
-  Lemma F_mul_1_l : forall x : F m, (1 * x)%F = x.
-  Proof.
-    intros; ring.
-  Qed.
-
-  Lemma F_ZToField_m : ZToField m = @ZToField m 0.
-  Proof.
-    Fdefn.
-    rewrite Zmod_0_l.
-    apply Z_mod_same_full.
-  Qed.
-
-  Lemma F_sub_m_l : forall x : F m, opp x = ZToField m - x.
-  Proof.
-    rewrite F_ZToField_m.
-    symmetry.
-    apply F_sub_0_l.
-  Qed.
-
-  Lemma opp_ZToField : forall x : Z, opp (ZToField x) = @ZToField m (m - x).
-  Proof.
-    Fdefn.
-    rewrite Zminus_mod, Z_mod_same_full, (Z.sub_0_l (x mod m)); reflexivity.
-  Qed.
-
-  Lemma F_pow_2_r : forall x : F m, x^2 = x*x.
-  Proof.
-    intros. ring.
-  Qed.
-
-  Lemma F_pow_3_r : forall x : F m, x^3 = x*x*x.
-  Proof.
-    intros. ring.
-  Qed.
-
-  Lemma F_pow_add : forall (x : F m) k j, x ^ j * x ^ k = x ^ (j + k).
-  Proof.
-    intros.
-    destruct (F_pow_spec x) as [exp_zero exp_succ].
-    induction j using N.peano_ind.
-    + rewrite exp_zero.
-      ring_simplify; eauto.
-    +
-    rewrite N.add_succ_l.
-    do 2 rewrite <- N.add_1_l.
-    do 2 rewrite exp_succ by apply N.neq_succ_0.
-    rewrite <- IHj.
-    ring.
-  Qed.
-
-  Lemma F_pow_compose : forall (x : F m) k j, (x ^ j) ^ k = x ^ (k * j).
-  Proof.
-    intros.
-    induction k using N.peano_ind; [rewrite Nmult_0_l; ring | ].
-    rewrite Nmult_Sn_m.
-    rewrite <- F_pow_add.
-    rewrite <- IHk.
-    rewrite <- N.add_1_l.
-    rewrite (proj2 (F_pow_spec _)).
-    ring.
-  Qed.
-
-  Lemma F_sub_add_swap : forall w x y z : F m, w - x = y - z <-> w + z = y + x.
-  Proof.
-    split; intro A;
-      [ replace w with (w - x + x) by ring
-      | replace w with (w + z - z) by ring ]; rewrite A; ring.
-  Qed.
-
-  Definition isSquare (x : F m) := exists sqrt_x, sqrt_x ^ 2 = x.
-
-  Lemma square_Zmod_F : forall (a : F m), isSquare a <->
-    (exists b : Z, ((b * b) mod m)%Z = a).
-  Proof.
-    split; intro A; destruct A as [sqrt_a sqrt_a_id]. {
-      exists sqrt_a.
-      rewrite <- FieldToZ_mul.
-      apply F_eq.
-      ring_simplify; auto.
-    } {
-      exists (ZToField sqrt_a).
-      rewrite ZToField_pow.
-      replace (Z.of_N 2) with 2%Z by auto.
-      rewrite Z.pow_2_r.
-      rewrite sqrt_a_id.
-      apply ZToField_FieldToZ.
-    }
-  Qed.
-
-  Lemma FieldToZ_range : forall x : F m, 0 < m -> 0 <= x < m.
-  Proof.
-    intros.
-    rewrite <- mod_FieldToZ.
-    apply Z.mod_pos_bound.
-    omega.
-  Qed.
-
-  Lemma FieldToZ_nonzero_range : forall x : F m, (x <> 0) -> 0 < m ->
-    (1 <= x < m)%Z.
-  Proof.
-    intros.
-    pose proof (FieldToZ_range x).
-    unfold not in *.
-    rewrite F_eq in H.
-    replace (FieldToZ 0) with 0%Z in H by auto.
-    omega.
-  Qed.
-
-  Lemma F_mul_comm : forall x y : F m, x*y = y*x.
-    intros; ring.
-  Qed.
-
-  Lemma Fq_sub_eq : forall x y a b : F m, a = b -> x-a = y-b -> x = y.
-  Proof.
-    intros x y a b Hab Hxayb; subst.
-    replace x with ((x - b) + b) by ring.
-    replace y with ((y - b) + b) by ring.
-    rewrite Hxayb; ring.
-  Qed.
-
-  Lemma F_FieldToZ_add_opp : forall x : F m, x <> 0 -> (FieldToZ x + FieldToZ (opp x) = m)%Z.
-  Proof.
-    intros.
-    rewrite FieldToZ_opp.
-    rewrite Z_mod_nz_opp_full, mod_FieldToZ; try omega.
-    rewrite mod_FieldToZ.
-    replace 0%Z with (@FieldToZ m 0) by auto.
-    intro false_eq.
-    rewrite <-F_eq in false_eq.
-    congruence.
-  Qed.
-
-End VariousModulo.
+    Lemma pow_3_r (x:F m) : x^3 = x*x*x.
+    Proof. pow_to_scalarmult_ref; simpl; ring. Qed.
+  End Pow.
+End Zmod.

--- a/src/ModularArithmetic/ModularArithmeticTheorems.v
+++ b/src/ModularArithmetic/ModularArithmeticTheorems.v
@@ -43,7 +43,8 @@ Ltac unwrap_F :=
   try apply eqsig_eq;
   demod.
 
-Global Instance eq_dec {m} : DecidableRel (@eq (F m)). exact _. Defined.
+(* FIXME: remove the pose proof once [monoid] no longer contains decidable equality *)
+Global Instance eq_dec {m} : DecidableRel (@eq (F m)). pose proof dec_eq_Z. exact _. Defined.
 
 Global Instance commutative_ring_modulo m
   : @Algebra.commutative_ring (F m) Logic.eq 0%F 1%F opp add sub mul.

--- a/src/ModularArithmetic/ModularBaseSystem.v
+++ b/src/ModularArithmetic/ModularBaseSystem.v
@@ -37,9 +37,9 @@ Section ModularBaseSystem.
    from_list (sub [[modulus_multiple]] [[us]] [[vs]])
    (length_sub length_to_list length_to_list length_to_list).
 
-  Definition zero : digits := encode (ZToField 0).
+  Definition zero : digits := encode (ZToField _ 0).
 
-  Definition one : digits := encode (ZToField 1).
+  Definition one : digits := encode (ZToField _ 1).
 
   (* Placeholder *)
   Definition opp (x : digits) : digits := encode (ModularArithmetic.opp (decode x)).

--- a/src/ModularArithmetic/ModularBaseSystem.v
+++ b/src/ModularArithmetic/ModularBaseSystem.v
@@ -37,18 +37,18 @@ Section ModularBaseSystem.
    from_list (sub [[modulus_multiple]] [[us]] [[vs]])
    (length_sub length_to_list length_to_list length_to_list).
 
-  Definition zero : digits := encode (ZToField _ 0).
+  Definition zero : digits := encode (F.of_Z _ 0).
 
-  Definition one : digits := encode (ZToField _ 1).
-
-  (* Placeholder *)
-  Definition opp (x : digits) : digits := encode (ModularArithmetic.opp (decode x)).
+  Definition one : digits := encode (F.of_Z _ 1).
 
   (* Placeholder *)
-  Definition inv (x : digits) : digits := encode (ModularArithmetic.inv (decode x)).
+  Definition opp (x : digits) : digits := encode (F.opp (decode x)).
 
   (* Placeholder *)
-  Definition div (x y : digits) : digits := encode (ModularArithmetic.div (decode x) (decode y)).
+  Definition inv (x : digits) : digits := encode (F.inv (decode x)).
+
+  (* Placeholder *)
+  Definition div (x y : digits) : digits := encode (F.div (decode x) (decode y)).
 
   Definition rep (us : digits) (x : F modulus) := decode us = x.
   Local Notation "u ~= x" := (rep u x).

--- a/src/ModularArithmetic/ModularBaseSystemField.v
+++ b/src/ModularArithmetic/ModularBaseSystemField.v
@@ -11,6 +11,7 @@ Local Open Scope Z_scope.
 Section ModularBaseSystemField.
   Context `{prm : PseudoMersenneBaseParams} {sc : SubtractionCoefficient modulus prm}
     (k_ c_ : Z) (k_subst : k = k_) (c_subst : c = c_).
+  Local Existing Instance prime_modulus.
   Local Notation base := (Pow2Base.base_from_limb_widths limb_widths).
   Local Notation digits := (tuple Z (length limb_widths)).
 
@@ -35,17 +36,13 @@ Section ModularBaseSystemField.
     apply carry_mul_rep; apply decode_rep.
   Qed.
 
-  Lemma zero_neq_one : eq zero one -> False.
-  Proof.
-   cbv [eq zero one]. erewrite !encode_rep. intro A.
-   eapply (PrimeFieldTheorems.Fq_1_neq_0 (prime_q := prime_modulus)).
-   congruence.
-  Qed.
+  Lemma _zero_neq_one : not (eq zero one).
+  Proof. cbv [eq zero one]. erewrite !encode_rep; apply zero_neq_one. Qed.
 
   Lemma modular_base_system_field :
     @field digits eq zero one opp add_opt sub_opt (carry_mul_opt k_ c_) inv div.
   Proof.
-    eapply (Field.isomorphism_to_subfield_field (phi := decode) (fieldR := PrimeFieldTheorems.field_modulo  (prime_q := prime_modulus))).
+    eapply (Field.isomorphism_to_subfield_field (phi := decode)).
     Grab Existential Variables.
     + intros; eapply encode_rep.
     + intros; eapply encode_rep.
@@ -55,9 +52,7 @@ Section ModularBaseSystemField.
     + intros; eapply sub_decode.
     + intros; eapply add_decode.
     + intros; eapply encode_rep.
-    + cbv [eq zero one]. erewrite !encode_rep. intro A.
-      eapply (PrimeFieldTheorems.Fq_1_neq_0 (prime_q := prime_modulus)).
-      congruence.
+    + eapply _zero_neq_one.
     + trivial.
     + repeat intro. cbv [div]. congruence.
     + repeat intro. cbv [inv]. congruence.
@@ -65,7 +60,6 @@ Section ModularBaseSystemField.
     + repeat intro. cbv [eq]. erewrite !sub_decode. congruence.
     + repeat intro. cbv [eq]. erewrite !add_decode. congruence.
     + repeat intro. cbv [opp]. congruence.
-    + cbv [eq]. auto using ModularArithmeticTheorems.F_eq_dec.
   Qed.
 
 End ModularBaseSystemField.

--- a/src/ModularArithmetic/ModularBaseSystemList.v
+++ b/src/ModularArithmetic/ModularBaseSystemList.v
@@ -16,7 +16,7 @@ Section Defs.
   Local Notation base := (base_from_limb_widths limb_widths).
   Local Notation "u [ i ]" := (nth_default 0 u i).
 
-  Definition decode (us : digits) : F modulus := ZToField (BaseSystem.decode base us).
+  Definition decode (us : digits) : F modulus := ZToField _ (BaseSystem.decode base us).
 
   Definition encode (x : F modulus) := encodeZ limb_widths x.
 

--- a/src/ModularArithmetic/ModularBaseSystemList.v
+++ b/src/ModularArithmetic/ModularBaseSystemList.v
@@ -16,9 +16,9 @@ Section Defs.
   Local Notation base := (base_from_limb_widths limb_widths).
   Local Notation "u [ i ]" := (nth_default 0 u i).
 
-  Definition decode (us : digits) : F modulus := ZToField _ (BaseSystem.decode base us).
+  Definition decode (us : digits) := F.of_Z modulus (BaseSystem.decode base us).
 
-  Definition encode (x : F modulus) := encodeZ limb_widths x.
+  Definition encode (x : F modulus) := encodeZ limb_widths (F.to_Z x).
 
   (* Converts from length of extended base to length of base by reduction modulo M.*)
   Definition reduce (us : digits) : digits :=

--- a/src/ModularArithmetic/ModularBaseSystemProofs.v
+++ b/src/ModularArithmetic/ModularBaseSystemProofs.v
@@ -21,6 +21,8 @@ Require Export Crypto.Util.FixCoqMistakes.
 Local Open Scope Z_scope.
 
 Local Opaque add_to_nth carry_simple.
+Local Arguments ZToField {_} _.
+Import ModularArithmeticTheorems.Zmod PrimeFieldTheorems.Zmod.
 
 Section PseudoMersenneProofs.
   Context `{prm :PseudoMersenneBaseParams}.
@@ -232,7 +234,7 @@ Section PseudoMersenneProofs.
     rewrite BaseSystemProofs.sub_rep, BaseSystemProofs.add_rep.
     rewrite ZToField_sub, ZToField_add, ZToField_mod.
     apply Fdecode_decode_mod in mm_spec; cbv [BaseSystem.decode] in *.
-    rewrite mm_spec, F_add_0_l.
+    rewrite mm_spec. rewrite Algebra.left_identity.
     f_equal; assumption.
   Qed.
 
@@ -297,11 +299,11 @@ Section CarryProofs.
     specialize_by eauto.
     cbv [ModularBaseSystemList.carry].
     break_if; subst; eauto.
-    apply F_eq.
+    apply eq_ZToField_iff.
     rewrite to_list_from_list.
     apply carry_decode_eq_reduce. auto.
     cbv [ModularBaseSystemList.decode].
-    apply ZToField_eqmod.
+    apply eq_ZToField_iff.
     rewrite to_list_from_list, carry_simple_decode_eq; try omega; distr_length; auto.
   Qed.
   Hint Resolve carry_rep.

--- a/src/ModularArithmetic/ModularBaseSystemProofs.v
+++ b/src/ModularArithmetic/ModularBaseSystemProofs.v
@@ -21,8 +21,6 @@ Require Export Crypto.Util.FixCoqMistakes.
 Local Open Scope Z_scope.
 
 Local Opaque add_to_nth carry_simple.
-Local Arguments ZToField {_} _.
-Import ModularArithmeticTheorems.Zmod PrimeFieldTheorems.Zmod.
 
 Section PseudoMersenneProofs.
   Context `{prm :PseudoMersenneBaseParams}.
@@ -79,7 +77,7 @@ Section PseudoMersenneProofs.
   Qed.
 
   Lemma encode_eq : forall x : F modulus,
-    ModularBaseSystemList.encode x = BaseSystem.encode base x (2 ^ k).
+    ModularBaseSystemList.encode x = BaseSystem.encode base (F.to_Z x) (2 ^ k).
   Proof.
     cbv [ModularBaseSystemList.encode BaseSystem.encode encodeZ]; intros.
     rewrite base_length.
@@ -91,9 +89,9 @@ Section PseudoMersenneProofs.
     autounfold; cbv [encode]; intros.
     rewrite to_list_from_list; autounfold.
     rewrite encode_eq, encode_rep.
-    + apply ZToField_FieldToZ.
+    + apply F.of_Z_to_Z.
     + apply bv.
-    + split; [ | etransitivity]; try (apply FieldToZ_range; auto using modulus_pos); auto.
+    + split; [ | etransitivity]; try (apply F.to_Z_range; auto using modulus_pos); auto.
     + eauto using base_upper_bound_compatible, limb_widths_nonneg.
   Qed.
 
@@ -102,7 +100,7 @@ Section PseudoMersenneProofs.
   Proof.
     autounfold; cbv [add]; intros.
     rewrite to_list_from_list; autounfold.
-    rewrite add_rep, ZToField_add.
+    rewrite add_rep, F.of_Z_add.
     f_equal; assumption.
   Qed.
 
@@ -161,12 +159,12 @@ Section PseudoMersenneProofs.
     intuition idtac; subst.
     rewrite to_list_from_list.
     cbv [ModularBaseSystemList.mul ModularBaseSystemList.decode].
-    rewrite ZToField_mod, reduce_rep, <-ZToField_mod.
+    rewrite F.of_Z_mod, reduce_rep, <-F.of_Z_mod.
     pose proof (@base_from_limb_widths_length limb_widths).
     rewrite mul_rep by (auto using ExtBaseVector || rewrite extended_base_length, !length_to_list; omega).
     rewrite 2decode_short by (rewrite ?base_from_limb_widths_length;
       auto using Nat.eq_le_incl, length_to_list with omega).
-    apply ZToField_mul.
+    apply F.of_Z_mul.
   Qed.
 
   Lemma nth_default_base_positive : forall i, (i < length base)%nat ->
@@ -191,11 +189,11 @@ Section PseudoMersenneProofs.
   Qed.
 
   Lemma Fdecode_decode_mod : forall us x,
-    decode us = x -> BaseSystem.decode base (to_list us) mod modulus = x.
+    decode us = x -> BaseSystem.decode base (to_list us) mod modulus = F.to_Z x.
   Proof.
     autounfold; intros.
     rewrite <-H.
-    apply FieldToZ_ZToField.
+    apply F.to_Z_of_Z.
   Qed.
 
   Definition carry_done us := forall i, (i < length base)%nat ->
@@ -232,7 +230,7 @@ Section PseudoMersenneProofs.
     rewrite to_list_from_list; autounfold.
     cbv [ModularBaseSystemList.sub].
     rewrite BaseSystemProofs.sub_rep, BaseSystemProofs.add_rep.
-    rewrite ZToField_sub, ZToField_add, ZToField_mod.
+    rewrite F.of_Z_sub, F.of_Z_add, F.of_Z_mod.
     apply Fdecode_decode_mod in mm_spec; cbv [BaseSystem.decode] in *.
     rewrite mm_spec. rewrite Algebra.left_identity.
     f_equal; assumption.
@@ -299,11 +297,11 @@ Section CarryProofs.
     specialize_by eauto.
     cbv [ModularBaseSystemList.carry].
     break_if; subst; eauto.
-    apply eq_ZToField_iff.
+    apply F.eq_of_Z_iff.
     rewrite to_list_from_list.
     apply carry_decode_eq_reduce. auto.
     cbv [ModularBaseSystemList.decode].
-    apply eq_ZToField_iff.
+    apply F.eq_of_Z_iff.
     rewrite to_list_from_list, carry_simple_decode_eq; try omega; distr_length; auto.
   Qed.
   Hint Resolve carry_rep.

--- a/src/ModularArithmetic/Pre.v
+++ b/src/ModularArithmetic/Pre.v
@@ -119,8 +119,8 @@ Program Definition inv_impl {m : BinNums.Z} :
     forall a : {z : BinNums.Z | z = z mod m},
     a <> exist (fun z : BinNums.Z => z = z mod m) (0 mod m) (Z_mod_mod 0 m) ->
     exist (fun z : BinNums.Z => z = z mod m)
-      ((proj1_sig a * proj1_sig (inv0 a)) mod m)
-      (Z_mod_mod (proj1_sig a * proj1_sig (inv0 a)) m) =
+      ((proj1_sig (inv0 a) * proj1_sig a) mod m)
+      (Z_mod_mod (proj1_sig (inv0 a) * proj1_sig a) m) =
     exist (fun z : BinNums.Z => z = z mod m) (1 mod m) (Z_mod_mod 1 m))}
      := mod_inv_sig.
 Next Obligation.
@@ -130,7 +130,7 @@ Next Obligation.
   assert (Hm':0 <= m - 2) by (pose proof prime_ge_2 m Hm; omega).
   assert (Ha:a mod m<>0) by (intro; apply Ha', exist_reduced_eq; congruence).
   cbv [proj1_sig mod_inv_sig].
-  transitivity ((a*powmod m a (Z.to_N (m - 2))) mod m); [destruct a; congruence|].
+  transitivity ((a*powmod m a (Z.to_N (m - 2))) mod m); [destruct a; f_equal; ring|].
   rewrite !powmod_Zpow_mod.
   rewrite Z2N.id by assumption.
   rewrite Zmult_mod_idemp_r.

--- a/src/ModularArithmetic/PrimeFieldTheorems.v
+++ b/src/ModularArithmetic/PrimeFieldTheorems.v
@@ -71,8 +71,9 @@ Module Zmod.
 
     Lemma Fq_inv_fermat (x:F q) : inv x = x ^ Z.to_N (q - 2)%Z.
     Proof.
-      destruct (dec (x = 0%F)) as [?|Hnz]; [subst x; rewrite inv_0|].
-      { admit. }
+      destruct (dec (x = 0%F)) as [?|Hnz].
+      { subst x; rewrite inv_0, pow_0_l; trivial.
+        change (0%N) with (Z.to_N 0%Z); rewrite Z2N.inj_iff; omega. }
       erewrite <-Algebra.Field.inv_unique; try reflexivity.
       rewrite eq_FieldToZ_iff, FieldToZ_mul, FieldToZ_pow, Z2N.id, FieldToZ_1 by omega.
       apply (fermat_inv q _ (FieldToZ x)); rewrite mod_FieldToZ; eapply FieldToZ_nonzero; trivial.

--- a/src/ModularArithmetic/PrimeFieldTheorems.v
+++ b/src/ModularArithmetic/PrimeFieldTheorems.v
@@ -13,33 +13,32 @@ Require Import Crypto.Util.Tactics.
 Require Import Crypto.Util.Decidable.
 Require Export Crypto.Util.FixCoqMistakes.
 Require Crypto.Algebra.
-Import Crypto.ModularArithmetic.ModularArithmeticTheorems.Zmod.
 
 Existing Class prime.
 
-Module Zmod.
+Module F.
   Section Field.
     Context (q:Z) {prime_q:prime q}.
-    Lemma inv_spec : inv 0%F = (0%F : F q) 
-                     /\ (prime q -> forall x : F q, x <> 0%F -> (inv x * x)%F = 1%F).
-    Proof. change (@inv q) with (proj1_sig (@inv_with_spec q)); destruct (@inv_with_spec q); eauto. Qed.
+    Lemma inv_spec : F.inv 0%F = (0%F : F q) 
+                     /\ (prime q -> forall x : F q, x <> 0%F -> (F.inv x * x)%F = 1%F).
+    Proof. change (@F.inv q) with (proj1_sig (@F.inv_with_spec q)); destruct (@F.inv_with_spec q); eauto. Qed.
 
-    Lemma inv_0 : inv 0 = ZToField q 0. Proof. destruct inv_spec; auto. Qed.
-    Lemma inv_nonzero (x:F q) : (x <> 0 -> inv x * x%F = 1)%F. Proof. destruct inv_spec; auto. Qed.
+    Lemma inv_0 : F.inv 0%F = F.of_Z q 0. Proof. destruct inv_spec; auto. Qed.
+    Lemma inv_nonzero (x:F q) : (x <> 0 -> F.inv x * x%F = 1)%F. Proof. destruct inv_spec; auto. Qed.
 
-    Global Instance field_modulo : @Algebra.field (F q) Logic.eq 0%F 1%F opp add sub mul inv div.
+    Global Instance field_modulo : @Algebra.field (F q) Logic.eq 0%F 1%F F.opp F.add F.sub F.mul F.inv F.div.
     Proof.
       repeat match goal with
              | _ => solve [ solve_proper
-                          | apply commutative_ring_modulo
+                          | apply F.commutative_ring_modulo
                           | apply inv_nonzero
                           | cbv [not]; pose proof prime_ge_2 q prime_q;
-                            rewrite Zmod.eq_FieldToZ_iff, !Zmod.FieldToZ_ZToField, !Zmod_small; omega ]
+                            rewrite F.eq_to_Z_iff, !F.to_Z_of_Z, !Zmod_small; omega ]
              | _ => split
              end.
     Qed.
 
-    Definition field_theory : field_theory 0%F 1%F add mul sub opp div inv eq
+    Definition field_theory : field_theory 0%F 1%F F.add F.mul F.sub F.opp F.div F.inv eq
       := Algebra.Field.field_theory_for_stdlib_tactic.
   End Field.
 
@@ -49,43 +48,44 @@ Module Zmod.
     Parameter prime_modulus : prime modulus.
   End PrimeModulus.
   Module FieldModulo (Export M : PrimeModulus).
-    Module Import RingM := RingModulo M.
-    Add Field _field : (field_theory modulus)
-                         (morphism (ring_morph modulus),
-                          constants [is_constant],
-                          div (morph_div_theory modulus),
-                          power_tac (power_theory modulus) [is_pow_constant]).
+    Module Import RingM := F.RingModulo M.
+    Add Field _field : (F.field_theory modulus)
+                         (morphism (F.ring_morph modulus),
+                          constants [F.is_constant],
+                          div (F.morph_div_theory modulus),
+                          power_tac (F.power_theory modulus) [F.is_pow_constant]).
   End FieldModulo.
 
   Section NumberThoery.
     Context {q:Z} {prime_q:prime q} {two_lt_q: 2 < q}.
     Local Open Scope F_scope.
     Add Field _field : (field_theory q)
-                         (morphism (ring_morph q),
-                          constants [is_constant],
-                          div (morph_div_theory q),
-                          power_tac (power_theory q) [is_pow_constant]).
+                         (morphism (F.ring_morph q),
+                          constants [F.is_constant],
+                          div (F.morph_div_theory q),
+                          power_tac (F.power_theory q) [F.is_pow_constant]).
 
-    Lemma FieldToZ_1 : @FieldToZ q 1 = 1%Z.
+    (* TODO: move to PrimeFieldTheorems *)
+    Lemma to_Z_1 : @F.to_Z q 1 = 1%Z.
     Proof. simpl. rewrite Zmod_small; omega. Qed.
 
-    Lemma Fq_inv_fermat (x:F q) : inv x = x ^ Z.to_N (q - 2)%Z.
+    Lemma Fq_inv_fermat (x:F q) : F.inv x = x ^ Z.to_N (q - 2)%Z.
     Proof.
       destruct (dec (x = 0%F)) as [?|Hnz].
-      { subst x; rewrite inv_0, pow_0_l; trivial.
+      { subst x; rewrite inv_0, F.pow_0_l; trivial.
         change (0%N) with (Z.to_N 0%Z); rewrite Z2N.inj_iff; omega. }
       erewrite <-Algebra.Field.inv_unique; try reflexivity.
-      rewrite eq_FieldToZ_iff, FieldToZ_mul, FieldToZ_pow, Z2N.id, FieldToZ_1 by omega.
-      apply (fermat_inv q _ (FieldToZ x)); rewrite mod_FieldToZ; eapply FieldToZ_nonzero; trivial.
+      rewrite F.eq_to_Z_iff, F.to_Z_mul, F.to_Z_pow, Z2N.id, to_Z_1 by omega.
+      apply (fermat_inv q _ (F.to_Z x)); rewrite F.mod_to_Z; eapply F.to_Z_nonzero; trivial.
     Qed.
     
     Lemma euler_criterion (a : F q) (a_nonzero : a <> 0) :
       (a ^ (Z.to_N (q / 2)) = 1) <-> (exists b, b*b = a).
     Proof.
-      pose proof FieldToZ_nonzero_range a; pose proof (odd_as_div q).
+      pose proof F.to_Z_nonzero_range a; pose proof (odd_as_div q).
       specialize_by ltac:(destruct (Z.prime_odd_or_2 _ prime_q); try omega; trivial).
-      rewrite eq_FieldToZ_iff, !FieldToZ_pow, !FieldToZ_1, !Z2N.id by omega.
-      rewrite square_iff, <-(euler_criterion (q/2)) by (trivial || omega); reflexivity.
+      rewrite F.eq_to_Z_iff, !F.to_Z_pow, !to_Z_1, !Z2N.id by omega.
+      rewrite F.square_iff, <-(euler_criterion (q/2)) by (trivial || omega); reflexivity.
     Qed.
 
     Global Instance Decidable_square (x:F q) : Decidable (exists y, y*y = x).
@@ -100,15 +100,15 @@ Module Zmod.
     Context {q:Z} {prime_q: prime q} {q_5mod8 : q mod 8 = 5}.
 
     (* This is always true, but easier to check by computation than to prove *)
-    Context (sqrt_minus1_valid : ((ZToField q 2 ^ Z.to_N (q / 4)) ^ 2 = opp 1)%F).
+    Context (sqrt_minus1_valid : ((F.of_Z q 2 ^ Z.to_N (q / 4)) ^ 2 = F.opp 1)%F).
     Local Open Scope F_scope.
     Add Field _field2 : (field_theory q)
-                          (morphism (ring_morph q),
-                           constants [is_constant],
-                           div (morph_div_theory q),
-                           power_tac (power_theory q) [is_pow_constant]).
+                          (morphism (F.ring_morph q),
+                           constants [F.is_constant],
+                           div (F.morph_div_theory q),
+                           power_tac (F.power_theory q) [F.is_pow_constant]).
 
-    Let sqrt_minus1 : F q :=  ZToField _ 2 ^ Z.to_N (q / 4).
+    Let sqrt_minus1 :=  F.of_Z q 2 ^ Z.to_N (q / 4).
 
     Lemma two_lt_q_5mod8 : 2 < q.
     Proof.
@@ -132,8 +132,8 @@ Module Zmod.
       assert (0 <= q/8)%Z by (apply Z.div_le_lower_bound; rewrite ?Z.mul_0_r; omega).
       assert (Z.to_N (q / 8 + 1) <> 0%N) by
           (intro Hbad; change (0%N) with (Z.to_N 0%Z) in Hbad; rewrite Z2N.inj_iff in Hbad; omega).
-      destruct (dec (x = 0)); [subst; rewrite !pow_0_l by (trivial || lazy_decide); reflexivity|].
-      rewrite !pow_pow_l.
+      destruct (dec (x = 0)); [subst; rewrite !F.pow_0_l by (trivial || lazy_decide); reflexivity|].
+      rewrite !F.pow_pow_l.
 
       replace (Z.to_N (q / 8 + 1) * (2*2))%N with (Z.to_N (q / 2 + 2))%N.
       Focus 2. { (* this is a boring but gnarly proof :/ *)
@@ -151,8 +151,8 @@ Module Zmod.
         ring.
       } Unfocus.
 
-      rewrite Z2N.inj_add, pow_add_r by zero_bounds.
-      replace (x ^ Z.to_N (q / 2)) with (@ZToField q 1) by
+      rewrite Z2N.inj_add, F.pow_add_r by zero_bounds.
+      replace (x ^ Z.to_N (q / 2)) with (F.of_Z q 1) by
           (symmetry; apply @euler_criterion; eauto).
       change (Z.to_N 2) with 2%N; ring.
     Qed.
@@ -161,14 +161,14 @@ Module Zmod.
                                        (sqrt_5mod8 x)*(sqrt_5mod8 x) = x.
     Proof.
       intros x x_square.
-      pose proof (eq_b4_a2 x x_square) as Hyy; rewrite !pow_2_r in Hyy.
+      pose proof (eq_b4_a2 x x_square) as Hyy; rewrite !F.pow_2_r in Hyy.
       destruct (Algebra.only_two_square_roots_choice _ x (x*x) Hyy eq_refl) as [Hb|Hb]; clear Hyy;
-        unfold sqrt_5mod8; break_if; rewrite !@pow_2_r in *; intuition.
+        unfold sqrt_5mod8; break_if; rewrite !@F.pow_2_r in *; intuition.
       ring_simplify.
-      unfold sqrt_minus1; rewrite @pow_2_r.
-      rewrite sqrt_minus1_valid; rewrite @pow_2_r.
+      unfold sqrt_minus1; rewrite @F.pow_2_r.
+      rewrite sqrt_minus1_valid; rewrite @F.pow_2_r.
       rewrite Hb.
       ring.
     Qed.
   End SquareRootsPrime5Mod8.
-End Zmod.
+End F.

--- a/src/ModularArithmetic/PrimeFieldTheorems.v
+++ b/src/ModularArithmetic/PrimeFieldTheorems.v
@@ -78,13 +78,6 @@ Module Zmod.
       rewrite eq_FieldToZ_iff, FieldToZ_mul, FieldToZ_pow, Z2N.id, FieldToZ_1 by omega.
       apply (fermat_inv q _ (FieldToZ x)); rewrite mod_FieldToZ; eapply FieldToZ_nonzero; trivial.
     Qed.
-
-    (* TODO: move to number thoery util *)
-    Lemma odd_as_div a : Z.odd a = true -> a = (2*(a/2) + 1)%Z.
-    Proof.
-      rewrite Zodd_mod, <-Zeq_is_eq_bool; intro H_1; rewrite <-H_1.
-      apply Z_div_mod_eq; reflexivity.
-    Qed.
     
     Lemma euler_criterion (a : F q) (a_nonzero : a <> 0) :
       (a ^ (Z.to_N (q / 2)) = 1) <-> (exists b, b*b = a).

--- a/src/ModularArithmetic/Tutorial.v
+++ b/src/ModularArithmetic/Tutorial.v
@@ -11,16 +11,18 @@ Section Mod24.
   Let q := 24.
 
   (* Boilerplate for letting Z numbers be interpreted as field elements *)
-  Let ZToFq := ZToField _ : BinNums.Z -> F q. Hint Unfold ZToFq. Local Coercion ZToFq : Z >-> F.
+  Let ZToFq := F.of_Z _ : BinNums.Z -> F q. Hint Unfold ZToFq.
+  Local Coercion ZToFq : Z >-> F.
+  Local Coercion F.to_Z : F >-> Z.
 
   (* Boilerplate for [ring]. Similar boilerplate works for [field] if
   the modulus is prime . *)
-  Add Ring _theory : (Zmod.ring_theory q)
-    (morphism (Zmod.ring_morph q),
+  Add Ring _theory : (F.ring_theory q)
+    (morphism (F.ring_morph q),
      preprocess [unfold ZToFq],
-     constants [Zmod.is_constant],
-     div (Zmod.morph_div_theory q),
-     power_tac (Zmod.power_theory q) [Zmod.is_pow_constant]).
+     constants [F.is_constant],
+     div (F.morph_div_theory q),
+     power_tac (F.power_theory q) [F.is_pow_constant]).
 
   Lemma sumOfSquares : forall a b: F q, (a+b)^2 = a^2 + 2*a*b + b^2.
   Proof.
@@ -38,16 +40,18 @@ Section Modq.
   Local Open Scope F_scope.
 
   (* Boilerplate for letting Z numbers be interpreted as field elements *)
-  Let ZToFq := ZToField _ : BinNums.Z -> F q. Hint Unfold ZToFq. Local Coercion ZToFq : Z >-> F.
+  Let ZToFq := F.of_Z _ : BinNums.Z -> F q. Hint Unfold ZToFq.
+  Local Coercion ZToFq : Z >-> F.
+  Local Coercion F.to_Z : F >-> Z.
 
   (* Boilerplate for [field]. Similar boilerplate works for [ring] if
   the modulus is not prime . *)
-  Add Field _theory' : (Zmod.field_theory q)
-    (morphism (Zmod.ring_morph q),
+  Add Field _theory' : (F.field_theory q)
+    (morphism (F.ring_morph q),
      preprocess [unfold ZToFq],
-     constants [Zmod.is_constant],
-     div (Zmod.morph_div_theory q),
-     power_tac (Zmod.power_theory q) [Zmod.is_pow_constant]).
+     constants [F.is_constant],
+     div (F.morph_div_theory q),
+     power_tac (F.power_theory q) [F.is_pow_constant]).
 
   Lemma sumOfSquares' : forall a b c: F q, c <> 0 -> ((a+b)/c)^2 = a^2/c^2 + 2*(a/c)*(b/c) + b^2/c^2.
   Proof.
@@ -58,13 +62,13 @@ End Modq.
 
 (*** The old way: Modules ***)
 
-Module Modulus31 <: Zmod.PrimeModulus.
+Module Modulus31 <: F.PrimeModulus.
   Definition modulus := 2^5 - 1.
   Lemma prime_modulus : prime modulus.
   Admitted.
 End Modulus31.
 
-Module Modulus127 <: Zmod.PrimeModulus.
+Module Modulus127 <: F.PrimeModulus.
   Definition modulus := 2^127 - 1.
   Lemma prime_modulus : prime modulus.
   Admitted.
@@ -72,14 +76,14 @@ End Modulus127.
 
 Module Example31.
   (* Then we can construct a field with that modulus *)
-  Module Import Field := Zmod.FieldModulo Modulus31.
+  Module Import Field := F.FieldModulo Modulus31.
   Import Modulus31.
 
   (* And pull in the appropriate notations *)
   Local Open Scope F_scope.
 
   (* First, let's solve a ring example*)
-  Lemma ring_example: forall x: F modulus, x * (ZToField _ 2) = x + x.
+  Lemma ring_example: forall x: F modulus, x * (F.of_Z _ 2) = x + x.
   Proof.
     intros.
     ring.
@@ -90,7 +94,7 @@ Module Example31.
     Therefore, it is necessary to explicitly rewrite the modulus
     (usually hidden by implicitn arguments) match the one passed to
     [FieldModulo]. *)
-  Lemma ring_example': forall x: F (2^5-1), x * (ZToField _ 2) = x + x.
+  Lemma ring_example': forall x: F (2^5-1), x * (F.of_Z _ 2) = x + x.
   Proof.
     intros.
     change (2^5-1)%Z with modulus.
@@ -106,7 +110,7 @@ Module Example31.
   Qed.
 
   (* Then an example with exponentiation *)
-  Lemma exp_example: forall x: F modulus, x ^ 2 + ZToField _ 2 * x + 1 = (x + 1) ^ 2.
+  Lemma exp_example: forall x: F modulus, x ^ 2 + F.of_Z _ 2 * x + 1 = (x + 1) ^ 2.
   Proof.
     intros; simpl.
     field; trivial.
@@ -141,7 +145,7 @@ End Example31.
 
 (* Notice that the field tactics work whether we know what the modulus is *)
 Module TimesZeroTransparentTestModule.
-  Module Import Theory := Zmod.FieldModulo Modulus127.
+  Module Import Theory := F.FieldModulo Modulus127.
   Import Modulus127.
   Local Open Scope F_scope.
 
@@ -156,8 +160,8 @@ End TimesZeroTransparentTestModule.
   significant overhead. Consider using an entirely abstract
   [Algebra.field] instead. *)
   
-Module TimesZeroParametricTestModule (M: Zmod.PrimeModulus).
-  Module Theory := Zmod.FieldModulo M.
+Module TimesZeroParametricTestModule (M: F.PrimeModulus).
+  Module Theory := F.FieldModulo M.
   Import Theory M.
   Local Open Scope F_scope.
 
@@ -166,24 +170,24 @@ Module TimesZeroParametricTestModule (M: Zmod.PrimeModulus).
     field.
   Qed.
 
-  Lemma realisticFraction : forall x y d : F modulus, 1 <> ZToField modulus 0 -> (x * 1 + y * 0) / (1 + d * x * 0 * y * 1) = x.
+  Lemma realisticFraction : forall x y d : F modulus, 1 <> F.of_Z modulus 0 -> (x * 1 + y * 0) / (1 + d * x * 0 * y * 1) = x.
   Proof.
     intros.
     field; assumption.
   Qed.
 
   Lemma biggerFraction : forall XP YP ZP TP XQ YQ ZQ TQ d : F modulus,
-   1 <> ZToField modulus 0 -> 
+   1 <> F.of_Z modulus 0 -> 
    ZQ <> 0 ->
    ZP <> 0 ->
    ZP * ZQ * ZP * ZQ + d * XP * XQ * YP * YQ <> 0 ->
-   ZP * ZToField _ 2 * ZQ * (ZP * ZQ) + XP * YP * ZToField _ 2 * d * (XQ * YQ) <> 0 ->
-   ZP * ZToField _ 2 * ZQ * (ZP * ZQ) - XP * YP * ZToField _ 2 * d * (XQ * YQ) <> 0 ->
+   ZP * F.of_Z _ 2 * ZQ * (ZP * ZQ) + XP * YP * F.of_Z _ 2 * d * (XQ * YQ) <> 0 ->
+   ZP * F.of_Z _ 2 * ZQ * (ZP * ZQ) - XP * YP * F.of_Z _ 2 * d * (XQ * YQ) <> 0 ->
 
    ((YP + XP) * (YQ + XQ) - (YP - XP) * (YQ - XQ)) *
-   (ZP * ZToField _ 2 * ZQ - XP * YP / ZP * ZToField _ 2 * d * (XQ * YQ / ZQ)) /
-   ((ZP * ZToField _ 2 * ZQ - XP * YP / ZP * ZToField _ 2 * d * (XQ * YQ / ZQ)) *
-    (ZP * ZToField _ 2 * ZQ + XP * YP / ZP * ZToField _ 2 * d * (XQ * YQ / ZQ))) =
+   (ZP * F.of_Z _ 2 * ZQ - XP * YP / ZP * F.of_Z _ 2 * d * (XQ * YQ / ZQ)) /
+   ((ZP * F.of_Z _ 2 * ZQ - XP * YP / ZP * F.of_Z _ 2 * d * (XQ * YQ / ZQ)) *
+    (ZP * F.of_Z _ 2 * ZQ + XP * YP / ZP * F.of_Z _ 2 * d * (XQ * YQ / ZQ))) =
    (XP / ZP * (YQ / ZQ) + YP / ZP * (XQ / ZQ)) / (1 + d * (XP / ZP) * (XQ / ZQ) * (YP / ZP) * (YQ / ZQ)).
   Proof.
     intros.

--- a/src/Spec/ModularArithmetic.v
+++ b/src/Spec/ModularArithmetic.v
@@ -35,7 +35,7 @@ Section FieldOperations.
   Definition inv_with_spec : { inv : F m -> F m
                              | inv zero = zero
                              /\ ( Znumtheory.prime m ->
-                                 forall a, a <> zero -> mul a (inv a) = one )
+                                 forall a, a <> zero -> mul (inv a) a = one )
                              } := Pre.inv_impl.
   Definition inv : F m -> F m := Eval hnf in proj1_sig inv_with_spec.
   Definition div (a b:F m) : F m := mul a (inv b).
@@ -49,7 +49,7 @@ End FieldOperations.
 
 Delimit Scope F_scope with F.
 Arguments F _%Z.
-Arguments ZToField {_} _%Z : simpl never.
+Arguments ZToField _%Z _%Z : simpl never, clear implicits.
 Arguments add {_} _%F _%F : simpl never.
 Arguments mul {_} _%F _%F : simpl never.
 Arguments sub {_} _%F _%F : simpl never.
@@ -57,11 +57,10 @@ Arguments div {_} _%F _%F : simpl never.
 Arguments pow {_} _%F _%N : simpl never.
 Arguments inv {_} _%F : simpl never.
 Arguments opp {_} _%F : simpl never.
-Local Open Scope F_scope.
 Infix "+" := add : F_scope.
 Infix "*" := mul : F_scope.
 Infix "-" := sub : F_scope.
 Infix "/" := div : F_scope.
 Infix "^" := pow : F_scope.
-Notation "0" := (ZToField 0) : F_scope.
-Notation "1" := (ZToField 1) : F_scope.
+Notation "0" := (ZToField _ 0) : F_scope.
+Notation "1" := (ZToField _ 1) : F_scope.

--- a/src/Spec/ModularArithmetic.v
+++ b/src/Spec/ModularArithmetic.v
@@ -3,6 +3,7 @@ Require Coq.ZArith.Znumtheory Coq.Numbers.BinNums.
 Require Crypto.ModularArithmetic.Pre.
 
 Delimit Scope N_scope with N.
+Bind Scope N_scope with BinNums.N.
 Infix "+" := BinNat.N.add : N_scope.
 Infix "*" := BinNat.N.mul : N_scope.
 Infix "-" := BinNat.N.sub : N_scope.
@@ -10,6 +11,7 @@ Infix "/" := BinNat.N.div : N_scope.
 Infix "^" := BinNat.N.pow : N_scope.
 
 Delimit Scope Z_scope with Z.
+Bind Scope Z_scope with BinInt.Z.
 Infix "+" := BinInt.Z.add : Z_scope.
 Infix "*" := BinInt.Z.mul : Z_scope.
 Infix "-" := BinInt.Z.sub : Z_scope.
@@ -18,49 +20,45 @@ Infix "^" := BinInt.Z.pow : Z_scope.
 Infix "mod" := BinInt.Z.modulo (at level 40, no associativity) : Z_scope.
 Local Open Scope Z_scope.
 
-Definition F (modulus : BinInt.Z) := { z : BinInt.Z | z = z mod modulus }.
-Definition ZToField {m} (a:BinNums.Z) : F m := exist _ (a mod m) (Pre.Z_mod_mod a m).
-Coercion FieldToZ {m} (a:F m) : BinNums.Z := proj1_sig a.
+Module F.
+  Definition F (m : BinInt.Z) := { z : BinInt.Z | z = z mod m }.
+  Local Obligation Tactic := auto using Pre.Z_mod_mod.
+  Program Definition of_Z  m  (a:BinNums.Z) : F m := a mod m.
+  Definition to_Z {m} (a:F m) : BinNums.Z := proj1_sig a.
 
-Section FieldOperations.
-  Context {m : BinInt.Z}.
-  Definition zero : F m := ZToField 0.
-  Definition one : F m := ZToField 1.
+  Section FieldOperations.
+    Context {m : BinInt.Z}.
+    Definition zero : F m := of_Z m 0.
+    Definition one : F m := of_Z m 1.
 
-  Definition add (a b:F m) : F m := ZToField (a + b).
-  Definition mul (a b:F m) : F m := ZToField (a * b).
-  Definition opp (a : F m) : F m := ZToField (0 - a).
-  Definition sub (a b:F m) : F m := add a (opp b).
+    Definition add (a b:F m) : F m := of_Z m (to_Z a + to_Z b).
+    Definition mul (a b:F m) : F m := of_Z m (to_Z a * to_Z b).
+    Definition opp (a : F m) : F m := of_Z m (0 - to_Z a).
+    Definition sub (a b:F m) : F m := add a (opp b).
 
-  Definition inv_with_spec : { inv : F m -> F m
-                             | inv zero = zero
-                             /\ ( Znumtheory.prime m ->
-                                 forall a, a <> zero -> mul (inv a) a = one )
-                             } := Pre.inv_impl.
-  Definition inv : F m -> F m := Eval hnf in proj1_sig inv_with_spec.
-  Definition div (a b:F m) : F m := mul a (inv b).
+    Definition inv_with_spec : { inv : F m -> F m
+                               | inv zero = zero
+                                 /\ ( Znumtheory.prime m ->
+                                      forall a, a <> zero -> mul (inv a) a = one )
+                               } := Pre.inv_impl.
+    Definition inv : F m -> F m := Eval hnf in proj1_sig inv_with_spec.
+    Definition div (a b:F m) : F m := mul a (inv b).
 
-  Definition pow_with_spec : { pow : F m -> BinNums.N -> F m
-                             | forall a, pow a 0%N = one
-                             /\ forall x, pow a (1 + x)%N = mul a (pow a x)
-                             } := Pre.pow_impl.
-  Definition pow : F m -> BinNums.N -> F m := Eval hnf in proj1_sig pow_with_spec.
-End FieldOperations.
+    Definition pow_with_spec : { pow : F m -> BinNums.N -> F m
+                               | forall a, pow a 0%N = one
+                                           /\ forall x, pow a (1 + x)%N = mul a (pow a x)
+                               } := Pre.pow_impl.
+    Definition pow : F m -> BinNums.N -> F m := Eval hnf in proj1_sig pow_with_spec.
+  End FieldOperations.
+End F.
 
+Notation F := F.F.
 Delimit Scope F_scope with F.
-Arguments F _%Z.
-Arguments ZToField _%Z _%Z : simpl never, clear implicits.
-Arguments add {_} _%F _%F : simpl never.
-Arguments mul {_} _%F _%F : simpl never.
-Arguments sub {_} _%F _%F : simpl never.
-Arguments div {_} _%F _%F : simpl never.
-Arguments pow {_} _%F _%N : simpl never.
-Arguments inv {_} _%F : simpl never.
-Arguments opp {_} _%F : simpl never.
-Infix "+" := add : F_scope.
-Infix "*" := mul : F_scope.
-Infix "-" := sub : F_scope.
-Infix "/" := div : F_scope.
-Infix "^" := pow : F_scope.
-Notation "0" := (ZToField _ 0) : F_scope.
-Notation "1" := (ZToField _ 1) : F_scope.
+Bind Scope F_scope with F.F.
+Infix "+" := F.add : F_scope.
+Infix "*" := F.mul : F_scope.
+Infix "-" := F.sub : F_scope.
+Infix "/" := F.div : F_scope.
+Infix "^" := F.pow : F_scope.
+Notation "0" := (F.of_Z _ 0) : F_scope.
+Notation "1" := (F.of_Z _ 1) : F_scope.

--- a/src/Spec/ModularWordEncoding.v
+++ b/src/Spec/ModularWordEncoding.v
@@ -13,12 +13,12 @@ Local Open Scope nat_scope.
 Section ModularWordEncoding.
   Context {m : Z} {sz : nat} {m_pos : (0 < m)%Z} {bound_check : Z.to_nat m < 2 ^ sz}.
 
-  Definition Fm_enc (x : F m) : word sz := NToWord sz (Z.to_N (FieldToZ x)).
+  Definition Fm_enc (x : F m) : word sz := NToWord sz (Z.to_N (F.to_Z x)).
 
   Definition Fm_dec (x_ : word sz) : option (F m) :=
     let z := Z.of_N (wordToN (x_)) in
     if Z_lt_dec z m
-      then Some (ZToField m z)
+      then Some (F.of_Z m z)
       else None
   .
 

--- a/src/Spec/ModularWordEncoding.v
+++ b/src/Spec/ModularWordEncoding.v
@@ -18,7 +18,7 @@ Section ModularWordEncoding.
   Definition Fm_dec (x_ : word sz) : option (F m) :=
     let z := Z.of_N (wordToN (x_)) in
     if Z_lt_dec z m
-      then Some (ZToField z)
+      then Some (ZToField m z)
       else None
   .
 

--- a/src/Spec/WeierstrassCurve.v
+++ b/src/Spec/WeierstrassCurve.v
@@ -11,8 +11,8 @@ Module E.
 
     Context {F Feq Fzero Fone Fopp Fadd Fsub Fmul Finv Fdiv} `{Algebra.field F Feq Fzero Fone Fopp Fadd Fsub Fmul Finv Fdiv}.
     Local Infix "=" := Feq : type_scope. Local Notation "a <> b" := (not (a = b)) : type_scope.
-    Local Infix "=?" := Algebra.eq_dec (at level 70, no associativity) : type_scope.
-    Local Notation "x =? y" := (Sumbool.bool_of_sumbool (Algebra.eq_dec x y)) : bool_scope.
+    Local Notation "x =? y" := (Decidable.dec (Feq x y)) (at level 70, no associativity) : type_scope.
+    Local Notation "x =? y" := (Sumbool.bool_of_sumbool (Decidable.dec (Feq x y))) : bool_scope.
     Local Infix "+" := Fadd. Local Infix "*" := Fmul.
     Local Infix "-" := Fsub. Local Infix "/" := Fdiv.
     Local Notation "- x" := (Fopp x).

--- a/src/Specific/GF1305.v
+++ b/src/Specific/GF1305.v
@@ -11,6 +11,7 @@ Require Import Crypto.Tactics.VerdiTactics.
 Require Import Crypto.Util.ZUtil.
 Require Import Crypto.Util.Tuple.
 Require Import Crypto.Util.Notations.
+Require Import Crypto.Util.Decidable.
 Require Import Crypto.Algebra.
 Import ListNotations.
 Require Import Coq.ZArith.ZArith Coq.ZArith.Zpower Coq.ZArith.ZArith Coq.ZArith.Znumtheory.
@@ -35,8 +36,7 @@ Definition mul2modulus : fe1305 :=
 
 Instance subCoeff : SubtractionCoefficient modulus params1305.
   apply Build_SubtractionCoefficient with (coeff := mul2modulus).
-  apply ZToField_eqmod.
-  cbv; reflexivity.
+  vm_decide.
 Defined.
 
 Definition freezePreconditions1305 : freezePreconditions params1305 int_width.

--- a/src/Specific/GF25519.v
+++ b/src/Specific/GF25519.v
@@ -11,6 +11,7 @@ Require Import Crypto.Tactics.VerdiTactics.
 Require Import Crypto.Util.ZUtil.
 Require Import Crypto.Util.Tuple.
 Require Import Crypto.Util.Notations.
+Require Import Crypto.Util.Decidable.
 Require Import Crypto.Algebra.
 Import ListNotations.
 Require Import Coq.ZArith.ZArith Coq.ZArith.Zpower Coq.ZArith.ZArith Coq.ZArith.Znumtheory.
@@ -33,8 +34,7 @@ Definition mul2modulus : fe25519 :=
 
 Instance subCoeff : SubtractionCoefficient modulus params25519.
   apply Build_SubtractionCoefficient with (coeff := mul2modulus).
-  apply ZToField_eqmod.
-  cbv; reflexivity.
+  vm_decide.
 Defined.
 
 Definition freezePreconditions25519 : freezePreconditions params25519 int_width.

--- a/src/Util/Decidable.v
+++ b/src/Util/Decidable.v
@@ -4,10 +4,13 @@ Require Import Coq.Logic.Eqdep_dec.
 Require Import Crypto.Util.Sigma.
 Require Import Crypto.Util.HProp.
 Require Import Crypto.Util.Equality.
+Require Import Coq.ZArith.BinInt.
+Require Import Coq.NArith.BinNat.
 
 Local Open Scope type_scope.
 
 Class Decidable (P : Prop) := dec : {P} + {~P}.
+Arguments dec _%type_scope {_}.
 
 Notation DecidableRel R := (forall x y, Decidable (R x y)).
 
@@ -86,11 +89,13 @@ Hint Extern 0 (Decidable (~?A)) => apply (@dec_not A) : typeclass_instances.
 Global Instance dec_eq_unit : DecidableRel (@eq unit) | 10. exact _. Defined.
 Global Instance dec_eq_bool : DecidableRel (@eq bool) | 10. exact _. Defined.
 Global Instance dec_eq_Empty_set : DecidableRel (@eq Empty_set) | 10. exact _. Defined.
-Global Instance dec_eq_nat : DecidableRel (@eq nat) | 10. exact _. Defined.
 Global Instance dec_eq_prod {A B} `{DecidableRel (@eq A), DecidableRel (@eq B)} : DecidableRel (@eq (A * B)) | 10. exact _. Defined.
 Global Instance dec_eq_sum {A B} `{DecidableRel (@eq A), DecidableRel (@eq B)} : DecidableRel (@eq (A + B)) | 10. exact _. Defined.
 Global Instance dec_eq_sigT_hprop {A P} `{DecidableRel (@eq A), forall a : A, IsHProp (P a)} : DecidableRel (@eq (@sigT A P)) | 10. exact _. Defined.
 Global Instance dec_eq_sig_hprop {A} {P : A -> Prop} `{DecidableRel (@eq A), forall a : A, IsHProp (P a)} : DecidableRel (@eq (@sig A P)) | 10. exact _. Defined.
+Global Instance dec_eq_nat : DecidableRel (@eq nat) | 10. exact _. Defined.
+Global Instance dec_eq_N : DecidableRel (@eq N) | 10 := N.eq_dec.
+Global Instance dec_eq_Z : DecidableRel (@eq Z) | 10 := Z.eq_dec.
 
 Lemma Decidable_respects_iff A B (H : A <-> B) : (Decidable A -> Decidable B) * (Decidable B -> Decidable A).
 Proof. solve_decidable_transparent. Defined.
@@ -100,6 +105,15 @@ Proof. solve_decidable_transparent. Defined.
 
 Lemma Decidable_iff_to_flip_impl A B (H : A <-> B) : Decidable B -> Decidable A.
 Proof. solve_decidable_transparent. Defined.
+
+Lemma dec_bool : forall {P} {Pdec:Decidable P}, (if dec P then true else false) = true -> P.
+Proof. intros. destruct dec; solve [ auto | discriminate ]. Qed.
+
+Ltac vm_decide := apply dec_bool; vm_compute; reflexivity.
+Ltac lazy_decide := apply dec_bool; lazy; reflexivity.
+
+Ltac vm_decide_no_check := apply dec_bool; vm_cast_no_check (eq_refl true).
+Ltac lazy_decide_no_check := apply dec_bool; exact_no_check (eq_refl true).
 
 (** For dubious compatibility with [eauto using]. *)
 Hint Extern 2 (Decidable _) => progress unfold Decidable : typeclass_instances core.

--- a/src/Util/Decidable.v
+++ b/src/Util/Decidable.v
@@ -1,6 +1,7 @@
 (** Typeclass for decidable propositions *)
 
 Require Import Coq.Logic.Eqdep_dec.
+Require Import Crypto.Util.FixCoqMistakes.
 Require Import Crypto.Util.Sigma.
 Require Import Crypto.Util.HProp.
 Require Import Crypto.Util.Equality.
@@ -96,6 +97,15 @@ Global Instance dec_eq_sig_hprop {A} {P : A -> Prop} `{DecidableRel (@eq A), for
 Global Instance dec_eq_nat : DecidableRel (@eq nat) | 10. exact _. Defined.
 Global Instance dec_eq_N : DecidableRel (@eq N) | 10 := N.eq_dec.
 Global Instance dec_eq_Z : DecidableRel (@eq Z) | 10 := Z.eq_dec.
+
+Lemma not_not P {d:Decidable P} : not (not P) <-> P.
+Proof. destruct (dec P); intuition. Qed.
+  
+Global Instance dec_ex_forall_not T (P:T->Prop) {d:Decidable (exists b, P b)} : Decidable (forall b, ~ P b).
+Proof.
+  destruct (dec (~ exists b, P b)) as [Hd|Hd]; [left|right];
+    [abstract eauto | abstract (rewrite not_not in Hd by eauto; destruct Hd; eauto) ].
+Defined.
 
 Lemma eqsig_eq {T} {U} {Udec:DecidableRel (@eq U)} (f g:T->U) (x x':T) pf pf' :
   (exist (fun x => f x = g x) x pf) = (exist (fun x => f x = g x) x' pf') <-> (x = x').

--- a/src/Util/Decidable.v
+++ b/src/Util/Decidable.v
@@ -97,6 +97,10 @@ Global Instance dec_eq_nat : DecidableRel (@eq nat) | 10. exact _. Defined.
 Global Instance dec_eq_N : DecidableRel (@eq N) | 10 := N.eq_dec.
 Global Instance dec_eq_Z : DecidableRel (@eq Z) | 10 := Z.eq_dec.
 
+Lemma eqsig_eq {T} {U} {Udec:DecidableRel (@eq U)} (f g:T->U) (x x':T) pf pf' :
+  (exist (fun x => f x = g x) x pf) = (exist (fun x => f x = g x) x' pf') <-> (x = x').
+Proof. apply path_sig_hprop_iff; auto using UIP_dec, Udec. Qed.
+
 Lemma Decidable_respects_iff A B (H : A <-> B) : (Decidable A -> Decidable B) * (Decidable B -> Decidable A).
 Proof. solve_decidable_transparent. Defined.
 

--- a/src/Util/Equality.v
+++ b/src/Util/Equality.v
@@ -73,7 +73,7 @@ Section gen.
   Proof.
     destruct H.
     unfold decode.
-    edestruct (@decode' x _).
+    edestruct (decode' (encode x eq_refl)).
     reflexivity.
   Defined.
 

--- a/src/Util/NumTheoryUtil.v
+++ b/src/Util/NumTheoryUtil.v
@@ -95,13 +95,13 @@ Proof.
   apply in_mod_ZPGroup; auto.
 Qed.
 
-Lemma fermat_inv : forall a, a mod p <> 0 -> (a * (a^(p-2) mod p)) mod p = 1.
+Lemma fermat_inv : forall a, a mod p <> 0 -> ((a^(p-2) mod p) * a) mod p = 1.
 Proof.
   intros.
   pose proof (prime_ge_2 _ prime_p).
-  rewrite Zmult_mod_idemp_r.
-  replace (a * a ^ (p - 2)) with (a^(p-1)).
-    2:replace (a * a ^ (p - 2)) with (a^1 * a ^ (p - 2)) by ring.
+  rewrite Zmult_mod_idemp_l.
+  replace (a ^ (p - 2) * a) with (a^(p-1)).
+    2:replace (a ^ (p - 2) * a) with (a^1 * a ^ (p - 2)) by ring.
     2:rewrite <-Zpower_exp; try f_equal; omega.
   auto using fermat_little.
 Qed.

--- a/src/Util/NumTheoryUtil.v
+++ b/src/Util/NumTheoryUtil.v
@@ -298,3 +298,10 @@ Proof.
   + prime_bound.
   + apply minus1_even_pow; [apply divide2_1mod4 | | apply Z_div_pos]; prime_bound.
 Qed.
+
+
+Lemma odd_as_div a : Z.odd a = true -> a = (2*(a/2) + 1)%Z.
+Proof.
+  rewrite Zodd_mod, <-Zeq_is_eq_bool; intro H_1; rewrite <-H_1.
+  apply Z_div_mod_eq; reflexivity.
+Qed.

--- a/src/WeierstrassCurve/Pre.v
+++ b/src/WeierstrassCurve/Pre.v
@@ -2,6 +2,7 @@ Require Import Coq.Classes.Morphisms. Require Coq.Setoids.Setoid.
 Require Import Crypto.Algebra.
 Require Import Crypto.Util.Tactics.
 Require Import Crypto.Util.Notations.
+Require Import Crypto.Util.Decidable.
 
 Local Open Scope core_scope.
 
@@ -34,8 +35,8 @@ Section Pre.
   Definition unifiedAdd' (P1' P2':F*F + ∞) : F*F + ∞ :=
     match P1', P2' with
     | (x1, y1), (x2, y2)
-      => if x1 =? x2 then
-           if y2 =? -y1 then
+      => if dec (x1 = x2) then
+           if dec (y2 = -y1) then
              ∞
            else ((3*x1^2+a)^2 / (2*y1)^2 - x1 - x1,
                    (2*x1+x1)*(3*x1^2+a) / (2*y1) - (3*x1^2+a)^3/(2*y1)^3-y1)


### PR DESCRIPTION
ModularArithmetic now uses Algebra lemmas in various places instead of
custom manual proofs. Similarly, Util.Decidable is used to state and
prove the relevant decidability results.

Backwards-incompatible changes:

F_some_lemma -> Zmod.some_lemma
Arguments ZToField _%Z _%Z : clear implicits.
inv_spec says inv x * x = 1, not x * inv x = 1