### PR TITLE
Freeze

### DIFF
--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -866,6 +866,20 @@ Section DivMod.
     then let x := Z.log2 b in (a >> x)%RT
     else Z.div a b.
 
+  Lemma div_correct a b : div a b = Z.div a b.
+  Proof.
+    cbv [div]; intros. break_match; try reflexivity.
+    rewrite Z.shiftr_div_pow2 by apply Z.log2_nonneg.
+    congruence.
+  Qed.
+
+  Lemma modulo_correct a b : modulo a b = Z.modulo a b.
+  Proof.
+    cbv [modulo]; intros. break_match; try reflexivity.
+    rewrite Z.land_ones by apply Z.log2_nonneg.
+    congruence.
+  Qed.
+
   Lemma div_mod a b (H:b <> 0) : a = b * div a b + modulo a b.
   Proof.
     cbv [div modulo]; intros. break_match; auto using Z.div_mod.

--- a/src/Arithmetic/Saturated.v
+++ b/src/Arithmetic/Saturated.v
@@ -192,7 +192,7 @@ Module Columns.
     Hint Rewrite compact_step_id : uncps.
 
     Definition compact_cps {n} (xs : (list Z)^n) {T} (f:Z * Z^n->T) :=
-      mapi_with_cps compact_step_cps 0 xs f.
+      Tuple.mapi_with_cps compact_step_cps 0 xs f.
 
     Definition compact {n} xs := @compact_cps n xs _ id.
     Lemma compact_id {n} xs {T} f : @compact_cps n xs T f = f (compact xs).
@@ -235,26 +235,6 @@ Module Columns.
       end.
       rewrite Z.div_add' by auto; nsatz.
     Qed.
-
-    (* TODO : move to Core? *)
-    Lemma Pos_eval_unit : B.Positional.eval (n:=0) weight tt = 0.
-    Proof. reflexivity. Qed.
-    Hint Rewrite Pos_eval_unit B.Positional.eval_single
-         @B.Positional.eval_step : push_basesystem_eval.
-    (* TODO : move to Core? *)
-    Lemma Pos_eval_left_append {n} : forall wt x xs,
-      B.Positional.eval wt (left_append (n:=n) x xs)
-      = wt n * x + B.Positional.eval wt xs.
-    Proof.
-      induction n; intros; try destruct xs;
-        unfold left_append; fold @left_append;
-        autorewrite with push_basesystem_eval; [ring|].
-      rewrite IHn.
-      rewrite (subst_append xs), hd_append, tl_append.
-      rewrite B.Positional.eval_step.
-      ring.
-    Qed.
-    Hint Rewrite @Pos_eval_left_append : push_basesystem_eval.
 
     Lemma small_mod_eq a b n: a mod n = b mod n -> 0 <= a < n -> a = b mod n.
     Proof. intros; rewrite <-(Z.mod_small a n); auto. Qed.
@@ -307,7 +287,7 @@ Module Columns.
                | _ => rewrite compact_digit_div, sum_cons
                | _ => rewrite compact_digit_mod, sum_cons
                | _ => rewrite map_left_append
-               | _ => rewrite eval_left_append
+               | _ => rewrite B.Positional.eval_left_append
                | _ => rewrite weight_0, ?Z.div_1_r, ?Z.mod_1_r
                | _ => rewrite Hdiv 
                | _ => rewrite Hmod 

--- a/src/Specific/ArithmeticSynthesisTest.v
+++ b/src/Specific/ArithmeticSynthesisTest.v
@@ -222,20 +222,19 @@ Section Ops51.
         apply Z.div_positive_gt_0; auto using wt_pos.
         apply wt_multiples.
     Qed.
-
-    Context {select_cps : forall n, Z -> Z^n -> forall {T}, (Z^n->T) -> T}
-            {select : forall n, Z -> Z^n -> Z^n}
-            {select_id : forall n cond x T f, @select_cps n cond x T f = f (select n cond x)}
-            {eval_select : forall n cond x,
-                B.Positional.eval wt (select n cond x) = if dec (cond = 0) then 0 else B.Positional.eval wt x}
-    .
-
-    Hint Rewrite select_id : uncps.
-    Hint Rewrite eval_select : push_basesystem_eval.
-
-    Hint Opaque freeze : uncps.
-    Hint Rewrite freeze_id : uncps.
   End PreFreeze.
+
+  Context {select_cps : forall n, Z -> Z^n -> forall {T}, (Z^n->T) -> T}
+          {select : forall n, Z -> Z^n -> Z^n}
+          {select_id : forall n cond x T f, @select_cps n cond x T f = f (select n cond x)}
+          {eval_select : forall n cond x,
+              B.Positional.eval wt (select n cond x) = if dec (cond = 0) then 0 else B.Positional.eval wt x}
+  .
+
+  Hint Rewrite select_id : uncps.
+  Hint Rewrite eval_select : push_basesystem_eval.
+  Hint Opaque freeze : uncps.
+  Hint Rewrite freeze_id : uncps.
   
   Definition freeze_sig :
     {freeze : (Z^sz -> Z^sz)%type |


### PR DESCRIPTION
Freeze implementation and proof. This includes changes to `Columns.compact` as well (making it obey a strict div/mod rule rather than a "split" rule; if the input is 'z' and the is output `(x,y)`, it must be true that `x = z mod m` and `y = x / m`, not just that `x + m * y = z`).