### PR TITLE
Coalesce Tuple.pointwise2 and Tuple.fieldwise

### DIFF
--- a/src/Util/ZRange.v
+++ b/src/Util/ZRange.v
@@ -34,7 +34,7 @@ Section with_bitwidth.
              end.
 
   Definition is_bounded_by {n} : Tuple.tuple zrange n -> Tuple.tuple Z n -> Prop
-    := Tuple.pointwise2 is_bounded_by'.
+    := Tuple.fieldwise is_bounded_by'.
 End with_bitwidth.
 
 Definition is_tighter_than_bool (x y : zrange) : bool


### PR DESCRIPTION
We don't need both of them.  We keep the definition of pointwise2
because it's needed for reification to work, and we keep the name of
fieldwise because it's used in more places.  This closes #137.