### PR TITLE
Generalize add_coordinates

### DIFF
--- a/src/Experiments/Ed25519.v
+++ b/src/Experiments/Ed25519.v
@@ -174,7 +174,8 @@ Proof. vm_decide. Qed.
 Let ErepAdd :=
   (@ExtendedCoordinates.Extended.add _ _ _ _ _ _ _ _ _ _
                                      a d GF25519Bounded.field25519 twedprm_ERep _
-                                     eq_a_minus1 twice_d (eq_refl _) ).
+                                     eq_a_minus1 twice_d (eq_refl _)
+                                     _ (fun _ _ => reflexivity (R:=Tuple.fieldwise (n:=4) GF25519BoundedCommon.eq) _)).
 
 Local Coercion Z.of_nat : nat >-> Z.
 Let ERepSel : bool -> Erep -> Erep -> Erep := fun b x y => if b then y else x.


### PR DESCRIPTION
This should give us the option to remove carries between add and mul
when we do bounded things.

Submitted as a PR for the purposes of sanity-checking.
