### PR TITLE
Dead code elimination and register assignment

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -79,7 +79,9 @@ src/Reflection/WfProofs.v
 src/Reflection/WfReflective.v
 src/Reflection/WfRel.v
 src/Reflection/Named/Compile.v
+src/Reflection/Named/ContextOn.v
 src/Reflection/Named/DeadCodeElimination.v
+src/Reflection/Named/EstablishLiveness.v
 src/Reflection/Named/NameUtil.v
 src/Reflection/Named/RegisterAssign.v
 src/Reflection/Named/Syntax.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -78,7 +78,10 @@ src/Reflection/TestCase.v
 src/Reflection/WfProofs.v
 src/Reflection/WfReflective.v
 src/Reflection/WfRel.v
+src/Reflection/Named/Compile.v
 src/Reflection/Named/NameUtil.v
+src/Reflection/Named/RegisterAssign.v
+src/Reflection/Named/Syntax.v
 src/Spec/CompleteEdwardsCurve.v
 src/Spec/EdDSA.v
 src/Spec/Encoding.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -79,6 +79,7 @@ src/Reflection/WfProofs.v
 src/Reflection/WfReflective.v
 src/Reflection/WfRel.v
 src/Reflection/Named/Compile.v
+src/Reflection/Named/DeadCodeElimination.v
 src/Reflection/Named/NameUtil.v
 src/Reflection/Named/RegisterAssign.v
 src/Reflection/Named/Syntax.v

--- a/src/Reflection/Named/Compile.v
+++ b/src/Reflection/Named/Compile.v
@@ -25,36 +25,41 @@ Section language.
   Local Notation nexprf := (@Named.exprf base_type_code interp_base_type op Name).
   Local Notation nexpr := (@Named.expr base_type_code interp_base_type op Name).
 
-  Fixpoint compilef {t} (e : exprf t) (ls : list Name) {struct e}
+  Fixpoint ocompilef {t} (e : exprf t) (ls : list (option Name)) {struct e}
     : option (nexprf t)
     := match e in @Syntax.exprf _ _ _ _ t return option (nexprf t) with
        | Const _ x => Some (Named.Const x)
        | Var _ x => Some (Named.Var x)
-       | Op _ _ op args => option_map (Named.Op op) (@compilef _ args ls)
+       | Op _ _ op args => option_map (Named.Op op) (@ocompilef _ args ls)
        | LetIn tx ex _ eC
-         => match @compilef _ ex nil, split_names tx ls with
+         => match @ocompilef _ ex nil, split_onames tx ls with
             | Some x, (Some n, ls')%core
-              => option_map (fun C => Named.LetIn tx n x C) (@compilef _ (eC n) ls')
+              => option_map (fun C => Named.LetIn tx n x C) (@ocompilef _ (eC n) ls')
             | _, _ => None
             end
-       | Pair _ ex _ ey => match @compilef _ ex nil, @compilef _ ey nil with
+       | Pair _ ex _ ey => match @ocompilef _ ex nil, @ocompilef _ ey nil with
                            | Some x, Some y => Some (Named.Pair x y)
                            | _, _ => None
                            end
        end.
 
-  Fixpoint compile {t} (e : expr t) (ls : list Name) {struct e}
+  Fixpoint ocompile {t} (e : expr t) (ls : list (option Name)) {struct e}
     : option (nexpr t)
     := match e in @Syntax.expr _ _ _ _ t return option (nexpr t) with
-       | Return _ x => option_map Named.Return (compilef x ls)
+       | Return _ x => option_map Named.Return (ocompilef x ls)
        | Abs _ _ f
          => match ls with
-            | cons n ls'
-              => option_map (Named.Abs n) (@compile _ (f n) ls')
+            | cons (Some n) ls'
+              => option_map (Named.Abs n) (@ocompile _ (f n) ls')
             | _ => None
             end
        end.
+
+  Definition compilef {t} (e : exprf t) (ls : list Name) := @ocompilef t e (List.map (@Some _) ls).
+  Definition compile {t} (e : expr t) (ls : list Name) := @ocompile t e (List.map (@Some _) ls).
 End language.
 
+Global Arguments ocompilef {_ _ _ _ _} e ls.
+Global Arguments ocompile {_ _ _ _ _} e ls.
 Global Arguments compilef {_ _ _ _ _} e ls.
 Global Arguments compile {_ _ _ _ _} e ls.

--- a/src/Reflection/Named/Compile.v
+++ b/src/Reflection/Named/Compile.v
@@ -1,0 +1,60 @@
+(** * PHOAS → Named Representation of Gallina *)
+Require Import Crypto.Reflection.Named.Syntax.
+Require Import Crypto.Reflection.Named.NameUtil.
+Require Import Crypto.Reflection.Syntax.
+
+Local Notation eta x := (fst x, snd x).
+
+Local Open Scope ctype_scope.
+Local Open Scope nexpr_scope.
+Local Open Scope expr_scope.
+Section language.
+  Context (base_type_code : Type)
+          (interp_base_type : base_type_code -> Type)
+          (op : flat_type base_type_code -> flat_type base_type_code -> Type)
+          (Name : Type).
+
+  Local Notation flat_type := (flat_type base_type_code).
+  Local Notation type := (type base_type_code).
+  Let Tbase := @Tbase base_type_code.
+  Local Coercion Tbase : base_type_code >-> Syntax.flat_type.
+  Local Notation interp_type := (interp_type interp_base_type).
+  Local Notation interp_flat_type := (interp_flat_type_gen interp_base_type).
+  Local Notation exprf := (@exprf base_type_code interp_base_type op (fun _ => Name)).
+  Local Notation expr := (@expr base_type_code interp_base_type op (fun _ => Name)).
+  Local Notation nexprf := (@Named.exprf base_type_code interp_base_type op Name).
+  Local Notation nexpr := (@Named.expr base_type_code interp_base_type op Name).
+
+  Fixpoint compilef {t} (e : exprf t) (ls : list Name) {struct e}
+    : option (nexprf t)
+    := match e in @Syntax.exprf _ _ _ _ t return option (nexprf t) with
+       | Const _ x => Some (Named.Const x)
+       | Var _ x => Some (Named.Var x)
+       | Op _ _ op args => option_map (Named.Op op) (@compilef _ args ls)
+       | LetIn tx ex _ eC
+         => match @compilef _ ex nil, split_names tx ls with
+            | Some x, (Some n, ls')%core
+              => option_map (fun C => Named.LetIn tx n x C) (@compilef _ (eC n) ls')
+            | _, _ => None
+            end
+       | Pair _ ex _ ey => match @compilef _ ex nil, @compilef _ ey nil with
+                           | Some x, Some y => Some (Named.Pair x y)
+                           | _, _ => None
+                           end
+       end.
+
+  Fixpoint compile {t} (e : expr t) (ls : list Name) {struct e}
+    : option (nexpr t)
+    := match e in @Syntax.expr _ _ _ _ t return option (nexpr t) with
+       | Return _ x => option_map Named.Return (compilef x ls)
+       | Abs _ _ f
+         => match ls with
+            | cons n ls'
+              => option_map (Named.Abs n) (@compile _ (f n) ls')
+            | _ => None
+            end
+       end.
+End language.
+
+Global Arguments compilef {_ _ _ _ _} e ls.
+Global Arguments compile {_ _ _ _ _} e ls.

--- a/src/Reflection/Named/ContextOn.v
+++ b/src/Reflection/Named/ContextOn.v
@@ -1,0 +1,16 @@
+(** * Transfer [Context] across an injection *)
+Require Import Crypto.Reflection.Named.Syntax.
+
+Section language.
+  Context {base_type_code Name1 Name2 : Type}
+          (f : Name2 -> Name1)
+          (f_inj : forall x y, f x = f y -> x = y)
+          {var : base_type_code -> Type}.
+
+  Definition ContextOn (Ctx : Context Name1 var) : Context Name2 var
+    := {| ContextT := Ctx;
+          lookupb ctx n t := lookupb ctx (f n) t;
+          extendb ctx n t v := extendb ctx (f n) v;
+          removeb ctx n t := removeb ctx (f n) t;
+          empty := empty |}.
+End language.

--- a/src/Reflection/Named/DeadCodeElimination.v
+++ b/src/Reflection/Named/DeadCodeElimination.v
@@ -1,0 +1,71 @@
+(** * PHOAS → Named Representation of Gallina *)
+Require Import Crypto.Reflection.Named.Syntax.
+Require Import Crypto.Reflection.Named.Compile.
+Require Import Crypto.Reflection.FilterLive.
+Require Import Crypto.Reflection.Syntax.
+
+Local Notation eta x := (fst x, snd x).
+
+Local Open Scope ctype_scope.
+Local Open Scope nexpr_scope.
+Local Open Scope expr_scope.
+Section language.
+  Context (base_type_code : Type)
+          (interp_base_type : base_type_code -> Type)
+          (op : flat_type base_type_code -> flat_type base_type_code -> Type)
+          (Name : Type).
+
+  Local Notation flat_type := (flat_type base_type_code).
+  Local Notation type := (type base_type_code).
+  Let Tbase := @Tbase base_type_code.
+  Local Coercion Tbase : base_type_code >-> Syntax.flat_type.
+  Local Notation interp_type := (interp_type interp_base_type).
+  Local Notation interp_flat_type := (interp_flat_type_gen interp_base_type).
+  Local Notation exprf := (@exprf base_type_code interp_base_type op (fun _ => Name)).
+  Local Notation expr := (@expr base_type_code interp_base_type op (fun _ => Name)).
+  Local Notation Expr := (@Expr base_type_code interp_base_type op).
+  Local Notation lexprf := (@Syntax.exprf base_type_code interp_base_type op (fun _ => list (option Name))).
+  Local Notation lexpr := (@Syntax.expr base_type_code interp_base_type op (fun _ => list (option Name))).
+  Local Notation nexprf := (@Named.exprf base_type_code interp_base_type op Name).
+  Local Notation nexpr := (@Named.expr base_type_code interp_base_type op Name).
+
+  Definition get_live_namesf (names : list Name) {t} (e : lexprf t) : list (option Name)
+    := filter_live_namesf
+         base_type_code interp_base_type op
+         (option Name) None
+         (fun x y => match x, y with
+                     | Some x, _ => Some x
+                     | _, Some y => Some y
+                     | None, None => None
+                     end)
+         nil (List.map (@Some _) names) e.
+  Definition get_live_names (names : list Name) {t} (e : lexpr t) : list (option Name)
+    := filter_live_names
+         base_type_code interp_base_type op
+         (option Name) None
+         (fun x y => match x, y with
+                     | Some x, _ => Some x
+                     | _, Some y => Some y
+                     | None, None => None
+                     end)
+         nil (List.map (@Some _) names) e.
+
+  Definition compile_and_eliminate_dead_codef
+             {t} (e : exprf t) (e' : lexprf t) (ls : list Name)
+    : option (nexprf t)
+    := ocompilef e (get_live_namesf ls e').
+
+  Definition compile_and_eliminate_dead_code
+             {t} (e : expr t) (e' : lexpr t) (ls : list Name)
+    : option (nexpr t)
+    := ocompile e (get_live_names ls e').
+
+  Definition CompileAndEliminateDeadCode
+             {t} (e : Expr t) (ls : list Name)
+    : option (nexpr t)
+    := compile_and_eliminate_dead_code (e _) (e _) ls.
+End language.
+
+Global Arguments compile_and_eliminate_dead_codef {_ _ _ _ t} _ _ ls.
+Global Arguments compile_and_eliminate_dead_code {_ _ _ _ t} _ _ ls.
+Global Arguments CompileAndEliminateDeadCode {_ _ _ _ t} _ ls.

--- a/src/Reflection/Named/EstablishLiveness.v
+++ b/src/Reflection/Named/EstablishLiveness.v
@@ -1,0 +1,109 @@
+(** * Compute a list of liveness values for each binding *)
+Require Import Coq.Lists.List.
+Require Import Crypto.Reflection.Syntax.
+Require Import Crypto.Reflection.Named.Syntax.
+Require Import Crypto.Reflection.CountLets.
+Require Import Crypto.Util.ListUtil.
+
+Local Notation eta x := (fst x, snd x).
+
+Local Open Scope ctype_scope.
+Delimit Scope nexpr_scope with nexpr.
+
+Inductive liveness := live | dead.
+Fixpoint merge_liveness (ls1 ls2 : list liveness) :=
+  match ls1, ls2 with
+  | cons x xs, cons y ys
+    => cons match x, y with
+            | live, _
+            | _, live
+              => live
+            | dead, dead
+              => dead
+            end
+            (@merge_liveness xs ys)
+  | nil, ls
+  | ls, nil
+    => ls
+  end.
+
+Section language.
+  Context (base_type_code : Type)
+          (interp_base_type : base_type_code -> Type)
+          (op : flat_type base_type_code -> flat_type base_type_code -> Type).
+
+  Local Notation flat_type := (flat_type base_type_code).
+  Local Notation type := (type base_type_code).
+  Let Tbase := @Tbase base_type_code.
+  Local Coercion Tbase : base_type_code >-> Syntax.flat_type.
+  Local Notation interp_type := (interp_type interp_base_type).
+  Local Notation interp_flat_type := (interp_flat_type_gen interp_base_type).
+  Local Notation exprf := (@exprf base_type_code interp_base_type op).
+  Local Notation expr := (@expr base_type_code interp_base_type op).
+
+  Section internal.
+    Context (Name : Type)
+            (OutName : Type)
+            {Context : Context Name (fun _ : base_type_code => list liveness)}.
+
+    Definition compute_livenessf_step
+               (compute_livenessf : forall (ctx : Context) {t} (e : exprf Name t) (prefix : list liveness), list liveness)
+               (ctx : Context)
+               {t} (e : exprf Name t) (prefix : list liveness)
+      : list liveness
+      := match e with
+         | Const _ x => prefix
+         | Var t' name => match lookup ctx t' name with
+                          | Some ls => ls
+                          | _ => nil
+                          end
+         | Op _ _ op args
+           => @compute_livenessf ctx _ args prefix
+         | LetIn tx n ex _ eC
+           => let lx := @compute_livenessf ctx _ ex prefix in
+              let lx := merge_liveness lx (prefix ++ repeat live (count_pairs tx)) in
+              let ctx := extend ctx n (SmartVal _ (fun _ => lx) tx) in
+              @compute_livenessf ctx _ eC (prefix ++ repeat dead (count_pairs tx))
+         | Pair _ ex _ ey
+           => merge_liveness (@compute_livenessf ctx _ ex prefix)
+                             (@compute_livenessf ctx _ ey prefix)
+         end.
+
+    Fixpoint compute_livenessf ctx {t} e prefix
+      := @compute_livenessf_step (@compute_livenessf) ctx t e prefix.
+
+    Fixpoint compute_liveness (ctx : Context)
+             {t} (e : expr Name t) (prefix : list liveness)
+      : list liveness
+      := match e with
+         | Return _ x => compute_livenessf ctx x prefix
+         | Abs src _ n f
+           => let prefix := prefix ++ (live::nil) in
+              let ctx := extendb (t:=src) ctx n prefix in
+              @compute_liveness ctx _ f prefix
+         end.
+
+    Section insert_dead.
+      Context (default_out : option OutName).
+
+      Fixpoint insert_dead_names_gen (ls : list liveness) (lsn : list OutName)
+        : list (option OutName)
+        := match ls with
+           | nil => nil
+           | cons live xs
+             => match lsn with
+                | cons n lsn' => Some n :: @insert_dead_names_gen xs lsn'
+                | nil => default_out :: @insert_dead_names_gen xs nil
+                end
+           | cons dead xs
+             => None :: @insert_dead_names_gen xs lsn
+           end.
+      Definition insert_dead_names {t} (e : expr Name t)
+        := insert_dead_names_gen (compute_liveness empty e nil).
+    End insert_dead.
+  End internal.
+End language.
+
+Global Arguments compute_livenessf {_ _ _ _ _} ctx {t} e prefix.
+Global Arguments compute_liveness {_ _ _ _ _} ctx {t} e prefix.
+Global Arguments insert_dead_names {_ _ _ _ _ _} default_out {t} e lsn.

--- a/src/Reflection/Named/RegisterAssign.v
+++ b/src/Reflection/Named/RegisterAssign.v
@@ -1,0 +1,120 @@
+(** * Reassign registers *)
+Require Import Coq.Strings.String Coq.Classes.RelationClasses.
+Require Import Coq.FSets.FMapPositive Coq.PArith.BinPos.
+Require Import Crypto.Reflection.Syntax.
+Require Import Crypto.Reflection.Named.Syntax.
+Require Import Crypto.Reflection.Named.NameUtil.
+Require Import Crypto.Util.Decidable.
+
+Local Notation eta x := (fst x, snd x).
+
+Local Open Scope ctype_scope.
+Delimit Scope nexpr_scope with nexpr.
+Section language.
+  Context (base_type_code : Type)
+          (interp_base_type : base_type_code -> Type)
+          (op : flat_type base_type_code -> flat_type base_type_code -> Type).
+
+  Local Notation flat_type := (flat_type base_type_code).
+  Local Notation type := (type base_type_code).
+  Let Tbase := @Tbase base_type_code.
+  Local Coercion Tbase : base_type_code >-> Syntax.flat_type.
+  Local Notation interp_type := (interp_type interp_base_type).
+  Local Notation interp_flat_type := (interp_flat_type_gen interp_base_type).
+  Local Notation exprf := (@exprf base_type_code interp_base_type op).
+  Local Notation expr := (@expr base_type_code interp_base_type op).
+
+  Section internal.
+    Context (InName OutName : Type)
+            {InContext : Context InName (fun _ : base_type_code => OutName)}
+            {ReverseContext : Context OutName (fun _ : base_type_code => InName)}
+            (InName_beq : InName -> InName -> bool).
+
+    Fixpoint register_reassignf (ctxi : InContext) (ctxr : ReverseContext)
+             {t} (e : exprf InName t) (new_names : list (option OutName))
+      : option (exprf OutName t)
+      := match e in Named.exprf _ _ _ _ t return option (exprf _ t) with
+         | Const _ x => Some (Const x)
+         | Var t' name => match lookupb ctxi name t' with
+                          | Some new_name
+                            => match lookupb ctxr new_name t' with
+                               | Some name'
+                                 => if InName_beq name name'
+                                    then Some (Var new_name)
+                                    else None
+                               | None => None
+                               end
+                          | None => None
+                          end
+         | Op _ _ op args
+           => option_map (Op op) (@register_reassignf ctxi ctxr _ args new_names)
+         | LetIn tx n ex _ eC
+           => let '(n', new_names') := eta (split_onames tx new_names) in
+              match n', @register_reassignf ctxi ctxr _ ex nil with
+              | Some n', Some x
+                => let ctxi := extend ctxi n n' in
+                   let ctxr := extend ctxr n' n in
+                   option_map (LetIn tx n' x) (@register_reassignf ctxi ctxr _ eC new_names')
+              | None, Some x
+                => let ctxi := remove ctxi n in
+                   @register_reassignf ctxi ctxr _ eC new_names'
+              | _, None => None
+              end
+         | Pair _ ex _ ey
+           => match @register_reassignf ctxi ctxr _ ex nil, @register_reassignf ctxi ctxr _ ey nil with
+              | Some x, Some y
+                => Some (Pair x y)
+              | _, _ => None
+              end
+         end.
+
+    Fixpoint register_reassign (ctxi : InContext) (ctxr : ReverseContext)
+             {t} (e : expr InName t) (new_names : list (option OutName))
+      : option (expr OutName t)
+      := match e in Named.expr _ _ _ _ t return option (expr _ t) with
+         | Return _ x => option_map Return (register_reassignf ctxi ctxr x new_names)
+         | Abs src _ n f
+           => let '(n', new_names') := eta (split_onames src new_names) in
+              match n' with
+              | Some n'
+                => let ctxi := extendb (t:=src) ctxi n n' in
+                   let ctxr := extendb (t:=src) ctxr n' n in
+                   option_map (Abs n') (@register_reassign ctxi ctxr _ f new_names')
+              | None => None
+              end
+         end.
+  End internal.
+
+  Section context_pos.
+    Global Instance pos_context {decR : DecidableRel (@eq base_type_code)}
+           (var : base_type_code -> Type) : Context positive var
+      := { ContextT := PositiveMap.t { t : _ & var t };
+           lookupb ctx key t := match PositiveMap.find key ctx with
+                                | Some v => match dec (projT1 v = t) with
+                                            | left pf => Some match pf in (_ = t) return var t with
+                                                              | eq_refl => projT2 v
+                                                              end
+                                            | right _ => None
+                                            end
+                                | None => None
+                                end;
+           extendb ctx key t v := PositiveMap.add key (existT _ t v) ctx;
+           removeb ctx key t := if dec (option_map (@projT1 _ _) (PositiveMap.find key ctx) = Some t)
+                                then PositiveMap.remove key ctx
+                                else ctx;
+           empty := PositiveMap.empty _ }.
+    Global Instance pos_context_nd
+           (var : Type)
+      : Context positive (fun _ : base_type_code => var)
+      := { ContextT := PositiveMap.t var;
+           lookupb ctx key t := PositiveMap.find key ctx;
+           extendb ctx key t v := PositiveMap.add key v ctx;
+           removeb ctx key t := PositiveMap.remove key ctx;
+           empty := PositiveMap.empty _ }.
+  End context_pos.
+End language.
+
+Global Arguments pos_context {_ _} var.
+Global Arguments pos_context_nd : clear implicits.
+Global Arguments register_reassign {_ _ _ _ _ _ _} _ ctxi ctxr {t} e _.
+Global Arguments register_reassignf {_ _ _ _ _ _ _} _ ctxi ctxr {t} e _.

--- a/src/Reflection/Named/Syntax.v
+++ b/src/Reflection/Named/Syntax.v
@@ -1,0 +1,200 @@
+(** * Named Representation of Gallina *)
+Require Import Coq.Classes.RelationClasses.
+Require Import Crypto.Reflection.Syntax.
+Require Import Crypto.Util.PointedProp.
+Require Import Crypto.Util.Tuple.
+Require Import Crypto.Util.Tactics.
+Require Import Crypto.Util.Notations.
+
+Class Context {base_type_code} (Name : Type) (var : base_type_code -> Type) :=
+  { ContextT : Type;
+    lookupb : ContextT -> Name -> forall {t : base_type_code}, option (var t);
+    extendb : ContextT -> Name -> forall {t : base_type_code}, var t -> ContextT;
+    removeb : ContextT -> Name -> base_type_code -> ContextT;
+    empty : ContextT }.
+Coercion ContextT : Context >-> Sortclass.
+Arguments ContextT {_ _ _ _}, {_ _ _} _.
+Arguments lookupb {_ _ _ _} _ _ {_}, {_ _ _ _} _ _ _.
+Arguments extendb {_ _ _ _} _ _ [_] _.
+Arguments removeb {_ _ _ _} _ _ _.
+Arguments empty {_ _ _ _}.
+
+Local Open Scope ctype_scope.
+Local Open Scope expr_scope.
+Delimit Scope nexpr_scope with nexpr.
+Module Export Named.
+  Section language.
+    Context (base_type_code : Type)
+            (interp_base_type : base_type_code -> Type)
+            (op : flat_type base_type_code -> flat_type base_type_code -> Type)
+            (Name : Type).
+
+    Local Notation flat_type := (flat_type base_type_code).
+    Local Notation type := (type base_type_code).
+    Let Tbase := @Tbase base_type_code.
+    Local Coercion Tbase : base_type_code >-> Syntax.flat_type.
+    Local Notation interp_type := (interp_type interp_base_type).
+    Local Notation interp_flat_type := (interp_flat_type_gen interp_base_type).
+
+
+    Section expr_param.
+      Section expr.
+        Inductive exprf : flat_type -> Type :=
+        | Const {t : flat_type} : interp_type t -> exprf t
+        | Var {t : base_type_code} : Name -> exprf t
+        | Op {t1 tR} : op t1 tR -> exprf t1 -> exprf tR
+        | LetIn : forall {tx}, interp_flat_type_gen (fun _ => Name) tx -> exprf tx -> forall {tC}, exprf tC -> exprf tC
+        | Pair : forall {t1}, exprf t1 -> forall {t2}, exprf t2 -> exprf (Prod t1 t2).
+        Bind Scope nexpr_scope with exprf.
+        Inductive expr : type -> Type :=
+        | Return {t} : exprf t -> expr t
+        | Abs {src dst} : Name -> expr dst -> expr (Arrow src dst).
+        Bind Scope nexpr_scope with expr.
+        Global Coercion Return : exprf >-> expr.
+        (** [SmartVar] is like [Var], except that it inserts
+          pair-projections and [Pair] as necessary to handle
+          [flat_type], and not just [base_type_code] *)
+        Definition SmartVar {t} : interp_flat_type_gen (fun _ => Name) t -> exprf t
+          := smart_interp_flat_map (f:=fun _ => Name) (g:=exprf) _ (fun t => Var) (fun A B x y => Pair x y).
+        Definition SmartConst {t} : interp_flat_type t -> @interp_flat_type_gen base_type_code exprf t
+          := smart_interp_flat_map (g:=@interp_flat_type_gen base_type_code exprf) _ (fun t => Const (t:=t)) (fun A B x y => pair x y).
+      End expr.
+
+      Section with_context.
+        Context {var : base_type_code -> Type}
+                {Context : Context Name var}.
+
+        Fixpoint extend (ctx : Context) {t : flat_type}
+                 (n : interp_flat_type_gen (fun _ => Name) t) (v : interp_flat_type_gen var t)
+          : Context
+          := match t return interp_flat_type_gen (fun _ => Name) t -> interp_flat_type_gen var t -> Context with
+             | Syntax.Tbase t => fun n v => extendb ctx n v
+             | Prod A B => fun n v
+                           => let ctx := @extend ctx A (fst n) (fst v) in
+                              let ctx := @extend ctx B (snd n) (snd v) in
+                              ctx
+             end n v.
+
+        Fixpoint remove (ctx : Context) {t : flat_type}
+                 (n : interp_flat_type_gen (fun _ => Name) t)
+          : Context
+          := match t return interp_flat_type_gen (fun _ => Name) t -> Context with
+             | Syntax.Tbase t => fun n => removeb ctx n t
+             | Prod A B => fun n
+                           => let ctx := @remove ctx A (fst n) in
+                              let ctx := @remove ctx B (snd n) in
+                              ctx
+             end n.
+
+        Definition lookup (ctx : Context) {t}
+          : interp_flat_type_gen (fun _ => Name) t -> option (interp_flat_type_gen var t)
+          := smart_interp_flat_map
+               base_type_code
+               (g := fun t => option (interp_flat_type_gen var t))
+               (fun t v => lookupb ctx v)
+               (fun A B x y => match x, y with
+                               | Some x', Some y' => Some (x', y')%core
+                               | _, _ => None
+                               end).
+
+        Section wf.
+          Fixpoint wff (ctx : Context) {t} (e : exprf t) : option pointed_Prop
+            := match e with
+               | Const _ x => Some trivial
+               | Var t n => match lookupb ctx n t return bool with
+                            | Some _ => true
+                            | None => false
+                            end
+               | Op _ _ op args => @wff ctx _ args
+               | LetIn _ n ex _ eC => @wff ctx _ ex /\ inject (forall v, prop_of_option (@wff (extend ctx n v) _ eC))
+               | Pair _ ex _ ey => @wff ctx _ ex /\ @wff ctx _ ey
+               end%option_pointed_prop.
+
+          Fixpoint wf (ctx : Context) {t} (e : expr t) : Prop
+            := match e with
+               | Return _ x => prop_of_option (wff ctx x)
+               | Abs src _ n f => forall v, @wf (extend ctx (t:=src) n v) _ f
+               end.
+        End wf.
+
+        Section interp_gen.
+          Context (output_interp_flat_type : flat_type -> Type)
+                  (interp_const : forall t, interp_flat_type t -> output_interp_flat_type t)
+                  (interp_var : forall t, var t -> output_interp_flat_type t)
+                  (interp_op : forall src dst, op src dst -> output_interp_flat_type src -> output_interp_flat_type dst)
+                  (interp_let : forall (tx : flat_type) (ex : output_interp_flat_type tx)
+                                       tC (eC : interp_flat_type_gen var tx -> output_interp_flat_type tC),
+                      output_interp_flat_type tC)
+                  (interp_pair : forall (tx : flat_type) (ex : output_interp_flat_type tx)
+                                        (ty : flat_type) (ey : output_interp_flat_type ty),
+                      output_interp_flat_type (Prod tx ty)).
+
+          Fixpoint interp_genf (ctx : Context) {t} (e : exprf t)
+            : prop_of_option (wff ctx e) -> output_interp_flat_type t
+            := match e in exprf t return prop_of_option (wff ctx e) -> output_interp_flat_type t with
+               | Const _ x => fun _ => interp_const _ x
+               | Var t' x => match lookupb ctx x t' as v
+                                   return prop_of_option (match v return bool with
+                                                          | Some _ => true
+                                                          | None => false
+                                                          end)
+                                          -> output_interp_flat_type t'
+                             with
+                             | Some v => fun _ => interp_var _ v
+                             | None => fun bad => match bad : False with end
+                             end
+               | Op _ _ op args => fun good => @interp_op _ _ op (@interp_genf ctx _ args good)
+               | LetIn _ n ex _ eC => fun good => let goodxC := proj1 (@prop_of_option_and _ _) good in
+                                                  let x := @interp_genf ctx _ ex (proj1 goodxC) in
+                                                  interp_let _ x _ (fun x => @interp_genf (extend ctx n x) _ eC (proj2 goodxC x))
+               | Pair _ ex _ ey => fun good => let goodxy := proj1 (@prop_of_option_and _ _) good in
+                                               let x := @interp_genf ctx _ ex (proj1 goodxy) in
+                                               let y := @interp_genf ctx _ ey (proj2 goodxy) in
+                                               interp_pair _ x _ y
+               end.
+        End interp_gen.
+      End with_context.
+
+      Section with_val_context.
+        Context (Context : Context Name interp_base_type)
+                (interp_op : forall src dst, op src dst -> interp_flat_type src -> interp_flat_type dst).
+        Definition interpf
+          : forall (ctx : Context) {t} (e : exprf t),
+            prop_of_option (wff ctx e) -> interp_flat_type t
+          := @interp_genf
+               interp_base_type Context interp_flat_type
+               (fun _ x => x) (fun _ x => x) interp_op (fun _ y _ f => let x := y in f x)
+               (fun _ x _ y => (x, y)%core).
+
+        Fixpoint interp (ctx : Context) {t} (e : expr t)
+          : wf ctx e -> interp_type t
+          := match e in expr t return wf ctx e -> interp_type t with
+             | Return _ x => interpf ctx x
+             | Abs _ _ n f => fun good v => @interp _ _ f (good v)
+             end.
+      End with_val_context.
+    End expr_param.
+  End language.
+End Named.
+
+Global Arguments Const {_ _ _ _ _} _.
+Global Arguments Var {_ _ _ _ _} _.
+Global Arguments SmartVar {_ _ _ _ _} _.
+Global Arguments SmartConst {_ _ _ _ _} _.
+Global Arguments Op {_ _ _ _ _ _} _ _.
+Global Arguments LetIn {_ _ _ _} _ {_} _ {_} _.
+Global Arguments Pair {_ _ _ _ _} _ {_} _.
+Global Arguments Return {_ _ _ _ _} _.
+Global Arguments Abs {_ _ _ _ _ _} _ _.
+Global Arguments extend {_ _ _ _} ctx {_} _ _.
+Global Arguments remove {_ _ _ _} ctx {_} _.
+Global Arguments lookup {_ _ _ _} ctx {_} _, {_ _ _ _} ctx _ _.
+Global Arguments wff {_ _ _ _ _ _} ctx {t} _.
+Global Arguments wf {_ _ _ _ _ _} ctx {t} _.
+Global Arguments interp_genf {_ _ _ _ var _} _ _ _ _ _ _ {ctx t} _ _.
+Global Arguments interpf {_ _ _ _ _ interp_op ctx t} _ _.
+Global Arguments interp {_ _ _ _ _ interp_op ctx t} _ _.
+
+Notation "'slet' x := A 'in' b" := (LetIn _ x A%nexpr b%nexpr) : nexpr_scope.
+Notation "'λn'  x .. y , t" := (Abs x .. (Abs y t%nexpr) .. ) : nexpr_scope.
+Notation "( x , y , .. , z )" := (Pair .. (Pair x%nexpr y%nexpr) .. z%nexpr) : nexpr_scope.

--- a/src/Specific/FancyMachine256/Core.v
+++ b/src/Specific/FancyMachine256/Core.v
@@ -1,11 +1,17 @@
 (** * A Fancy Machine with 256-bit registers *)
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms.
-Require Export Coq.ZArith.ZArith.
+Require Import Coq.PArith.BinPos Coq.micromega.Psatz.
+Require Export Coq.ZArith.ZArith Coq.Lists.List.
+Require Import Crypto.Util.Decidable.
 Require Export Crypto.BoundedArithmetic.Interface.
 Require Export Crypto.BoundedArithmetic.ArchitectureToZLike.
 Require Export Crypto.BoundedArithmetic.ArchitectureToZLikeProofs.
 Require Export Crypto.Util.Tuple.
 Require Import Crypto.Util.Option Crypto.Util.Sigma Crypto.Util.Prod.
+Require Export Crypto.Reflection.Named.Syntax.
+Require Import Crypto.Reflection.Named.DeadCodeElimination.
+Require Import Crypto.Reflection.CountLets.
+Require Import Crypto.Reflection.Named.ContextOn.
 Require Export Crypto.Reflection.Syntax.
 Require Import Crypto.Reflection.Linearize.
 Require Import Crypto.Reflection.Inline.
@@ -13,6 +19,8 @@ Require Import Crypto.Reflection.CommonSubexpressionElimination.
 Require Export Crypto.Reflection.Reify.
 Require Export Crypto.Util.ZUtil.
 Require Export Crypto.Util.Notations.
+Require Import Crypto.Util.ListUtil.
+Export ListNotations.
 
 Open Scope Z_scope.
 Local Notation eta x := (fst x, snd x).
@@ -25,6 +33,8 @@ Section reflection.
   Local Set Boolean Equality Schemes.
   Local Set Decidable Equality Schemes.
   Inductive base_type := TZ | Tbool | TW.
+  Global Instance dec_base_type : DecidableRel (@eq base_type)
+    := base_type_eq_dec.
   Definition interp_base_type (v : base_type) : Type :=
     match v with
     | TZ => Z
@@ -94,6 +104,27 @@ Section reflection.
        end.
 
   Definition CSE {t} e := @CSE base_type SConstT op_code base_type_beq SConstT_beq op_code_beq internal_base_type_dec_bl interp_base_type op symbolicify_const symbolicify_op t e (fun _ => nil).
+
+  Inductive inline_option := opt_inline | opt_default | opt_noinline.
+
+  Definition postprocess var t (e : @exprf base_type interp_base_type op var t)
+    : @inline_directive base_type interp_base_type op var t
+    := let opt : inline_option
+           := match e with
+              | Op _ _ OPshl _ => opt_inline
+              | Op _ _ OPshr _ => opt_inline
+              | _ => opt_default
+              end in
+       match opt with
+       | opt_noinline => no_inline e
+       | opt_default => default_inline e
+       | opt_inline => match t as t' return exprf _ _ _ t' -> inline_directive t' with
+                       | Tbase _ => fun e => inline e
+                       | _ => fun e => default_inline e
+                       end e
+       end.
+
+  Definition Inline {t} e := @InlineConstGen base_type interp_base_type op postprocess t e.
 End reflection.
 
 Ltac base_reify_op op op_head ::=
@@ -121,7 +152,7 @@ Ltac base_reify_type T ::=
 Ltac Reify' e := Reify.Reify' base_type (interp_base_type _) op e.
 Ltac Reify e :=
   let v := Reify.Reify base_type (interp_base_type _) op e in
-  constr:(CSE _ (InlineConst (Linearize v))).
+  constr:(Inline _ (CSE _ (InlineConst (Linearize v)))).
 (*Ltac Reify_rhs := Reify.Reify_rhs base_type (interp_base_type _) op (interp_op _).*)
 
 (** ** Raw Syntax Trees *)
@@ -132,226 +163,172 @@ Ltac Reify e :=
     [string] identifiers and using them for pretty-printing...  It
     might also be possible to verify this layer, too, by adding a
     partial interpretation function... *)
-Section syn.
-  Context {var : base_type -> Type}.
-  Inductive syntax :=
-  | RegPInv
-  | RegMod
-  | RegMuLow
-  | RegZero
-  | cConstZ : Z -> syntax
-  | cConstBool : bool -> syntax
-  | cLowerHalf : syntax -> syntax
-  | cUpperHalf : syntax -> syntax
-  | cLeftShifted : syntax -> Z -> syntax
-  | cRightShifted : syntax -> Z -> syntax
-  | cVar : var TW -> syntax
-  | cVarC : var Tbool -> syntax
-  | cBind : syntax -> (var TW -> syntax) -> syntax
-  | cBindCarry : syntax -> (var Tbool -> var TW -> syntax) -> syntax
-  | cMul128 : syntax -> syntax -> syntax
-  | cRshi : syntax -> syntax -> Z -> syntax
-  | cSelc : var Tbool -> syntax -> syntax -> syntax
-  | cAddc : var Tbool -> syntax -> syntax -> syntax
-  | cAddm : syntax -> syntax -> syntax
-  | cAdd : syntax -> syntax -> syntax
-  | cSub : syntax -> syntax -> syntax
-  | cPair : syntax -> syntax -> syntax
-  | cAbs {t} : (var t -> syntax) -> syntax
-  | cINVALID {T} (_ : T).
-End syn.
 
-Notation "'Return' x" := (cVar x) (at level 200).
-Notation "'c.Mul128' ( x , A , B ) , b" :=
-  (cBind (cMul128 A B) (fun x => b))
-    (at level 200, b at level 200, format "'c.Mul128' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , b" :=
-  (cBindCarry (cAdd A B) (fun _ x => b))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , b" :=
-  (cBindCarry (cAdd (cVar A) B) (fun _ x => b))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , b" :=
-  (cBindCarry (cAdd A B) (fun c x => cBindCarry (cAddc c A1 B1) (fun _ x1 => b)))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , b" :=
-  (cBindCarry (cAdd A B) (fun c x => cBindCarry (cAddc c (cVar A1) B1) (fun _ x1 => b)))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , b" :=
-  (cBindCarry (cAdd (cVar A) B) (fun c x => cBindCarry (cAddc c A1 B1) (fun _ x1 => b)))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , b" :=
-  (cBindCarry (cAdd (cVar A) B) (fun c x => cBindCarry (cAddc c (cVar A1) B1) (fun _ x1 => b)))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , 'c.Selc' ( x2 , A2 , B2 ) , b" :=
-  (cBindCarry (cAdd A B) (fun c x => cBindCarry (cAddc c A1 B1) (fun c1 x1 => cBind (cSelc c1 A2 B2) (fun x2 => b))))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' 'c.Selc' ( x2 ,  A2 ,  B2 ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , 'c.Selc' ( x2 , A2 , B2 ) , b" :=
-  (cBindCarry (cAdd (cVar A) B) (fun c x => cBindCarry (cAddc c A1 B1) (fun c1 x1 => cBind (cSelc c1 A2 B2) (fun x2 => b))))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' 'c.Selc' ( x2 ,  A2 ,  B2 ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , 'c.Selc' ( x2 , A2 , B2 ) , b" :=
-  (cBindCarry (cAdd A B) (fun c x => cBindCarry (cAddc c (cVar A1) B1) (fun c1 x1 => cBind (cSelc c1 A2 B2) (fun x2 => b))))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' 'c.Selc' ( x2 ,  A2 ,  B2 ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , 'c.Selc' ( x2 , A2 , B2 ) , b" :=
-  (cBindCarry (cAdd (cVar A) B) (fun c x => cBindCarry (cAddc c (cVar A1) B1) (fun c1 x1 => cBind (cSelc c1 A2 B2) (fun x2 => b))))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' 'c.Selc' ( x2 ,  A2 ,  B2 ) , '//' b").
-Notation "'c.Add' ( x , A , B ) , 'c.Addc' ( x1 , A1 , B1 ) , 'c.Selc' ( x2 , A2 , B2 ) , b" :=
-  (cBindCarry (cAdd (cVar A) (cVar B)) (fun c x => cBindCarry (cAddc c (cVar A1) (cVar B1)) (fun c1 x1 => cBind (cSelc c1 A2 B2) (fun x2 => b))))
-    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' 'c.Addc' ( x1 ,  A1 ,  B1 ) , '//' 'c.Selc' ( x2 ,  A2 ,  B2 ) , '//' b").
+Local Set Decidable Equality Schemes.
+Local Set Boolean Equality Schemes.
 
-Notation "'c.Sub' ( x , A , B ) , b" :=
-  (cBindCarry (cSub A B) (fun _ x => b))
-    (at level 200, b at level 200, format "'c.Sub' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Sub' ( x , A , B ) , b" :=
-  (cBindCarry (cSub (cVar A) B) (fun _ x => b))
-    (at level 200, b at level 200, format "'c.Sub' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Sub' ( x , A , B ) , b" :=
-  (cBindCarry (cSub A (cVar B)) (fun _ x => b))
-    (at level 200, b at level 200, format "'c.Sub' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Sub' ( x , A , B ) , b" :=
-  (cBindCarry (cSub (cVar A) (cVar B)) (fun _ x => b))
-    (at level 200, b at level 200, format "'c.Sub' ( x ,  A ,  B ) , '//' b").
+Inductive Register :=
+| RegPInv | RegMod | RegMuLow | RegZero
+| y | t1 | t2 | lo | hi | out | src1 | src2 | tmp | q | qHigh | x | xHigh
+| SpecialCarryBit
+| scratch | scratchplus (n : nat).
 
-Notation "'c.Addm' ( x , A , B ) , b" :=
-  (cBind (cAddm A B) (fun x => b))
-    (at level 200, b at level 200, format "'c.Addm' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Addm' ( x , A , B ) , b" :=
-  (cBind (cAddm A (cVar B)) (fun x => b))
-    (at level 200, b at level 200, format "'c.Addm' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Addm' ( x , A , B ) , b" :=
-  (cBind (cAddm (cVar A) B) (fun x => b))
-    (at level 200, b at level 200, format "'c.Addm' ( x ,  A ,  B ) , '//' b").
-Notation "'c.Addm' ( x , A , B ) , b" :=
-  (cBind (cAddm (cVar A) (cVar B)) (fun x => b))
-    (at level 200, b at level 200, format "'c.Addm' ( x ,  A ,  B ) , '//' b").
+Notation "'scratch+' n" := (scratchplus n) (format "'scratch+' n", at level 10).
 
-Notation "'c.Rshi' ( x , A , B , C ) , b" :=
-  (cBind (cRshi (cVar A) (cVar B) C) (fun x => b))
-    (at level 200, b at level 200, format "'c.Rshi' ( x ,  A ,  B ,  C ) , '//' b").
+Definition pos_of_Register (r : Register) :=
+  match r with
+  | RegPInv => 1
+  | RegMod => 2
+  | RegMuLow => 3
+  | RegZero => 4
+  | y => 5
+  | t1 => 6
+  | t2 => 7
+  | lo => 8
+  | hi => 9
+  | out => 10
+  | src1 => 11
+  | src2 => 12
+  | tmp => 13
+  | q => 14
+  | qHigh => 15
+  | x => 16
+  | xHigh => 17
+  | SpecialCarryBit => 18
+  | scratch => 19
+  | scratchplus n => 19 + Pos.of_nat (S n)
+  end%positive.
 
-Notation "'c.LowerHalf' ( x )" :=
-  (cLowerHalf x)
-    (at level 200, format "'c.LowerHalf' ( x )").
-Notation "'c.LowerHalf' ( x )" :=
-  (cLowerHalf (cVar x))
-    (at level 200, format "'c.LowerHalf' ( x )").
-Notation "'c.UpperHalf' ( x )" :=
-  (cUpperHalf x)
-    (at level 200, format "'c.UpperHalf' ( x )").
-Notation "'c.UpperHalf' ( x )" :=
-  (cUpperHalf (cVar x))
-    (at level 200, format "'c.UpperHalf' ( x )").
-Notation "'c.LeftShifted' { x , v }" :=
-  (cLeftShifted x v)
-    (at level 200, format "'c.LeftShifted' { x ,  v }").
-Notation "'c.LeftShifted' { x , v }" :=
-  (cLeftShifted (cVar x) v)
-    (at level 200, format "'c.LeftShifted' { x ,  v }").
-Notation "'c.RightShifted' { x , v }" :=
-  (cRightShifted x v)
-    (at level 200, format "'c.RightShifted' { x ,  v }").
-Notation "'c.RightShifted' { x , v }" :=
-  (cRightShifted (cVar x) v)
-    (at level 200, format "'c.RightShifted' { x ,  v }").
-Notation "'λ'  x .. y , t" := (cAbs (fun x => .. (cAbs (fun y => t)) ..))
-  (at level 200, x binder, y binder, right associativity).
+Lemma pos_of_Register_inj x y : pos_of_Register x = pos_of_Register y -> x = y.
+Proof.
+  unfold pos_of_Register; repeat break_match; subst;
+    try rewrite Pos.add_cancel_l; try rewrite Nat2Pos.inj_iff;
+      try solve [ simpl; congruence | intros; exfalso; lia ].
+Qed.
 
-Definition Syntax := forall var, @syntax var.
+Global Instance RegisterContext {var : base_type -> Type} : Context Register var
+  := ContextOn pos_of_Register (RegisterAssign.pos_context var).
+
+Definition syntax {ops : fancy_machine.instructions (2 * 128)}
+  := Named.expr base_type (interp_base_type ops) op Register.
+
+Class wf_empty {ops} {var} {t} (e : Named.expr base_type (interp_base_type ops) op Register t)
+  := mk_wf_empty : @Named.wf base_type (interp_base_type ops) op Register var _ empty t e.
+Global Hint Extern 0 (wf_empty _) => vm_compute; intros; constructor : typeclass_instances.
 
 (** Assemble a well-typed easily interpretable expression into a
     syntax tree we can use for pretty-printing. *)
 Section assemble.
-  Context (ops : fancy_machine.instructions (2 * 128)).
+  Context {ops : fancy_machine.instructions (2 * 128)}.
 
-  Section with_var.
-    Context {var : base_type -> Type}.
+  Definition AssembleSyntax' {t} (e : Expr base_type (interp_base_type _) op t) (ls : list Register)
+    : option (syntax t)
+    := CompileAndEliminateDeadCode e ls.
+  Definition AssembleSyntax {t} e ls (res := @AssembleSyntax' t e ls)
+    := match res return match res with None => _ | _ => _ end with
+       | Some v => v
+       | None => I
+       end.
 
-    Fixpoint assemble_syntax_const
-             {t}
-      : interp_flat_type_gen (interp_base_type _) t -> @syntax var
-      := match t return interp_flat_type_gen (interp_base_type _) t -> @syntax var with
-         | Tbase TZ => cConstZ
-         | Tbase Tbool => cConstBool
-         | Tbase t => fun _ => cINVALID t
-         | Prod A B => fun xy => cPair (@assemble_syntax_const A (fst xy))
-                                       (@assemble_syntax_const B (snd xy))
-         end.
+  Definition dummy_registers (n : nat) : list Register
+    := List.map scratchplus (seq 0 n).
+  Definition DefaultRegisters {t} (e : Expr base_type (interp_base_type _) op t) : list Register
+    := dummy_registers (CountBinders e).
 
-    Definition assemble_syntaxf_step
-               (assemble_syntaxf : forall {t} (v : @Syntax.exprf base_type (interp_base_type _) op (fun _ => @syntax var) t), @syntax var)
-               {t} (v : @Syntax.exprf base_type (interp_base_type _) op (fun _ => @syntax var) t) : @syntax var.
-    Proof.
-      refine match v return @syntax var with
-             | Syntax.Const t x => assemble_syntax_const x
-             | Syntax.Var _ x => x
-             | Syntax.Op t1 tR op args
-               => let v := @assemble_syntaxf t1 args in
-                 (* handle both associativities of pairs in 3-ary
-                    operators, in case we ever change the
-                    associativity *)
-                  match op, v with
-                  | OPldi    , cConstZ 0 => RegZero
-                  | OPldi    , cConstZ v => cINVALID v
-                  | OPldi    , RegZero => RegZero
-                  | OPldi    , RegMod => RegMod
-                  | OPldi    , RegMuLow => RegMuLow
-                  | OPldi    , RegPInv => RegPInv
-                  | OPshrd   , cPair x (cPair y (cConstZ n)) => cRshi x y n
-                  | OPshrd   , cPair (cPair x y) (cConstZ n) => cRshi x y n
-                  | OPshl    , cPair w (cConstZ n) => cLeftShifted w n
-                  | OPshr    , cPair w (cConstZ n) => cRightShifted w n
-                  | OPmkl    , _ => cINVALID op
-                  | OPadc    , cPair (cPair x y) (cVarC c) => cAddc c x y
-                  | OPadc    , cPair x (cPair y (cVarC c)) => cAddc c x y
-                  | OPadc    , cPair (cPair x y) (cConstBool false) => cAdd x y
-                  | OPadc    , cPair x (cPair y (cConstBool false)) => cAdd x y
-                  | OPsubc   , cPair (cPair x y) (cConstBool false) => cSub x y
-                  | OPsubc   , cPair x (cPair y (cConstBool false)) => cSub x y
-                  | OPmulhwll, cPair x y => cMul128 (cLowerHalf x) (cLowerHalf y)
-                  | OPmulhwhl, cPair x y => cMul128 (cUpperHalf x) (cLowerHalf y)
-                  | OPmulhwhh, cPair x y => cMul128 (cUpperHalf x) (cUpperHalf y)
-                  | OPselc   , cPair (cVarC c) (cPair x y) => cSelc c x y
-                  | OPselc   , cPair (cPair (cVarC c) x) y => cSelc c x y
-                  | OPaddm   , cPair x (cPair y RegMod) => cAddm x y
-                  | OPaddm   , cPair (cPair x y) RegMod => cAddm x y
-                  | _, _ => cINVALID op
-                  end
-             | Syntax.LetIn tx ex _ eC
-               => let ex' := @assemble_syntaxf _ ex in
-                 let eC' := fun x => @assemble_syntaxf _ (eC x) in
-                 let special := match ex' with
-                                | RegZero as ex'' | RegMuLow as ex'' | RegMod as ex'' | RegPInv as ex''
-                                | cUpperHalf _ as ex'' | cLowerHalf _ as ex''
-                                | cLeftShifted _ _ as ex''
-                                | cRightShifted _ _ as ex''
-                                  => Some ex''
-                                | _ => None
-                                end in
-                 match special, tx return (interp_flat_type_gen _ tx -> _) -> _ with
-                 | Some x, Tbase _ => fun eC' => eC' x
-                 | _, Tbase TW
-                   => fun eC' => cBind ex' (fun x => eC' (cVar x))
-                 | _, Prod (Tbase Tbool) (Tbase TW)
-                   => fun eC' => cBindCarry ex' (fun c x => eC' (cVarC c, cVar x))
-                 | _, _
-                   => fun _ => cINVALID (fun x : Prop => x)
-                 end eC'
-             | Syntax.Pair _ ex _ ey
-               => cPair (@assemble_syntaxf _ ex) (@assemble_syntaxf _ ey)
-             end.
-    Defined.
+  Definition DefaultAssembleSyntax {t} e := @AssembleSyntax t e (DefaultRegisters e).
 
-    Fixpoint assemble_syntaxf {t} v {struct v} : @syntax var
-      := @assemble_syntaxf_step (@assemble_syntaxf) t v.
-    Fixpoint assemble_syntax {t} (v : @Syntax.expr base_type (interp_base_type _) op (fun _ => @syntax var) t) (args : list (@syntax var)) {struct v}
-      : @syntax var
-      := match v, args return @syntax var with
-         | Syntax.Return _ x, _ => assemble_syntaxf x
-         | Syntax.Abs _ _ f, nil => cAbs (fun x => @assemble_syntax _ (f (cVar x)) args)
-         | Syntax.Abs _ _ f, cons v vs => @assemble_syntax _ (f v) vs
-         end.
-  End with_var.
-
-  Definition AssembleSyntax {t} (v : Syntax.Expr _ _ _ t) (args : list Syntax) : Syntax
-    := fun var => @assemble_syntax var t (v _) (List.map (fun f => f var) args).
+  Definition Interp {t} e {wf : wf_empty e}
+    := @Named.interp base_type (interp_base_type _) op Register _ (interp_op _) empty t e wf.
 End assemble.
+
+Export Reflection.Named.Syntax.
+Open Scope nexpr_scope.
+Open Scope ctype_scope.
+Open Scope type_scope.
+Open Scope core_scope.
+
+Notation Return x := (Var x).
+Notation ldi z := (Op OPldi (Const z%Z)).
+Notation "'slet' x := A 'in' b" := (LetIn _ x (Op OPldi (Var A%nexpr)) b%nexpr) : nexpr_scope.
+Notation "'c.Rshi' ( x , A , B , C ) , b" :=
+  (LetIn _ x (Op OPshrd (Pair (Pair (Var A) (Var B)) (Const C%Z))) b)
+    (at level 200, b at level 200, format "'c.Rshi' ( x ,  A ,  B ,  C ) , '//' b").
+Notation "'c.Mul128' ( x , 'c.UpperHalf' ( A ) , 'c.UpperHalf' ( B ) ) , b" :=
+  (LetIn _ x (Op OPmulhwhh (Pair (Var A) (Var B))) b)
+    (at level 200, b at level 200, format "'c.Mul128' ( x ,  'c.UpperHalf' ( A ) ,  'c.UpperHalf' ( B ) ) , '//' b").
+Notation "'c.Mul128' ( x , 'c.UpperHalf' ( A ) , 'c.LowerHalf' ( B ) ) , b" :=
+  (LetIn _ x (Op OPmulhwhl (Pair (Var A) (Var B))) b)
+    (at level 200, b at level 200, format "'c.Mul128' ( x ,  'c.UpperHalf' ( A ) ,  'c.LowerHalf' ( B ) ) , '//' b").
+Notation "'c.Mul128' ( x , 'c.LowerHalf' ( A ) , 'c.LowerHalf' ( B ) ) , b" :=
+  (LetIn _ x (Op OPmulhwll (Pair (Var A) (Var B))) b)
+    (at level 200, b at level 200, format "'c.Mul128' ( x ,  'c.LowerHalf' ( A ) ,  'c.LowerHalf' ( B ) ) , '//' b").
+Notation "'c.LeftShifted' { x , v }" :=
+  (Op OPshl (Pair (Var x) (Const v%Z)))
+    (at level 200, format "'c.LeftShifted' { x ,  v }").
+Notation "'c.RightShifted' { x , v }" :=
+  (Op OPshr (Pair (Var x) (Const v%Z)))
+    (at level 200, format "'c.RightShifted' { x ,  v }").
+
+Notation "'c.Add' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPadc (Pair (Pair A B) (Const false))) b)
+    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Add' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPadc (Pair (Pair (Var A) B) (Const false))) b)
+    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Add' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPadc (Pair (Pair A (Var B)) (Const false))) b)
+    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Add' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPadc (Pair (Pair (Var A) (Var B)) (Const false))) b)
+    (at level 200, b at level 200, format "'c.Add' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Addc' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPadc (Pair (Pair A B) (Var SpecialCarryBit))) b)
+    (at level 200, b at level 200, format "'c.Addc' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Addc' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPadc (Pair (Pair (Var A) B) (Var SpecialCarryBit))) b)
+    (at level 200, b at level 200, format "'c.Addc' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Addc' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPadc (Pair (Pair A (Var B)) (Var SpecialCarryBit))) b)
+    (at level 200, b at level 200, format "'c.Addc' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Addc' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPadc (Pair (Pair (Var A) (Var B)) (Var SpecialCarryBit))) b)
+    (at level 200, b at level 200, format "'c.Addc' ( x ,  A ,  B ) , '//' b").
+
+Notation "'c.Sub' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPsubc (Pair (Pair A B) (Const false))) b)
+    (at level 200, b at level 200, format "'c.Sub' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Sub' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPsubc (Pair (Pair (Var A) B) (Const false))) b)
+    (at level 200, b at level 200, format "'c.Sub' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Sub' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPsubc (Pair (Pair A (Var B)) (Const false))) b)
+    (at level 200, b at level 200, format "'c.Sub' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Sub' ( x , A , B ) , b" :=
+  (LetIn _ (pair SpecialCarryBit x) (Op OPsubc (Pair (Pair (Var A) (Var B)) (Const false))) b)
+    (at level 200, b at level 200, format "'c.Sub' ( x ,  A ,  B ) , '//' b").
+
+Notation "'c.Addm' ( x , A , B ) , b" :=
+  (LetIn _ x (Op OPaddm (Pair (Pair A B) (Var RegMod))) b)
+    (at level 200, b at level 200, format "'c.Addm' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Addm' ( x , A , B ) , b" :=
+  (LetIn _ x (Op OPaddm (Pair (Pair (Var A) B) (Var RegMod))) b)
+    (at level 200, b at level 200, format "'c.Addm' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Addm' ( x , A , B ) , b" :=
+  (LetIn _ x (Op OPaddm (Pair (Pair A (Var B)) (Var RegMod))) b)
+    (at level 200, b at level 200, format "'c.Addm' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Addm' ( x , A , B ) , b" :=
+  (LetIn _ x (Op OPaddm (Pair (Pair (Var A) (Var B)) (Var RegMod))) b)
+    (at level 200, b at level 200, format "'c.Addm' ( x ,  A ,  B ) , '//' b").
+
+Notation "'c.Selc' ( x , A , B ) , b" :=
+  (LetIn _ x (Op OPselc (Pair (Pair (Var SpecialCarryBit) A) B)) b)
+    (at level 200, b at level 200, format "'c.Selc' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Selc' ( x , A , B ) , b" :=
+  (LetIn _ x (Op OPselc (Pair (Pair (Var SpecialCarryBit) (Var A)) B)) b)
+    (at level 200, b at level 200, format "'c.Selc' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Selc' ( x , A , B ) , b" :=
+  (LetIn _ x (Op OPselc (Pair (Pair (Var SpecialCarryBit) A) (Var B))) b)
+    (at level 200, b at level 200, format "'c.Selc' ( x ,  A ,  B ) , '//' b").
+Notation "'c.Selc' ( x , A , B ) , b" :=
+  (LetIn _ x (Op OPselc (Pair (Pair (Var SpecialCarryBit) (Var A)) (Var B))) b)
+    (at level 200, b at level 200, format "'c.Selc' ( x ,  A ,  B ) , '//' b").


### PR DESCRIPTION
This is on top of #66 

Still no proofs, but there's working dead code elimination and register assignment.  The interface is that you provide a list of names, and these names are used, in order, after dead code is dropped.  (You can also skip dead code elimination when compiling.)  If you try to reuse a register that still alive when you overwrite it, the compilation returns `None`.  This integrates well with the carry bit; as long as all operations that set/clear the carry bit bind a carry value in the syntax tree, you can use the same "register" for all of the carry bits, and you'll be informed if you're trying to use a clobbered carry bit.

The fancy machine assembly is now checked and interpreted (rather than there being a pretty-printing-only syntax tree).

Warts:
- `vm_compute` would take upwards of 2 hours (estimated); we use `lazy` instead.  (See [bug #5096](https://coq.inria.fr/bugs/show_bug.cgi?id=5096).)
- This is nearly enough to do a nice version of Barrett / Montgomery without common-subexpression elimination; what's left is either doing correctness proofs, or figuring out how to do sanity-checking without eta-expansion, or moving to 8.5 and using primitive projections.

Things I want feedback on:
- the interface for compilation / dead code elimination / register assignment (is it reasonable and useful?)
- dropping support for `vm_compute` (using `lazy` here, but also supporting `native_compute`)
- anything else you feel like commenting on