### PR TITLE
Generalize add_coordinates

### DIFF
--- a/src/Experiments/Ed25519.v
+++ b/src/Experiments/Ed25519.v
@@ -189,7 +189,8 @@ Proof. vm_decide. Qed.
 Definition ErepAdd :=
   (@ExtendedCoordinates.Extended.add _ _ _ _ _ _ _ _ _ _
                                      a d GF25519Bounded.field25519 twedprm_ERep _
-                                     eq_a_minus1 twice_d (eq_refl _) ).
+                                     eq_a_minus1 twice_d (eq_refl _)
+                                     _ (fun _ _ => reflexivity _)).
 
 Local Coercion Z.of_nat : nat >-> Z.
 Definition ERepSel : bool -> Erep -> Erep -> Erep := fun b x y => if b then y else x.


### PR DESCRIPTION
This is in preparation for dropping extra carries.  What remains to be
done, after this and #106, is to finish packaging up the reified
[add_coordinates] so that it can operate on [Tuple.tuple
GF25519BoundedCommon.fe25519 4], and then to prove

```coq
forall twice_d P1 P2, Tuple.fieldwise GF25519BoundedCommon.eq
  (<reflected add_coordinates> twice_d P1 P2)
  (@ExtendedCoordinates.Extended.add_coordinates GF25519BoundedCommon.fe25519
        GF25519Bounded.add GF25519Bounded.sub GF25519Bounded.mul twice_d
   P1 P2)
```

I'm not sure how to do this, or even what the right structure for the
proof is.