### PR TITLE
Use Bounded Z in GF25519Bounded and fill Ed25519 with bounded things

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -129,6 +129,7 @@ src/Specific/GF1305.v
 src/Specific/GF25519.v
 src/Specific/GF25519Bounded.v
 src/Specific/GF25519BoundedCommon.v
+src/Specific/GF25519BoundedCommonWord.v
 src/Specific/SC25519.v
 src/Specific/FancyMachine256/Barrett.v
 src/Specific/FancyMachine256/Core.v

--- a/src/Assembly/GF25519BoundedInstantiation.v
+++ b/src/Assembly/GF25519BoundedInstantiation.v
@@ -5,7 +5,7 @@ Require Import Crypto.Assembly.Compile.
 Require Import Crypto.Assembly.LL.
 Require Import Crypto.Assembly.GF25519.
 Require Import Crypto.Specific.GF25519.
-Require Import Crypto.Specific.GF25519BoundedCommon.
+Require Import Crypto.Specific.GF25519BoundedCommonWord.
 Require Import Crypto.Util.Tactics.
 Require Import Crypto.Util.LetIn.
 Require Import Crypto.Util.Tuple.
@@ -41,13 +41,13 @@ Section Operations.
   Definition ropp : ExprUnOp := Opp.wordProg.
 End Operations.
 
-Definition interp_bexpr : ExprBinOp -> Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W
+Definition interp_bexpr : ExprBinOp -> Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W
   := interp_bexpr'.
-Definition interp_uexpr : ExprUnOp -> Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W
+Definition interp_uexpr : ExprUnOp -> Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W
   := interp_uexpr'.
-Axiom interp_uexpr_FEToZ : ExprUnOpFEToZ -> Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.word64.
-Axiom interp_uexpr_FEToWire : ExprUnOpFEToWire -> Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.wire_digitsW.
-Axiom interp_uexpr_WireToFE : ExprUnOpWireToFE -> Specific.GF25519BoundedCommon.wire_digitsW -> Specific.GF25519BoundedCommon.fe25519W.
+Axiom interp_uexpr_FEToZ : ExprUnOpFEToZ -> Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.word64.
+Axiom interp_uexpr_FEToWire : ExprUnOpFEToWire -> Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.wire_digitsW.
+Axiom interp_uexpr_WireToFE : ExprUnOpWireToFE -> Specific.GF25519BoundedCommonWord.wire_digitsW -> Specific.GF25519BoundedCommonWord.fe25519W.
 Axiom rfreeze : ExprUnOp.
 Axiom rge_modulus : ExprUnOpFEToZ.
 Axiom rpack : ExprUnOpFEToWire.
@@ -67,34 +67,34 @@ Declare Reduction asm_interp
             Evaluables.ezero Evaluables.toT Evaluables.fromT Evaluables.eadd Evaluables.esub Evaluables.emul Evaluables.eshiftr Evaluables.eand Evaluables.eltb Evaluables.eeqb
             Evaluables.WordEvaluable Evaluables.ZEvaluable].
 
-Definition interp_radd : Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W
+Definition interp_radd : Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W
   := Eval asm_interp in interp_bexpr radd.
 Print interp_radd.
 Definition interp_radd_correct : interp_radd = interp_bexpr radd := eq_refl.
-Definition interp_rsub : Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W
+Definition interp_rsub : Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W
   := Eval asm_interp in interp_bexpr rsub.
 (*Print interp_rsub.*)
 Definition interp_rsub_correct : interp_rsub = interp_bexpr rsub := eq_refl.
-Definition interp_rmul : Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W
+Definition interp_rmul : Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W
   := Eval asm_interp in interp_bexpr rmul.
 (*Print interp_rmul.*)
 Definition interp_rmul_correct : interp_rmul = interp_bexpr rmul := eq_refl.
-Definition interp_ropp : Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W
+Definition interp_ropp : Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W
   := Eval asm_interp in interp_uexpr ropp.
 Definition interp_ropp_correct : interp_ropp = interp_uexpr ropp := eq_refl.
-Definition interp_rfreeze : Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.fe25519W
+Definition interp_rfreeze : Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.fe25519W
   := Eval asm_interp in interp_uexpr rfreeze.
 Definition interp_rfreeze_correct : interp_rfreeze = interp_uexpr rfreeze := eq_refl.
 
-Definition interp_rge_modulus : Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.word64
+Definition interp_rge_modulus : Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.word64
   := Eval asm_interp in interp_uexpr_FEToZ rge_modulus.
 Definition interp_rge_modulus_correct : interp_rge_modulus = interp_uexpr_FEToZ rge_modulus := eq_refl.
 
-Definition interp_rpack : Specific.GF25519BoundedCommon.fe25519W -> Specific.GF25519BoundedCommon.wire_digitsW
+Definition interp_rpack : Specific.GF25519BoundedCommonWord.fe25519W -> Specific.GF25519BoundedCommonWord.wire_digitsW
   := Eval asm_interp in interp_uexpr_FEToWire rpack.
 Definition interp_rpack_correct : interp_rpack = interp_uexpr_FEToWire rpack := eq_refl.
 
-Definition interp_runpack : Specific.GF25519BoundedCommon.wire_digitsW -> Specific.GF25519BoundedCommon.fe25519W
+Definition interp_runpack : Specific.GF25519BoundedCommonWord.wire_digitsW -> Specific.GF25519BoundedCommonWord.fe25519W
   := Eval asm_interp in interp_uexpr_WireToFE runpack.
 Definition interp_runpack_correct : interp_runpack = interp_uexpr_WireToFE runpack := eq_refl.
 

--- a/src/Specific/GF25519Bounded.v
+++ b/src/Specific/GF25519Bounded.v
@@ -7,7 +7,7 @@ Require Import Crypto.ModularArithmetic.ModularBaseSystemProofs.
 Require Import Crypto.ModularArithmetic.ModularBaseSystemOpt.
 Require Import Crypto.Specific.GF25519.
 Require Import Crypto.Specific.GF25519BoundedCommon.
-Require Import Crypto.Assembly.GF25519BoundedInstantiation.
+(*Require Import Crypto.Assembly.GF25519BoundedInstantiation.*)
 Require Import Bedrock.Word Crypto.Util.WordUtil.
 Require Import Coq.Lists.List Crypto.Util.ListUtil.
 Require Import Crypto.Tactics.VerdiTactics.
@@ -45,7 +45,7 @@ Local Ltac define_unop_WireToFE f opW blem :=
   abstract bounded_wire_digits_t opW blem.
 
 Local Opaque Let_In.
-Local Arguments interp_radd / _ _.
+(*Local Arguments interp_radd / _ _.
 Local Arguments interp_rsub / _ _.
 Local Arguments interp_rmul / _ _.
 Local Arguments interp_ropp / _.
@@ -57,7 +57,16 @@ Definition oppW (f : fe25519W) : fe25519W := Eval simpl in interp_ropp f.
 Definition freezeW (f : fe25519W) : fe25519W := Eval simpl in interp_rfreeze f.
 Definition ge_modulusW (f : fe25519W) : word64 := Eval simpl in interp_rge_modulus f.
 Definition packW (f : fe25519W) : wire_digitsW := Eval simpl in interp_rpack f.
-Definition unpackW (f : wire_digitsW) : fe25519W := Eval simpl in interp_runpack f.
+Definition unpackW (f : wire_digitsW) : fe25519W := Eval simpl in interp_runpack f.*)
+Definition addW (f g : fe25519W) : fe25519W := Eval cbv beta delta [carry_add] in carry_add f g.
+Definition subW (f g : fe25519W) : fe25519W := Eval cbv beta delta [carry_sub] in carry_sub f g.
+Definition mulW (f g : fe25519W) : fe25519W := Eval cbv beta delta [mul] in mul f g.
+Definition oppW (f : fe25519W) : fe25519W := Eval cbv beta delta [carry_opp] in carry_opp f.
+Definition freezeW (f : fe25519W) : fe25519W := Eval cbv beta delta [freeze] in freeze f.
+Definition ge_modulusW (f : fe25519W) : word64 := Eval cbv beta delta [ge_modulus] in ge_modulus f.
+Definition packW (f : fe25519W) : wire_digitsW := Eval cbv beta delta [pack] in pack f.
+Definition unpackW (f : wire_digitsW) : fe25519W := Eval cbv beta delta [unpack] in unpack f.
+
 Local Transparent Let_In.
 Definition powW (f : fe25519W) chain := fold_chain_opt (proj1_fe25519W one) mulW chain [f].
 Definition invW (f : fe25519W) : fe25519W
@@ -69,21 +78,21 @@ Local Ltac port_correct_and_bounded pre_rewrite opW interp_rop rop_cb :=
   intros; apply rop_cb; assumption.
 
 Lemma addW_correct_and_bounded : ibinop_correct_and_bounded addW carry_add.
-Proof. port_correct_and_bounded interp_radd_correct addW interp_radd radd_correct_and_bounded. Qed.
+Proof. (*port_correct_and_bounded interp_radd_correct addW interp_radd radd_correct_and_bounded. Qed.*) Admitted.
 Lemma subW_correct_and_bounded : ibinop_correct_and_bounded subW carry_sub.
-Proof. port_correct_and_bounded interp_rsub_correct subW interp_rsub rsub_correct_and_bounded. Qed.
+Proof. (*port_correct_and_bounded interp_rsub_correct subW interp_rsub rsub_correct_and_bounded. Qed.*) Admitted.
 Lemma mulW_correct_and_bounded : ibinop_correct_and_bounded mulW mul.
-Proof. port_correct_and_bounded interp_rmul_correct mulW interp_rmul rmul_correct_and_bounded. Qed.
+Proof. (*port_correct_and_bounded interp_rmul_correct mulW interp_rmul rmul_correct_and_bounded. Qed.*) Admitted.
 Lemma oppW_correct_and_bounded : iunop_correct_and_bounded oppW carry_opp.
-Proof. port_correct_and_bounded interp_ropp_correct oppW interp_ropp ropp_correct_and_bounded. Qed.
+Proof. (*port_correct_and_bounded interp_ropp_correct oppW interp_ropp ropp_correct_and_bounded. Qed.*) Admitted.
 Lemma freezeW_correct_and_bounded : iunop_correct_and_bounded freezeW freeze.
-Proof. port_correct_and_bounded interp_rfreeze_correct freezeW interp_rfreeze rfreeze_correct_and_bounded. Qed.
+Proof. (*port_correct_and_bounded interp_rfreeze_correct freezeW interp_rfreeze rfreeze_correct_and_bounded. Qed.*) Admitted.
 Lemma ge_modulusW_correct : iunop_FEToZ_correct ge_modulusW ge_modulus.
-Proof. port_correct_and_bounded interp_rge_modulus_correct ge_modulusW interp_rge_modulus rge_modulus_correct_and_bounded. Qed.
+Proof. (*port_correct_and_bounded interp_rge_modulus_correct ge_modulusW interp_rge_modulus rge_modulus_correct_and_bounded. Qed.*) Admitted.
 Lemma packW_correct_and_bounded : iunop_FEToWire_correct_and_bounded packW pack.
-Proof. port_correct_and_bounded interp_rpack_correct packW interp_rpack rpack_correct_and_bounded. Qed.
+Proof. (*port_correct_and_bounded interp_rpack_correct packW interp_rpack rpack_correct_and_bounded. Qed.*) Admitted.
 Lemma unpackW_correct_and_bounded : iunop_WireToFE_correct_and_bounded unpackW unpack.
-Proof. port_correct_and_bounded interp_runpack_correct unpackW interp_runpack runpack_correct_and_bounded. Qed.
+Proof. (*port_correct_and_bounded interp_runpack_correct unpackW interp_runpack runpack_correct_and_bounded. Qed.*) Admitted.
 
 Lemma powW_correct_and_bounded chain : iunop_correct_and_bounded (fun x => powW x chain) (fun x => pow x chain).
 Proof.
@@ -92,9 +101,9 @@ Proof.
   { reflexivity. }
   { reflexivity. }
   { intros; progress rewrite <- ?mul_correct,
-            <- ?(fun X Y => proj1 (rmul_correct_and_bounded _ _ X Y)) by assumption.
-    apply rmul_correct_and_bounded; assumption. }
-  { intros; change mulW with interp_rmul; rewrite interp_rmul_correct; symmetry; apply rmul_correct_and_bounded; assumption. }
+            <- ?(fun X Y => proj1 (mulW_correct_and_bounded _ _ X Y)) by assumption.
+    apply mulW_correct_and_bounded; assumption. }
+  { intros; rewrite (fun X Y => proj1 (mulW_correct_and_bounded _ _ X Y)) by assumption; reflexivity. }
   { intros [|?]; autorewrite with simpl_nth_default;
       (assumption || reflexivity). }
 Qed.
@@ -104,7 +113,7 @@ Proof.
   intro f.
   assert (H : forall f, invW f = powW f (chain inv_ec))
     by abstract (cbv -[Let_In fe25519W mulW]; reflexivity).
-  rewrite !H.
+  rewrite H.
   rewrite inv_correct.
   cbv [inv_opt].
   rewrite <- pow_correct.
@@ -117,7 +126,7 @@ Proof.
   hnf in f, g; destruct_head' prod.
   eexists.
   cbv [GF25519.fieldwiseb fe25519WToZ].
-  rewrite !word64eqb_Zeqb.
+  rewrite ?word64eqb_Zeqb.
   reflexivity.
 Defined.
 
@@ -137,6 +146,8 @@ Proof.
 Qed.
 
 Local Arguments freezeW : simpl never.
+Local Arguments fe25519WToZ !_ / .
+Local Opaque freezeW.
 
 Definition eqbW_sig (f g : fe25519W)
   : { b | is_bounded (fe25519WToZ f) = true
@@ -180,7 +191,7 @@ Definition sqrtW_sig
 Proof.
   eexists.
   unfold GF25519.sqrt.
-  intros; rewrite <- (fun pf => proj1 (powW_correct_and_bounded _ _ pf)) by assumption.
+  intros; set_evars; rewrite <- (fun pf => proj1 (powW_correct_and_bounded _ _ pf)) by assumption; subst_evars.
   match goal with
   | [ |- context G[dlet x := fe25519WToZ ?v in @?f x] ]
     => let G' := context G[dlet x := v in f (fe25519WToZ x)] in

--- a/src/Specific/GF25519BoundedCommonWord.v
+++ b/src/Specific/GF25519BoundedCommonWord.v
@@ -21,17 +21,14 @@ Require Import Coq.ZArith.ZArith Coq.ZArith.Zpower Coq.ZArith.ZArith Coq.ZArith.
 Local Open Scope Z.
 
 (* BEGIN aliases for word extraction *)
-Definition word64 := Z.
+Definition word64 := Word.word 64.
 Coercion word64ToZ (x : word64) : Z
-  := x.
-Coercion ZToWord64 (x : Z) : word64 := x.
-Definition w64eqb (x y : word64) := Z.eqb x y.
+  := Z.of_N (wordToN x).
+Coercion ZToWord64 (x : Z) : word64 := NToWord _ (Z.to_N x).
+Definition w64eqb (x y : word64) := weqb x y.
 
 Lemma word64eqb_Zeqb x y : (word64ToZ x =? word64ToZ y)%Z = w64eqb x y.
-Proof. reflexivity. Qed.
-
-Arguments word64 : simpl never.
-Global Opaque word64.
+Proof. apply wordeqb_Zeqb. Qed.
 
 (* END aliases for word extraction *)
 
@@ -92,9 +89,8 @@ Definition wire_digit_bounds : list (Z * Z)
   := Eval compute in
       List.repeat (0, 2^32-1)%Z 7 ++ ((0,2^31-1)%Z :: nil).
 
-Local Opaque word64.
-Definition fe25519W := Eval cbv (*-[word64]*) in (tuple word64 (length limb_widths)).
-Definition wire_digitsW := Eval cbv (*-[word64]*) in (tuple word64 8).
+Definition fe25519W := Eval cbv -[word64] in (tuple word64 (length limb_widths)).
+Definition wire_digitsW := Eval cbv -[word64] in (tuple word64 8).
 Definition fe25519WToZ (x : fe25519W) : Specific.GF25519.fe25519
   := let '(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9) := x in
      (x0 : Z, x1 : Z, x2 : Z, x3 : Z, x4 : Z, x5 : Z, x6 : Z, x7 : Z, x8 : Z, x9 : Z).
@@ -203,7 +199,7 @@ Proof.
       unfold_is_bounded_in H;
       destruct_head and;
       Z.ltb_to_lt;
-      rewrite ?ZToWord64ToZ by (simpl; omega);
+      rewrite !ZToWord64ToZ by (simpl; omega);
       assumption
     ).
 Defined.
@@ -245,7 +241,7 @@ Proof.
   unfold_is_bounded_in pf.
   destruct_head and.
   Z.ltb_to_lt.
-  rewrite ?ZToWord64ToZ by (rewrite unfold_Pow2_64; cbv [Pow2_64]; omega).
+  rewrite !ZToWord64ToZ by (rewrite unfold_Pow2_64; cbv [Pow2_64]; omega).
   reflexivity.
 Qed.
 
@@ -274,7 +270,7 @@ Proof.
       unfold_is_bounded_in H;
       destruct_head and;
       Z.ltb_to_lt;
-      rewrite ?ZToWord64ToZ by (simpl; omega);
+      rewrite !ZToWord64ToZ by (simpl; omega);
       assumption
     ).
 Defined.
@@ -316,7 +312,7 @@ Proof.
   unfold_is_bounded_in pf.
   destruct_head and.
   Z.ltb_to_lt.
-  rewrite ?ZToWord64ToZ by (rewrite unfold_Pow2_64; cbv [Pow2_64]; omega).
+  rewrite !ZToWord64ToZ by (rewrite unfold_Pow2_64; cbv [Pow2_64]; omega).
   reflexivity.
 Qed.
 


### PR DESCRIPTION
This plugs admitted lemmas for the boundedness proofs into Experiments/Ed25519.

This should not change the code that's being run (though I haven't looked at the extracted code at all; e.g., we might need more extraction directives).

Currently, `feDec` is unsound; I was under the impression that `unpack` requires 25/26 bounds on its input to produce sane output.  But `feDec` gives only the guarantee that the elements are bounded by the wordsize.  So there's something fishy going on here. (@andres-erbsen @jadephilipoom do you know what's going on?)

Reverting the change from bounded words to bounded Z should take no more than 2.5 hours (an overestimate for how long it took me to make the bounded-Z changes for PR), if we decide to go that way.

@andres-erbsen I'd like to assign you to inspecting the extracted code and deciding what, if anything, needs further unfolding / extraction directives.