### PR TITLE
Test fewer Coq versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,18 @@ matrix:
       env: COQ_VERSION="8.5"    COQ_PACKAGE="coq-8.5"                        COQPRIME="coqprime"     PPA="ppa:jgross-h/many-coq-versions"
     - dist: precise
       env: COQ_VERSION="8.4pl6" COQ_PACKAGE="coq-8.4pl6 libcoq-ocaml-8.4pl6" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
-    - dist: precise
-      env: COQ_VERSION="8.4pl5" COQ_PACKAGE="coq-8.4pl5 libcoq-ocaml-8.4pl5" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
-    - dist: precise
-      env: COQ_VERSION="8.4pl4" COQ_PACKAGE="coq-8.4pl4 libcoq-ocaml-8.4pl4" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
-    - dist: precise
-      env: COQ_VERSION="8.4pl3" COQ_PACKAGE="coq-8.4pl3 libcoq-ocaml-8.4pl3" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
-    - dist: precise
-      env: COQ_VERSION="8.4pl2" COQ_PACKAGE="coq-8.4pl2 libcoq-ocaml-8.4pl2" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
-    - dist: precise
-      env: COQ_VERSION="8.4pl1" COQ_PACKAGE="coq-8.4pl1 libcoq-ocaml-8.4pl1" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
-    - dist: precise
-      env: COQ_VERSION="8.4"    COQ_PACKAGE="coq-8.4 libcoq-ocaml-8.4"    COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
+#    - dist: precise
+#      env: COQ_VERSION="8.4pl5" COQ_PACKAGE="coq-8.4pl5 libcoq-ocaml-8.4pl5" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
+#    - dist: precise
+#      env: COQ_VERSION="8.4pl4" COQ_PACKAGE="coq-8.4pl4 libcoq-ocaml-8.4pl4" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
+#    - dist: precise
+#      env: COQ_VERSION="8.4pl3" COQ_PACKAGE="coq-8.4pl3 libcoq-ocaml-8.4pl3" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
+#    - dist: precise
+#      env: COQ_VERSION="8.4pl2" COQ_PACKAGE="coq-8.4pl2 libcoq-ocaml-8.4pl2" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
+#    - dist: precise
+#      env: COQ_VERSION="8.4pl1" COQ_PACKAGE="coq-8.4pl1 libcoq-ocaml-8.4pl1" COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
+#    - dist: precise
+#      env: COQ_VERSION="8.4"    COQ_PACKAGE="coq-8.4 libcoq-ocaml-8.4"    COQPRIME="coqprime-8.4" PPA="ppa:jgross-h/many-coq-versions-ocaml-3-temp-while-over-quota-2"
     - dist: trusty
       env: COQ_VERSION="8.4"    COQ_PACKAGE="coq"        COQPRIME="coqprime-8.4" PPA=""
 


### PR DESCRIPTION
Each version of 8.4 takes around 17 minutes to complete.  I've yet to see anything that behaves differently among 8.4{,pl1,pl2,pl3,pl4}, or among 8.4pl{5,6}.  So if we keep 8.4pl3 (the version of Coq distributed in debian trusty), and 8.4pl6, we should capture the range of behaviors, and save about an hour-and-a-quarter per test.