### PR TITLE
Add definitions for zselect and add_get_carry

### DIFF
--- a/src/Util/ZUtil/Definitions.v
+++ b/src/Util/ZUtil/Definitions.v
@@ -4,4 +4,16 @@ Local Open Scope Z_scope.
 
 Module Z.
   Definition pow2_mod n i := (n &' (Z.ones i)).
+
+  Definition zselect (cond zero_case nonzero_case : Z) :=
+    if cond =? 0 then zero_case else nonzero_case.
+
+  Definition get_carry (bitwidth : Z) (v : Z) : Z * Z
+    := (v mod 2^bitwidth, v / 2^bitwidth).
+  Definition add_with_carry (c : Z) (x y : Z) : Z
+    := c + x + y.
+  Definition add_with_get_carry (bitwidth : Z) (c : Z) (x y : Z) : Z * Z
+    := get_carry bitwidth (add_with_carry c x y).
+  Definition add_get_carry (bitwidth : Z) (x y : Z) : Z * Z
+    := get_carry bitwidth (x + y).
 End Z.

--- a/src/Util/ZUtil/Definitions.v
+++ b/src/Util/ZUtil/Definitions.v
@@ -15,5 +15,5 @@ Module Z.
   Definition add_with_get_carry (bitwidth : Z) (c : Z) (x y : Z) : Z * Z
     := get_carry bitwidth (add_with_carry c x y).
   Definition add_get_carry (bitwidth : Z) (x y : Z) : Z * Z
-    := get_carry bitwidth (x + y).
+    := add_with_get_carry bitwidth 0 x y.
 End Z.

--- a/src/Util/ZUtil/Morphisms.v
+++ b/src/Util/ZUtil/Morphisms.v
@@ -2,6 +2,8 @@
 Require Import Coq.omega.Omega.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.RelationPairs.
+Require Import Crypto.Util.ZUtil.Definitions.
 Local Open Scope Z_scope.
 
 Module Z.
@@ -42,4 +44,6 @@ Module Z.
   Proof. intros ???; apply Z.log2_le_mono; assumption. Qed.
   Lemma pow_Zpos_le_Proper_flip x : Proper (Basics.flip Z.le ==> Basics.flip Z.le) (Z.pow (Z.pos x)).
   Proof. intros ???; apply Z.pow_le_mono_r; try reflexivity; try assumption. Qed.
+  Lemma add_with_carry_le_Proper : Proper (Z.le ==> Z.le ==> Z.le ==> Z.le) Z.add_with_carry.
+  Proof. unfold Z.add_with_carry; repeat (omega || intro). Qed.
 End Z.


### PR DESCRIPTION
In ZUtil/Definitions.v

@jadephilipoom Are these definitions that you can work with?  (I changed them a bit from the definitions you're using, and am having them work only for powers of 2, in part so that the reified code doesn't need to carry around large values on every add, and so that I don't need to hard-code the expanded value of 2¹²⁸ into the notations); does this seem reasonable?)

@andres-erbsen Is this general enough?  Is restricting ourselves to powers of two okay?