### PR TITLE
Define Montgomery reduction / multiplication on Z

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -52,6 +52,7 @@ src/ModularArithmetic/PseudoMersenneBaseParams.v
 src/ModularArithmetic/Tutorial.v
 src/ModularArithmetic/BarrettReduction/Z.v
 src/ModularArithmetic/Montgomery/Z.v
+src/ModularArithmetic/Montgomery/ZProofs.v
 src/Spec/CompleteEdwardsCurve.v
 src/Spec/EdDSA.v
 src/Spec/Encoding.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -51,6 +51,7 @@ src/ModularArithmetic/PseudoMersenneBaseParamProofs.v
 src/ModularArithmetic/PseudoMersenneBaseParams.v
 src/ModularArithmetic/Tutorial.v
 src/ModularArithmetic/BarrettReduction/Z.v
+src/ModularArithmetic/Montgomery/Z.v
 src/Spec/CompleteEdwardsCurve.v
 src/Spec/EdDSA.v
 src/Spec/Encoding.v

--- a/src/ModularArithmetic/Montgomery/Z.v
+++ b/src/ModularArithmetic/Montgomery/Z.v
@@ -1,0 +1,275 @@
+(*** Montgomery Multiplication *)
+(** This file implements Montgomery Form, Montgomery Reduction, and
+    Montgomery Multiplication on [Z].  We follow Wikipedia. *)
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Structures.Equalities.
+Require Import Crypto.Util.ZUtil Crypto.Util.Tactics.
+Require Import Crypto.Util.Notations.
+
+Declare Module Nop : Nop.
+Module Import ImportEquivModuloInstances := Z.EquivModuloInstances Nop.
+
+Local Existing Instance eq_Reflexive. (* speed up setoid_rewrite as per https://coq.inria.fr/bugs/show_bug.cgi?id=4978 *)
+
+Local Open Scope Z_scope.
+Delimit Scope montgomery_naive_scope with montgomery_naive.
+Delimit Scope montgomery_scope with montgomery.
+Definition montgomeryZ := Z.
+Bind Scope montgomery_scope with montgomeryZ.
+
+Section montgomery.
+  Context (N : Z)
+          (N_reasonable : N <> 0)
+          (R : Z)
+          (R_good : Z.gcd N R = 1).
+  Local Notation "x ≡ y" := (Z.equiv_modulo N x y) : type_scope.
+  Local Notation "x ≡ᵣ y" := (Z.equiv_modulo R x y) : type_scope.
+  Context (R' : Z)
+          (R'_good : R * R' ≡ 1).
+  (** Quoting Wikipedia <https://en.wikipedia.org/wiki/Montgomery_modular_multiplication>: *)
+  (** In modular arithmetic computation, Montgomery modular
+      multiplication, more commonly referred to as Montgomery
+      multiplication, is a method for performing fast modular
+      multiplication, introduced in 1985 by the American mathematician
+      Peter L. Montgomery. *)
+  (** Given two integers [a] and [b], the classical modular
+      multiplication algorithm computes [ab mod N]. Montgomery
+      multiplication works by transforming [a] and [b] into a special
+      representation known as Montgomery form. For a modulus [N], the
+      Montgomery form of [a] is defined to be [aR mod N] for some
+      constant [R] depending only on [N] and the underlying computer
+      architecture. If [aR mod N] and [bR mod N] are the Montgomery
+      forms of [a] and [b], then their Montgomery product is [abR mod
+      N]. Montgomery multiplication is a fast algorithm to compute the
+      Montgomery product. Transforming the result out of Montgomery
+      form yields the classical modular product [ab mod N]. *)
+
+  Lemma R'_good' : R' * R ≡ 1.
+  Proof. rewrite <- R'_good; apply f_equal2; lia. Qed.
+
+  Definition to_montgomery_naive (x : Z) : montgomeryZ := x * R.
+  Definition from_montgomery_naive (x : montgomeryZ) : Z := x * R'.
+  Lemma to_from_montgomery_naive x : to_montgomery_naive (from_montgomery_naive x) ≡ x.
+  Proof.
+    unfold to_montgomery_naive, from_montgomery_naive.
+    rewrite <- Z.mul_assoc, R'_good'.
+    autorewrite with zsimplify; reflexivity.
+  Qed.
+  Lemma from_to_montgomery_naive x : from_montgomery_naive (to_montgomery_naive x) ≡ x.
+  Proof.
+    unfold to_montgomery_naive, from_montgomery_naive.
+    rewrite <- Z.mul_assoc, R'_good.
+    autorewrite with zsimplify; reflexivity.
+  Qed.
+
+  (** * Modular arithmetic and Montgomery form *)
+  Section general.
+    (** Addition and subtraction in Montgomery form are the same as
+        ordinary modular addition and subtraction because of the
+        distributive law: *)
+    (** [aR + bR = (a+b)R], *)
+    (** [aR - bR = (a-b)R]. *)
+    (** This is a consequence of the fact that, because [gcd(R, N) =
+        1], multiplication by [R] is an isomorphism on the additive
+        group [ℤ/Nℤ]. *)
+
+    Definition add : montgomeryZ -> montgomeryZ -> montgomeryZ := fun aR bR => aR + bR.
+    Definition sub : montgomeryZ -> montgomeryZ -> montgomeryZ := fun aR bR => aR - bR.
+    Local Infix "+" := add : montgomery_scope.
+    Local Infix "-" := sub : montgomery_scope.
+
+    Lemma add_correct_naive x y : from_montgomery_naive (x + y) = from_montgomery_naive x + from_montgomery_naive y.
+    Proof. unfold from_montgomery_naive, add; lia. Qed.
+    Lemma add_correct_naive_to x y : to_montgomery_naive (x + y) = (to_montgomery_naive x + to_montgomery_naive y)%montgomery.
+    Proof. unfold to_montgomery_naive, add; lia. Qed.
+    Lemma sub_correct_naive x y : from_montgomery_naive (x - y) = from_montgomery_naive x - from_montgomery_naive y.
+    Proof. unfold from_montgomery_naive, sub; lia. Qed.
+    Lemma sub_correct_naive_to x y : to_montgomery_naive (x - y) = (to_montgomery_naive x - to_montgomery_naive y)%montgomery.
+    Proof. unfold to_montgomery_naive, sub; lia. Qed.
+
+    (** Multiplication in Montgomery form, however, is seemingly more
+        complicated. The usual product of [aR] and [bR] does not
+        represent the product of [a] and [b] because it has an extra
+        factor of R: *)
+    (** [(aR mod N)(bR mod N) mod N = (abR)R mod N]. *)
+    (** Computing products in Montgomery form requires removing the
+        extra factor of [R]. While division by [R] is cheap, the
+        intermediate product [(aR mod N)(bR mod N)] is not divisible
+        by [R] because the modulo operation has destroyed that
+        property. *)
+    (** Removing the extra factor of R can be done by multiplying by
+        an integer [R′] such that [RR' ≡ 1 (mod N)], that is, by an
+        [R′] whose residue class is the modular inverse of [R] mod
+        [N]. Then, working modulo [N], *)
+    (** [(aR mod N)(bR mod N)R' ≡ (aR)(bR)R⁻¹ ≡ (ab)R  (mod N)]. *)
+
+    Definition mul_naive : montgomeryZ -> montgomeryZ -> montgomeryZ
+      := fun aR bR => aR * bR * R'.
+    Local Infix "*" := mul_naive : montgomery_scope.
+
+    Theorem mul_correct_naive x y : from_montgomery_naive (x * y) = from_montgomery_naive x * from_montgomery_naive y.
+    Proof. unfold from_montgomery_naive, mul_naive; lia. Qed.
+    Theorem mul_correct_naive_to x y : to_montgomery_naive (x * y) ≡ (to_montgomery_naive x * to_montgomery_naive y)%montgomery.
+    Proof.
+      unfold to_montgomery_naive, mul_naive.
+      rewrite <- !Z.mul_assoc, R'_good.
+      autorewrite with zsimplify; apply (f_equal2 Z.modulo); lia.
+    Qed.
+  End general.
+
+  (** * The REDC algorithm *)
+  Section redc.
+    (** While the above algorithm is correct, it is slower than
+        multiplication in the standard representation because of the
+        need to multiply by [R′] and divide by [N]. Montgomery
+        reduction, also known as REDC, is an algorithm that
+        simultaneously computes the product by [R′] and reduces modulo
+        [N] more quickly than the naive method. The speed is because
+        all computations are done using only reduction and divisions
+        with respect to [R], not [N]: *)
+    (**
+<<
+function REDC is
+    input: Integers R and N with gcd(R, N) = 1,
+           Integer N′ in [0, R − 1] such that NN′ ≡ −1 mod R,
+           Integer T in the range [0, RN − 1]
+    output: Integer S in the range [0, N − 1] such that S ≡ TR⁻¹ mod N
+
+    m ← ((T mod R)N′) mod R
+    t ← (T + mN) / R
+    if t ≥ N then
+        return t − N
+    else
+        return t
+    end if
+end function
+>> *)
+    Context (N' : Z)
+            (N'_in_range : 0 <= N' < R)
+            (N'_good : N * N' ≡ᵣ -1).
+    Section redc.
+      Context (T : Z)
+              (T_in_range : 0 <= T < R * N).
+
+      Lemma N'_good' : N' * N ≡ᵣ -1.
+      Proof. rewrite <- N'_good; apply f_equal2; lia. Qed.
+
+      Let m := ((T mod R) * N') mod R.
+      Let t := (T + m * N) / R.
+      Definition reduce : montgomeryZ
+        := if N <=? t then
+             t - N
+           else
+             t.
+
+      Lemma N'_good'_alt x : (((x mod R) * (N' mod R)) mod R) * (N mod R) ≡ᵣ x * -1.
+      Proof.
+        rewrite <- N'_good', Z.mul_assoc.
+        unfold Z.equiv_modulo; push_Zmod.
+        reflexivity.
+      Qed.
+
+      Lemma reduce_correct_helper : t ≡ T * R'.
+      Proof.
+        transitivity ((T + m * N) * R').
+        { subst t m.
+          autorewrite with zstrip_div; push_Zmod.
+          rewrite N'_good'_alt.
+          autorewrite with zsimplify pull_Zmod.
+          reflexivity. }
+        unfold Z.equiv_modulo; push_Zmod; autorewrite with zsimplify; reflexivity.
+      Qed.
+
+      Lemma reduce_correct : reduce ≡ T * R'.
+      Proof.
+        unfold reduce.
+        break_match; rewrite reduce_correct_helper; unfold Z.equiv_modulo;
+          autorewrite with push_Zmod zsimplify; reflexivity.
+      Qed.
+
+      Lemma reduce_in_range : 0 <= reduce < N.
+      Proof.
+        assert (0 <= m < R) by (subst m; auto with zarith).
+        assert (0 <= T + m * N < 2 * R * N) by nia.
+        assert (0 <= t < 2 * N) by (subst t; auto with zarith lia).
+        unfold reduce; break_match; Z.ltb_to_lt; nia.
+      Qed.
+    End redc.
+
+    (** * Arithmetic in Montgomery form *)
+    Section arithmetic.
+      (** Many operations of interest modulo [N] can be expressed
+          equally well in Montgomery form. Addition, subtraction,
+          negation, comparison for equality, multiplication by an
+          integer not in Montgomery form, and greatest common divisors
+          with [N] may all be done with the standard algorithms. *)
+      (** When [R > N], most other arithmetic operations can be
+          expressed in terms of REDC. This assumption implies that the
+          product of two representatives [mod N] is less than [RN],
+          the exact hypothesis necessary for REDC to generate correct
+          output. In particular, the product of [aR mod N] and [bR mod
+          N] is [REDC((aR mod N)(bR mod N))]. The combined operation
+          of multiplication and REDC is often called Montgomery
+          multiplication. *)
+      Definition mul : montgomeryZ -> montgomeryZ -> montgomeryZ
+        := fun aR bR => reduce (aR * bR).
+      Local Infix "*" := mul : montgomery_scope.
+
+      (** Conversion into Montgomery form is done by computing
+          [REDC((a mod N)(R² mod N))]. Conversion out of Montgomery
+          form is done by computing [REDC(aR mod N)]. The modular
+          inverse of [aR mod N] is [REDC((aR mod N)⁻¹(R³ mod
+          N))]. Modular exponentiation can be done using
+          exponentiation by squaring by initializing the initial
+          product to the Montgomery representation of 1, that is, to
+          [R mod N], and by replacing the multiply and square steps by
+          Montgomery multiplies. *)
+      Definition to_montgomery (a : Z) : montgomeryZ := reduce (a * (R*R mod N)).
+      Definition from_montgomery (aR : montgomeryZ) : Z := reduce aR.
+      Lemma to_from_montgomery a : to_montgomery (from_montgomery a) ≡ a.
+      Proof.
+        unfold to_montgomery, from_montgomery.
+        transitivity ((a * 1) * 1); [ | apply f_equal2; lia ].
+        rewrite <- !R'_good, !reduce_correct.
+        unfold Z.equiv_modulo; push_Zmod; pull_Zmod.
+        apply f_equal2; lia.
+      Qed.
+      Lemma from_to_montgomery a : from_montgomery (to_montgomery a) ≡ a.
+      Proof.
+        unfold to_montgomery, from_montgomery.
+        rewrite !reduce_correct.
+        transitivity (a * ((R * (R * R' mod N) * R') mod N)).
+        { unfold Z.equiv_modulo; push_Zmod; pull_Zmod.
+          apply f_equal2; lia. }
+        { repeat first [ rewrite R'_good
+                       | reflexivity
+                       | push_Zmod; pull_Zmod; progress autorewrite with zsimplify
+                       | progress unfold Z.equiv_modulo ]. }
+      Qed.
+
+      Theorem mul_correct x y : from_montgomery (x * y) ≡ from_montgomery x * from_montgomery y.
+      Proof.
+        unfold from_montgomery, mul.
+        rewrite !reduce_correct; apply f_equal2; lia.
+      Qed.
+      Theorem mul_correct_to x y : to_montgomery (x * y) ≡ (to_montgomery x * to_montgomery y)%montgomery.
+      Proof.
+        unfold to_montgomery, mul.
+        rewrite !reduce_correct.
+        transitivity (x * y * R * 1 * 1 * 1);
+          [ rewrite <- R'_good at 1
+          | rewrite <- R'_good at 1 2 3 ];
+          autorewrite with zsimplify;
+          unfold Z.equiv_modulo; push_Zmod; pull_Zmod.
+        { apply f_equal2; lia. }
+        { apply f_equal2; lia. }
+      Qed.
+    End arithmetic.
+  End redc.
+End montgomery.
+
+Infix "+" := add : montgomery_scope.
+Infix "-" := sub : montgomery_scope.
+Infix "*" := mul_naive : montgomery_naive_scope.
+Infix "*" := mul : montgomery_scope.
+
+Module Import LocalizeEquivModuloInstances := Z.RemoveEquivModuloInstances Nop.

--- a/src/ModularArithmetic/Montgomery/Z.v
+++ b/src/ModularArithmetic/Montgomery/Z.v
@@ -80,11 +80,11 @@ Section montgomery.
     Lemma add_correct_naive x y : from_montgomery_naive (x + y) = from_montgomery_naive x + from_montgomery_naive y.
     Proof. unfold from_montgomery_naive, add; lia. Qed.
     Lemma add_correct_naive_to x y : to_montgomery_naive (x + y) = (to_montgomery_naive x + to_montgomery_naive y)%montgomery.
-    Proof. unfold to_montgomery_naive, add; lia. Qed.
+    Proof. unfold to_montgomery_naive, add; autorewrite with push_Zmul; reflexivity. Qed.
     Lemma sub_correct_naive x y : from_montgomery_naive (x - y) = from_montgomery_naive x - from_montgomery_naive y.
     Proof. unfold from_montgomery_naive, sub; lia. Qed.
     Lemma sub_correct_naive_to x y : to_montgomery_naive (x - y) = (to_montgomery_naive x - to_montgomery_naive y)%montgomery.
-    Proof. unfold to_montgomery_naive, sub; lia. Qed.
+    Proof. unfold to_montgomery_naive, sub; autorewrite with push_Zmul; reflexivity. Qed.
 
     (** Multiplication in Montgomery form, however, is seemingly more
         complicated. The usual product of [aR] and [bR] does not

--- a/src/ModularArithmetic/Montgomery/Z.v
+++ b/src/ModularArithmetic/Montgomery/Z.v
@@ -147,8 +147,7 @@ end function
             (N'_in_range : 0 <= N' < R)
             (N'_good : N * N' ≡ᵣ -1).
     Section redc.
-      Context (T : Z)
-              (T_in_range : 0 <= T < R * N).
+      Context (T : Z).
 
       Lemma N'_good' : N' * N ≡ᵣ -1.
       Proof. rewrite <- N'_good; apply f_equal2; lia. Qed.
@@ -186,8 +185,9 @@ end function
           autorewrite with push_Zmod zsimplify; reflexivity.
       Qed.
 
-      Lemma reduce_in_range : 0 <= reduce < N.
+      Lemma reduce_in_range : 0 <= T < R * N -> 0 <= reduce < N.
       Proof.
+        intro.
         assert (0 <= m < R) by (subst m; auto with zarith).
         assert (0 <= T + m * N < 2 * R * N) by nia.
         assert (0 <= t < 2 * N) by (subst t; auto with zarith lia).

--- a/src/ModularArithmetic/Montgomery/ZProofs.v
+++ b/src/ModularArithmetic/Montgomery/ZProofs.v
@@ -1,0 +1,250 @@
+(*** Montgomery Multiplication *)
+(** This file implements the proofs for Montgomery Form, Montgomery
+    Reduction, and Montgomery Multiplication on [Z].  We follow
+    Wikipedia. *)
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Structures.Equalities.
+Require Import Crypto.ModularArithmetic.Montgomery.Z.
+Require Import Crypto.Util.ZUtil Crypto.Util.Tactics.
+Require Import Crypto.Util.Notations.
+
+Declare Module Nop : Nop.
+Module Import ImportEquivModuloInstances := Z.EquivModuloInstances Nop.
+
+Local Existing Instance eq_Reflexive. (* speed up setoid_rewrite as per https://coq.inria.fr/bugs/show_bug.cgi?id=4978 *)
+
+Local Open Scope Z_scope.
+
+Section montgomery.
+  Context (N : Z)
+          (N_reasonable : N <> 0)
+          (R : Z)
+          (R_good : Z.gcd N R = 1).
+  Local Notation "x ≡ y" := (Z.equiv_modulo N x y) : type_scope.
+  Local Notation "x ≡ᵣ y" := (Z.equiv_modulo R x y) : type_scope.
+  Context (R' : Z)
+          (R'_good : R * R' ≡ 1).
+
+  Lemma R'_good' : R' * R ≡ 1.
+  Proof. rewrite <- R'_good; apply f_equal2; lia. Qed.
+
+  Local Notation to_montgomery_naive := (to_montgomery_naive R) (only parsing).
+  Local Notation from_montgomery_naive := (from_montgomery_naive R') (only parsing).
+
+  Lemma to_from_montgomery_naive x : to_montgomery_naive (from_montgomery_naive x) ≡ x.
+  Proof.
+    unfold Z.to_montgomery_naive, Z.from_montgomery_naive.
+    rewrite <- Z.mul_assoc, R'_good'.
+    autorewrite with zsimplify; reflexivity.
+  Qed.
+  Lemma from_to_montgomery_naive x : from_montgomery_naive (to_montgomery_naive x) ≡ x.
+  Proof.
+    unfold Z.to_montgomery_naive, Z.from_montgomery_naive.
+    rewrite <- Z.mul_assoc, R'_good.
+    autorewrite with zsimplify; reflexivity.
+  Qed.
+
+  (** * Modular arithmetic and Montgomery form *)
+  Section general.
+    Local Infix "+" := add : montgomery_scope.
+    Local Infix "-" := sub : montgomery_scope.
+    Local Infix "*" := (mul_naive R') : montgomery_scope.
+
+    Lemma add_correct_naive x y : from_montgomery_naive (x + y) = from_montgomery_naive x + from_montgomery_naive y.
+    Proof. unfold Z.from_montgomery_naive, add; lia. Qed.
+    Lemma add_correct_naive_to x y : to_montgomery_naive (x + y) = (to_montgomery_naive x + to_montgomery_naive y)%montgomery.
+    Proof. unfold Z.to_montgomery_naive, add; autorewrite with push_Zmul; reflexivity. Qed.
+    Lemma sub_correct_naive x y : from_montgomery_naive (x - y) = from_montgomery_naive x - from_montgomery_naive y.
+    Proof. unfold Z.from_montgomery_naive, sub; lia. Qed.
+    Lemma sub_correct_naive_to x y : to_montgomery_naive (x - y) = (to_montgomery_naive x - to_montgomery_naive y)%montgomery.
+    Proof. unfold Z.to_montgomery_naive, sub; autorewrite with push_Zmul; reflexivity. Qed.
+
+    Theorem mul_correct_naive x y : from_montgomery_naive (x * y) = from_montgomery_naive x * from_montgomery_naive y.
+    Proof. unfold from_montgomery_naive, mul_naive; lia. Qed.
+    Theorem mul_correct_naive_to x y : to_montgomery_naive (x * y) ≡ (to_montgomery_naive x * to_montgomery_naive y)%montgomery.
+    Proof.
+      unfold Z.to_montgomery_naive, mul_naive.
+      rewrite <- !Z.mul_assoc, R'_good.
+      autorewrite with zsimplify; apply (f_equal2 Z.modulo); lia.
+    Qed.
+  End general.
+
+  (** * The REDC algorithm *)
+  Section redc.
+    Context (N' : Z)
+            (N'_in_range : 0 <= N' < R)
+            (N'_good : N * N' ≡ᵣ -1).
+
+    Lemma N'_good' : N' * N ≡ᵣ -1.
+    Proof. rewrite <- N'_good; apply f_equal2; lia. Qed.
+
+    Lemma N'_good'_alt x : (((x mod R) * (N' mod R)) mod R) * (N mod R) ≡ᵣ x * -1.
+    Proof.
+      rewrite <- N'_good', Z.mul_assoc.
+      unfold Z.equiv_modulo; push_Zmod.
+      reflexivity.
+    Qed.
+
+    Section redc.
+      Context (T : Z).
+
+      Local Notation m := (((T mod R) * N') mod R).
+      Local Notation prereduce := (prereduce N R N').
+
+      Local Ltac t_fin_correct :=
+        unfold Z.equiv_modulo; push_Zmod; autorewrite with zsimplify; reflexivity.
+
+      Lemma prereduce_correct : prereduce T ≡ T * R'.
+      Proof.
+        transitivity ((T + m * N) * R').
+        { unfold Z.prereduce.
+          autorewrite with zstrip_div; push_Zmod.
+          rewrite N'_good'_alt.
+          autorewrite with zsimplify pull_Zmod.
+          reflexivity. }
+        t_fin_correct.
+      Qed.
+
+      Lemma reduce_correct : reduce N R N' T ≡ T * R'.
+      Proof.
+        unfold reduce.
+        break_match; rewrite prereduce_correct; t_fin_correct.
+      Qed.
+
+      Lemma partial_reduce_correct : partial_reduce N R N' T ≡ T * R'.
+      Proof.
+        unfold partial_reduce.
+        break_match; rewrite prereduce_correct; t_fin_correct.
+      Qed.
+
+      Let m_small : 0 <= m < R. Proof. auto with zarith. Qed.
+
+      Section generic.
+        Lemma prereduce_in_range_gen B
+        : 0 <= N
+          -> 0 <= T <= R * B
+          -> 0 <= prereduce T < B + N.
+        Proof. unfold Z.prereduce; auto with zarith nia. Qed.
+      End generic.
+
+      Section N_very_small.
+        Context (N_very_small : 0 <= 4 * N < R).
+
+        Lemma prereduce_in_range_very_small
+          : 0 <= T <= (2 * N - 1) * (2 * N - 1)
+            -> 0 <= prereduce T < 2 * N.
+        Proof. pose proof (prereduce_in_range_gen N); nia. Qed.
+      End N_very_small.
+
+      Section N_small.
+        Context (N_small : 0 <= 2 * N < R).
+
+        Lemma prereduce_in_range_small
+          : 0 <= T <= (2 * N - 1) * (N - 1)
+            -> 0 <= prereduce T < 2 * N.
+        Proof. pose proof (prereduce_in_range_gen N); nia. Qed.
+
+        Lemma prereduce_in_range_small_fully_reduced
+          : 0 <= T <= 2 * N
+            -> 0 <= prereduce T <= N.
+        Proof. pose proof (prereduce_in_range_gen 1); nia. Qed.
+      End N_small.
+
+      Section N_small_enough.
+        Context (N_small_enough : 0 <= N < R).
+
+        Lemma prereduce_in_range_small_enough
+          : 0 <= T <= R * R
+            -> 0 <= prereduce T < R + N.
+        Proof. pose proof (prereduce_in_range_gen R); nia. Qed.
+
+        Lemma reduce_in_range_R
+          : 0 <= T <= R * R
+            -> 0 <= reduce N R N' T < R.
+        Proof.
+          intro H; pose proof (prereduce_in_range_small_enough H).
+          unfold reduce, prereduce in *; break_match; Z.ltb_to_lt; nia.
+        Qed.
+
+        Lemma partial_reduce_in_range_R
+          : 0 <= T <= R * R
+            -> 0 <= partial_reduce N R N' T < R.
+        Proof.
+          intro H; pose proof (prereduce_in_range_small_enough H).
+          unfold partial_reduce, prereduce in *; break_match; Z.ltb_to_lt; nia.
+        Qed.
+      End N_small_enough.
+
+      Section unconstrained.
+        Lemma prereduce_in_range
+          : 0 <= T <= R * N
+            -> 0 <= prereduce T < 2 * N.
+        Proof. pose proof (prereduce_in_range_gen N); nia. Qed.
+
+        Lemma reduce_in_range
+        : 0 <= T <= R * N
+          -> 0 <= reduce N R N' T < N.
+        Proof.
+          intro H; pose proof (prereduce_in_range H).
+          unfold reduce, prereduce in *; break_match; Z.ltb_to_lt; nia.
+        Qed.
+
+        Lemma partial_reduce_in_range
+        : 0 <= T <= R * N
+          -> Z.min 0 (R - N) <= partial_reduce N R N' T < 2 * N.
+        Proof.
+          intro H; pose proof (prereduce_in_range H).
+          unfold partial_reduce, prereduce in *; break_match; Z.ltb_to_lt;
+            apply Z.min_case_strong; nia.
+        Qed.
+      End unconstrained.
+    End redc.
+
+    (** * Arithmetic in Montgomery form *)
+    Section arithmetic.
+      Local Infix "*" := (mul N R N') : montgomery_scope.
+
+      Local Notation to_montgomery := (to_montgomery N R N').
+      Local Notation from_montgomery := (from_montgomery N R N').
+      Lemma to_from_montgomery a : to_montgomery (from_montgomery a) ≡ a.
+      Proof.
+        unfold Z.to_montgomery, Z.from_montgomery.
+        transitivity ((a * 1) * 1); [ | apply f_equal2; lia ].
+        rewrite <- !R'_good, !reduce_correct.
+        unfold Z.equiv_modulo; push_Zmod; pull_Zmod.
+        apply f_equal2; lia.
+      Qed.
+      Lemma from_to_montgomery a : from_montgomery (to_montgomery a) ≡ a.
+      Proof.
+        unfold Z.to_montgomery, Z.from_montgomery.
+        rewrite !reduce_correct.
+        transitivity (a * ((R * (R * R' mod N) * R') mod N)).
+        { unfold Z.equiv_modulo; push_Zmod; pull_Zmod.
+          apply f_equal2; lia. }
+        { repeat first [ rewrite R'_good
+                       | reflexivity
+                       | push_Zmod; pull_Zmod; progress autorewrite with zsimplify
+                       | progress unfold Z.equiv_modulo ]. }
+      Qed.
+
+      Theorem mul_correct x y : from_montgomery (x * y) ≡ from_montgomery x * from_montgomery y.
+      Proof.
+        unfold Z.from_montgomery, mul.
+        rewrite !reduce_correct; apply f_equal2; lia.
+      Qed.
+      Theorem mul_correct_to x y : to_montgomery (x * y) ≡ (to_montgomery x * to_montgomery y)%montgomery.
+      Proof.
+        unfold Z.to_montgomery, mul.
+        rewrite !reduce_correct.
+        transitivity (x * y * R * 1 * 1 * 1);
+          [ rewrite <- R'_good at 1
+          | rewrite <- R'_good at 1 2 3 ];
+          autorewrite with zsimplify;
+          unfold Z.equiv_modulo; push_Zmod; pull_Zmod.
+        { apply f_equal2; lia. }
+        { apply f_equal2; lia. }
+      Qed.
+    End arithmetic.
+  End redc.
+End montgomery.
+
+Module Import LocalizeEquivModuloInstances := Z.RemoveEquivModuloInstances Nop.

--- a/src/ModularArithmetic/Montgomery/ZProofs.v
+++ b/src/ModularArithmetic/Montgomery/ZProofs.v
@@ -59,7 +59,7 @@ Section montgomery.
     Proof. unfold Z.to_montgomery_naive, sub; autorewrite with push_Zmul; reflexivity. Qed.
 
     Theorem mul_correct_naive x y : from_montgomery_naive (x * y) = from_montgomery_naive x * from_montgomery_naive y.
-    Proof. unfold from_montgomery_naive, mul_naive; lia. Qed.
+    Proof. unfold Z.from_montgomery_naive, mul_naive; lia. Qed.
     Theorem mul_correct_naive_to x y : to_montgomery_naive (x * y) ≡ (to_montgomery_naive x * to_montgomery_naive y)%montgomery.
     Proof.
       unfold Z.to_montgomery_naive, mul_naive.
@@ -162,7 +162,7 @@ Section montgomery.
             -> 0 <= reduce N R N' T < R.
         Proof.
           intro H; pose proof (prereduce_in_range_small_enough H).
-          unfold reduce, prereduce in *; break_match; Z.ltb_to_lt; nia.
+          unfold reduce, Z.prereduce in *; break_match; Z.ltb_to_lt; nia.
         Qed.
 
         Lemma partial_reduce_in_range_R
@@ -170,7 +170,7 @@ Section montgomery.
             -> 0 <= partial_reduce N R N' T < R.
         Proof.
           intro H; pose proof (prereduce_in_range_small_enough H).
-          unfold partial_reduce, prereduce in *; break_match; Z.ltb_to_lt; nia.
+          unfold partial_reduce, Z.prereduce in *; break_match; Z.ltb_to_lt; nia.
         Qed.
       End N_small_enough.
 
@@ -185,7 +185,7 @@ Section montgomery.
           -> 0 <= reduce N R N' T < N.
         Proof.
           intro H; pose proof (prereduce_in_range H).
-          unfold reduce, prereduce in *; break_match; Z.ltb_to_lt; nia.
+          unfold reduce, Z.prereduce in *; break_match; Z.ltb_to_lt; nia.
         Qed.
 
         Lemma partial_reduce_in_range
@@ -193,7 +193,7 @@ Section montgomery.
           -> Z.min 0 (R - N) <= partial_reduce N R N' T < 2 * N.
         Proof.
           intro H; pose proof (prereduce_in_range H).
-          unfold partial_reduce, prereduce in *; break_match; Z.ltb_to_lt;
+          unfold partial_reduce, Z.prereduce in *; break_match; Z.ltb_to_lt;
             apply Z.min_case_strong; nia.
         Qed.
       End unconstrained.


### PR DESCRIPTION
This is partly done for my own benefit, to internalize how Montgomery
multiplication works, and partly done as a template for word-based
Montgomery multiplication when the carrying does not take advantage of
the fact that we are using a pseudomersenne prime.

(@agl @mschilder123 @andres-erbsen @jadephilipoom) I'm looking for feedback on style, as well as correctness of transcription for ECC.