### PR TITLE
Add a linear-time sigT-returning reflective identity function

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -106,6 +106,7 @@ src/Reflection/BoundByCastWf.v
 src/Reflection/CommonSubexpressionElimination.v
 src/Reflection/Conversion.v
 src/Reflection/CountLets.v
+src/Reflection/DependentIdentitySigmaByEq.v
 src/Reflection/Equality.v
 src/Reflection/Eta.v
 src/Reflection/EtaInterp.v

--- a/src/Reflection/DependentIdentitySigmaByEq.v
+++ b/src/Reflection/DependentIdentitySigmaByEq.v
@@ -46,40 +46,93 @@ Section demo_by_eq.
 
   Section parametrized.
     Context (M : Type -> Type)
-            (let_in : forall A B, A -> (A -> M B) -> M B)
             (ret : forall A, A -> M A)
             (denote : forall A, M A -> A)
             (bind : forall A B, M A -> (A -> M B) -> M B).
-    Fixpoint mpexist_id {t} (e : @exprf base_type_code op ivar t)
-      : M { t' : _ & @exprf base_type_code op var t' }
-      := match e with
-         | TT => ret _ (existT _ _ TT)
-         | Var t v => ret _ (existT _ (Tbase t) v)
-         | Op t1 tR opc args
-           => bind _ _ (@mpexist_id _ args)
-                   (fun argsv
-                    => ret _ (let (argsvT, argsv) := argsv in
-                              existT _ _ (Op opc (cast_exprf argsv))))
-         | Pair tx ex ty ey
-           => bind _ _ (@mpexist_id _ ex)
-                   (fun xv
-                    => bind _ _ (@mpexist_id _ ey)
-                            (fun yv
-                             => ret _ (let (xvT, xv) := xv in
-                                       let (yvT, yv) := yv in
-                                       existT _ _ (Pair xv yv))))
-         | LetIn tx ex tC eC
-           => let_in _ _ (fun v => denote _ (@mpexist_id _ (eC v)))
-                     (fun Cv
-                      => bind _ _ (@mpexist_id _ ex)
-                              (fun xv
+    Section with_let_in.
+      Context (let_in : forall T
+                               (A:=interp_flat_type ivar T -> { t' : _ & @exprf base_type_code op var t' })
+                               (B:={ t' : _ & @exprf base_type_code op var t' }),
+                  A -> (A -> M B) -> M B).
+      Fixpoint mpexist_id {t} (e : @exprf base_type_code op ivar t)
+        : M { t' : _ & @exprf base_type_code op var t' }
+        := match e with
+           | TT => ret _ (existT _ _ TT)
+           | Var t v => ret _ (existT _ (Tbase t) v)
+           | Op t1 tR opc args
+             => bind _ _ (@mpexist_id _ args)
+                     (fun argsv
+                      => ret _ (let (argsvT, argsv) := argsv in
+                                existT _ _ (Op opc (cast_exprf argsv))))
+           | Pair tx ex ty ey
+             => bind _ _ (@mpexist_id _ ex)
+                     (fun xv
+                      => bind _ _ (@mpexist_id _ ey)
+                              (fun yv
                                => ret _ (let (xvT, xv) := xv in
-                                         existT
-                                           _
-                                           (projT1 (Cv failf))
-                                           (LetIn xv
-                                                  (fun v => cast_exprf (projT2 (Cv (cast_ivarf (SmartVarVarf v)))))))))
-         end.
+                                         let (yvT, yv) := yv in
+                                         existT _ _ (Pair xv yv))))
+           | LetIn tx ex tC eC
+             => let_in _ (fun v => denote _ (@mpexist_id _ (eC v)))
+                       (fun Cv
+                        => bind _ _ (@mpexist_id _ ex)
+                                (fun xv
+                                 => ret _ (let (xvT, xv) := xv in
+                                           existT
+                                             _
+                                             (projT1 (Cv failf))
+                                             (LetIn xv
+                                                    (fun v => cast_exprf (projT2 (Cv (cast_ivarf (SmartVarVarf v)))))))))
+           end.
+    (*Let type_of {var' t} (e : @exprf base_type_code op var' t) : flat_type base_type_code :=
+      match e with
+      | TT => t
+      | _ => t
+      end.
+    Fixpoint mpexist_id_nd {t} (e : @exprf base_type_code op ivar t)
+      : M (@exprf base_type_code op var t)
+      := match e with
+         | TT => ret _ TT
+         | Var t v => ret _ v
+         | Op t1 tR opc args
+           => bind _ _ (@mpexist_id_nd _ args)
+                   (fun argsv
+                    => ret _ (Op opc (cast_exprf argsv)))
+         | Pair tx ex ty ey
+           => bind _ _ (@mpexist_id_nd _ ex)
+                   (fun xv
+                    => bind _ _ (@mpexist_id_nd _ ey)
+                            (fun yv
+                             => ret _ (Pair xv yv)))
+         | LetIn tx ex tC eC
+           => let_in _ _ (fun v => denote _ (@mpexist_id_nd _ (eC v)))
+                     (fun Cv
+                      => bind _ (@exprf base_type_code op var tC) (@mpexist_id_nd _ ex)
+                              (fun xv
+                               => ret _ (LetIn xv
+                                               (fun v => cast_exprf (B:=tC) (cast_exprf (B:=type_of (Cv failf)) (Cv (cast_ivarf (SmartVarVarf v))))))))
+         end.*)
+    End with_let_in.
+
+    Section push_let_in_types_only.
+      Context (let_in : forall T t'
+                               (A:=interp_flat_type ivar T -> @exprf base_type_code op var t')
+                               (B:=@exprf base_type_code op var t'),
+                  A -> (A -> M B) -> M B).
+      Definition push_let_in_on_types
+                 T
+                 (A:=interp_flat_type ivar T -> { t' : _ & @exprf base_type_code op var t' })
+                 (B:={ t' : _ & @exprf base_type_code op var t' })
+                 (x : A)
+                 (f : A -> M B)
+        : M B
+        := let (xfailfT, xfailf) := x failf in
+           bind _ _ (let_in T xfailfT
+                            (fun v => cast_exprf (projT2 (x v)))
+                            (fun x' => bind _ _ (f (fun v => existT _ _ (x' v)))
+                                            (fun v => ret _ (cast_exprf (projT2 v)))))
+                (fun pr => ret _ (existT _ _ pr)).
+    End push_let_in_types_only.
   End parametrized.
   Fixpoint exist_id {t} (e : @exprf base_type_code op ivar t)
     : { t' : _ & @exprf base_type_code op var t' }
@@ -105,15 +158,34 @@ Section demo_by_eq.
   Definition mexist_id {t} (e : @exprf base_type_code op ivar t)
     : LetInM { t' : _ & @exprf base_type_code op var t' }
     := Eval cbv [mpexist_id] in
-        @mpexist_id (fun T => LetInM T) (@LetInMonad.let_in) (@LetInMonad.ret) (@LetInMonad.denote) (@LetInMonad.bind) t e.
-  Definition pexist_id (let_in : forall A B, A -> (A -> B) -> B)
+        @mpexist_id (fun T => LetInM T) (@LetInMonad.ret) (@LetInMonad.denote) (@LetInMonad.bind) (fun T => @LetInMonad.let_in _ _) t e.
+  Definition mpush_let_in_on_types
+    := Eval cbv [push_let_in_on_types] in
+        @push_let_in_on_types (fun T => LetInM T) (@LetInMonad.ret) (@LetInMonad.bind) (fun T t' => @LetInMonad.let_in _ _).
+  Definition pexist_id (let_in : forall T, _ -> (_ -> _) -> _)
              {t} (e : @exprf base_type_code op ivar t)
     : { t' : _ & @exprf base_type_code op var t' }
     := Eval cbv [mpexist_id] in
-        @mpexist_id (fun T => T) (let_in) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) t e.
+        @mpexist_id (fun T => T) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) let_in t e.
+  Definition ppush_let_in_on_types (let_in : forall T t', _ -> _ -> _)
+    := Eval cbv [push_let_in_on_types] in
+        @push_let_in_on_types (fun T => T) (fun _ v => v) (fun _ _ x f => f x) let_in.
   Definition dexist_id
              {t} (e : @exprf base_type_code op ivar t)
     : { t' : _ & @exprf base_type_code op var t' }
     := Eval cbv [mpexist_id] in
-        @mpexist_id (fun T => T) (fun _ _ x f => dlet y := x in f y) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) t e.
+        @mpexist_id (fun T => T) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) (fun _ x f => dlet y := x in f y) t e.
+  Definition dpush_let_in_on_types
+    := Eval cbv [push_let_in_on_types] in
+        @push_let_in_on_types (fun T => T) (fun _ v => v) (fun _ _ x f => f x) (fun _ _ x f => dlet y := x in f y).
+  (*Definition pexist_id_nd (let_in : forall A B, A -> (A -> B) -> B)
+             {t} (e : @exprf base_type_code op ivar t)
+    : @exprf base_type_code op var t
+    := Eval cbv [mpexist_id_nd] in
+        @mpexist_id_nd (fun T => T) (let_in) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) t e.
+  Definition dexist_id_nd
+             {t} (e : @exprf base_type_code op ivar t)
+    : @exprf base_type_code op var t
+    := Eval cbv [mpexist_id_nd] in
+        @mpexist_id_nd (fun T => T) (fun _ _ x f => dlet y := x in f y) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) t e.*)
 End demo_by_eq.

--- a/src/Reflection/DependentIdentitySigmaByEq.v
+++ b/src/Reflection/DependentIdentitySigmaByEq.v
@@ -3,7 +3,6 @@ Require Import Crypto.Reflection.Syntax.
 Require Import Crypto.Reflection.Equality.
 Require Import Crypto.Reflection.SmartMap.
 Require Import Crypto.Util.LetIn.
-Require Import Crypto.Util.LetInMonad.
 
 Section demo_by_eq.
   Context {base_type_code : Type}
@@ -45,147 +44,45 @@ Section demo_by_eq.
     := cast_or (interp_flat_type _) x (@failf _).
 
   Section parametrized.
-    Context (M : Type -> Type)
-            (ret : forall A, A -> M A)
-            (denote : forall A, M A -> A)
-            (bind : forall A B, M A -> (A -> M B) -> M B).
-    Section with_let_in.
-      Context (let_in : forall T
-                               (A:=interp_flat_type ivar T -> { t' : _ & @exprf base_type_code op var t' })
-                               (B:={ t' : _ & @exprf base_type_code op var t' }),
-                  A -> (A -> M B) -> M B).
-      Fixpoint mpexist_id {t} (e : @exprf base_type_code op ivar t)
-        : M { t' : _ & @exprf base_type_code op var t' }
-        := match e with
-           | TT => ret _ (existT _ _ TT)
-           | Var t v => ret _ (existT _ (Tbase t) v)
-           | Op t1 tR opc args
-             => bind _ _ (@mpexist_id _ args)
-                     (fun argsv
-                      => ret _ (let (argsvT, argsv) := argsv in
-                                existT _ _ (Op opc (cast_exprf argsv))))
-           | Pair tx ex ty ey
-             => bind _ _ (@mpexist_id _ ex)
-                     (fun xv
-                      => bind _ _ (@mpexist_id _ ey)
-                              (fun yv
-                               => ret _ (let (xvT, xv) := xv in
-                                         let (yvT, yv) := yv in
-                                         existT _ _ (Pair xv yv))))
-           | LetIn tx ex tC eC
-             => let_in _ (fun v => denote _ (@mpexist_id _ (eC v)))
-                       (fun Cv
-                        => bind _ _ (@mpexist_id _ ex)
-                                (fun xv
-                                 => ret _ (let (xvT, xv) := xv in
-                                           existT
-                                             _
-                                             (projT1 (Cv failf))
-                                             (LetIn xv
-                                                    (fun v => cast_exprf (projT2 (Cv (cast_ivarf (SmartVarVarf v)))))))))
-           end.
-    (*Let type_of {var' t} (e : @exprf base_type_code op var' t) : flat_type base_type_code :=
-      match e with
-      | TT => t
-      | _ => t
-      end.
-    Fixpoint mpexist_id_nd {t} (e : @exprf base_type_code op ivar t)
-      : M (@exprf base_type_code op var t)
+    Context (let_in : forall T t'
+                             (A:=interp_flat_type ivar T -> @exprf base_type_code op var t')
+                             (B:=@exprf base_type_code op var t'),
+                A -> (A -> B) -> B).
+    Fixpoint pexist_id {t} (e : @exprf base_type_code op ivar t)
+      : { t' : _ & @exprf base_type_code op var t' }
       := match e with
-         | TT => ret _ TT
-         | Var t v => ret _ v
+         | TT => existT _ _ TT
+         | Var t v => existT _ (Tbase t) v
          | Op t1 tR opc args
-           => bind _ _ (@mpexist_id_nd _ args)
-                   (fun argsv
-                    => ret _ (Op opc (cast_exprf argsv)))
+           => let (argsT, argsv) := @pexist_id _ args in
+              existT _ _ (Op opc (cast_exprf argsv))
          | Pair tx ex ty ey
-           => bind _ _ (@mpexist_id_nd _ ex)
-                   (fun xv
-                    => bind _ _ (@mpexist_id_nd _ ey)
-                            (fun yv
-                             => ret _ (Pair xv yv)))
+           => let (xT, xv) := @pexist_id _ ex in
+              let (yT, yv) := @pexist_id _ ey in
+              existT _ _ (Pair xv yv)
          | LetIn tx ex tC eC
-           => let_in _ _ (fun v => denote _ (@mpexist_id_nd _ (eC v)))
-                     (fun Cv
-                      => bind _ (@exprf base_type_code op var tC) (@mpexist_id_nd _ ex)
-                              (fun xv
-                               => ret _ (LetIn xv
-                                               (fun v => cast_exprf (B:=tC) (cast_exprf (B:=type_of (Cv failf)) (Cv (cast_ivarf (SmartVarVarf v))))))))
-         end.*)
-    End with_let_in.
-
-    Section push_let_in_types_only.
-      Context (let_in : forall T t'
-                               (A:=interp_flat_type ivar T -> @exprf base_type_code op var t')
-                               (B:=@exprf base_type_code op var t'),
-                  A -> (A -> M B) -> M B).
-      Definition push_let_in_on_types
-                 T
-                 (A:=interp_flat_type ivar T -> { t' : _ & @exprf base_type_code op var t' })
-                 (B:={ t' : _ & @exprf base_type_code op var t' })
-                 (x : A)
-                 (f : A -> M B)
-        : M B
-        := let (xfailfT, xfailf) := x failf in
-           bind _ _ (let_in T xfailfT
-                            (fun v => cast_exprf (projT2 (x v)))
-                            (fun x' => bind _ _ (f (fun v => existT _ _ (x' v)))
-                                            (fun v => ret _ (cast_exprf (projT2 v)))))
-                (fun pr => ret _ (existT _ _ pr)).
-    End push_let_in_types_only.
+           => dlet Cv := (fun v => @pexist_id _ (eC v)) in
+              let (CfailT, Cfailv) := Cv failf in
+              existT
+                _
+                CfailT
+                (let_in
+                   _ CfailT
+                   (fun v => cast_exprf (projT2 (Cv v)))
+                   (fun Cv'
+                    => let (xT, xv) := @pexist_id _ ex in
+                       LetIn xv
+                             (fun v => cast_exprf (Cv' (cast_ivarf (SmartVarVarf v))))))
+         end.
   End parametrized.
-  Fixpoint exist_id {t} (e : @exprf base_type_code op ivar t)
-    : { t' : _ & @exprf base_type_code op var t' }
-    := match e with
-       | TT => existT _ _ TT
-       | Var t v => existT _ (Tbase t) v
-       | Op t1 tR opc args
-         => let (argsvT, argsv) := @exist_id _ args in
-            existT _ _ (Op opc (cast_exprf argsv))
-       | Pair tx ex ty ey
-         => let (xvT, xv) := @exist_id _ ex in
-            let (yvT, yv) := @exist_id _ ey in
-            existT _ _ (Pair xv yv)
-       | LetIn tx ex tC eC
-         => let (xvT, xv) := @exist_id _ ex in
-            let Cv := (fun v => @exist_id _ (eC v)) in
-            existT
-              _
-              (projT1 (Cv failf))
-              (LetIn xv
-                     (fun v => cast_exprf (projT2 (Cv (cast_ivarf (SmartVarVarf v))))))
-       end.
-  Definition mexist_id {t} (e : @exprf base_type_code op ivar t)
-    : LetInM { t' : _ & @exprf base_type_code op var t' }
-    := Eval cbv [mpexist_id] in
-        @mpexist_id (fun T => LetInM T) (@LetInMonad.ret) (@LetInMonad.denote) (@LetInMonad.bind) (fun T => @LetInMonad.let_in _ _) t e.
-  Definition mpush_let_in_on_types
-    := Eval cbv [push_let_in_on_types] in
-        @push_let_in_on_types (fun T => LetInM T) (@LetInMonad.ret) (@LetInMonad.bind) (fun T t' => @LetInMonad.let_in _ _).
-  Definition pexist_id (let_in : forall T, _ -> (_ -> _) -> _)
+  Definition exist_id
              {t} (e : @exprf base_type_code op ivar t)
     : { t' : _ & @exprf base_type_code op var t' }
-    := Eval cbv [mpexist_id] in
-        @mpexist_id (fun T => T) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) let_in t e.
-  Definition ppush_let_in_on_types (let_in : forall T t', _ -> _ -> _)
-    := Eval cbv [push_let_in_on_types] in
-        @push_let_in_on_types (fun T => T) (fun _ v => v) (fun _ _ x f => f x) let_in.
+    := Eval cbv beta iota delta [pexist_id Let_In] in
+        @pexist_id (fun _ _ x f => let y := x in f y) t e.
   Definition dexist_id
              {t} (e : @exprf base_type_code op ivar t)
     : { t' : _ & @exprf base_type_code op var t' }
-    := Eval cbv [mpexist_id] in
-        @mpexist_id (fun T => T) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) (fun _ x f => dlet y := x in f y) t e.
-  Definition dpush_let_in_on_types
-    := Eval cbv [push_let_in_on_types] in
-        @push_let_in_on_types (fun T => T) (fun _ v => v) (fun _ _ x f => f x) (fun _ _ x f => dlet y := x in f y).
-  (*Definition pexist_id_nd (let_in : forall A B, A -> (A -> B) -> B)
-             {t} (e : @exprf base_type_code op ivar t)
-    : @exprf base_type_code op var t
-    := Eval cbv [mpexist_id_nd] in
-        @mpexist_id_nd (fun T => T) (let_in) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) t e.
-  Definition dexist_id_nd
-             {t} (e : @exprf base_type_code op ivar t)
-    : @exprf base_type_code op var t
-    := Eval cbv [mpexist_id_nd] in
-        @mpexist_id_nd (fun T => T) (fun _ _ x f => dlet y := x in f y) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) t e.*)
+    := Eval cbv [pexist_id] in
+        @pexist_id (fun _ _ x f => dlet y := x in f y) t e.
 End demo_by_eq.

--- a/src/Reflection/DependentIdentitySigmaByEq.v
+++ b/src/Reflection/DependentIdentitySigmaByEq.v
@@ -1,0 +1,119 @@
+Require Import Coq.Bool.Sumbool.
+Require Import Crypto.Reflection.Syntax.
+Require Import Crypto.Reflection.Equality.
+Require Import Crypto.Reflection.SmartMap.
+Require Import Crypto.Util.LetIn.
+Require Import Crypto.Util.LetInMonad.
+
+Section demo_by_eq.
+  Context {base_type_code : Type}
+          {op : flat_type base_type_code -> flat_type base_type_code -> Type}
+          {var : base_type_code -> Type}
+          (base_type_code_beq : base_type_code -> base_type_code -> bool)
+          (base_type_code_bl_transparent : forall a b, base_type_code_beq a b = true -> a = b)
+          (faileb : forall var t, @exprf base_type_code op var (Tbase t)).
+
+  Local Notation ivar := (fun t => @exprf base_type_code op var (Tbase t)).
+
+  Fixpoint faile {t} : @exprf base_type_code op var t
+    := match t with
+       | Tbase T => faileb _ _
+       | Unit => TT
+       | Prod A B => Pair (@faile A) (@faile B)
+       end.
+  Fixpoint failf {t} : interp_flat_type ivar t
+    := match t with
+       | Tbase T => faileb _ _
+       | Unit => tt
+       | Prod A B => (@failf A, @failf B)%core
+       end.
+
+  Definition cast_or (P : flat_type base_type_code -> Type) {A B : flat_type base_type_code}
+             (x : P A) (default : P B)
+    : P B
+    := match sumbool_of_bool (@flat_type_beq _ base_type_code_beq A B) with
+       | left pf => match @flat_type_dec_bl _ _ base_type_code_bl_transparent _ _ pf with
+                    | eq_refl => x
+                    end
+       | right _ => default
+       end.
+  Definition cast_exprf {A B} (x : @exprf base_type_code op var A)
+    : @exprf base_type_code op var B
+    := cast_or (@exprf base_type_code op var) x (@faile _).
+  Definition cast_ivarf {A B} (x : interp_flat_type ivar A)
+    : interp_flat_type ivar B
+    := cast_or (interp_flat_type _) x (@failf _).
+
+  Section parametrized.
+    Context (M : Type -> Type)
+            (let_in : forall A B, A -> (A -> M B) -> M B)
+            (ret : forall A, A -> M A)
+            (denote : forall A, M A -> A)
+            (bind : forall A B, M A -> (A -> M B) -> M B).
+    Fixpoint mpexist_id {t} (e : @exprf base_type_code op ivar t)
+      : M { t' : _ & @exprf base_type_code op var t' }
+      := match e with
+         | TT => ret _ (existT _ _ TT)
+         | Var t v => ret _ (existT _ (Tbase t) v)
+         | Op t1 tR opc args
+           => bind _ _ (@mpexist_id _ args)
+                   (fun argsv
+                    => ret _ (let (argsvT, argsv) := argsv in
+                              existT _ _ (Op opc (cast_exprf argsv))))
+         | Pair tx ex ty ey
+           => bind _ _ (@mpexist_id _ ex)
+                   (fun xv
+                    => bind _ _ (@mpexist_id _ ey)
+                            (fun yv
+                             => ret _ (let (xvT, xv) := xv in
+                                       let (yvT, yv) := yv in
+                                       existT _ _ (Pair xv yv))))
+         | LetIn tx ex tC eC
+           => let_in _ _ (fun v => denote _ (@mpexist_id _ (eC v)))
+                     (fun Cv
+                      => bind _ _ (@mpexist_id _ ex)
+                              (fun xv
+                               => ret _ (let (xvT, xv) := xv in
+                                         existT
+                                           _
+                                           (projT1 (Cv failf))
+                                           (LetIn xv
+                                                  (fun v => cast_exprf (projT2 (Cv (cast_ivarf (SmartVarVarf v)))))))))
+         end.
+  End parametrized.
+  Fixpoint exist_id {t} (e : @exprf base_type_code op ivar t)
+    : { t' : _ & @exprf base_type_code op var t' }
+    := match e with
+       | TT => existT _ _ TT
+       | Var t v => existT _ (Tbase t) v
+       | Op t1 tR opc args
+         => let (argsvT, argsv) := @exist_id _ args in
+            existT _ _ (Op opc (cast_exprf argsv))
+       | Pair tx ex ty ey
+         => let (xvT, xv) := @exist_id _ ex in
+            let (yvT, yv) := @exist_id _ ey in
+            existT _ _ (Pair xv yv)
+       | LetIn tx ex tC eC
+         => let (xvT, xv) := @exist_id _ ex in
+            let Cv := (fun v => @exist_id _ (eC v)) in
+            existT
+              _
+              (projT1 (Cv failf))
+              (LetIn xv
+                     (fun v => cast_exprf (projT2 (Cv (cast_ivarf (SmartVarVarf v))))))
+       end.
+  Definition mexist_id {t} (e : @exprf base_type_code op ivar t)
+    : LetInM { t' : _ & @exprf base_type_code op var t' }
+    := Eval cbv [mpexist_id] in
+        @mpexist_id (fun T => LetInM T) (@LetInMonad.let_in) (@LetInMonad.ret) (@LetInMonad.denote) (@LetInMonad.bind) t e.
+  Definition pexist_id (let_in : forall A B, A -> (A -> B) -> B)
+             {t} (e : @exprf base_type_code op ivar t)
+    : { t' : _ & @exprf base_type_code op var t' }
+    := Eval cbv [mpexist_id] in
+        @mpexist_id (fun T => T) (let_in) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) t e.
+  Definition dexist_id
+             {t} (e : @exprf base_type_code op ivar t)
+    : { t' : _ & @exprf base_type_code op var t' }
+    := Eval cbv [mpexist_id] in
+        @mpexist_id (fun T => T) (fun _ _ x f => dlet y := x in f y) (fun _ v => v) (fun _ v => v) (fun _ _ x f => f x) t e.
+End demo_by_eq.

--- a/src/Reflection/TestCase.v
+++ b/src/Reflection/TestCase.v
@@ -241,19 +241,13 @@ Section dependent_sigma_eq.
     Definition gen_let_sequence n := gen_let_sequence' n (Op (Const 1) TT).
   End gen.
 
-  Definition mexist_idf {var} {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
-    := @mexist_id
-         base_type op var base_type_beq
-         internal_base_type_dec_bl
-         (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
-         t e.
   Definition dexist_idf {var} {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
     := @dexist_id
          base_type op var base_type_beq
          internal_base_type_dec_bl
          (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
          t e.
-  Definition pexist_idf {var} (let_in : forall T, _ -> (_ -> _) -> _)
+  Definition pexist_idf {var} (let_in : forall T t', _ -> (_ -> _) -> _)
              {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
     := @pexist_id
          base_type op var base_type_beq
@@ -261,20 +255,7 @@ Section dependent_sigma_eq.
          (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
          let_in
          t e.
-  Definition ppush_let_in_on_types {var} (let_in : forall T t', _ -> (_ -> _) -> _)
-    := @ppush_let_in_on_types
-         base_type op var base_type_beq
-         internal_base_type_dec_bl
-         (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
-         let_in.
-  (*Definition pexist_idf_nd (let_in : forall A B, A -> (A -> B) -> B)
-             {var} {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
-    := @pexist_id_nd
-         base_type op var base_type_beq
-         internal_base_type_dec_bl
-         (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
-         let_in
-         t e.*)
+
   Definition seq0 {var} := Eval vm_compute in @gen_let_sequence var 0.
   Definition seq1 {var} := Eval vm_compute in @gen_let_sequence var 1.
   Definition seq2 {var} := Eval vm_compute in @gen_let_sequence var 2.
@@ -325,11 +306,8 @@ Section dependent_sigma_eq.
   Definition seq47 {var} := Eval vm_compute in @gen_let_sequence var 47.
   Definition seq48 {var} := Eval vm_compute in @gen_let_sequence var 48.
   Definition seq49 {var} := Eval vm_compute in @gen_let_sequence var 49.
-  (*Definition exist_idf {var t} e := LetInMonad.denote (@mexist_idf var t e).*)
   (*Definition exist_idf {var t} e := @dexist_idf var t e.*)
-  (*Definition exist_idf {var t} e let_in := @pexist_idf var let_in t e.*)
-  Definition exist_idf {var t} e let_in := @pexist_idf var (ppush_let_in_on_types let_in) t e.
-  (*Definition exist_idf {var t} e let_in := @pexist_idf_nd let_in var t e.*)
+  Definition exist_idf {var t} e let_in := @pexist_idf var let_in t e.
 
   Section with_var.
     Context {var : base_type -> Type}.
@@ -385,7 +363,6 @@ Section dependent_sigma_eq.
     Time Definition seq47' := Eval seqr in @exist_idf var (Tbase Tnat) seq47.
     Time Definition seq48' := Eval seqr in @exist_idf var (Tbase Tnat) seq48.
     Time Definition seq49' := Eval seqr in @exist_idf var (Tbase Tnat) seq49.
-    (*Time Definition seq49'' := Eval seqr in @mapf base_type op var var (fun _ x => x) (fun _ x => x) _ seq49.*)
 
     Time Definition seq0'' := Eval seqr in seq0' (fun _ _ x f => f x).
     Time Definition seq1'' := Eval seqr in seq1' (fun _ _ x f => f x).

--- a/src/Reflection/TestCase.v
+++ b/src/Reflection/TestCase.v
@@ -12,6 +12,7 @@ Require Import Crypto.Reflection.CommonSubexpressionElimination.
 Require Crypto.Reflection.Linearize Crypto.Reflection.Inline.
 Require Import Crypto.Reflection.WfReflective.
 Require Import Crypto.Reflection.Conversion.
+Require Import Crypto.Reflection.DependentIdentitySigmaByEq.
 Require Import Crypto.Util.NatUtil.
 
 Import ReifyDebugNotations.
@@ -225,3 +226,148 @@ Module bounds.
                                          (exist _ {| lower := 0 ; value := x ; upper := 10 |} xpf)
                                          (exist _ {| lower := 100 ; value := y ; upper := 1000 |} ypf))).
 End bounds.
+
+Section dependent_sigma_eq.
+  Section gen.
+    Import Reflection.Syntax.
+    Context {var : base_type -> Type}.
+    Fixpoint gen_let_sequence' (n : nat) (rv : @exprf base_type op var (Tbase Tnat))
+      : @exprf base_type op var (Tbase Tnat)
+      := match n with
+         | 0 => rv
+         | S n' => LetIn (Op Add (Pair rv rv))
+                         (fun v => gen_let_sequence' n' (@Var base_type op var Tnat v))
+         end.
+    Definition gen_let_sequence n := gen_let_sequence' n (Op (Const 1) TT).
+  End gen.
+
+  Definition mexist_idf {var} {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
+    := @mexist_id
+         base_type op var base_type_beq
+         internal_base_type_dec_bl
+         (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
+         t e.
+  Definition dexist_idf {var} {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
+    := @dexist_id
+         base_type op var base_type_beq
+         internal_base_type_dec_bl
+         (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
+         t e.
+  Definition pexist_idf (let_in : forall A B, A -> (A -> B) -> B)
+             {var} {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
+    := @pexist_id
+         base_type op var base_type_beq
+         internal_base_type_dec_bl
+         (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
+         let_in
+         t e.
+  Definition seq0 {var} := Eval vm_compute in @gen_let_sequence var 0.
+  Definition seq1 {var} := Eval vm_compute in @gen_let_sequence var 1.
+  Definition seq2 {var} := Eval vm_compute in @gen_let_sequence var 2.
+  Definition seq3 {var} := Eval vm_compute in @gen_let_sequence var 2.
+  Definition seq4 {var} := Eval vm_compute in @gen_let_sequence var 4.
+  Definition seq5 {var} := Eval vm_compute in @gen_let_sequence var 5.
+  Definition seq6 {var} := Eval vm_compute in @gen_let_sequence var 6.
+  Definition seq7 {var} := Eval vm_compute in @gen_let_sequence var 7.
+  Definition seq8 {var} := Eval vm_compute in @gen_let_sequence var 8.
+  Definition seq9 {var} := Eval vm_compute in @gen_let_sequence var 9.
+  Definition seq10 {var} := Eval vm_compute in @gen_let_sequence var 10.
+  Definition seq11 {var} := Eval vm_compute in @gen_let_sequence var 11.
+  Definition seq12 {var} := Eval vm_compute in @gen_let_sequence var 12.
+  Definition seq13 {var} := Eval vm_compute in @gen_let_sequence var 13.
+  Definition seq14 {var} := Eval vm_compute in @gen_let_sequence var 14.
+  Definition seq15 {var} := Eval vm_compute in @gen_let_sequence var 15.
+  Definition seq16 {var} := Eval vm_compute in @gen_let_sequence var 16.
+  Definition seq17 {var} := Eval vm_compute in @gen_let_sequence var 17.
+  Definition seq18 {var} := Eval vm_compute in @gen_let_sequence var 18.
+  Definition seq19 {var} := Eval vm_compute in @gen_let_sequence var 19.
+  Definition seq20 {var} := Eval vm_compute in @gen_let_sequence var 20.
+  Definition seq21 {var} := Eval vm_compute in @gen_let_sequence var 21.
+  Definition seq22 {var} := Eval vm_compute in @gen_let_sequence var 22.
+  Definition seq23 {var} := Eval vm_compute in @gen_let_sequence var 23.
+  Definition seq24 {var} := Eval vm_compute in @gen_let_sequence var 24.
+  Definition seq25 {var} := Eval vm_compute in @gen_let_sequence var 25.
+  Definition seq26 {var} := Eval vm_compute in @gen_let_sequence var 26.
+  Definition seq27 {var} := Eval vm_compute in @gen_let_sequence var 27.
+  Definition seq28 {var} := Eval vm_compute in @gen_let_sequence var 28.
+  Definition seq29 {var} := Eval vm_compute in @gen_let_sequence var 29.
+  Definition seq30 {var} := Eval vm_compute in @gen_let_sequence var 30.
+  Definition seq31 {var} := Eval vm_compute in @gen_let_sequence var 31.
+  Definition seq32 {var} := Eval vm_compute in @gen_let_sequence var 32.
+  Definition seq33 {var} := Eval vm_compute in @gen_let_sequence var 33.
+  Definition seq34 {var} := Eval vm_compute in @gen_let_sequence var 34.
+  Definition seq35 {var} := Eval vm_compute in @gen_let_sequence var 35.
+  Definition seq36 {var} := Eval vm_compute in @gen_let_sequence var 36.
+  Definition seq37 {var} := Eval vm_compute in @gen_let_sequence var 37.
+  Definition seq38 {var} := Eval vm_compute in @gen_let_sequence var 38.
+  Definition seq39 {var} := Eval vm_compute in @gen_let_sequence var 39.
+  Definition seq40 {var} := Eval vm_compute in @gen_let_sequence var 40.
+  Definition seq41 {var} := Eval vm_compute in @gen_let_sequence var 41.
+  Definition seq42 {var} := Eval vm_compute in @gen_let_sequence var 42.
+  Definition seq43 {var} := Eval vm_compute in @gen_let_sequence var 43.
+  Definition seq44 {var} := Eval vm_compute in @gen_let_sequence var 44.
+  Definition seq45 {var} := Eval vm_compute in @gen_let_sequence var 45.
+  Definition seq46 {var} := Eval vm_compute in @gen_let_sequence var 46.
+  Definition seq47 {var} := Eval vm_compute in @gen_let_sequence var 47.
+  Definition seq48 {var} := Eval vm_compute in @gen_let_sequence var 48.
+  Definition seq49 {var} := Eval vm_compute in @gen_let_sequence var 49.
+  (*Definition exist_idf {var t} e := LetInMonad.denote (@mexist_idf var t e).*)
+  (*Definition exist_idf {var t} e := @dexist_idf var t e.*)
+  Definition exist_idf {var t} e let_in := @pexist_idf let_in var t e.
+
+  Section with_var.
+    Context {var : base_type -> Type}.
+    Opaque Let_In.
+    Declare Reduction seqr := vm_compute.
+    Time Definition seq0' := Eval seqr in @exist_idf var (Tbase Tnat) seq0.
+    Time Definition seq1' := Eval seqr in @exist_idf var (Tbase Tnat) seq1.
+    Time Definition seq2' := Eval seqr in @exist_idf var (Tbase Tnat) seq2.
+    Time Definition seq3' := Eval seqr in @exist_idf var (Tbase Tnat) seq3.
+    Time Definition seq4' := Eval seqr in @exist_idf var (Tbase Tnat) seq4.
+    Time Definition seq5' := Eval seqr in @exist_idf var (Tbase Tnat) seq5.
+    Time Definition seq6' := Eval seqr in @exist_idf var (Tbase Tnat) seq6.
+    Time Definition seq7' := Eval seqr in @exist_idf var (Tbase Tnat) seq7.
+    Time Definition seq8' := Eval seqr in @exist_idf var (Tbase Tnat) seq8.
+    Time Definition seq9' := Eval seqr in @exist_idf var (Tbase Tnat) seq9.
+    Time Definition seq10' := Eval seqr in @exist_idf var (Tbase Tnat) seq10.
+    Time Definition seq11' := Eval seqr in @exist_idf var (Tbase Tnat) seq11.
+    Time Definition seq12' := Eval seqr in @exist_idf var (Tbase Tnat) seq12.
+    Time Definition seq13' := Eval seqr in @exist_idf var (Tbase Tnat) seq13.
+    Time Definition seq14' := Eval seqr in @exist_idf var (Tbase Tnat) seq14.
+    Time Definition seq15' := Eval seqr in @exist_idf var (Tbase Tnat) seq15.
+    Time Definition seq16' := Eval seqr in @exist_idf var (Tbase Tnat) seq16.
+    Time Definition seq17' := Eval seqr in @exist_idf var (Tbase Tnat) seq17.
+    Time Definition seq18' := Eval seqr in @exist_idf var (Tbase Tnat) seq18.
+    Time Definition seq19' := Eval seqr in @exist_idf var (Tbase Tnat) seq19.
+    Time Definition seq20' := Eval seqr in @exist_idf var (Tbase Tnat) seq20.
+    Time Definition seq21' := Eval seqr in @exist_idf var (Tbase Tnat) seq21.
+    Time Definition seq22' := Eval seqr in @exist_idf var (Tbase Tnat) seq22.
+    Time Definition seq23' := Eval seqr in @exist_idf var (Tbase Tnat) seq23.
+    Time Definition seq24' := Eval seqr in @exist_idf var (Tbase Tnat) seq24.
+    Time Definition seq25' := Eval seqr in @exist_idf var (Tbase Tnat) seq25.
+    Time Definition seq26' := Eval seqr in @exist_idf var (Tbase Tnat) seq26.
+    Time Definition seq27' := Eval seqr in @exist_idf var (Tbase Tnat) seq27.
+    Time Definition seq28' := Eval seqr in @exist_idf var (Tbase Tnat) seq28.
+    Time Definition seq29' := Eval seqr in @exist_idf var (Tbase Tnat) seq29.
+    Time Definition seq30' := Eval seqr in @exist_idf var (Tbase Tnat) seq30.
+    Time Definition seq31' := Eval seqr in @exist_idf var (Tbase Tnat) seq31.
+    Time Definition seq32' := Eval seqr in @exist_idf var (Tbase Tnat) seq32.
+    Time Definition seq33' := Eval seqr in @exist_idf var (Tbase Tnat) seq33.
+    Time Definition seq34' := Eval seqr in @exist_idf var (Tbase Tnat) seq34.
+    Time Definition seq35' := Eval seqr in @exist_idf var (Tbase Tnat) seq35.
+    Time Definition seq36' := Eval seqr in @exist_idf var (Tbase Tnat) seq36.
+    Time Definition seq37' := Eval seqr in @exist_idf var (Tbase Tnat) seq37.
+    Time Definition seq38' := Eval seqr in @exist_idf var (Tbase Tnat) seq38.
+    Time Definition seq39' := Eval seqr in @exist_idf var (Tbase Tnat) seq39.
+    Time Definition seq40' := Eval seqr in @exist_idf var (Tbase Tnat) seq40.
+    Time Definition seq41' := Eval seqr in @exist_idf var (Tbase Tnat) seq41.
+    Time Definition seq42' := Eval seqr in @exist_idf var (Tbase Tnat) seq42.
+    Time Definition seq43' := Eval seqr in @exist_idf var (Tbase Tnat) seq43.
+    Time Definition seq44' := Eval seqr in @exist_idf var (Tbase Tnat) seq44.
+    Time Definition seq45' := Eval seqr in @exist_idf var (Tbase Tnat) seq45.
+    Time Definition seq46' := Eval seqr in @exist_idf var (Tbase Tnat) seq46.
+    Time Definition seq47' := Eval seqr in @exist_idf var (Tbase Tnat) seq47.
+    Time Definition seq48' := Eval seqr in @exist_idf var (Tbase Tnat) seq48.
+    Time Definition seq49' := Eval seqr in @exist_idf var (Tbase Tnat) seq49.
+  End with_var.
+End dependent_sigma_eq.

--- a/src/Reflection/TestCase.v
+++ b/src/Reflection/TestCase.v
@@ -253,14 +253,28 @@ Section dependent_sigma_eq.
          internal_base_type_dec_bl
          (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
          t e.
-  Definition pexist_idf (let_in : forall A B, A -> (A -> B) -> B)
-             {var} {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
+  Definition pexist_idf {var} (let_in : forall T, _ -> (_ -> _) -> _)
+             {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
     := @pexist_id
          base_type op var base_type_beq
          internal_base_type_dec_bl
          (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
          let_in
          t e.
+  Definition ppush_let_in_on_types {var} (let_in : forall T t', _ -> (_ -> _) -> _)
+    := @ppush_let_in_on_types
+         base_type op var base_type_beq
+         internal_base_type_dec_bl
+         (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
+         let_in.
+  (*Definition pexist_idf_nd (let_in : forall A B, A -> (A -> B) -> B)
+             {var} {t} (e : @Syntax.exprf base_type op (fun t => @Syntax.exprf base_type op var (Tbase t)) t)
+    := @pexist_id_nd
+         base_type op var base_type_beq
+         internal_base_type_dec_bl
+         (fun _ b => Syntax.Op (make_const _ match b return interp_base_type b with Tnat => 0 end) Syntax.TT)
+         let_in
+         t e.*)
   Definition seq0 {var} := Eval vm_compute in @gen_let_sequence var 0.
   Definition seq1 {var} := Eval vm_compute in @gen_let_sequence var 1.
   Definition seq2 {var} := Eval vm_compute in @gen_let_sequence var 2.
@@ -313,7 +327,9 @@ Section dependent_sigma_eq.
   Definition seq49 {var} := Eval vm_compute in @gen_let_sequence var 49.
   (*Definition exist_idf {var t} e := LetInMonad.denote (@mexist_idf var t e).*)
   (*Definition exist_idf {var t} e := @dexist_idf var t e.*)
-  Definition exist_idf {var t} e let_in := @pexist_idf let_in var t e.
+  (*Definition exist_idf {var t} e let_in := @pexist_idf var let_in t e.*)
+  Definition exist_idf {var t} e let_in := @pexist_idf var (ppush_let_in_on_types let_in) t e.
+  (*Definition exist_idf {var t} e let_in := @pexist_idf_nd let_in var t e.*)
 
   Section with_var.
     Context {var : base_type -> Type}.
@@ -369,5 +385,57 @@ Section dependent_sigma_eq.
     Time Definition seq47' := Eval seqr in @exist_idf var (Tbase Tnat) seq47.
     Time Definition seq48' := Eval seqr in @exist_idf var (Tbase Tnat) seq48.
     Time Definition seq49' := Eval seqr in @exist_idf var (Tbase Tnat) seq49.
+    (*Time Definition seq49'' := Eval seqr in @mapf base_type op var var (fun _ x => x) (fun _ x => x) _ seq49.*)
+
+    Time Definition seq0'' := Eval seqr in seq0' (fun _ _ x f => f x).
+    Time Definition seq1'' := Eval seqr in seq1' (fun _ _ x f => f x).
+    Time Definition seq2'' := Eval seqr in seq2' (fun _ _ x f => f x).
+    Time Definition seq3'' := Eval seqr in seq3' (fun _ _ x f => f x).
+    Time Definition seq4'' := Eval seqr in seq4' (fun _ _ x f => f x).
+    Time Definition seq5'' := Eval seqr in seq5' (fun _ _ x f => f x).
+    Time Definition seq6'' := Eval seqr in seq6' (fun _ _ x f => f x).
+    Time Definition seq7'' := Eval seqr in seq7' (fun _ _ x f => f x).
+    Time Definition seq8'' := Eval seqr in seq8' (fun _ _ x f => f x).
+    Time Definition seq9'' := Eval seqr in seq9' (fun _ _ x f => f x).
+    Time Definition seq10'' := Eval seqr in seq10' (fun _ _ x f => f x).
+    Time Definition seq11'' := Eval seqr in seq11' (fun _ _ x f => f x).
+    Time Definition seq12'' := Eval seqr in seq12' (fun _ _ x f => f x).
+    Time Definition seq13'' := Eval seqr in seq13' (fun _ _ x f => f x).
+    Time Definition seq14'' := Eval seqr in seq14' (fun _ _ x f => f x).
+    Time Definition seq15'' := Eval seqr in seq15' (fun _ _ x f => f x).
+    Time Definition seq16'' := Eval seqr in seq16' (fun _ _ x f => f x).
+    Time Definition seq17'' := Eval seqr in seq17' (fun _ _ x f => f x).
+    Time Definition seq18'' := Eval seqr in seq18' (fun _ _ x f => f x).
+    Time Definition seq19'' := Eval seqr in seq19' (fun _ _ x f => f x).
+    Time Definition seq20'' := Eval seqr in seq20' (fun _ _ x f => f x).
+    Time Definition seq21'' := Eval seqr in seq21' (fun _ _ x f => f x).
+    Time Definition seq22'' := Eval seqr in seq22' (fun _ _ x f => f x).
+    Time Definition seq23'' := Eval seqr in seq23' (fun _ _ x f => f x).
+    Time Definition seq24'' := Eval seqr in seq24' (fun _ _ x f => f x).
+    Time Definition seq25'' := Eval seqr in seq25' (fun _ _ x f => f x).
+    Time Definition seq26'' := Eval seqr in seq26' (fun _ _ x f => f x).
+    Time Definition seq27'' := Eval seqr in seq27' (fun _ _ x f => f x).
+    Time Definition seq28'' := Eval seqr in seq28' (fun _ _ x f => f x).
+    Time Definition seq29'' := Eval seqr in seq29' (fun _ _ x f => f x).
+    Time Definition seq30'' := Eval seqr in seq30' (fun _ _ x f => f x).
+    Time Definition seq31'' := Eval seqr in seq31' (fun _ _ x f => f x).
+    Time Definition seq32'' := Eval seqr in seq32' (fun _ _ x f => f x).
+    Time Definition seq33'' := Eval seqr in seq33' (fun _ _ x f => f x).
+    Time Definition seq34'' := Eval seqr in seq34' (fun _ _ x f => f x).
+    Time Definition seq35'' := Eval seqr in seq35' (fun _ _ x f => f x).
+    Time Definition seq36'' := Eval seqr in seq36' (fun _ _ x f => f x).
+    Time Definition seq37'' := Eval seqr in seq37' (fun _ _ x f => f x).
+    Time Definition seq38'' := Eval seqr in seq38' (fun _ _ x f => f x).
+    Time Definition seq39'' := Eval seqr in seq39' (fun _ _ x f => f x).
+    Time Definition seq40'' := Eval seqr in seq40' (fun _ _ x f => f x).
+    Time Definition seq41'' := Eval seqr in seq41' (fun _ _ x f => f x).
+    Time Definition seq42'' := Eval seqr in seq42' (fun _ _ x f => f x).
+    Time Definition seq43'' := Eval seqr in seq43' (fun _ _ x f => f x).
+    Time Definition seq44'' := Eval seqr in seq44' (fun _ _ x f => f x).
+    Time Definition seq45'' := Eval seqr in seq45' (fun _ _ x f => f x).
+    Time Definition seq46'' := Eval seqr in seq46' (fun _ _ x f => f x).
+    Time Definition seq47'' := Eval seqr in seq47' (fun _ _ x f => f x).
+    Time Definition seq48'' := Eval seqr in seq48' (fun _ _ x f => f x).
+    Time Definition seq49'' := Eval seqr in seq49' (fun _ _ x f => f x).
   End with_var.
 End dependent_sigma_eq.


### PR DESCRIPTION
By parametrizing over a let-in function, we can have a constant time* `vm_compute`able function on syntax trees that returns a sigma type.

Note that this is currently more general than it needs to be, because I was playing with monads before I realized that simply parameterizing on `let_in` would work.  If you prefer, I can strip out the monadic parameterization, and make the code a bit simpler.  (If we're going to merge this at all, that is.)

*I assert constant-time based on this plot of the times on my machine for the `pexist_idf` case:
![image](https://cloud.githubusercontent.com/assets/396076/23378337/f6c9da10-fd00-11e6-9f0e-c2817d43712a.png)

If we fuse that with the `ppush_let_in_on_types` operation, as is done in the second commit, we get about a 50x speedup (still about 2x slower than just walking the tree):
![image](https://cloud.githubusercontent.com/assets/396076/23380986/e7568a24-fd0a-11e6-9ff9-b6ecf7c8d1be.png)

Alas, I don't see a way to get out of needing two separate reduction steps; if we fuse the two remaining reductions, it blows up to exponential time.