### PR TITLE
word manipulation functions for secret key formatting

### DIFF
--- a/src/Util/WordUtil.v
+++ b/src/Util/WordUtil.v
@@ -1,6 +1,7 @@
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.NatUtil.
+Require Import Crypto.Util.Tactics.
 Require Import Bedrock.Word.
 Require Import RelationClasses.
 
@@ -77,6 +78,7 @@ Proof. exact (proj1 ((proj2_sig wordsize_eq_sig) a b)). Qed.
 Ltac wordsize_eq_to_eq :=
   repeat match goal with
          | [H: wordsize_eq _ _ |- _] => apply wordsize_eq_eq in H
+         | [H: wordsize_eq _ _ |- _] => unique pose proof (wordsize_eq_eq _ _ H)
          | |- wordsize_eq _ _ => apply eq_wordsize_eq
          end.
 
@@ -105,3 +107,15 @@ Definition clearlow {n b:nat} {H:n <= b} (w:word b) : word b :=
 
 Definition setbit {n b:nat} {H:n < b} (w:word b) : word b :=
   wor (cast_word( wzero (b-n-1)  ++ wones 1 ++ wzero n )) w.
+
+Lemma wordToNat_cast_word : forall {n} (w:word n) m pf,
+  wordToNat (@cast_word n m pf w) = wordToNat w.
+Proof.
+  induction w; destruct m eqn:Heqm;
+    simpl; intros; wordsize_eq_to_eq;
+      rewrite ?IHw; solve [trivial | discriminate].
+Qed.
+
+Lemma wordToN_cast_word {n} (w:word n) m pf :
+  wordToN (@cast_word n m pf w) = wordToN w.
+Proof. rewrite !wordToN_nat, wordToNat_cast_word; reflexivity. Qed.


### PR DESCRIPTION
These need to be constant time with respect to the words being manipulated, so converting to N and operating there is no good.

@JasonGross @achlipala: I introduced some machinery for working with words whose sizes are equal by `Logic.eq` but not convertible, and I am not sure whether what I did is a good way to go about it.  The core of it is `cast_word {n m} : forall {pf:wordsize_eq n m}, word n -> word m`, an identity function that only uses the proof argument in impossible cases, so the proof can be opaque. I also added hooks for proving word size equalities using hints (`omega` for now), and `Qed`-wrapped the goal type so that other tactic/typeclass machinery does not mess with it.

No correctness proofs yet, but should be rather straightforward, so I am punting until we actually decide we want to do this this way.