### PR TITLE
Add opt versions of add, sub, opp

### DIFF
--- a/src/ModularArithmetic/ModularBaseSystem.v
+++ b/src/ModularArithmetic/ModularBaseSystem.v
@@ -60,9 +60,22 @@ Section ModularBaseSystem.
   (* Placeholder *)
   Definition div (x y : digits) : digits := encode (F.div (decode x) (decode y)).
 
+  Definition carry_ (carry_chain : list nat) (us : digits) : digits :=
+    from_list (carry_sequence carry_chain [[us]]) (length_carry_sequence length_to_list).
+
+  Definition carry_add (carry_chain : list nat) (us vs : digits) : digits :=
+    carry_ carry_chain (add us vs).
   Definition carry_mul (carry_chain : list nat) (us vs : digits) : digits :=
-    from_list (carry_sequence carry_chain [[mul us vs]]) (length_carry_sequence length_to_list).
-  
+    carry_ carry_chain (mul us vs).
+  Definition carry_sub (carry_chain : list nat) (modulus_multiple: digits)
+             (modulus_multiple_correct : decode modulus_multiple = 0%F)
+             (us vs : digits) : digits :=
+    carry_ carry_chain (sub modulus_multiple modulus_multiple_correct us vs).
+  Definition carry_opp (carry_chain : list nat) (modulus_multiple : digits)
+             (modulus_multiple_correct : decode modulus_multiple = 0%F)
+             (x : digits) : digits :=
+    carry_ carry_chain (opp modulus_multiple modulus_multiple_correct x).
+
   Definition rep (us : digits) (x : F modulus) := decode us = x.
   Local Notation "u ~= x" := (rep u x).
   Local Hint Unfold rep.
@@ -102,7 +115,7 @@ Section ModularBaseSystem.
 
   Definition pack (x : digits) : target_digits :=
     from_list (pack target_widths_nonneg bits_eq [[x]]) length_pack.
-  
+
   Definition unpack (x : target_digits) : digits :=
     from_list (unpack target_widths_nonneg bits_eq [[x]]) length_unpack.
 

--- a/src/ModularArithmetic/ModularBaseSystem.v
+++ b/src/ModularArithmetic/ModularBaseSystem.v
@@ -74,7 +74,7 @@ Section ModularBaseSystem.
   Definition carry_opp (carry_chain : list nat) (modulus_multiple : digits)
              (modulus_multiple_correct : decode modulus_multiple = 0%F)
              (x : digits) : digits :=
-    carry_ carry_chain (opp modulus_multiple modulus_multiple_correct x).
+    carry_sub carry_chain modulus_multiple modulus_multiple_correct zero x.
 
   Definition rep (us : digits) (x : F modulus) := decode us = x.
   Local Notation "u ~= x" := (rep u x).

--- a/src/ModularArithmetic/ModularBaseSystemOpt.v
+++ b/src/ModularArithmetic/ModularBaseSystemOpt.v
@@ -533,29 +533,20 @@ Section Subtraction.
     : opp_opt us = opp coeff coeff_mod us
     := proj2_sig (opp_opt_sig us).
 
-  Definition carry_opp_opt_sig {T} (f:digits -> T)
-    (us : digits) : { x | x = f (carry_opp carry_chain coeff coeff_mod us) }.
+  Definition carry_opp_opt_sig (us : digits) : { b : digits | b = carry_opp carry_chain coeff coeff_mod us }.
   Proof.
     eexists.
     cbv [carry_opp].
-    rewrite <-carry__opt_cps_correct, <-opp_opt_correct.
-    cbv [carry_sequence_opt_cps carry__opt_cps opp_opt opp sub_opt].
-    rewrite to_list_from_list.
+    rewrite <-carry_sub_opt_correct.
     reflexivity.
   Defined.
 
-  Definition carry_opp_opt_cps {T} (f:digits -> T) (us : digits) : T
-    := Eval cbv [proj1_sig carry_opp_opt_sig] in proj1_sig (carry_opp_opt_sig f us).
+  Definition carry_opp_opt (us : digits) : digits
+    := Eval cbv [proj1_sig carry_opp_opt_sig] in proj1_sig (carry_opp_opt_sig us).
 
-  Definition carry_opp_opt_cps_correct {T} (f:digits -> T) (us : digits)
-    : carry_opp_opt_cps f us = f (carry_opp carry_chain coeff coeff_mod us)
-    := proj2_sig (carry_opp_opt_sig f us).
-
-  Definition carry_opp_opt := carry_opp_opt_cps id.
-
-  Definition carry_opp_opt_correct (us : digits)
-    : carry_opp_opt us = carry_opp carry_chain coeff coeff_mod us :=
-    carry_opp_opt_cps_correct id us.
+  Definition carry_opp_opt_correct us
+    : carry_opp_opt us = carry_opp carry_chain coeff coeff_mod us
+    := proj2_sig (carry_opp_opt_sig us).
 
 End Subtraction.
 

--- a/src/ModularArithmetic/ModularBaseSystemProofs.v
+++ b/src/ModularArithmetic/ModularBaseSystemProofs.v
@@ -360,7 +360,7 @@ Section FieldOperationProofs.
     + eapply _zero_neq_one.
     + trivial.
   Qed.
-  End FieldProofs.
+End FieldProofs.
 
 End FieldOperationProofs.
 Opaque encode add mul sub inv pow.

--- a/src/Specific/GF25519.v
+++ b/src/Specific/GF25519.v
@@ -325,10 +325,10 @@ Definition carry_opp_sig (f : fe25519) :
   { g : fe25519 | g = carry_opp_opt f }.
 Proof.
   eexists.
-  rewrite <-(@app_10_correct fe25519).
-  cbv.
-  autorewrite with zsimplify_fast zsimplify_Z_to_pos; cbv. (* FIXME: The speed of this rewrite depends on the fact that we have 10 limbs; there are some lemmas in [zsimplify_Z_to_pos] which are specific to 10. *)
-  autorewrite with zsimplify_Z_to_pos; cbv.
+  cbv [carry_opp_opt].
+  rewrite <-carry_sub_correct.
+  rewrite zero_subst.
+  cbv [carry_sub].
   reflexivity.
 Defined.
 


### PR DESCRIPTION
Implementing @jadephilipoom's idea to carry on these to make the word versions into a field.

@jadephilipoom, there are two `Admitted` proofs here.  Can I assign you to fill them in?