### PR TITLE
CSE modulo arithmetic without inlining

### DIFF
--- a/src/Compilers/CommonSubexpressionEliminationInterp.v
+++ b/src/Compilers/CommonSubexpressionEliminationInterp.v
@@ -40,7 +40,8 @@ Section symbolic.
           (symbolize_op : forall s d, op s d -> op_code)
           (denote_op : forall s d, op_code -> option (op s d)).
   Local Notation symbolic_expr := (symbolic_expr base_type_code op_code).
-  Context (normalize_symbolic_op_arguments : op_code -> symbolic_expr -> symbolic_expr).
+  Context (normalize_symbolic_op_arguments : op_code -> symbolic_expr -> symbolic_expr)
+          (inline_symbolic_expr_in_lookup : bool).
 
   Local Notation symbolic_expr_beq := (@symbolic_expr_beq base_type_code op_code base_type_code_beq op_code_beq).
   Local Notation symbolic_expr_lb := (@internal_symbolic_expr_dec_lb base_type_code op_code base_type_code_beq op_code_beq base_type_code_lb op_code_lb).
@@ -57,9 +58,9 @@ Section symbolic.
 
   Local Notation symbolicify_smart_var := (@symbolicify_smart_var base_type_code op_code).
   Local Notation symbolize_exprf := (@symbolize_exprf base_type_code op_code op symbolize_op).
-  Local Notation csef := (@csef base_type_code op_code base_type_code_beq op_code_beq base_type_code_bl op symbolize_op normalize_symbolic_op_arguments).
-  Local Notation cse := (@cse base_type_code op_code base_type_code_beq op_code_beq base_type_code_bl op symbolize_op normalize_symbolic_op_arguments).
-  Local Notation CSE := (@CSE base_type_code op_code base_type_code_beq op_code_beq base_type_code_bl op symbolize_op normalize_symbolic_op_arguments).
+  Local Notation csef := (@csef base_type_code op_code base_type_code_beq op_code_beq base_type_code_bl op symbolize_op normalize_symbolic_op_arguments inline_symbolic_expr_in_lookup).
+  Local Notation cse := (@cse base_type_code op_code base_type_code_beq op_code_beq base_type_code_bl op symbolize_op normalize_symbolic_op_arguments inline_symbolic_expr_in_lookup).
+  Local Notation CSE := (@CSE base_type_code op_code base_type_code_beq op_code_beq base_type_code_bl op symbolize_op normalize_symbolic_op_arguments inline_symbolic_expr_in_lookup).
   Local Notation SymbolicExprContext := (@SymbolicExprContext base_type_code op_code base_type_code_beq op_code_beq base_type_code_bl).
   Local Notation SymbolicExprContextOk := (@SymbolicExprContextOk base_type_code op_code base_type_code_beq op_code_beq base_type_code_bl base_type_code_lb op_code_bl op_code_lb).
   Local Notation prepend_prefix := (@prepend_prefix base_type_code op).

--- a/src/Compilers/TestCase.v
+++ b/src/Compilers/TestCase.v
@@ -187,7 +187,7 @@ Section cse.
        | Mul => SMul
        | Sub => SSub
        end.
-  Definition CSE {t} e := @CSE base_type op_code base_type_beq op_code_beq internal_base_type_dec_bl op symbolicify_op (fun _ x => x) t e (fun _ => nil).
+  Definition CSE {t} e := @CSE base_type op_code base_type_beq op_code_beq internal_base_type_dec_bl op symbolicify_op (fun _ x => x) true t e (fun _ => nil).
 End cse.
 
 Definition example_expr_simplified := Eval vm_compute in InlineConst is_const (ANormal example_expr).

--- a/src/Compilers/Z/Bounds/Pipeline/Definition.v
+++ b/src/Compilers/Z/Bounds/Pipeline/Definition.v
@@ -61,9 +61,9 @@ Require Import Crypto.Compilers.Z.InlineWf.
 Require Import Crypto.Compilers.Linearize.
 Require Import Crypto.Compilers.LinearizeInterp.
 Require Import Crypto.Compilers.LinearizeWf.
-Require Import Crypto.Compilers.Z.CommonSubexpressionElimination.
+(*Require Import Crypto.Compilers.Z.CommonSubexpressionElimination.
 Require Import Crypto.Compilers.Z.CommonSubexpressionEliminationInterp.
-Require Import Crypto.Compilers.Z.CommonSubexpressionEliminationWf.
+Require Import Crypto.Compilers.Z.CommonSubexpressionEliminationWf.*)
 Require Import Crypto.Compilers.Z.ArithmeticSimplifierWf.
 Require Import Crypto.Compilers.Z.Bounds.MapCastByDeBruijn.
 Require Import Crypto.Compilers.Z.Bounds.MapCastByDeBruijnInterp.
@@ -83,7 +83,7 @@ Definition PostWfPipeline
         let e := SimplifyArith e in
         let e := ANormal e in
         let e := InlineConst e in
-        let e := CSE false e in
+        (*let e := CSE false e in*)
         let e := MapCast _ e input_bounds in
         option_map
           (projT2_map

--- a/src/Compilers/Z/Bounds/Pipeline/Definition.v
+++ b/src/Compilers/Z/Bounds/Pipeline/Definition.v
@@ -61,6 +61,9 @@ Require Import Crypto.Compilers.Z.InlineWf.
 Require Import Crypto.Compilers.Linearize.
 Require Import Crypto.Compilers.LinearizeInterp.
 Require Import Crypto.Compilers.LinearizeWf.
+Require Import Crypto.Compilers.Z.CommonSubexpressionElimination.
+Require Import Crypto.Compilers.Z.CommonSubexpressionEliminationInterp.
+Require Import Crypto.Compilers.Z.CommonSubexpressionEliminationWf.
 Require Import Crypto.Compilers.Z.ArithmeticSimplifierWf.
 Require Import Crypto.Compilers.Z.Bounds.MapCastByDeBruijn.
 Require Import Crypto.Compilers.Z.Bounds.MapCastByDeBruijnInterp.
@@ -80,6 +83,7 @@ Definition PostWfPipeline
         let e := SimplifyArith e in
         let e := ANormal e in
         let e := InlineConst e in
+        let e := CSE false e in
         let e := MapCast _ e input_bounds in
         option_map
           (projT2_map

--- a/src/Compilers/Z/CommonSubexpressionElimination.v
+++ b/src/Compilers/Z/CommonSubexpressionElimination.v
@@ -151,25 +151,25 @@ Definition normalize_symbolic_expr_mod_c (opc : symbolic_op) (args : symbolic_ex
        => args
      end.
 
-Definition csef {var t} (v : exprf _ _ t) xs
+Definition csef inline_symbolic_expr_in_lookup {var t} (v : exprf _ _ t) xs
   := @csef base_type symbolic_op base_type_beq symbolic_op_beq
            internal_base_type_dec_bl op symbolize_op
            normalize_symbolic_expr_mod_c
-           var t v xs.
+           var inline_symbolic_expr_in_lookup t v xs.
 
-Definition cse {var} (prefix : list _) {t} (v : expr _ _ t) xs
+Definition cse inline_symbolic_expr_in_lookup {var} (prefix : list _) {t} (v : expr _ _ t) xs
   := @cse base_type symbolic_op base_type_beq symbolic_op_beq
           internal_base_type_dec_bl op symbolize_op
           normalize_symbolic_expr_mod_c
-          var prefix t v xs.
+          inline_symbolic_expr_in_lookup var prefix t v xs.
 
-Definition CSE_gen {t} (e : Expr _ _ t) (prefix : forall var, list { t : flat_type base_type & exprf _ _ t })
+Definition CSE_gen inline_symbolic_expr_in_lookup {t} (e : Expr _ _ t) (prefix : forall var, list { t : flat_type base_type & exprf _ _ t })
   : Expr _ _ t
   := @CSE base_type symbolic_op base_type_beq symbolic_op_beq
           internal_base_type_dec_bl op symbolize_op
           normalize_symbolic_expr_mod_c
-          t e prefix.
+          inline_symbolic_expr_in_lookup t e prefix.
 
-Definition CSE {t} (e : Expr _ _ t)
+Definition CSE inline_symbolic_expr_in_lookup {t} (e : Expr _ _ t)
   : Expr _ _ t
-  := @CSE_gen t e (fun _ => nil).
+  := @CSE_gen inline_symbolic_expr_in_lookup t e (fun _ => nil).

--- a/src/Compilers/Z/CommonSubexpressionEliminationInterp.v
+++ b/src/Compilers/Z/CommonSubexpressionEliminationInterp.v
@@ -6,16 +6,16 @@ Require Import Crypto.Compilers.Z.Syntax.
 Require Import Crypto.Compilers.CommonSubexpressionEliminationInterp.
 Require Import Crypto.Compilers.Z.CommonSubexpressionElimination.
 
-Lemma InterpCSE_gen t (e : Expr _ _ t) prefix
+Lemma InterpCSE_gen inline_symbolic_expr_in_lookup t (e : Expr _ _ t) prefix
       (Hwf : Wf e)
-  : forall x, Interp interp_op (@CSE_gen t e prefix) x = Interp interp_op e x.
+  : forall x, Interp interp_op (@CSE_gen inline_symbolic_expr_in_lookup t e prefix) x = Interp interp_op e x.
 Proof.
   apply InterpCSE;
     auto using internal_base_type_dec_bl, internal_base_type_dec_lb, internal_symbolic_op_dec_bl, internal_symbolic_op_dec_lb, denote_symbolic_op.
 Qed.
 
-Lemma InterpCSE t (e : Expr _ _ t) (Hwf : Wf e)
-  : forall x, Interp interp_op (@CSE t e) x = Interp interp_op e x.
+Lemma InterpCSE inline_symbolic_expr_in_lookup t (e : Expr _ _ t) (Hwf : Wf e)
+  : forall x, Interp interp_op (@CSE inline_symbolic_expr_in_lookup t e) x = Interp interp_op e x.
 Proof.
   apply InterpCSE_gen; auto.
 Qed.

--- a/src/Compilers/Z/CommonSubexpressionEliminationWf.v
+++ b/src/Compilers/Z/CommonSubexpressionEliminationWf.v
@@ -5,7 +5,7 @@ Require Import Crypto.Compilers.Z.Syntax.
 Require Import Crypto.Compilers.CommonSubexpressionEliminationWf.
 Require Import Crypto.Compilers.Z.CommonSubexpressionElimination.
 
-Lemma Wf_CSE_gen t (e : Expr _ _ t)
+Lemma Wf_CSE_gen inline_symbolic_expr_in_lookup t (e : Expr _ _ t)
       prefix
       (Hlen : forall var1 var2, length (prefix var1) = length (prefix var2))
       (Hprefix : forall var1 var2 n t1 t2 e1 e2,
@@ -13,14 +13,14 @@ Lemma Wf_CSE_gen t (e : Expr _ _ t)
           -> List.nth_error (prefix var2) n = Some (existT _ t2 e2)
           -> exists pf : t1 = t2, wff nil (eq_rect _ (@exprf _ _ _) e1 _ pf) e2)
       (Hwf : Wf e)
-  : Wf (@CSE_gen t e prefix).
+  : Wf (@CSE_gen inline_symbolic_expr_in_lookup t e prefix).
 Proof.
   apply Wf_CSE; auto using internal_base_type_dec_bl, internal_base_type_dec_lb, internal_symbolic_op_dec_bl, internal_symbolic_op_dec_lb.
 Qed.
 
-Lemma Wf_CSE t (e : Expr _ _ t)
+Lemma Wf_CSE inline_symbolic_expr_in_lookup t (e : Expr _ _ t)
       (Hwf : Wf e)
-  : Wf (@CSE t e).
+  : Wf (@CSE inline_symbolic_expr_in_lookup t e).
 Proof.
   apply Wf_CSE_gen; simpl; auto.
   { destruct n; simpl; try congruence. }

--- a/src/Specific/FancyMachine256/Core.v
+++ b/src/Specific/FancyMachine256/Core.v
@@ -108,7 +108,7 @@ Section reflection.
        | OPaddm => SOPaddm
        end.
 
-  Definition CSE {t} e := @CSE base_type op_code base_type_beq op_code_beq internal_base_type_dec_bl op symbolicify_op (fun _ x => x) t e (fun _ => nil).
+  Definition CSE {t} e := @CSE base_type op_code base_type_beq op_code_beq internal_base_type_dec_bl op symbolicify_op (fun _ x => x) true t e (fun _ => nil).
 
   Inductive inline_option := opt_inline | opt_default | opt_noinline.
 


### PR DESCRIPTION
This takes care of most of #158.  The remaining bits are reworking the Wf and interpretation lemmas to actually work.  (The former needs a only bit of rethinking and rephrasing to handle the fact that sometimes we change the stored symbolic expression from a complicated one to a fresh variable, while the latter needs major surgery, which Adam tells me is easy.)