### PR TITLE
SubWithBorrow

### DIFF
--- a/src/Compilers/Z/ArithmeticSimplifier.v
+++ b/src/Compilers/Z/ArithmeticSimplifier.v
@@ -32,6 +32,7 @@ Section language.
                     | OpConst _ z => fun _ _ => const_of _ z
                     | Opp TZ TZ => fun _ args => neg_expr _ args
                     | AddWithGetCarry _ _ _ _ _ _ => fun _ _ => I
+                    | SubWithGetBorrow _ _ _ _ _ _ => fun _ _ => I
                     | _ => fun e _ => gen_expr _ e
                     end (Op opc args) args)
          | TT => Some tt
@@ -187,6 +188,8 @@ Section language.
          | Zselect _ _ _ _ as opc
          | AddWithCarry _ _ _ _ as opc
          | AddWithGetCarry _ _ _ _ _ _ as opc
+         | SubWithBorrow _ _ _ _ as opc
+         | SubWithGetBorrow _ _ _ _ _ _ as opc
            => Op opc
          end.
   End with_var.

--- a/src/Compilers/Z/ArithmeticSimplifier.v
+++ b/src/Compilers/Z/ArithmeticSimplifier.v
@@ -5,6 +5,7 @@ Require Import Crypto.Compilers.Rewriter.
 Require Import Crypto.Compilers.Z.Syntax.
 
 Section language.
+  Context (convert_adc_to_sbb : bool).
   Local Notation exprf := (@exprf base_type op).
   Local Notation Expr := (@Expr base_type op).
 
@@ -178,108 +179,116 @@ Section language.
                  end
          | AddWithCarry TZ TZ TZ TZ as opc
            => fun args
-              => match interp_as_expr_or_const args with
-                 | Some (const_of c, const_of x, const_of y)
-                   => Op (OpConst (interp_op _ _ opc (c, x, y))) TT
-                 | Some (c, gen_expr x, y)
-                   => let y' := match y with
-                                | const_of y => if (y <? 0)%Z
-                                                then Some (Op (OpConst (-y)) TT)
-                                                else None
-                                | neg_expr y => Some y
-                                | gen_expr _ => None
-                                end in
-                      match y' with
-                      | Some y => Op (SubWithBorrow TZ TZ TZ TZ)
-                                     (match c with
-                                      | const_of c => Op (OpConst (-c)) TT
-                                      | neg_expr c => c
-                                      | gen_expr c => Op (Opp TZ TZ) c
-                                      end,
-                                      x, y)%expr
-                      | None => Op opc args
+              => if convert_adc_to_sbb
+                 then match interp_as_expr_or_const args with
+                      | Some (const_of c, const_of x, const_of y)
+                        => Op (OpConst (interp_op _ _ opc (c, x, y))) TT
+                      | Some (c, gen_expr x, y)
+                        => let y' := match y with
+                                     | const_of y => if (y <? 0)%Z
+                                                     then Some (Op (OpConst (-y)) TT)
+                                                     else None
+                                     | neg_expr y => Some y
+                                     | gen_expr _ => None
+                                     end in
+                           match y' with
+                           | Some y => Op (SubWithBorrow TZ TZ TZ TZ)
+                                          (match c with
+                                           | const_of c => Op (OpConst (-c)) TT
+                                           | neg_expr c => c
+                                           | gen_expr c => Op (Opp TZ TZ) c
+                                           end,
+                                           x, y)%expr
+                           | None => Op opc args
+                           end
+                      | _ => Op opc args
                       end
-                 | _ => Op opc args
-                 end
+                 else Op opc args
          | AddWithGetCarry bw TZ TZ TZ TZ TZ as opc
            => fun args
-              => match interp_as_expr_or_const args with
-                 | Some (const_of c, const_of x, const_of y)
-                   => let '(v, c) := interp_op _ _ opc (c, x, y) in
-                      (Op (OpConst v) TT, Op (OpConst c) TT)%expr
-                 | Some (c, gen_expr x, y)
-                   => let y' := match y with
-                                | const_of y => if (y <? 0)%Z
-                                                then Some (Op (OpConst (-y)) TT)
-                                                else None
-                                | neg_expr y => Some y
-                                | gen_expr _ => None
-                                end in
-                      match y' with
-                      | Some y => LetIn (Op (SubWithGetBorrow bw TZ TZ TZ TZ TZ)
-                                            (match c with
-                                             | const_of c => Op (OpConst (-c)) TT
-                                             | neg_expr c => c
-                                             | gen_expr c => Op (Opp TZ TZ) c
-                                             end,
-                                             x, y)%expr)
-                                        (fun '(v, c) => (Var v, Op (Opp TZ TZ) (Var c))%expr)
-                      | None => Op opc args
+              => if convert_adc_to_sbb
+                 then match interp_as_expr_or_const args with
+                      | Some (const_of c, const_of x, const_of y)
+                        => let '(v, c) := interp_op _ _ opc (c, x, y) in
+                           (Op (OpConst v) TT, Op (OpConst c) TT)%expr
+                      | Some (c, gen_expr x, y)
+                        => let y' := match y with
+                                     | const_of y => if (y <? 0)%Z
+                                                     then Some (Op (OpConst (-y)) TT)
+                                                     else None
+                                     | neg_expr y => Some y
+                                     | gen_expr _ => None
+                                     end in
+                           match y' with
+                           | Some y => LetIn (Op (SubWithGetBorrow bw TZ TZ TZ TZ TZ)
+                                                 (match c with
+                                                  | const_of c => Op (OpConst (-c)) TT
+                                                  | neg_expr c => c
+                                                  | gen_expr c => Op (Opp TZ TZ) c
+                                                  end,
+                                                  x, y)%expr)
+                                             (fun '(v, c) => (Var v, Op (Opp TZ TZ) (Var c))%expr)
+                           | None => Op opc args
+                           end
+                      | _ => Op opc args
                       end
-                 | _ => Op opc args
-                 end
+                 else Op opc args
          | SubWithBorrow TZ TZ TZ TZ as opc
            => fun args
-              => match interp_as_expr_or_const args with
-                 | Some (const_of c, const_of x, const_of y)
-                   => Op (OpConst (interp_op _ _ opc (c, x, y))) TT
-                 | Some (c, gen_expr x, y)
-                   => let y' := match y with
-                                | const_of y => if (y <? 0)%Z
-                                                then Some (Op (OpConst (-y)) TT)
-                                                else None
-                                | neg_expr y => Some y
-                                | gen_expr _ => None
-                                end in
-                      match y' with
-                      | Some y => Op (AddWithCarry TZ TZ TZ TZ)
-                                     (match c with
-                                      | const_of c => Op (OpConst (-c)) TT
-                                      | neg_expr c => c
-                                      | gen_expr c => Op (Opp TZ TZ) c
-                                      end,
-                                      x, y)%expr
-                      | None => Op opc args
+              => if convert_adc_to_sbb
+                 then match interp_as_expr_or_const args with
+                      | Some (const_of c, const_of x, const_of y)
+                        => Op (OpConst (interp_op _ _ opc (c, x, y))) TT
+                      | Some (c, gen_expr x, y)
+                        => let y' := match y with
+                                     | const_of y => if (y <? 0)%Z
+                                                     then Some (Op (OpConst (-y)) TT)
+                                                     else None
+                                     | neg_expr y => Some y
+                                     | gen_expr _ => None
+                                     end in
+                           match y' with
+                           | Some y => Op (AddWithCarry TZ TZ TZ TZ)
+                                          (match c with
+                                           | const_of c => Op (OpConst (-c)) TT
+                                           | neg_expr c => c
+                                           | gen_expr c => Op (Opp TZ TZ) c
+                                           end,
+                                           x, y)%expr
+                           | None => Op opc args
+                           end
+                      | _ => Op opc args
                       end
-                 | _ => Op opc args
-                 end
+                 else Op opc args
          | SubWithGetBorrow bw TZ TZ TZ TZ TZ as opc
            => fun args
-              => match interp_as_expr_or_const args with
-                 | Some (const_of c, const_of x, const_of y)
-                   => let '(v, c) := interp_op _ _ opc (c, x, y) in
-                      (Op (OpConst v) TT, Op (OpConst c) TT)%expr
-                 | Some (c, gen_expr x, y)
-                   => let y' := match y with
-                                | const_of y => if (y <? 0)%Z
-                                                then Some (Op (OpConst (-y)) TT)
-                                                else None
-                                | neg_expr y => Some y
-                                | gen_expr _ => None
-                                end in
-                      match y' with
-                      | Some y => LetIn (Op (AddWithGetCarry bw TZ TZ TZ TZ TZ)
-                                            (match c with
-                                             | const_of c => Op (OpConst (-c)) TT
-                                             | neg_expr c => c
-                                             | gen_expr c => Op (Opp TZ TZ) c
-                                             end,
-                                             x, y)%expr)
-                                        (fun '(v, c) => (Var v, Op (Opp TZ TZ) (Var c))%expr)
-                      | None => Op opc args
+              => if convert_adc_to_sbb
+                 then match interp_as_expr_or_const args with
+                      | Some (const_of c, const_of x, const_of y)
+                        => let '(v, c) := interp_op _ _ opc (c, x, y) in
+                           (Op (OpConst v) TT, Op (OpConst c) TT)%expr
+                      | Some (c, gen_expr x, y)
+                        => let y' := match y with
+                                     | const_of y => if (y <? 0)%Z
+                                                     then Some (Op (OpConst (-y)) TT)
+                                                     else None
+                                     | neg_expr y => Some y
+                                     | gen_expr _ => None
+                                     end in
+                           match y' with
+                           | Some y => LetIn (Op (AddWithGetCarry bw TZ TZ TZ TZ TZ)
+                                                 (match c with
+                                                  | const_of c => Op (OpConst (-c)) TT
+                                                  | neg_expr c => c
+                                                  | gen_expr c => Op (Opp TZ TZ) c
+                                                  end,
+                                                  x, y)%expr)
+                                             (fun '(v, c) => (Var v, Op (Opp TZ TZ) (Var c))%expr)
+                           | None => Op opc args
+                           end
+                      | _ => Op opc args
                       end
-                 | _ => Op opc args
-                 end
+                 else Op opc args
          | Add _ _ _ as opc
          | Sub _ _ _ as opc
          | Mul _ _ _ as opc

--- a/src/Compilers/Z/ArithmeticSimplifierInterp.v
+++ b/src/Compilers/Z/ArithmeticSimplifierInterp.v
@@ -145,8 +145,8 @@ Local Arguments Z.add !_ !_.
 Local Arguments Z.sub !_ !_.
 Local Arguments Z.opp !_.
 
-Lemma InterpSimplifyArith {t} (e : Expr t)
-  : forall x, Interp interp_op (SimplifyArith e) x = Interp interp_op e x.
+Lemma InterpSimplifyArith {convert_adc_to_sbb} {t} (e : Expr t)
+  : forall x, Interp interp_op (SimplifyArith convert_adc_to_sbb e) x = Interp interp_op e x.
 Proof.
   apply InterpRewriteOp; intros; unfold simplify_op_expr.
   break_innermost_match;

--- a/src/Compilers/Z/ArithmeticSimplifierInterp.v
+++ b/src/Compilers/Z/ArithmeticSimplifierInterp.v
@@ -10,6 +10,7 @@ Require Import Crypto.Compilers.Z.ArithmeticSimplifier.
 Require Import Crypto.Compilers.Z.ArithmeticSimplifierUtil.
 Require Import Crypto.Compilers.Z.Syntax.Equality.
 Require Import Crypto.Util.ZUtil.
+Require Import Crypto.Util.ZUtil.AddGetCarry.
 Require Import Crypto.Util.Option.
 Require Import Crypto.Util.Prod.
 Require Import Crypto.Util.Sum.
@@ -36,6 +37,7 @@ Local Ltac break_t_step :=
         | progress inversion_prod
         | progress inversion_inverted_expr
         | progress inversion_flat_type
+        | progress subst_prod
         | progress destruct_head'_and
         | progress destruct_head'_prod
         | progress eliminate_hprop_eq
@@ -72,6 +74,12 @@ Proof.
                    | progress invert_op ]. }
 Qed.
 
+Local Ltac rewrite_interp_as_expr_or_const_correct_base _ :=
+  match goal with
+  | [ |- context[interpf _ ?e] ]
+    => erewrite !(@interp_as_expr_or_const_correct_base _ e) by eassumption; cbv beta iota
+  end.
+
 Lemma interp_as_expr_or_const_correct_prod_base {A B} e (v : _ * _)
   : @interp_as_expr_or_const interp_base_type (Prod (Tbase A) (Tbase B)) e = Some v
     -> interpf interp_op e = (match fst v with
@@ -90,8 +98,47 @@ Proof.
                  | progress simpl in *
                  | progress intros
                  | break_t_step
-                 | erewrite !interp_as_expr_or_const_correct_base by eassumption; cbv beta iota ].
+                 | rewrite_interp_as_expr_or_const_correct_base () ].
 Qed.
+
+Local Ltac rewrite_interp_as_expr_or_const_correct_prod_base _ :=
+  match goal with
+  | [ |- context[interpf _ ?e] ]
+    => erewrite !(@interp_as_expr_or_const_correct_prod_base _ _ e) by eassumption; cbv beta iota
+  end.
+
+Lemma interp_as_expr_or_const_correct_prod3_base {A B C} e (v : _ * _ * _)
+  : @interp_as_expr_or_const interp_base_type (Prod (Prod (Tbase A) (Tbase B)) (Tbase C)) e = Some v
+    -> interpf interp_op e = (match fst (fst v) with
+                              | const_of z => cast_const (t1:=TZ) z
+                              | gen_expr e => interpf interp_op e
+                              | neg_expr e => interpf interp_op (Op (Opp _ _) e)
+                              end,
+                              match snd (fst v) with
+                              | const_of z => cast_const (t1:=TZ) z
+                              | gen_expr e => interpf interp_op e
+                              | neg_expr e => interpf interp_op (Op (Opp _ _) e)
+                              end,
+                              match snd v with
+                              | const_of z => cast_const (t1:=TZ) z
+                              | gen_expr e => interpf interp_op e
+                              | neg_expr e => interpf interp_op (Op (Opp _ _) e)
+                              end).
+Proof.
+  invert_expr;
+    repeat first [ fin_t
+                 | progress simpl in *
+                 | progress intros
+                 | break_t_step
+                 | rewrite_interp_as_expr_or_const_correct_base ()
+                 | rewrite_interp_as_expr_or_const_correct_prod_base () ].
+Qed.
+
+Local Ltac rewrite_interp_as_expr_or_const_correct_prod3_base _ :=
+  match goal with
+  | [ |- context[interpf _ ?e] ]
+    => erewrite !(@interp_as_expr_or_const_correct_prod3_base _ _ _ e) by eassumption; cbv beta iota
+  end.
 
 Local Arguments Z.mul !_ !_.
 Local Arguments Z.add !_ !_.
@@ -104,17 +151,18 @@ Proof.
   apply InterpRewriteOp; intros; unfold simplify_op_expr.
   break_innermost_match;
     repeat first [ fin_t
+                 | progress cbv [LetIn.Let_In]
                  | progress simpl in *
                  | progress subst
-                 | erewrite !interp_as_expr_or_const_correct_prod_base by eassumption; cbv beta iota
-                 | erewrite !interp_as_expr_or_const_correct_base by eassumption; cbv beta iota
-                 | match goal with
-                   | [ |- context[interpf _ ?e] ]
-                     => erewrite !(@interp_as_expr_or_const_correct_base _ e) by eassumption; cbv beta iota
-                   end
+                 | progress subst_prod
+                 | rewrite_interp_as_expr_or_const_correct_base ()
+                 | rewrite_interp_as_expr_or_const_correct_prod_base ()
+                 | rewrite_interp_as_expr_or_const_correct_prod3_base ()
                  | progress unfold interp_op, lift_op
                  | progress Z.ltb_to_lt
-                 | progress rewrite ?Z.land_0_l, ?Z.land_0_r, ?Z.lor_0_l, ?Z.lor_0_r ].
+                 | progress rewrite ?Z.land_0_l, ?Z.land_0_r, ?Z.lor_0_l, ?Z.lor_0_r
+                 | rewrite !Z.sub_with_borrow_to_add_get_carry
+                 | progress autorewrite with zsimplify_fast ].
 Qed.
 
 Hint Rewrite @InterpSimplifyArith : reflective_interp.

--- a/src/Compilers/Z/ArithmeticSimplifierInterp.v
+++ b/src/Compilers/Z/ArithmeticSimplifierInterp.v
@@ -151,7 +151,7 @@ Proof.
   apply InterpRewriteOp; intros; unfold simplify_op_expr.
   break_innermost_match;
     repeat first [ fin_t
-                 | progress cbv [LetIn.Let_In]
+                 | progress cbv [LetIn.Let_In Z.zselect]
                  | progress simpl in *
                  | progress subst
                  | progress subst_prod
@@ -162,7 +162,8 @@ Proof.
                  | progress Z.ltb_to_lt
                  | progress rewrite ?Z.land_0_l, ?Z.land_0_r, ?Z.lor_0_l, ?Z.lor_0_r
                  | rewrite !Z.sub_with_borrow_to_add_get_carry
-                 | progress autorewrite with zsimplify_fast ].
+                 | progress autorewrite with zsimplify_fast
+                 | break_innermost_match_step ].
 Qed.
 
 Hint Rewrite @InterpSimplifyArith : reflective_interp.

--- a/src/Compilers/Z/ArithmeticSimplifierWf.v
+++ b/src/Compilers/Z/ArithmeticSimplifierWf.v
@@ -220,9 +220,9 @@ Local Ltac pose_wff_prod3 :=
     => pose proof (wff_interp_as_expr_or_const_prod3_base Hwf H1 H2); clear H1 H2
   end.
 
-Lemma Wf_SimplifyArith {t} (e : Expr t)
+Lemma Wf_SimplifyArith {convert_adc_to_sbb} {t} (e : Expr t)
       (Hwf : Wf e)
-  : Wf (SimplifyArith e).
+  : Wf (SimplifyArith convert_adc_to_sbb e).
 Proof.
   apply Wf_RewriteOp; [ | assumption ].
   intros ???????? Hwf'; unfold simplify_op_expr;

--- a/src/Compilers/Z/Bounds/Pipeline/Definition.v
+++ b/src/Compilers/Z/Bounds/Pipeline/Definition.v
@@ -89,12 +89,13 @@ Definition PostWfPipeline
   := Build_ProcessedReflectivePackage_from_option_sigma
        e input_bounds
        (let e := InlineConst e in
-        let e := SimplifyArith e in
-        let e := InlineConst e in
-        let e := SimplifyArith e in
+        let e := InlineConst (SimplifyArith e) in
+        let e := InlineConst (SimplifyArith e) in
+        let e := InlineConst (SimplifyArith e) in
         let e := if opts.(anf) then ANormal e else e in
         let e := InlineConst e in
         let e := RewriteAdc e in
+        let e := InlineConst (SimplifyArith e) in
         (*let e := CSE false e in*)
         let e := MapCast _ e input_bounds in
         option_map

--- a/src/Compilers/Z/Bounds/Pipeline/Definition.v
+++ b/src/Compilers/Z/Bounds/Pipeline/Definition.v
@@ -34,7 +34,7 @@ Require Import Crypto.Compilers.Z.ArithmeticSimplifierInterp.
 (** *** Definition of the Pre-Wf Pipeline *)
 (** Do not change the name or the type of this definition *)
 Definition PreWfPipeline {t} (e : Expr base_type op t) : Expr base_type op _
-  := ExprEta (SimplifyArith (Linearize e)).
+  := ExprEta (SimplifyArith false (Linearize e)).
 
 (** *** Correctness proof of the Pre-Wf Pipeline *)
 (** Do not change the statement of this lemma.  You shouldn't need to
@@ -89,13 +89,13 @@ Definition PostWfPipeline
   := Build_ProcessedReflectivePackage_from_option_sigma
        e input_bounds
        (let e := InlineConst e in
-        let e := InlineConst (SimplifyArith e) in
-        let e := InlineConst (SimplifyArith e) in
-        let e := InlineConst (SimplifyArith e) in
-        let e := if opts.(anf) then ANormal e else e in
-        let e := InlineConst e in
+        let e := InlineConst (SimplifyArith false e) in
+        let e := InlineConst (SimplifyArith false e) in
+        let e := InlineConst (SimplifyArith false e) in
+        let e := if opts.(anf) then InlineConst (ANormal e) else e in
         let e := RewriteAdc e in
-        let e := InlineConst (SimplifyArith e) in
+        let e := InlineConstAndOpp (Linearize (SimplifyArith true e)) in
+        let e := InlineConstAndOpp (Linearize (SimplifyArith true e)) in
         (*let e := CSE false e in*)
         let e := MapCast _ e input_bounds in
         option_map

--- a/src/Compilers/Z/Bounds/Pipeline/Definition.v
+++ b/src/Compilers/Z/Bounds/Pipeline/Definition.v
@@ -95,6 +95,7 @@ Definition PostWfPipeline
         let e := if opts.(anf) then InlineConst (ANormal e) else e in
         let e := RewriteAdc e in
         let e := InlineConstAndOpp (Linearize (SimplifyArith true e)) in
+        let e := if opts.(anf) then InlineConstAndOpp (ANormal e) else e in
         let e := InlineConstAndOpp (Linearize (SimplifyArith true e)) in
         (*let e := CSE false e in*)
         let e := MapCast _ e input_bounds in

--- a/src/Compilers/Z/Reify.v
+++ b/src/Compilers/Z/Reify.v
@@ -22,11 +22,18 @@ Ltac base_reify_op op op_head extra ::=
      | @Z.opp => constr:(reify_op op op_head 1 (Opp TZ TZ))
      | @Z.zselect => constr:(reify_op op op_head 3 (Zselect TZ TZ TZ TZ))
      | @Z.add_with_carry => constr:(reify_op op op_head 3 (AddWithCarry TZ TZ TZ TZ))
+     | @Z.sub_with_borrow => constr:(reify_op op op_head 3 (SubWithBorrow TZ TZ TZ TZ))
      | @Z.add_with_get_carry
        => lazymatch extra with
           | @Z.add_with_get_carry ?bit_width _ _ _
             => constr:(reify_op op op_head 3 (AddWithGetCarry bit_width TZ TZ TZ TZ TZ))
           | _ => fail 100 "Anomaly: In Reflection.Z.base_reify_op: head is Z.add_with_get_carry but body is wrong:" extra
+          end
+     | @Z.sub_with_get_borrow
+       => lazymatch extra with
+          | @Z.sub_with_get_borrow ?bit_width _ _ _
+            => constr:(reify_op op op_head 3 (SubWithGetBorrow bit_width TZ TZ TZ TZ TZ))
+          | _ => fail 100 "Anomaly: In Reflection.Z.base_reify_op: head is Z.sub_with_get_borrow but body is wrong:" extra
           end
      end.
 Ltac base_reify_type T ::=
@@ -34,10 +41,10 @@ Ltac base_reify_type T ::=
      | Z => TZ
      end.
 Ltac Reify' e :=
-  let e := (eval cbv beta delta [Z.add_get_carry] in e) in
+  let e := (eval cbv beta delta [Z.add_get_carry Z.sub_get_borrow] in e) in
   Compilers.Reify.Reify' base_type interp_base_type op e.
 Ltac Reify e :=
-  let e := (eval cbv beta delta [Z.add_get_carry] in e) in
+  let e := (eval cbv beta delta [Z.add_get_carry Z.sub_get_borrow] in e) in
   let v := Compilers.Reify.Reify base_type interp_base_type op make_const e in
   constr:(ExprEta v).
 Ltac prove_ExprEta_Compile_correct :=

--- a/src/Compilers/Z/Syntax.v
+++ b/src/Compilers/Z/Syntax.v
@@ -30,6 +30,8 @@ Inductive op : flat_type base_type -> flat_type base_type -> Type :=
 | Zselect T1 T2 T3 Tout : op (Tbase T1 * Tbase T2 * Tbase T3) (Tbase Tout)
 | AddWithCarry T1 T2 T3 Tout : op (Tbase T1 * Tbase T2 * Tbase T3) (Tbase Tout)
 | AddWithGetCarry (bitwidth : Z) T1 T2 T3 Tout1 Tout2 : op (Tbase T1 * Tbase T2 * Tbase T3) (Tbase Tout1 * Tbase Tout2)
+| SubWithBorrow T1 T2 T3 Tout : op (Tbase T1 * Tbase T2 * Tbase T3) (Tbase Tout)
+| SubWithGetBorrow (bitwidth : Z) T1 T2 T3 Tout1 Tout2 : op (Tbase T1 * Tbase T2 * Tbase T3) (Tbase Tout1 * Tbase Tout2)
 .
 
 Definition interp_base_type (v : base_type) : Type :=
@@ -85,6 +87,8 @@ Definition Zinterp_op src dst (f : op src dst)
      | Zselect _ _ _ _ => fun ctf => let '(c, t, f) := eta3 ctf in Z.zselect c t f
      | AddWithCarry _ _ _ _ => fun cxy => let '(c, x, y) := eta3 cxy in Z.add_with_carry c x y
      | AddWithGetCarry bitwidth _ _ _ _ _ => fun cxy => let '(c, x, y) := eta3 cxy in Z.add_with_get_carry bitwidth c x y
+     | SubWithBorrow _ _ _ _ => fun cxy => let '(c, x, y) := eta3 cxy in Z.sub_with_borrow c x y
+     | SubWithGetBorrow bitwidth _ _ _ _ _ => fun cxy => let '(c, x, y) := eta3 cxy in Z.sub_with_get_borrow bitwidth c x y
      end%Z.
 
 Definition interp_op src dst (f : op src dst) : interp_flat_type interp_base_type src -> interp_flat_type interp_base_type dst

--- a/src/Compilers/Z/Syntax/Equality.v
+++ b/src/Compilers/Z/Syntax/Equality.v
@@ -47,6 +47,10 @@ Definition op_beq_hetero {t1 tR t1' tR'} (f : op t1 tR) (g : op t1' tR') : bool
        => base_type_beq T1 T1' && base_type_beq T2 T2' && base_type_beq T3 T3' && base_type_beq Tout Tout'
      | AddWithGetCarry bitwidth T1 T2 T3 Tout1 Tout2, AddWithGetCarry bitwidth' T1' T2' T3' Tout1' Tout2'
        => Z.eqb bitwidth bitwidth' && base_type_beq T1 T1' && base_type_beq T2 T2' && base_type_beq T3 T3' && base_type_beq Tout1 Tout1' && base_type_beq Tout2 Tout2'
+     | SubWithBorrow T1 T2 T3 Tout, SubWithBorrow T1' T2' T3' Tout'
+       => base_type_beq T1 T1' && base_type_beq T2 T2' && base_type_beq T3 T3' && base_type_beq Tout Tout'
+     | SubWithGetBorrow bitwidth T1 T2 T3 Tout1 Tout2, SubWithGetBorrow bitwidth' T1' T2' T3' Tout1' Tout2'
+       => Z.eqb bitwidth bitwidth' && base_type_beq T1 T1' && base_type_beq T2 T2' && base_type_beq T3 T3' && base_type_beq Tout1 Tout1' && base_type_beq Tout2 Tout2'
      | OpConst _ _, _
      | Add _ _ _, _
      | Sub _ _ _, _
@@ -59,6 +63,8 @@ Definition op_beq_hetero {t1 tR t1' tR'} (f : op t1 tR) (g : op t1' tR') : bool
      | Zselect _ _ _ _, _
      | AddWithCarry _ _ _ _, _
      | AddWithGetCarry _ _ _ _ _ _, _
+     | SubWithBorrow _ _ _ _, _
+     | SubWithGetBorrow _ _ _ _ _ _, _
        => false
      end%bool.
 

--- a/src/Compilers/Z/Syntax/Util.v
+++ b/src/Compilers/Z/Syntax/Util.v
@@ -71,6 +71,8 @@ Definition genericize_op {var' src dst} (opc : op src dst) {f}
      | Zselect _ _ _ _ => fun _ _ => Zselect _ _ _ _
      | AddWithCarry _ _ _ _ => fun _ _ => AddWithCarry _ _ _ _
      | AddWithGetCarry bitwidth _ _ _ _ _ => fun _ _ => AddWithGetCarry bitwidth _ _ _ _ _
+     | SubWithBorrow _ _ _ _ => fun _ _ => SubWithBorrow _ _ _ _
+     | SubWithGetBorrow bitwidth _ _ _ _ _ => fun _ _ => SubWithGetBorrow bitwidth _ _ _ _ _
      end.
 
 Lemma cast_const_id {t} v

--- a/src/Specific/IntegrationTestFreezeDisplay.log
+++ b/src/Specific/IntegrationTestFreezeDisplay.log
@@ -3,36 +3,21 @@ Interp-η
 (λ var : Syntax.base_type → Type,
  λ '(x7, x8, x6, x4, x2)%core,
  uint64_t x10, bool x11 = subborrow_u51(0x0, x2, 0x7ffffffffffed);
- ℤ x12 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x11);
- uint64_t x14, bool x15 = addcarryx_u51(0x0, 0x0, x10);
- ℤ x16 = x12 + x15;
- uint64_t x18, bool x19 = subborrow_u51(0x0, x4, 0x7ffffffffffff);
- ℤ x20 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x19);
- uint64_t x22, ℤ x23 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) Syntax.TZ (Syntax.TWord 6) (Syntax.TWord 6) Syntax.TZ) (0x0, Return x16, Return x18);
- ℤ x24 = x20 + x23;
- uint64_t x26, bool x27 = subborrow_u51(0x0, x6, 0x7ffffffffffff);
- ℤ x28 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x27);
- uint64_t x30, ℤ x31 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) Syntax.TZ (Syntax.TWord 6) (Syntax.TWord 6) Syntax.TZ) (0x0, Return x24, Return x26);
- ℤ x32 = x28 + x31;
- uint64_t x34, bool x35 = subborrow_u51(0x0, x8, 0x7ffffffffffff);
- ℤ x36 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x35);
- uint64_t x38, ℤ x39 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) Syntax.TZ (Syntax.TWord 6) (Syntax.TWord 6) Syntax.TZ) (0x0, Return x32, Return x34);
- ℤ x40 = x36 + x39;
- uint64_t x42, bool x43 = subborrow_u51(0x0, x7, 0x7ffffffffffff);
- ℤ x44 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x43);
- uint64_t x46, ℤ x47 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) Syntax.TZ (Syntax.TWord 6) (Syntax.TWord 6) Syntax.TZ) (0x0, Return x40, Return x42);
- ℤ x48 = x44 + x47;
- uint64_t x49 = (uint64_t) (x48 == 0 ? 0x0 : 0xffffffffffffffffL);
- uint64_t x50 = x49 & 0x7ffffffffffed;
- uint64_t x52, bool x53 = addcarryx_u51(0x0, x14, x50);
- uint64_t x54 = x49 & 0x7ffffffffffff;
- uint64_t x56, bool x57 = addcarryx_u51(x53, x22, x54);
- uint64_t x58 = x49 & 0x7ffffffffffff;
- uint64_t x60, bool x61 = addcarryx_u51(x57, x30, x58);
- uint64_t x62 = x49 & 0x7ffffffffffff;
- uint64_t x64, bool x65 = addcarryx_u51(x61, x38, x62);
- uint64_t x66 = x49 & 0x7ffffffffffff;
- uint64_t x68, bool _ = addcarryx_u51(x65, x46, x66);
- (Return x68, Return x64, Return x60, Return x56, Return x52))
+ uint64_t x13, bool x14 = subborrow_u51(Op (Syntax.Opp Syntax.TZ (Syntax.TWord 0)) (Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x11)), x4, 0x7ffffffffffff);
+ uint64_t x16, bool x17 = subborrow_u51(x14, x6, 0x7ffffffffffff);
+ uint64_t x19, bool x20 = subborrow_u51(x17, x8, 0x7ffffffffffff);
+ uint64_t x22, bool x23 = subborrow_u51(x20, x7, 0x7ffffffffffff);
+ uint64_t x24 = (uint64_t) (Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x23) == 0 ? 0x0 : 0xffffffffffffffffL);
+ uint64_t x25 = x24 & 0x7ffffffffffed;
+ uint64_t x27, bool x28 = addcarryx_u51(0x0, x10, x25);
+ uint64_t x29 = x24 & 0x7ffffffffffff;
+ uint64_t x31, bool x32 = addcarryx_u51(x28, x13, x29);
+ uint64_t x33 = x24 & 0x7ffffffffffff;
+ uint64_t x35, bool x36 = addcarryx_u51(x32, x16, x33);
+ uint64_t x37 = x24 & 0x7ffffffffffff;
+ uint64_t x39, bool x40 = addcarryx_u51(x36, x19, x37);
+ uint64_t x41 = x24 & 0x7ffffffffffff;
+ uint64_t x43, bool _ = addcarryx_u51(x40, x22, x41);
+ (Return x43, Return x39, Return x35, Return x31, Return x27))
 x
      : word64 * word64 * word64 * word64 * word64 → ReturnType (uint64_t * uint64_t * uint64_t * uint64_t * uint64_t)

--- a/src/Specific/IntegrationTestFreezeDisplay.log
+++ b/src/Specific/IntegrationTestFreezeDisplay.log
@@ -2,22 +2,37 @@
 Interp-η
 (λ var : Syntax.base_type → Type,
  λ '(x7, x8, x6, x4, x2)%core,
- uint64_t x10, ℤ x11 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) (Syntax.TWord 6) Syntax.TZ (Syntax.TWord 6) Syntax.TZ) (0x0, Return x2, Const (-2251799813685229));
- uint64_t x13, ℤ x14 = Op (Syntax.AddWithGetCarry 51 Syntax.TZ (Syntax.TWord 6) Syntax.TZ (Syntax.TWord 6) Syntax.TZ) (Return x11, Return x4, Const (-2251799813685247));
- uint64_t x16, ℤ x17 = Op (Syntax.AddWithGetCarry 51 Syntax.TZ (Syntax.TWord 6) Syntax.TZ (Syntax.TWord 6) Syntax.TZ) (Return x14, Return x6, Const (-2251799813685247));
- uint64_t x19, ℤ x20 = Op (Syntax.AddWithGetCarry 51 Syntax.TZ (Syntax.TWord 6) Syntax.TZ (Syntax.TWord 6) Syntax.TZ) (Return x17, Return x8, Const (-2251799813685247));
- uint64_t x22, ℤ x23 = Op (Syntax.AddWithGetCarry 51 Syntax.TZ (Syntax.TWord 6) Syntax.TZ (Syntax.TWord 6) Syntax.TZ) (Return x20, Return x7, Const (-2251799813685247));
- uint64_t x24 = (uint64_t) (x23 == 0 ? 0x0 : 0xffffffffffffffffL);
- uint64_t x25 = x24 & 0x7ffffffffffed;
- uint64_t x27, bool x28 = addcarryx_u51(0x0, x10, x25);
- uint64_t x29 = x24 & 0x7ffffffffffff;
- uint64_t x31, bool x32 = addcarryx_u51(x28, x13, x29);
- uint64_t x33 = x24 & 0x7ffffffffffff;
- uint64_t x35, bool x36 = addcarryx_u51(x32, x16, x33);
- uint64_t x37 = x24 & 0x7ffffffffffff;
- uint64_t x39, bool x40 = addcarryx_u51(x36, x19, x37);
- uint64_t x41 = x24 & 0x7ffffffffffff;
- uint64_t x43, bool _ = addcarryx_u51(x40, x22, x41);
- (Return x43, Return x39, Return x35, Return x31, Return x27))
+ uint64_t x10, bool x11 = subborrow_u51(0x0, x2, 0x7ffffffffffed);
+ ℤ x12 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x11);
+ uint64_t x14, bool x15 = addcarryx_u51(0x0, 0x0, x10);
+ ℤ x16 = x12 + x15;
+ uint64_t x18, bool x19 = subborrow_u51(0x0, x4, 0x7ffffffffffff);
+ ℤ x20 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x19);
+ uint64_t x22, ℤ x23 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) Syntax.TZ (Syntax.TWord 6) (Syntax.TWord 6) Syntax.TZ) (0x0, Return x16, Return x18);
+ ℤ x24 = x20 + x23;
+ uint64_t x26, bool x27 = subborrow_u51(0x0, x6, 0x7ffffffffffff);
+ ℤ x28 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x27);
+ uint64_t x30, ℤ x31 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) Syntax.TZ (Syntax.TWord 6) (Syntax.TWord 6) Syntax.TZ) (0x0, Return x24, Return x26);
+ ℤ x32 = x28 + x31;
+ uint64_t x34, bool x35 = subborrow_u51(0x0, x8, 0x7ffffffffffff);
+ ℤ x36 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x35);
+ uint64_t x38, ℤ x39 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) Syntax.TZ (Syntax.TWord 6) (Syntax.TWord 6) Syntax.TZ) (0x0, Return x32, Return x34);
+ ℤ x40 = x36 + x39;
+ uint64_t x42, bool x43 = subborrow_u51(0x0, x7, 0x7ffffffffffff);
+ ℤ x44 = Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x43);
+ uint64_t x46, ℤ x47 = Op (Syntax.AddWithGetCarry 51 (Syntax.TWord 0) Syntax.TZ (Syntax.TWord 6) (Syntax.TWord 6) Syntax.TZ) (0x0, Return x40, Return x42);
+ ℤ x48 = x44 + x47;
+ uint64_t x49 = (uint64_t) (x48 == 0 ? 0x0 : 0xffffffffffffffffL);
+ uint64_t x50 = x49 & 0x7ffffffffffed;
+ uint64_t x52, bool x53 = addcarryx_u51(0x0, x14, x50);
+ uint64_t x54 = x49 & 0x7ffffffffffff;
+ uint64_t x56, bool x57 = addcarryx_u51(x53, x22, x54);
+ uint64_t x58 = x49 & 0x7ffffffffffff;
+ uint64_t x60, bool x61 = addcarryx_u51(x57, x30, x58);
+ uint64_t x62 = x49 & 0x7ffffffffffff;
+ uint64_t x64, bool x65 = addcarryx_u51(x61, x38, x62);
+ uint64_t x66 = x49 & 0x7ffffffffffff;
+ uint64_t x68, bool _ = addcarryx_u51(x65, x46, x66);
+ (Return x68, Return x64, Return x60, Return x56, Return x52))
 x
      : word64 * word64 * word64 * word64 * word64 → ReturnType (uint64_t * uint64_t * uint64_t * uint64_t * uint64_t)

--- a/src/Specific/IntegrationTestFreezeDisplay.log
+++ b/src/Specific/IntegrationTestFreezeDisplay.log
@@ -7,7 +7,7 @@ Interp-η
  uint64_t x16, bool x17 = subborrow_u51(x14, x6, 0x7ffffffffffff);
  uint64_t x19, bool x20 = subborrow_u51(x17, x8, 0x7ffffffffffff);
  uint64_t x22, bool x23 = subborrow_u51(x20, x7, 0x7ffffffffffff);
- uint64_t x24 = (uint64_t) (Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x23) == 0 ? 0x0 : 0xffffffffffffffffL);
+ uint64_t x24 = (uint64_t) (x23 == 0 ? 0x0 : 0xffffffffffffffffL);
  uint64_t x25 = x24 & 0x7ffffffffffed;
  uint64_t x27, bool x28 = addcarryx_u51(0x0, x10, x25);
  uint64_t x29 = x24 & 0x7ffffffffffff;

--- a/src/Specific/IntegrationTestFreezeDisplay.log
+++ b/src/Specific/IntegrationTestFreezeDisplay.log
@@ -3,7 +3,7 @@ Interp-η
 (λ var : Syntax.base_type → Type,
  λ '(x7, x8, x6, x4, x2)%core,
  uint64_t x10, bool x11 = subborrow_u51(0x0, x2, 0x7ffffffffffed);
- uint64_t x13, bool x14 = subborrow_u51(Op (Syntax.Opp Syntax.TZ (Syntax.TWord 0)) (Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x11)), x4, 0x7ffffffffffff);
+ uint64_t x13, bool x14 = subborrow_u51(x11, x4, 0x7ffffffffffff);
  uint64_t x16, bool x17 = subborrow_u51(x14, x6, 0x7ffffffffffff);
  uint64_t x19, bool x20 = subborrow_u51(x17, x8, 0x7ffffffffffff);
  uint64_t x22, bool x23 = subborrow_u51(x20, x7, 0x7ffffffffffff);

--- a/src/Util/ZUtil/AddGetCarry.v
+++ b/src/Util/ZUtil/AddGetCarry.v
@@ -70,4 +70,8 @@ Module Z.
       reflexivity.
   Qed.
 
+  Lemma sub_with_borrow_to_add_get_carry c x y
+    : Z.sub_with_borrow c x y = Z.add_with_carry (-c) x (-y).
+  Proof. reflexivity. Qed.
+
 End Z.

--- a/src/Util/ZUtil/Definitions.v
+++ b/src/Util/ZUtil/Definitions.v
@@ -18,6 +18,16 @@ Module Z.
   Definition add_get_carry (bitwidth : Z) (x y : Z) : Z * Z
     := add_with_get_carry bitwidth 0 x y.
 
+  Definition get_borrow (bitwidth : Z) (v : Z) : Z * Z
+    := let '(v, c) := get_carry bitwidth v in
+       (v, -c).
+  Definition sub_with_borrow (c : Z) (x y : Z) : Z
+    := add_with_carry (-c) x (-y).
+  Definition sub_with_get_borrow (bitwidth : Z) (c : Z) (x y : Z) : Z * Z
+    := get_borrow bitwidth (sub_with_borrow c x y).
+  Definition sub_get_borrow (bitwidth : Z) (x y : Z) : Z * Z
+    := sub_with_get_borrow bitwidth 0 x y.
+
   (* splits at [bound], not [2^bitwidth]; wrapper to make add_getcarry
   work if input is not known to be a power of 2 *)
   Definition add_get_carry_full (bound : Z) (x y : Z) : Z * Z

--- a/src/Util/ZUtil/Morphisms.v
+++ b/src/Util/ZUtil/Morphisms.v
@@ -46,4 +46,6 @@ Module Z.
   Proof. intros ???; apply Z.pow_le_mono_r; try reflexivity; try assumption. Qed.
   Lemma add_with_carry_le_Proper : Proper (Z.le ==> Z.le ==> Z.le ==> Z.le) Z.add_with_carry.
   Proof. unfold Z.add_with_carry; repeat (omega || intro). Qed.
+  Lemma sub_with_borrow_le_Proper : Proper (Basics.flip Z.le ==> Z.le ==> Basics.flip Z.le ==> Z.le) Z.sub_with_borrow.
+  Proof. unfold Z.sub_with_borrow, Z.add_with_carry, Basics.flip; repeat (omega || intro). Qed.
 End Z.


### PR DESCRIPTION
Freeze is now almost pretty:
```
λ x : word64 * word64 * word64 * word64 * word64,
Interp-η
(λ var : Syntax.base_type → Type,
 λ '(x7, x8, x6, x4, x2)%core,
 uint64_t x10, bool x11 = subborrow_u51(0x0, x2, 0x7ffffffffffed);
 uint64_t x13, bool x14 = subborrow_u51(Op (Syntax.Opp Syntax.TZ (Syntax.TWord 0)) (Op (Syntax.Opp (Syntax.TWord 0) Syntax.TZ) (Return x11)), x4, 0x7ffffffffffff);
 uint64_t x16, bool x17 = subborrow_u51(x14, x6, 0x7ffffffffffff);
 uint64_t x19, bool x20 = subborrow_u51(x17, x8, 0x7ffffffffffff);
 uint64_t x22, bool x23 = subborrow_u51(x20, x7, 0x7ffffffffffff);
 uint64_t x24 = (uint64_t) (x23 == 0 ? 0x0 : 0xffffffffffffffffL);
 uint64_t x25 = x24 & 0x7ffffffffffed;
 uint64_t x27, bool x28 = addcarryx_u51(0x0, x10, x25);
 uint64_t x29 = x24 & 0x7ffffffffffff;
 uint64_t x31, bool x32 = addcarryx_u51(x28, x13, x29);
 uint64_t x33 = x24 & 0x7ffffffffffff;
 uint64_t x35, bool x36 = addcarryx_u51(x32, x16, x33);
 uint64_t x37 = x24 & 0x7ffffffffffff;
 uint64_t x39, bool x40 = addcarryx_u51(x36, x19, x37);
 uint64_t x41 = x24 & 0x7ffffffffffff;
 uint64_t x43, bool _ = addcarryx_u51(x40, x22, x41);
 (Return x43, Return x39, Return x35, Return x31, Return x27))
x
     : word64 * word64 * word64 * word64 * word64 → ReturnType (uint64_t * uint64_t * uint64_t * uint64_t * uint64_t)
```

However, I'm really confused why one of the sbb's has a *negative* borrow bit (i.e., the second line is doing `x11 + x4 - 0x7ffffffffffff`, which is not a sub-with-borrow, but instead a sub-with-carry.......)  @andres-erbsen ? @jadephilipoom ?
(I'm also confused why it came out this way, since when I do the transformation in my head, this doesn't seem to happen?  But there are no admits...)