### PR TITLE
Don't rely on autogenerated names

### DIFF
--- a/Bedrock/Nomega.v
+++ b/Bedrock/Nomega.v
@@ -27,12 +27,12 @@ Theorem Nneq_out : forall n m,
   n <> m
   -> nat_of_N n <> nat_of_N m.
   intuition.
-  apply nat_of_N_eq in H0; tauto.
+  match goal with H0 : _ |- _ => apply nat_of_N_eq in H0; tauto end.
 Qed.
 
 Theorem Nlt_out : forall n m, n < m
   -> (nat_of_N n < nat_of_N m)%nat.
-  unfold Nlt; intros.
+  unfold Nlt; intros ?? H.
   rewrite nat_of_Ncompare in H.
   apply nat_compare_Lt_lt; assumption.
 Qed.
@@ -46,7 +46,7 @@ Qed.
 
 Theorem Nge_out : forall n m, n >= m
   -> (nat_of_N n >= nat_of_N m)%nat.
-  unfold Nge; intros.
+  unfold Nge; intros ?? H.
   rewrite nat_of_Ncompare in H.
   apply nat_compare_ge; assumption.
 Qed.

--- a/src/Algebra/Field.v
+++ b/src/Algebra/Field.v
@@ -19,7 +19,7 @@ Section Field.
   Lemma left_inv_unique x ix : ix * x = one -> ix = inv x.
   Proof using Type*.
     intro Hix.
-    assert (ix*x*inv x = inv x).
+    assert (H0 : ix*x*inv x = inv x).
     - rewrite Hix, left_identity; reflexivity.
     - rewrite <-associative, right_multiplicative_inverse, right_identity in H0; trivial.
       intro eq_x_0. rewrite eq_x_0, Ring.mul_0_r in Hix.
@@ -39,8 +39,8 @@ Section Field.
   Lemma mul_cancel_l_iff : forall x y, y <> 0 ->
                                        (x * y = y <-> x = one).
   Proof using Type*.
-    intros.
-    split; intros.
+    intros x y H0.
+    split; intros H1.
     + rewrite <-(right_multiplicative_inverse y) by assumption.
       rewrite <-H1 at 1; rewrite <-associative.
       rewrite right_multiplicative_inverse by assumption.

--- a/src/Algebra/Monoid.v
+++ b/src/Algebra/Monoid.v
@@ -12,7 +12,7 @@ Section Monoid.
   Lemma cancel_right z iz (Hinv:op z iz = id) :
     forall x y, x * z = y * z <-> x = y.
   Proof using Type*.
-    split; intros.
+    intros x y; split; intro.
     { assert (op (op x z) iz = op (op y z) iz) as Hcut by (rewrite_hyp ->!*; reflexivity).
       rewrite <-associative in Hcut.
       rewrite <-!associative, !Hinv, !right_identity in Hcut; exact Hcut. }
@@ -22,7 +22,7 @@ Section Monoid.
   Lemma cancel_left z iz (Hinv:op iz z = id) :
     forall x y, z * x = z * y <-> x = y.
   Proof using Type*.
-    split; intros.
+    intros x y; split; intros.
     { assert (op iz (op z x) = op iz (op z y)) as Hcut by (rewrite_hyp ->!*; reflexivity).
       rewrite !associative, !Hinv, !left_identity in Hcut; exact Hcut. }
     { rewrite_hyp ->!*; reflexivity. }

--- a/src/Algebra/ScalarMult.v
+++ b/src/Algebra/ScalarMult.v
@@ -36,8 +36,7 @@ Section ScalarMultProperties.
 
   Lemma scalarmult_ext : forall n P, mul n P = scalarmult_ref n P.
   Proof using Type*.
-
-    induction n; simpl @scalarmult_ref; intros; rewrite <-?IHn; (apply scalarmult_0_l || apply scalarmult_S_l).
+    induction n as [|n IHn]; simpl @scalarmult_ref; intros; rewrite <-?IHn; (apply scalarmult_0_l || apply scalarmult_S_l).
   Qed.
 
   Lemma scalarmult_1_l : forall P, 1*P = P.
@@ -45,16 +44,16 @@ Section ScalarMultProperties.
 
   Lemma scalarmult_add_l : forall (n m:nat) (P:G), ((n + m)%nat * P = n * P + m * P).
   Proof using Type*.
-    induction n; intros;
+    induction n as [|n IHn]; intros;
       rewrite ?scalarmult_0_l, ?scalarmult_S_l, ?plus_Sn_m, ?plus_O_n, ?scalarmult_S_l, ?left_identity, <-?associative, <-?IHn; reflexivity.
   Qed.
 
   Lemma scalarmult_zero_r : forall m, m * zero = zero.
-  Proof using Type*. induction m; rewrite ?scalarmult_S_l, ?scalarmult_0_l, ?left_identity, ?IHm; try reflexivity. Qed.
+  Proof using Type*. induction m as [|? IHm]; rewrite ?scalarmult_S_l, ?scalarmult_0_l, ?left_identity, ?IHm; try reflexivity. Qed.
 
   Lemma scalarmult_assoc : forall (n m : nat) P, n * (m * P) = (m * n)%nat * P.
   Proof using Type*.
-    induction n; intros.
+    induction n as [|n IHn]; intros.
     { rewrite <-mult_n_O, !scalarmult_0_l. reflexivity. }
     { rewrite scalarmult_S_l, <-mult_n_Sm, <-Plus.plus_comm, scalarmult_add_l.
       rewrite IHn. reflexivity. }
@@ -65,7 +64,7 @@ Section ScalarMultProperties.
 
   Lemma scalarmult_mod_order : forall l B, l <> 0%nat -> l*B = zero -> forall n, n mod l * B = n * B.
   Proof using Type*.
-    intros ? ? Hnz Hmod ?.
+    intros l B Hnz Hmod n.
     rewrite (NPeano.Nat.div_mod n l Hnz) at 2.
     rewrite scalarmult_add_l, scalarmult_times_order, left_identity by auto. reflexivity.
   Qed.
@@ -83,7 +82,7 @@ Section ScalarMultHomomorphism.
   Lemma homomorphism_scalarmult : forall n P, phi (MUL n P) = mul n (phi P).
   Proof using Type*.
     setoid_rewrite scalarmult_ext.
-    induction n; intros; simpl; rewrite ?Monoid.homomorphism, ?IHn; easy.
+    induction n as [|n IHn]; intros; simpl; rewrite ?Monoid.homomorphism, ?IHn; easy.
   Qed.
 End ScalarMultHomomorphism.
 

--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -358,7 +358,7 @@ Module B.
     Lemma split_cps_id s p: forall {T} f,
         @split_cps s p T f = f (split s p).
     Proof.
-      induction p;
+      induction p as [|?? IHp];
         repeat match goal with
                | _ => rewrite IHp
                | _ => progress (cbv [split]; prove_id)
@@ -525,9 +525,9 @@ Module B.
       Proof using Type.
         cbv [eval Associational.eval to_associational_cps zeros].
         pose proof (seq_length n 0). generalize dependent (seq 0 n).
-        intro xs; revert n; induction xs; intros;
+        intro xs; revert n; induction xs as [|?? IHxs]; intros n H;
           [autorewrite with uncps; reflexivity|].
-        intros; destruct n; [distr_length|].
+        destruct n as [|n]; [distr_length|].
         specialize (IHxs n). autorewrite with uncps in *.
         rewrite !@Tuple.to_list_repeat in *.
         simpl List.repeat. rewrite map_cons, combine_cons, map_cons.
@@ -809,7 +809,7 @@ Module B.
           eval wt (Tuple.left_append (n:=n) x xs)
           = wt n * x + eval wt xs.
       Proof.
-        induction n; intros; try destruct xs;
+        induction n as [|n IHn]; intros wt x xs; try destruct xs;
           unfold Tuple.left_append; fold @Tuple.left_append;
             autorewrite with push_basesystem_eval; [ring|].
         rewrite (Tuple.subst_append xs), Tuple.hd_append, Tuple.tl_append.
@@ -820,8 +820,8 @@ Module B.
       Lemma eval_wt_equiv {n} :forall wta wtb (x:tuple Z n),
           (forall i, wta i = wtb i) -> eval wta x = eval wtb x.
       Proof.
-        destruct n; [reflexivity|].
-        induction n; intros; [rewrite !eval_single, H; reflexivity|].
+        destruct n as [|n]; [reflexivity|].
+        induction n as [|n IHn]; intros wta wtb x H; [rewrite !eval_single, H; reflexivity|].
         simpl tuple in *; destruct x.
         change (t, z) with (Tuple.append (n:=S n) z t).
         rewrite !eval_step. rewrite (H 0%nat). apply Group.cancel_left.
@@ -853,7 +853,7 @@ Module B.
 
       Lemma map_and_0 {n} (p:tuple Z n) : Tuple.map (Z.land 0) p = zeros n.
       Proof.
-        induction n; [destruct p; reflexivity | ].
+        induction n as [|n IHn]; [destruct p; reflexivity | ].
         rewrite (Tuple.subst_append p), Tuple.map_append, Z.land_0_l, IHn.
         reflexivity.
       Qed.

--- a/src/Arithmetic/ModularArithmeticPre.v
+++ b/src/Arithmetic/ModularArithmeticPre.v
@@ -60,7 +60,7 @@ Qed.
 
 Lemma powmod_Zpow_mod : forall m a n, powmod m a n = (a^Z.of_N n) mod m.
 Proof.
-  induction n using N.peano_ind; [auto|].
+  induction n as [|n IHn] using N.peano_ind; [auto|].
   rewrite <-N.add_1_l.
   rewrite powmod_1plus.
   rewrite IHn.
@@ -76,7 +76,7 @@ Local Obligation Tactic := idtac.
 Program Definition pow_impl_sig {m} (a:{z : Z | z = z mod m}) (x:N) : {z : Z | z = z mod m}
   := powmod m (proj1_sig a) x.
 Next Obligation.
-  intros; destruct x; [simpl; rewrite Zmod_mod; reflexivity|].
+  intros m a x; destruct x; [simpl; rewrite Zmod_mod; reflexivity|].
   rewrite N_pos_1plus.
   rewrite powmod_1plus.
   rewrite Zmod_mod; reflexivity.
@@ -122,7 +122,7 @@ Program Definition inv_impl {m : BinNums.Z} :
     exist (fun z : BinNums.Z => z = z mod m) (1 mod m) (Z_mod_mod 1 m))}
      := mod_inv_sig.
 Next Obligation.
-  split.
+  intros m; split.
   { apply exist_reduced_eq; rewrite Zmod_0_l; reflexivity. }
   intros Hm [a pfa] Ha'. apply exist_reduced_eq.
   assert (Hm':0 <= m - 2) by (pose proof prime_ge_2 m Hm; omega).

--- a/src/Arithmetic/PrimeFieldTheorems.v
+++ b/src/Arithmetic/PrimeFieldTheorems.v
@@ -66,9 +66,9 @@ Module F.
       rewrite F.square_iff, <-(euler_criterion (q/2)) by (trivial || omega); reflexivity.
     Qed.
 
-    Global Instance Decidable_square (x:F q) : Decidable (exists y, y*y = x).
+    Global Instance Decidable_square : forall (x:F q), Decidable (exists y, y*y = x).
     Proof.
-      destruct (dec (x = 0)).
+      intro x; destruct (dec (x = 0)).
       { left. abstract (exists 0; subst; apply Ring.mul_0_l). }
       { eapply Decidable_iff_to_impl; [eapply euler_criterion; assumption | exact _]. }
     Defined.
@@ -186,7 +186,7 @@ Module F.
 
     Lemma mul_square_sqrt_minus1 : forall x, sqrt_minus1 * x * (sqrt_minus1 * x) = F.opp (x * x).
     Proof using prime_q sqrt_minus1_valid.
-      intros.
+      intros x.
       transitivity (F.opp 1 * (x * x)); [ | field].
       rewrite <-sqrt_minus1_valid.
       field.
@@ -208,7 +208,7 @@ Module F.
     Lemma sqrt_5mod8_correct : forall x,
       ((exists y, y*y = x) <-> (sqrt_5mod8 x)*(sqrt_5mod8 x) = x).
     Proof using Type*.
-      cbv [sqrt_5mod8]; intros.
+      cbv [sqrt_5mod8]; intros x.
       destruct (F.eq_dec x 0).
       {
         repeat match goal with

--- a/src/Arithmetic/Saturated.v
+++ b/src/Arithmetic/Saturated.v
@@ -145,7 +145,7 @@ Module Columns.
     Lemma eval_from_S {n}: forall i (inp : (list Z)^(S n)),
         eval_from i inp = eval_from (S i) (tl inp) + weight i * sum (hd inp).
     Proof using Type.
-      intros; cbv [eval_from].
+      intros i inp; cbv [eval_from].
       replace inp with (append (hd inp) (tl inp))
         by (simpl in *; destruct n; destruct inp; reflexivity).
       rewrite map_append, B.Positional.eval_step, hd_append, tl_append.
@@ -280,7 +280,7 @@ Module Columns.
 
       apply mapi_with'_linvariant; [|tauto].
 
-      clear n inp. intros until 0. intros Hst Hys [Hmod Hdiv].
+      clear n inp. intros n st x0 xs ys Hst Hys [Hmod Hdiv].
       pose proof (weight_positive n). pose proof (weight_divides n).
       autorewrite with push_basesystem_eval.
       destruct n; cbv [mapi_with] in *; simpl tuple in *;
@@ -338,7 +338,7 @@ Module Columns.
       List.map sum (update_nth i (cons x) l) =
       update_nth i (Z.add x) (List.map sum l).
     Proof using Type.
-      induction l; intros; destruct i; simpl; rewrite ?IHl; reflexivity.
+      induction l as [|a l IHl]; intros i x; destruct i; simpl; rewrite ?IHl; reflexivity.
     Qed.
 
     Lemma cons_to_nth_add_to_nth n i x t :
@@ -367,7 +367,7 @@ Module Columns.
 
     Lemma map_sum_nils n : map sum (nils n) = B.Positional.zeros n.
     Proof using Type.
-      cbv [nils B.Positional.zeros]; induction n; [reflexivity|].
+      cbv [nils B.Positional.zeros]; induction n as [|n]; [reflexivity|].
       change (repeat nil (S n)) with (@nil Z :: repeat nil n).
       rewrite map_repeat, sum_nil. reflexivity.
     Qed.

--- a/src/Compilers/CommonSubexpressionEliminationWf.v
+++ b/src/Compilers/CommonSubexpressionEliminationWf.v
@@ -99,7 +99,7 @@ Section symbolic.
       : wff G' (@csef var1 t e1 m1) (@csef var2 t e2 m2).
     Proof.
       revert dependent m1; revert m2; revert dependent G'.
-      induction Hwf; simpl; intros; try constructor; auto.
+      induction Hwf; simpl; intros G' HGG' m2 m1 Hlen Hm1m2None Hm1m2Some; try constructor; auto.
       { erewrite wff_norm_symbolize_exprf by eassumption.
         break_innermost_match;
           try match goal with
@@ -170,7 +170,7 @@ Section symbolic.
           (Hwf : wff G e1 e2)
       : wff G (@prepend_prefix var1' t e1 prefix1) (@prepend_prefix var2' t e2 prefix2).
     Proof.
-      revert dependent G; revert dependent prefix2; induction prefix1, prefix2; simpl; intros; try congruence.
+      revert dependent G; revert dependent prefix2; induction prefix1, prefix2; simpl; intros Hlen Hprefix G Hwf; try congruence.
       { pose proof (Hprefix 0) as H0; specialize (fun n => Hprefix (S n)).
         destruct_head sigT; simpl in *.
         specialize (H0 _ _ _ _ eq_refl eq_refl); destruct_head ex; subst; simpl in *.

--- a/src/Compilers/Equality.v
+++ b/src/Compilers/Equality.v
@@ -51,7 +51,7 @@ Section language.
   Lemma flat_type_dec_bl X : forall Y, flat_type_beq X Y = true -> X = Y.
   Proof. clear base_type_code_lb; induction X, Y; t. Defined.
   Lemma flat_type_dec_lb X : forall Y, X = Y -> flat_type_beq X Y = true.
-  Proof. clear base_type_code_bl; intros; subst Y; induction X; t. Defined.
+  Proof. clear base_type_code_bl; intros Y **; subst Y; induction X; t. Defined.
   Definition flat_type_eq_dec (X Y : flat_type) : {X = Y} + {X <> Y}
     := match Sumbool.sumbool_of_bool (flat_type_beq X Y) with
        | left pf => left (flat_type_dec_bl _ _ pf)
@@ -65,7 +65,7 @@ Section language.
   Lemma type_dec_bl X : forall Y, type_beq X Y = true -> X = Y.
   Proof. clear base_type_code_lb; pose proof flat_type_dec_bl; induction X, Y; t. Defined.
   Lemma type_dec_lb X : forall Y, X = Y -> type_beq X Y = true.
-  Proof. clear base_type_code_bl; pose proof flat_type_dec_lb; intros; subst Y; induction X; t. Defined.
+  Proof. clear base_type_code_bl; pose proof flat_type_dec_lb; intros Y **; subst Y; induction X; t. Defined.
   Definition type_eq_dec (X Y : type) : {X = Y} + {X <> Y}
     := match Sumbool.sumbool_of_bool (type_beq X Y) with
        | left pf => left (type_dec_bl _ _ pf)

--- a/src/Compilers/MapCastByDeBruijnInterp.v
+++ b/src/Compilers/MapCastByDeBruijnInterp.v
@@ -66,6 +66,7 @@ Section language.
                         then fun pf => left (base_type_code_bl_transparent _ _ pf)
                         else fun pf => right _) eq_refl).
     { clear -pf base_type_code_lb.
+      let pf := pf in
       abstract (intro; erewrite base_type_code_lb in pf by eassumption; congruence). }
   Defined.
 

--- a/src/Compilers/MapCastByDeBruijnWf.v
+++ b/src/Compilers/MapCastByDeBruijnWf.v
@@ -64,6 +64,7 @@ Section language.
                         then fun pf => left (base_type_code_bl_transparent _ _ pf)
                         else fun pf => right _) eq_refl).
     { clear -pf base_type_code_lb.
+      let pf := pf in
       abstract (intro; erewrite base_type_code_lb in pf by eassumption; congruence). }
   Defined.
 

--- a/src/Compilers/Named/ContextProperties/NameUtil.v
+++ b/src/Compilers/Named/ContextProperties/NameUtil.v
@@ -47,7 +47,7 @@ Section with_context.
     : (exists t, @find_Name n T N = Some t)
       <-> List.In (Some n) (List.firstn (CountLets.count_pairs T) ls).
   Proof using Type.
-    revert dependent ls; intro ls; revert ls ls'; induction T; intros;
+    revert dependent ls; intro ls; revert ls ls'; induction T; intros ls ls' H;
       [ | | specialize (IHT1 (fst N) ls (snd (split_onames T1 ls)));
             specialize (IHT2 (snd N) (snd (split_onames T1 ls)) (snd (split_onames (T1 * T2) ls))) ];
       repeat first [ misc_oname_t_step
@@ -77,7 +77,11 @@ Section with_context.
     rewrite fst_split_onames_firstn, snd_split_onames_skipn in H.
     inversion_prod; subst.
     split; [ split | intros [? ?] ]; eauto using In_firstn, oname_list_unique_specialize.
-    eapply In_firstn_skipn_split in H; destruct_head' or; eauto; exfalso; eauto.
+    match goal with
+    | [ H : List.In (Some _) ?ls |- _ ]
+      => is_var ls;
+           eapply In_firstn_skipn_split in H; destruct_head' or; eauto; exfalso; eauto
+    end.
   Qed.
 
   Lemma split_onames_find_Name_Some_unique
@@ -97,7 +101,7 @@ Section with_context.
     : @find_Name_and_val var' t n T N V None = Some v
       <-> List.In (existT (fun t => (Name * var' t)%type) t (n, v)) (Wf.flatten_binding_list N V).
   Proof using Type.
-    revert dependent ls; intro ls; revert ls ls'; induction T; intros;
+    revert dependent ls; intro ls; revert ls ls'; induction T; intros ls ls' Hls H;
       [ | | specialize (IHT1 (fst N) (fst V) ls (snd (split_onames T1 ls)));
             specialize (IHT2 (snd N) (snd V) (snd (split_onames T1 ls)) (snd (split_onames (T1 * T2) ls))) ];
       repeat first [ find_Name_and_val_default_to_None_step

--- a/src/Compilers/Named/ContextProperties/Proper.v
+++ b/src/Compilers/Named/ContextProperties/Proper.v
@@ -41,15 +41,15 @@ Section with_context.
                  | rewrite lookupb_removeb_different by assumption
                  | solve [ auto ] ].
 
-  Global Instance extendb_Proper {t} : Proper (context_equiv ==> eq ==> eq ==> context_equiv) (@extendb t) | 10.
+  Global Instance extendb_Proper : forall {t}, Proper (context_equiv ==> eq ==> eq ==> context_equiv) (@extendb t) | 10.
   Proof.
-    intros ??? n n0 ???? n' t'; subst n0; subst; proper_t n n' t t'.
+    intros t ??? n n0 ???? n' t'; subst n0; subst; proper_t n n' t t'.
   Qed.
-  Global Instance removeb_Proper {t} : Proper (context_equiv ==> eq ==> context_equiv) (@removeb t) | 10.
+  Global Instance removeb_Proper : forall {t}, Proper (context_equiv ==> eq ==> context_equiv) (@removeb t) | 10.
   Proof.
-    intros ??? n n0 ? n' t'; subst n0; subst; proper_t n n' t t'.
+    intros t ??? n n0 ? n' t'; subst n0; subst; proper_t n n' t t'.
   Qed.
-  Global Instance lookupb_Proper {t} : Proper (context_equiv ==> eq ==> eq) (@lookupb t) | 10.
+  Global Instance lookupb_Proper : forall {t}, Proper (context_equiv ==> eq ==> eq) (@lookupb t) | 10.
   Proof. repeat intro; subst; auto. Qed.
 
   Local Ltac proper_t2 t :=
@@ -68,13 +68,14 @@ Section with_context.
       first [ eapply IHt2; [ eapply IHt1 | .. ]; auto
             | idtac ] ].
 
-  Global Instance extend_Proper {t} : Proper (context_equiv ==> eq ==> eq ==> context_equiv) (@extend t) | 10.
-  Proof. proper_t2 t. Qed.
-  Global Instance remove_Proper {t} : Proper (context_equiv ==> eq ==> context_equiv) (@remove t) | 10.
-  Proof. proper_t2 t. Qed.
-  Global Instance lookup_Proper {t} : Proper (context_equiv ==> eq ==> eq) (@lookup t) | 10.
+  Global Instance extend_Proper : forall {t}, Proper (context_equiv ==> eq ==> eq ==> context_equiv) (@extend t) | 10.
+  Proof. intro t; proper_t2 t. Qed.
+  Global Instance remove_Proper : forall {t}, Proper (context_equiv ==> eq ==> context_equiv) (@remove t) | 10.
+  Proof. intro t; proper_t2 t. Qed.
+
+  Global Instance lookup_Proper : forall {t}, Proper (context_equiv ==> eq ==> eq) (@lookup t) | 10.
   Proof.
-    proper_t2 t.
+    intro t; proper_t2 t.
     repeat match goal with
            | [ |- context G[lookup (?A * ?B) ?ctx (?na, ?nb)] ]
              => let G' := context G[match lookup A ctx na, lookup B ctx nb with
@@ -88,7 +89,7 @@ Section with_context.
              | _ => progress subst
              | _ => progress inversion_option
              | _ => reflexivity
-             | [ H : lookup _ _ _ = ?x, H' : lookup _ _ _ = ?y |- _ ]
+             | [ IHt2 : Proper _ (lookup t2), H : lookup _ _ _ = ?x, H' : lookup _ _ _ = ?y |- _ ]
                => assert (x = y)
                  by (rewrite <- H, <- H'; first [ eapply IHt1 | eapply IHt2 ]; (assumption || reflexivity));
                     clear H H'

--- a/src/Compilers/Named/NameUtilProperties.v
+++ b/src/Compilers/Named/NameUtilProperties.v
@@ -171,7 +171,7 @@ Section language.
         (t : flat_type base_type_code) (ls : list Name)
     : fst (split_names t ls) <> None <-> List.length ls >= count_pairs t.
   Proof using Type.
-    revert ls; induction t; intros;
+    revert ls; induction t; intros ls;
       try solve [ destruct ls; simpl; intuition (omega || congruence) ].
     repeat first [ progress simpl in *
                  | progress break_innermost_match_step

--- a/src/Compilers/TestCase.v
+++ b/src/Compilers/TestCase.v
@@ -212,17 +212,17 @@ Module bounds.
   Definition add_bounded_pf (x y : bounded_pf) : bounded_pf.
   Proof.
     exists (map_bounded_f2 plus false (proj1_sig x) (proj1_sig y)).
-    simpl; abstract (destruct x, y; simpl; omega).
+    simpl; let x := x in let y := y in abstract (destruct x, y; simpl; omega).
   Defined.
   Definition mul_bounded_pf (x y : bounded_pf) : bounded_pf.
   Proof.
     exists (map_bounded_f2 mult false (proj1_sig x) (proj1_sig y)).
-    simpl; abstract (destruct x, y; simpl; nia).
+    simpl; let x := x in let y := y in abstract (destruct x, y; simpl; nia).
   Defined.
   Definition sub_bounded_pf (x y : bounded_pf) : bounded_pf.
   Proof.
     exists (map_bounded_f2 minus true (proj1_sig x) (proj1_sig y)).
-    simpl; abstract (destruct x, y; simpl; omega).
+    simpl; let x := x in let y := y in abstract (destruct x, y; simpl; omega).
   Defined.
   Definition interp_base_type_bounds (v : base_type) : Type :=
     match v with

--- a/src/Compilers/Z/ArithmeticSimplifierWf.v
+++ b/src/Compilers/Z/ArithmeticSimplifierWf.v
@@ -115,7 +115,8 @@ Lemma wff_interp_as_expr_or_const_base {var1 var2 t} {G e1 e2 v1 v2}
        end.
 Proof.
   invert_one_expr e1; intros; break_innermost_match; intros;
-    try invert_one_expr e2; intros;
+    try (let e2 := match goal with Hwf : wff ?G ?e1 ?e2 |- _ => e2 end in
+         invert_one_expr e2); intros;
       repeat first [ fin_t
                    | progress simpl in *
                    | progress intros
@@ -157,7 +158,9 @@ Lemma wff_interp_as_expr_or_const_prod_base {var1 var2 A B} {G e1 e2} {v1 v2 : _
           end.
 Proof.
   invert_one_expr e1; intros; break_innermost_match; intros; try exact I;
-    try invert_one_expr e2; intros; break_innermost_match; intros; try exact I;
+    try (let e2 := match goal with Hwf : wff ?G ?e1 ?e2 |- _ => e2 end in
+         invert_one_expr e2);
+    intros; break_innermost_match; intros; try exact I;
       repeat first [ pret_step
                    | pose_wff_base
                    | break_t_step
@@ -206,7 +209,9 @@ Lemma wff_interp_as_expr_or_const_prod3_base {var1 var2 A B C} {G e1 e2} {v1 v2 
           end.
 Proof.
   invert_one_expr e1; intros; break_innermost_match; intros; try exact I;
-    try invert_one_expr e2; intros; break_innermost_match; intros; try exact I;
+    try (let e2 := match goal with Hwf : wff ?G ?e1 ?e2 |- _ => e2 end in
+         invert_one_expr e2);
+    intros; break_innermost_match; intros; try exact I;
       repeat first [ pret_step
                    | pose_wff_base
                    | pose_wff_prod

--- a/src/Compilers/Z/Bounds/Interpretation.v
+++ b/src/Compilers/Z/Bounds/Interpretation.v
@@ -288,7 +288,7 @@ Module Import Bounds.
     := interp_flat_type_rel_pointwise (@is_bounded_by').
 
   Local Arguments interp_base_type !_ / .
-  Global Instance dec_eq_interp_flat_type {T} : DecidableRel (@eq (interp_flat_type interp_base_type T)) | 10.
+  Global Instance dec_eq_interp_flat_type : forall {T}, DecidableRel (@eq (interp_flat_type interp_base_type T)) | 10.
   Proof.
     induction T; destruct_head base_type; simpl; exact _.
   Defined.

--- a/src/Curves/Edwards/AffineProofs.v
+++ b/src/Curves/Edwards/AffineProofs.v
@@ -44,7 +44,7 @@ Module E.
     Local Notation mul   := (E.mul(nonzero_a:=nonzero_a)(square_a:=square_a)(nonsquare_d:=nonsquare_d)).
 
     Program Definition opp (P:point) : point := (Fopp (fst P), (snd P)).
-    Next Obligation. destruct P as [ [??]?]; cbv; fsatz. Qed.
+    Next Obligation. match goal with P : point |- _ => destruct P as [ [??]?] end; cbv; fsatz. Qed.
 
     Ltac t_step :=
       match goal with
@@ -203,7 +203,10 @@ Module E.
         cbv [compress decompress exist_option coordinates] in *; intros.
         t.
         intro.
-        apply (H0 f); [|congruence].
+        match goal with
+        | [ H0 : _ |- False ]
+          => apply (H0 f); [|congruence]
+        end.
         admit.
         intro. Prod.inversion_prod; subst.
         rewrite solve_correct in y.

--- a/src/Curves/Edwards/XYZT.v
+++ b/src/Curves/Edwards/XYZT.v
@@ -105,7 +105,12 @@ Module Extended.
           let Z3 := F*G in
           (X3, Y3, Z3, T3)
         end.
-      Next Obligation. pose proof (E.denominator_nonzero _ nonzero_a square_a _ nonsquare_d _ _ (proj2_sig (to_twisted P1))  _ _  (proj2_sig (to_twisted P2))); t. Qed.
+      Next Obligation.
+        match goal with
+        | [ |- match (let (_, _) := coordinates ?P1 in let (_, _) := _ in let (_, _) := _ in let (_, _) := coordinates ?P2 in _) with _ => _ end ]
+          => pose proof (E.denominator_nonzero _ nonzero_a square_a _ nonsquare_d _ _ (proj2_sig (to_twisted P1))  _ _  (proj2_sig (to_twisted P2)))
+        end; t.
+      Qed.
 
       Global Instance isomorphic_commutative_group_m1 :
         @Group.isomorphic_commutative_groups

--- a/src/Curves/Montgomery/Affine.v
+++ b/src/Curves/Montgomery/Affine.v
@@ -2,6 +2,7 @@ Require Import Crypto.Algebra.Field.
 Require Import Crypto.Util.GlobalSettings.
 Require Import Crypto.Util.Sum Crypto.Util.Prod.
 Require Import Crypto.Util.Tactics.BreakMatch.
+Require Import Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Spec.MontgomeryCurve Crypto.Spec.WeierstrassCurve.
 
 Module M.
@@ -30,7 +31,7 @@ Module M.
       | (x, y) => (x, -y)
       | ∞ => ∞
       end.
-    Next Obligation. Proof. destruct P; cbv; break_match; trivial; fsatz. Qed.
+    Next Obligation. Proof. destruct_head @M.point; cbv; break_match; trivial; fsatz. Qed.
 
     Local Notation add := (M.add(b_nonzero:=b_nonzero)).
     Local Notation point := (@M.point F Feq Fadd Fmul a b).
@@ -52,14 +53,14 @@ Module M.
         | (x, y) => ((x + a/3)/b, y/b)
         | _ => ∞
         end.
-      Next Obligation. Proof. destruct P; cbv; break_match; trivial; fsatz. Qed.
+      Next Obligation. Proof. destruct_head' @point; cbv; break_match; trivial; fsatz. Qed.
 
       Program Definition of_Weierstrass (P:Wpoint) : point :=
         match W.coordinates P return F*F+∞ with
         | (x,y) => (b*x-a/3, b*y)
         | _ => ∞
         end.
-      Next Obligation. Proof. destruct P; cbv; break_match; trivial; fsatz. Qed.
+      Next Obligation. Proof. destruct_head' @Wpoint; cbv; break_match; trivial; fsatz. Qed.
     End MontgomeryWeierstrass.
   End MontgomeryCurve.
 End M.

--- a/src/Curves/Weierstrass/Projective.v
+++ b/src/Curves/Weierstrass/Projective.v
@@ -123,8 +123,11 @@ Module Projective.
       end.
     Next Obligation.
     Proof.
-      destruct P as [p ?]; destruct p as [p Z1]; destruct p as [X1 Y1].
-      destruct Q as [q ?]; destruct q as [q Z2]; destruct q as [X2 Y2].
+      match goal with
+      | [ |- match (let (_, _) := proj1_sig ?P in let (_, _) := _ in let (_, _) := proj1_sig ?Q in _) with _ => _ end ]
+        => destruct P as [p ?]; destruct p as [p Z1]; destruct p as [X1 Y1];
+             destruct Q as [q ?]; destruct q as [q Z2]; destruct q as [X2 Y2]
+      end.
       t.
       all: try abstract fsatz.
       (* FIXME: the final fsatz starts requiring 56 <> 0 if

--- a/src/LegacyArithmetic/BaseSystemProofs.v
+++ b/src/LegacyArithmetic/BaseSystemProofs.v
@@ -122,7 +122,8 @@ Section BaseSystemProofs.
              end.
     rewrite (combine_truncate_r vs bs); apply (f_equal2 Z.add); trivial; [].
     unfold combine; break_match.
-    { apply (f_equal (@length _)) in Heql; simpl length in Heql; rewrite skipn_length in Heql; omega. }
+    { let Heql := match goal with H : _ = nil |- _ => H end in
+      apply (f_equal (@length _)) in Heql; simpl length in Heql; rewrite skipn_length in Heql; omega. }
     { cbv -[Z.add Z.mul]; ring_simplify; f_equal.
       assert (HH: nth_error (z0 :: l) 0 = Some z) by
           (

--- a/src/LegacyArithmetic/Double/Proofs/Decode.v
+++ b/src/LegacyArithmetic/Double/Proofs/Decode.v
@@ -145,9 +145,10 @@ Hint Rewrite
 
 Hint Rewrite @tuple_decoder_S @tuple_decoder_O @tuple_decoder_m1 using solve [ auto with zarith ] : simpl_tuple_decoder.
 
-Global Instance tuple_decoder_mod {n W} {decode : decoder n W} {k} {isdecode : is_decode decode} (w : tuple W (S (S k)))
-  : tuple_decoder (k := S k) (fst w) <~= tuple_decoder w mod 2^(S k * n).
+Global Instance tuple_decoder_mod : forall {n W} {decode : decoder n W} {k} {isdecode : is_decode decode} (w : tuple W (S (S k))),
+    tuple_decoder (k := S k) (fst w) <~= tuple_decoder w mod 2^(S k * n).
 Proof.
+  intros n W decode k isdecode w.
   pose proof (snd w).
   assert (0 <= n) by eauto using decode_exponent_nonnegative.
   assert (0 <= (S k) * n) by nia.
@@ -156,9 +157,10 @@ Proof.
   reflexivity.
 Qed.
 
-Global Instance tuple_decoder_div {n W} {decode : decoder n W} {k} {isdecode : is_decode decode} (w : tuple W (S (S k)))
-  : decode (snd w) <~= tuple_decoder w / 2^(S k * n).
+Global Instance tuple_decoder_div : forall {n W} {decode : decoder n W} {k} {isdecode : is_decode decode} (w : tuple W (S (S k))),
+    decode (snd w) <~= tuple_decoder w / 2^(S k * n).
 Proof.
+  intros n W decode k isdecode w.
   pose proof (snd w).
   assert (0 <= n) by eauto using decode_exponent_nonnegative.
   assert (0 <= (S k) * n) by nia.
@@ -169,16 +171,18 @@ Proof.
   reflexivity.
 Qed.
 
-Global Instance tuple2_decoder_mod {n W} {decode : decoder n W} {isdecode : is_decode decode} (w : tuple W 2)
-  : decode (fst w) <~= tuple_decoder w mod 2^n.
+Global Instance tuple2_decoder_mod : forall {n W} {decode : decoder n W} {isdecode : is_decode decode} (w : tuple W 2),
+    decode (fst w) <~= tuple_decoder w mod 2^n.
 Proof.
+  intros n W decode isdecode w.
   generalize (@tuple_decoder_mod n W decode 0 isdecode w).
   autorewrite with simpl_tuple_decoder; trivial.
 Qed.
 
-Global Instance tuple2_decoder_div {n W} {decode : decoder n W} {isdecode : is_decode decode} (w : tuple W 2)
-  : decode (snd w) <~= tuple_decoder w / 2^n.
+Global Instance tuple2_decoder_div : forall {n W} {decode : decoder n W} {isdecode : is_decode decode} (w : tuple W 2),
+    decode (snd w) <~= tuple_decoder w / 2^n.
 Proof.
+  intros n W decode isdecode w.
   generalize (@tuple_decoder_div n W decode 0 isdecode w).
   autorewrite with simpl_tuple_decoder; trivial.
 Qed.

--- a/src/LegacyArithmetic/Double/Proofs/RippleCarryAddSub.v
+++ b/src/LegacyArithmetic/Double/Proofs/RippleCarryAddSub.v
@@ -122,12 +122,13 @@ Section ripple_carry_adc.
   Proof using Type. apply ripple_carry_tuple_SS. Qed.
 
   Local Opaque Z.of_nat.
-  Global Instance ripple_carry_is_add_with_carry {k}
-         {isdecode : is_decode decode}
-         {is_adc : is_add_with_carry adc}
-    : is_add_with_carry (ripple_carry_adc (k := k) adc).
+  Global Instance ripple_carry_is_add_with_carry
+    : forall {k}
+             {isdecode : is_decode decode}
+             {is_adc : is_add_with_carry adc},
+      is_add_with_carry (ripple_carry_adc (k := k) adc).
   Proof using Type.
-    destruct k as [|k].
+    destruct k as [|k]; intros isdecode is_adc.
     { constructor; simpl; intros; autorewrite with zsimplify; reflexivity. }
     { induction k as [|k IHk].
       { cbv [ripple_carry_adc ripple_carry_tuple to_list].
@@ -166,12 +167,13 @@ Section ripple_carry_subc.
   Proof using Type. apply ripple_carry_tuple_SS. Qed.
 
   Local Opaque Z.of_nat.
-  Global Instance ripple_carry_is_sub_with_carry {k}
-         {isdecode : is_decode decode}
-         {is_subc : is_sub_with_carry subc}
-    : is_sub_with_carry (ripple_carry_subc (k := k) subc).
+  Global Instance ripple_carry_is_sub_with_carry
+    : forall {k}
+             {isdecode : is_decode decode}
+             {is_subc : is_sub_with_carry subc},
+      is_sub_with_carry (ripple_carry_subc (k := k) subc).
   Proof using Type.
-    destruct k as [|k].
+    destruct k as [|k]; intros isdecode is_subc.
     { constructor; repeat (intros [] || intro); autorewrite with simpl_tuple_decoder zsimplify; reflexivity. }
     { induction k as [|k IHk].
       { cbv [ripple_carry_subc ripple_carry_tuple to_list].

--- a/src/LegacyArithmetic/InterfaceProofs.v
+++ b/src/LegacyArithmetic/InterfaceProofs.v
@@ -99,8 +99,9 @@ Global Instance decode_proj n W (dec : W -> Z)
   : @decode n W {| decode := dec |} =~> dec.
 Proof. reflexivity. Qed.
 
-Global Instance decode_if_bool n W (decode : decoder n W) (b : bool) x y
-  : decode (if b then x else y)
+Global Instance decode_if_bool n W (decode : decoder n W)
+  : forall (b : bool) x y,
+    decode (if b then x else y)
     =~> if b then decode x else decode y.
 Proof. destruct b; reflexivity. Qed.
 

--- a/src/Primitives/EdDSARepChange.v
+++ b/src/Primitives/EdDSARepChange.v
@@ -60,7 +60,7 @@ Section EdDSA.
   Definition verify'_sig : { verify | forall mlen (message:word mlen) (pk:word b) (sig:word (b+b)),
       verify mlen message pk sig = true <-> valid message pk sig }.
   Proof.
-    eexists; intros; set_evars.
+    eexists; intros mlen message pk sig; set_evars.
     unfold Spec.EdDSA.valid.
     setoid_rewrite solve_for_R.
     setoid_rewrite combine_eq_iff.

--- a/src/Primitives/MxDHRepChange.v
+++ b/src/Primitives/MxDHRepChange.v
@@ -100,7 +100,7 @@ Section MxDHRepChange.
          R (proj (fold_left step xs init)) (fold_left step' xs init').
   Proof using Type.
     generalize dependent init; generalize dependent init'.
-    induction xs; [solve [eauto]|].
+    induction xs as [|?? IHxs]; [solve [eauto]|].
     repeat intro; simpl; rewrite IHxs by eauto.
     apply (_ : Proper ((R ==> eq ==> R) ==> SetoidList.eqlistA eq ==> R ==> R) (@fold_left _ _));
       try reflexivity;

--- a/src/Spec/CompleteEdwardsCurve.v
+++ b/src/Spec/CompleteEdwardsCurve.v
@@ -39,7 +39,7 @@ Module E.
         (x1, y1), (x2, y2) =>
         (((x1*y2  +  y1*x2)/(1 + d*x1*x2*y1*y2)) , ((y1*y2 - a*x1*x2)/(1 - d*x1*x2*y1*y2)))
       end.
-    Next Obligation. destruct P1 as [[??]?], P2 as [[??]?]; eapply Pre.onCurve_add; eauto. Qed.
+    Next Obligation. do 2 match goal with P : point |- _ => destruct P as [[??]?] end; eapply Pre.onCurve_add; eauto. Qed.
 
     Fixpoint mul (n:nat) (P : point) : point :=
       match n with

--- a/src/Specific/ArithmeticSynthesisTest.v
+++ b/src/Specific/ArithmeticSynthesisTest.v
@@ -115,7 +115,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m:=m) wt in
                  eval (add a b) = (eval a  + eval b)%F }.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a b.
     pose proof wt_nonzero.
     let x := constr:(
         Positional.add_cps (n := sz) wt a b id) in
@@ -128,7 +128,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m:=m) wt in
                  eval (sub a b) = (eval a - eval b)%F}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a b.
     pose proof wt_nonzero.
     let x := constr:(
          Positional.sub_cps (n:=sz) (coef := coef) wt a b id) in
@@ -141,7 +141,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m := m) wt in
                  eval (opp a) = F.opp (eval a)}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a.
     pose proof wt_nonzero.
     let x := constr:(
          Positional.opp_cps (n:=sz) (coef := coef) wt a id) in
@@ -154,7 +154,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m := m) wt in
                  eval (mul a b) = (eval a  * eval b)%F}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a b.
     pose proof wt_nonzero.
     let x := constr:(
          Positional.mul_cps (n:=sz) (m:=sz2) wt a b
@@ -190,7 +190,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m := m) wt in
                  eval (square a) = (eval a  * eval a)%F}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a.
     pose proof wt_nonzero.
     let x := constr:(
          Positional.mul_cps (n:=sz) (m:=sz2) wt a a
@@ -221,7 +221,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m := m) wt in
                  eval (carry a) = eval a}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a.
     pose proof wt_nonzero. pose proof wt_divides_chain1.
     pose proof div_mod. pose proof wt_divides_chain2.
     let x := constr:(
@@ -262,7 +262,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m := m) wt in
                  eval (freeze a) = eval a}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a ?.
     pose proof wt_nonzero. pose proof wt_pos.
     pose proof div_mod. pose proof wt_divides_full_pos.
     pose proof wt_multiples.

--- a/src/Specific/ArithmeticSynthesisTest130.v
+++ b/src/Specific/ArithmeticSynthesisTest130.v
@@ -115,7 +115,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m:=m) wt in
                  eval (add a b) = (eval a  + eval b)%F }.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a b.
     pose proof wt_nonzero.
     let x := constr:(
         Positional.add_cps (n := sz) wt a b id) in
@@ -128,7 +128,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m:=m) wt in
                  eval (sub a b) = (eval a - eval b)%F}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a b.
     pose proof wt_nonzero.
     let x := constr:(
          Positional.sub_cps (n:=sz) (coef := coef) wt a b id) in
@@ -141,7 +141,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m := m) wt in
                  eval (opp a) = F.opp (eval a)}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a.
     pose proof wt_nonzero.
     let x := constr:(
          Positional.opp_cps (n:=sz) (coef := coef) wt a id) in
@@ -154,7 +154,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m := m) wt in
                  eval (mul a b) = (eval a  * eval b)%F}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a b.
     pose proof wt_nonzero.
     let x := constr:(
          Positional.mul_cps (n:=sz) (m:=sz2) wt a b
@@ -176,7 +176,7 @@ Section Ops51.
                  let eval := Positional.Fdecode (m := m) wt in
                  eval (carry a) = eval a}.
   Proof.
-    eexists; cbv beta zeta; intros.
+    eexists; cbv beta zeta; intros a.
     pose proof wt_nonzero. pose proof wt_divides_chain1.
     pose proof div_mod. pose proof wt_divides_chain2.
     let x := constr:(

--- a/src/Specific/IntegrationTestFreeze.v
+++ b/src/Specific/IntegrationTestFreeze.v
@@ -51,7 +51,7 @@ Section BoundedField25p5.
     | [ |- { f | forall a, ?phi (f a) = @?rhs a } ]
       => apply lift1_sig with (P:=fun a f => phi f = rhs a)
     end.
-    intros.
+    intros a.
     eexists_sig_etransitivity. all:cbv [phi].
     rewrite <- (proj2_sig freeze_sig).
     { set (freezeZ := proj1_sig freeze_sig).

--- a/src/Specific/IntegrationTestLadderstep.v
+++ b/src/Specific/IntegrationTestLadderstep.v
@@ -92,7 +92,7 @@ Section BoundedField25p5.
       | forall a24 x1 Q Q', let eval := B.Positional.Fdecode wt in Tuple.map (n:=2) (Tuple.map (n:=2) eval) (xzladderstep a24 x1 Q Q') = FMxzladderstep (eval a24) (eval x1) (Tuple.map (n:=2) eval Q) (Tuple.map (n:=2) eval Q') }.
   Proof.
     exists Mxzladderstep.
-    intros.
+    intros a24 x1 Q Q' eval.
     cbv [Mxzladderstep FMxzladderstep M.donnaladderstep].
     destruct Q, Q'; cbv [map map' fst snd Let_In eval].
     repeat rewrite ?(proj2_sig add_sig), ?(proj2_sig mul_sig), ?(proj2_sig square_sig), ?(proj2_sig sub_sig), ?(proj2_sig carry_sig).

--- a/src/Specific/IntegrationTestLadderstep130.v
+++ b/src/Specific/IntegrationTestLadderstep130.v
@@ -57,7 +57,7 @@ Section BoundedField25p5.
       | forall a24 x1 Q Q', let eval := B.Positional.Fdecode wt in Tuple.map (n:=2) (Tuple.map (n:=2) eval) (xzladderstep a24 x1 Q Q') = FMxzladderstep (eval a24) (eval x1) (Tuple.map (n:=2) eval Q) (Tuple.map (n:=2) eval Q') }.
   Proof.
     exists (@M.xzladderstep _ (proj1_sig add_sig) (proj1_sig sub_sig) (fun x y => proj1_sig carry_sig (proj1_sig mul_sig x y))).
-    intros.
+    intros a24 x1 Q Q' eval.
     cbv [FMxzladderstep M.xzladderstep].
     destruct Q, Q'; cbv [map map' fst snd Let_In eval].
     repeat rewrite ?(proj2_sig add_sig), ?(proj2_sig mul_sig), ?(proj2_sig sub_sig), ?(proj2_sig carry_sig).

--- a/src/Specific/IntegrationTestMul.v
+++ b/src/Specific/IntegrationTestMul.v
@@ -50,7 +50,7 @@ Section BoundedField25p5.
     | [ |- { f | forall a b, ?phi (f a b) = @?rhs a b } ]
       => apply lift2_sig with (P:=fun a b f => phi f = rhs a b)
     end.
-    intros.
+    intros a b.
     eexists_sig_etransitivity. all:cbv [phi].
     rewrite <- (proj2_sig mul_sig).
     symmetry; rewrite <- (proj2_sig carry_sig); symmetry.

--- a/src/Specific/IntegrationTestSquare.v
+++ b/src/Specific/IntegrationTestSquare.v
@@ -50,7 +50,7 @@ Section BoundedField25p5.
     | [ |- { f | forall a, ?phi (f a) = @?rhs a } ]
       => apply lift1_sig with (P:=fun a f => phi f = rhs a)
     end.
-    intros.
+    intros a.
     eexists_sig_etransitivity. all:cbv [phi].
     rewrite <- (proj2_sig square_sig).
     symmetry; rewrite <- (proj2_sig carry_sig); symmetry.

--- a/src/Specific/IntegrationTestSub.v
+++ b/src/Specific/IntegrationTestSub.v
@@ -50,7 +50,7 @@ Section BoundedField25p5.
     | [ |- { f | forall a b, ?phi (f a b) = @?rhs a b } ]
       => apply lift2_sig with (P:=fun a b f => phi f = rhs a b)
     end.
-    intros.
+    intros a b.
     eexists_sig_etransitivity. all:cbv [phi].
     rewrite <- (proj2_sig sub_sig).
     symmetry; rewrite <- (proj2_sig carry_sig); symmetry.

--- a/src/Util/AdditionChainExponentiation.v
+++ b/src/Util/AdditionChainExponentiation.v
@@ -39,7 +39,7 @@ Section AddChainExp.
       (Hl:Logic.eq (length acc) (length ref)),
       fold_chain id op is acc = (fold_chain 0 N.add is ref) * x.
   Proof using Type*.
-    induction is; intros; simpl @fold_chain.
+    intro x; induction is; intros acc ref H Hl; simpl @fold_chain.
     { repeat break_match; specialize (H 0%nat); rewrite ?nth_default_cons, ?nth_default_cons_S in H;
       solve [ simpl length in *; discriminate | apply H | rewrite scalarmult_0_l; reflexivity ]. }
     { repeat break_match. eapply IHis; intros; [|auto with distr_length]; [].
@@ -52,8 +52,8 @@ Section AddChainExp.
 
   Lemma fold_chain_exp x is: fold_chain id op is [x] = (fold_chain 0 N.add is [1]) * x.
   Proof using Type*.
-    eapply fold_chain_exp'; intros; trivial.
-    destruct i; try destruct i; rewrite ?nth_default_cons_S, ?nth_default_cons, ?nth_default_nil;
+    eapply fold_chain_exp'; trivial; intros i.
+    destruct i as [|i]; try destruct i; rewrite ?nth_default_cons_S, ?nth_default_cons, ?nth_default_nil;
       rewrite ?scalarmult_1_l, ?scalarmult_0_l; reflexivity.
   Qed.
 End AddChainExp.

--- a/src/Util/CPSUtil.v
+++ b/src/Util/CPSUtil.v
@@ -48,7 +48,7 @@ Fixpoint map_cps {A B} (g : A->B) ls
   end.
 Lemma map_cps_correct {A B} g ls: forall {T} f,
     @map_cps A B g ls T f = f (map g ls).
-Proof. induction ls; simpl; intros; rewrite ?IHls; reflexivity. Qed.
+Proof. induction ls as [|?? IHls]; simpl; intros; rewrite ?IHls; reflexivity. Qed.
 Create HintDb uncps discriminated. Hint Rewrite @map_cps_correct : uncps.
 
 Fixpoint flat_map_cps {A B} (g:A->forall {T}, (list B->T)->T) (ls : list A) {T} (f:list B->T)  :=
@@ -61,7 +61,7 @@ Lemma flat_map_cps_correct {A B} (g:A->forall {T}, (list B->T)->T) ls :
     (forall x T h, @g x T h = h (g x id)) ->
     @flat_map_cps A B g ls T f = f (List.flat_map (fun x => g x id) ls).
 Proof.
-  induction ls; intros; [reflexivity|].
+  induction ls as [|?? IHls]; intros T f H; [reflexivity|].
   simpl flat_map_cps. simpl flat_map.
   rewrite H; erewrite IHls by eassumption.
   reflexivity.
@@ -81,7 +81,7 @@ Fixpoint from_list_default'_cps {A} (d y:A) n xs:
 Lemma from_list_default'_cps_correct {A} n : forall d y l {T} f,
     @from_list_default'_cps A d y n l T f = f (Tuple.from_list_default' d y n l).
 Proof.
-  induction n; intros; simpl; [reflexivity|].
+  induction n as [|? IHn]; intros; simpl; [reflexivity|].
   break_match; subst; apply IHn.
 Qed.
 Definition from_list_default_cps {A} (d:A) n (xs:list A) :
@@ -136,7 +136,7 @@ Lemma on_tuple_cps_correct {A B} d (g:list A -> forall {T}, (list B->T)->T)
       (Hg : forall x {T} h, @g x T h = h (g x id)) : forall H,
     @on_tuple_cps A B d g n m xs T f = f (@Tuple.on_tuple A B (fun x => g x id) n m H xs).
 Proof.
-  cbv [on_tuple_cps Tuple.on_tuple]; intros.
+  cbv [on_tuple_cps Tuple.on_tuple]; intros H.
   rewrite to_list_cps_correct, Hg, from_list_default_cps_correct.
   rewrite (Tuple.from_list_default_eq _ _ _ (H _ (Tuple.length_to_list _))).
   reflexivity.
@@ -188,7 +188,7 @@ Lemma fold_right_cps2_correct {A B} g a0 l : forall {T} f,
   (forall b a T h, @g b a T h = h (@g b a A id)) ->
   @fold_right_cps2 A B g a0 l T f = f (List.fold_right (fun b a => @g b a A id) a0 l).
 Proof.
-  induction l; intros; [reflexivity|].
+  induction l as [|?? IHl]; intros T f H; [reflexivity|].
   simpl fold_right_cps2. simpl fold_right.
   rewrite H; erewrite IHl by eassumption.
   rewrite H; reflexivity.
@@ -225,7 +225,7 @@ Fixpoint fold_right_cps {A B} (g:B->A->A) (a0:A) (l:list B) {T} (f:A->T) :=
   end.
 Lemma fold_right_cps_correct {A B} g a0 l: forall {T} f,
     @fold_right_cps A B g a0 l T f = f (List.fold_right g a0 l).
-Proof. induction l; intros; simpl; rewrite ?IHl; auto. Qed.
+Proof. induction l as [|? l IHl]; intros; simpl; rewrite ?IHl; auto. Qed.
 Hint Rewrite @fold_right_cps_correct : uncps.
 
 Definition fold_right_no_starter_cps {A} g ls {T} (f:option A->T) :=
@@ -278,7 +278,7 @@ Module Tuple.
   Lemma mapi_with'_cps_correct {S A B n} : forall i f start xs T ret,
   (forall i s a R (ret:_->R), f i s a R ret = ret (f i s a _ id)) ->
   @mapi_with'_cps S A B n i f start xs T ret = ret (mapi_with' i (fun i s a => f i s a _ id) start xs).
-  Proof. induction n; intros; simpl; rewrite H, ?IHn by assumption; reflexivity. Qed.
+  Proof. induction n as [|n IHn]; intros i f start xs T ret H; simpl; rewrite H, ?IHn by assumption; reflexivity. Qed.
   Lemma mapi_with_cps_correct {S A B n} f start xs T ret
   (H:forall i s a R (ret:_->R), f i s a R ret = ret (f i s a _ id))
   : @mapi_with_cps S A B n f start xs T ret = ret (mapi_with (fun i s a => f i s a _ id) start xs).

--- a/src/Util/Decidable.v
+++ b/src/Util/Decidable.v
@@ -16,8 +16,8 @@ Notation DecidableRel R := (forall x y, Decidable (R x y)).
 Global Instance hprop_eq_dec {A} `{DecidableRel (@eq A)} : IsHPropRel (@eq A) | 10.
 Proof. repeat intro; apply UIP_dec; trivial with nocore. Qed.
 
-Global Instance eq_dec_hprop {A} {x y : A} `{hp : IsHProp A} : Decidable (@eq A x y) | 5.
-Proof. left; apply hp. Qed.
+Global Instance eq_dec_hprop {A} {x y : A} {hp : IsHProp A} : Decidable (@eq A x y) | 5.
+Proof. left; auto. Qed.
 
 Ltac no_equalities_about x0 y0 :=
   lazymatch goal with
@@ -111,15 +111,16 @@ Global Instance dec_ge_Z : DecidableRel BinInt.Z.ge := ZArith_dec.Z_ge_dec.
 Global Instance dec_match_pair {A B} {P : A -> B -> Prop} {x : A * B}
        {HD : Decidable (P (fst x) (snd x))}
   : Decidable (let '(a, b) := x in P a b) | 1.
-Proof. destruct x; assumption. Defined.
+Proof. edestruct (_ : _ * _); assumption. Defined.
 
 Lemma not_not P {d:Decidable P} : not (not P) <-> P.
 Proof. destruct (dec P); intuition. Qed.
 
-Global Instance dec_ex_forall_not T (P:T->Prop) {d:Decidable (exists b, P b)} : Decidable (forall b, ~ P b).
+Global Instance dec_ex_forall_not : forall T (P:T->Prop) {d:Decidable (exists b, P b)}, Decidable (forall b, ~ P b).
 Proof.
+  intros T P d.
   destruct (dec (~ exists b, P b)) as [Hd|Hd]; [left|right];
-    [abstract eauto | abstract (rewrite not_not in Hd by eauto; destruct Hd; eauto) ].
+    [abstract eauto | let Hd := Hd in abstract (rewrite not_not in Hd by eauto; destruct Hd; eauto) ].
 Defined.
 
 Lemma eqsig_eq {T} {U} {Udec:DecidableRel (@eq U)} (f g:T->U) (x x':T) pf pf' :

--- a/src/Util/Equality.v
+++ b/src/Util/Equality.v
@@ -83,8 +83,9 @@ Section gen.
     reflexivity.
   Defined.
 
-  Global Instance isiso_encode {y} : IsIso (encode y).
+  Global Instance isiso_encode : forall {y}, IsIso (encode y).
   Proof.
+    intro y.
     exists (@decode y).
     { intro H.
       unfold decode.

--- a/src/Util/FixedWordSizesEquality.v
+++ b/src/Util/FixedWordSizesEquality.v
@@ -23,6 +23,7 @@ Lemma pow2_inj_helper x y : 2^x = 2^y -> x = y.
 Proof.
   destruct (NatUtil.nat_eq_dec x y) as [pf|pf]; [ intros; assumption | ].
   intro H; exfalso.
+  let pf := pf in
   abstract (apply pf; eapply NPeano.Nat.pow_inj_r; [ | eassumption ]; omega).
 Defined.
 Lemma pow2_inj_helper_refl x p : pow2_inj_helper x x p = eq_refl.
@@ -43,6 +44,7 @@ Proof.
   intros [pf H]; exists (pow2_inj_helper x y pf); subst v'.
   destruct (NatUtil.nat_eq_dec x y) as [H|H];
     [ | exfalso; clear -pf H;
+        let pf := pf in
         abstract (apply pow2_inj_helper in pf; omega) ].
   subst; rewrite pow2_inj_helper_refl; simpl.
   pose proof (NatUtil.UIP_nat_transparent _ _ pf eq_refl); subst pf.
@@ -99,7 +101,10 @@ Proof.
          | _, _
            => fun x y pf => match _ : False with end
          end;
-    try abstract (rewrite wordT_beq_hetero_type_lb_false in pf by omega; clear -pf; congruence).
+    match goal with
+    | [ pf : _ = _ |- _ ]
+      => abstract (rewrite wordT_beq_hetero_type_lb_false in pf by omega; clear -pf; congruence)
+    end.
 Defined.
 
 Lemma ZToWord_gen_wordToZ_gen : forall {sz} v, ZToWord_gen (@wordToZ_gen sz v) = v.
@@ -123,7 +128,7 @@ Qed.
 Lemma wordToZ_gen_ZToWord_gen_mod : forall {sz} w, (0 <= w)%Z -> wordToZ_gen (@ZToWord_gen sz w) = (w mod (2^Z.of_nat sz))%Z.
 Proof.
   unfold ZToWord_gen, wordToZ_gen.
-  intros.
+  intros sz w H.
   rewrite wordToN_NToWord_mod.
   rewrite N2Z.inj_mod by (destruct sz; simpl; congruence).
   rewrite Z2N.id, N2Z.inj_pow, nat_N_Z by assumption.

--- a/src/Util/ForLoop/InvariantFramework.v
+++ b/src/Util/ForLoop/InvariantFramework.v
@@ -16,7 +16,7 @@ Lemma repeat_function_ind {stateT} (P : nat -> stateT -> Prop)
   : P 0 (repeat_function body count st).
 Proof.
   revert dependent st; revert dependent body; revert dependent P.
-  induction count; intros; [ exact Pbefore | ].
+  induction count as [|? IHcount]; intros P body Pbody st Pbefore; [ exact Pbefore | ].
   { rewrite repeat_function_unroll1_end; apply Pbody; [ omega | ].
     apply (IHcount (fun c => P (S c))); auto with omega. }
 Qed.

--- a/src/Util/ForLoop/Unrolling.v
+++ b/src/Util/ForLoop/Unrolling.v
@@ -31,7 +31,7 @@ Section with_body.
     : repeat_function body (S count) st
       = body 1 (repeat_function (fun count => body (S count)) count st).
   Proof using Type.
-    revert st; induction count; [ reflexivity | ].
+    revert st; induction count as [|? IHcount]; [ reflexivity | ].
     intros; simpl in *; rewrite <- IHcount; reflexivity.
   Qed.
 

--- a/src/Util/HList.v
+++ b/src/Util/HList.v
@@ -142,13 +142,14 @@ Proof.
   destruct n; [ simpl; tauto | apply fold_right_and_True_hlist' ].
 Qed.
 
-Global Instance mapt_Proper {n A F B}
-  : Proper
+Global Instance mapt_Proper
+  : forall {n A F B},
+    Proper
       ((forall_relation (fun x => pointwise_relation _ Logic.eq))
          ==> forall_relation (fun ts => Logic.eq ==> Logic.eq))
       (@mapt n A F B).
 Proof.
-  unfold forall_relation, pointwise_relation, respectful.
+  intro n; unfold forall_relation, pointwise_relation, respectful.
   repeat intro; subst; destruct n as [|n]; [ reflexivity | ].
   induction n; simpl in *; congruence.
 Qed.

--- a/src/Util/IterAssocOp.v
+++ b/src/Util/IterAssocOp.v
@@ -26,7 +26,7 @@ Section IterAssocOp.
 
   Lemma Pos_iter_op_succ : forall p a, Pos.iter_op op (Pos.succ p) a === op a (Pos.iter_op op p a).
   Proof using Type*.
-   induction p; intros; simpl; rewrite ?Algebra.Hierarchy.associative, ?IHp; reflexivity.
+   induction p as [p IHp|p IHp|]; intros; simpl; rewrite ?Algebra.Hierarchy.associative, ?IHp; reflexivity.
   Qed.
 
   Lemma N_iter_op_succ : forall n a, N_iter_op (N.succ n) a  === op a (N_iter_op n a).
@@ -36,7 +36,7 @@ Section IterAssocOp.
 
   Lemma N_iter_op_is_nat_iter_op : forall n a, N_iter_op n a === nat_iter_op (N.to_nat n) a.
   Proof using Type*.
-    induction n using N.peano_ind; intros; rewrite ?N2Nat.inj_succ, ?N_iter_op_succ, ?IHn; reflexivity.
+    induction n as [|n IHn] using N.peano_ind; intros; rewrite ?N2Nat.inj_succ, ?N_iter_op_succ, ?IHn; reflexivity.
   Qed.
 
   Context {sel:bool->T->T->T} {sel_correct:forall b x y, sel b x y = if b then y else x}.
@@ -90,7 +90,7 @@ Section IterAssocOp.
   Lemma funexp_test_and_op_index : forall a x acc y,
     fst (funexp (test_and_op a) (x, acc) y) = x - y.
   Proof using Type.
-    induction y; simpl; rewrite <- ?Minus.minus_n_O; try reflexivity.
+    induction y as [|? IHy]; simpl; rewrite <- ?Minus.minus_n_O; try reflexivity.
     match goal with |- context[funexp ?a ?b ?c] => destruct (funexp a b c) as [i acc'] end.
     simpl in IHy.
     unfold test_and_op.
@@ -129,7 +129,7 @@ Global Instance Proper_funexp {T R} {Equivalence_R:Equivalence R}
   : Proper ((R==>R) ==> R ==> Logic.eq ==> R) (@funexp T).
 Proof.
   repeat intro; subst.
-  match goal with [n0 : nat |- _ ] => rename n0 into n; induction n end; [solve [trivial]|].
+  match goal with [n0 : nat |- _ ] => rename n0 into n; induction n as [|n IHn] end; [solve [trivial]|].
   match goal with
       [H: (_ ==> _)%signature _ _ |- _ ] =>
       etransitivity; solve [eapply (H _ _ IHn)|reflexivity]
@@ -169,7 +169,8 @@ Global Instance Proper_iter_op {T R} {Equivalence_R:@Equivalence T R} :
 Proof.
   repeat match goal with
            | _ => solve [ reflexivity | congruence | eauto 99 ]
-           | _ => progress eapply (Proper_funexp (R:=(fun nt NT => Logic.eq (fst nt) (fst NT) /\ R (snd nt) (snd NT))))
+           | [ R : _ |- _ ]
+             => progress eapply (Proper_funexp (R:=(fun nt NT => Logic.eq (fst nt) (fst NT) /\ R (snd nt) (snd NT))))
            | _ => progress eapply Proper_test_and_op
            | _ => progress split
            | _ => progress (cbv [fst snd pointwise_relation respectful] in * )

--- a/src/Util/NUtil.v
+++ b/src/Util/NUtil.v
@@ -26,7 +26,7 @@ Module N.
 
   Lemma size_nat_equiv : forall n, N.size_nat n = N.to_nat (N.size n).
   Proof.
-    destruct n; auto; simpl; induction p; simpl; auto; rewrite IHp, Pnat.Pos2Nat.inj_succ; reflexivity.
+    destruct n as [|p]; auto; simpl; induction p as [p IHp|p IHp|]; simpl; auto; rewrite IHp, Pnat.Pos2Nat.inj_succ; reflexivity.
   Qed.
 
   Lemma size_nat_le a b : (a <= b)%N -> (N.size_nat a <= N.size_nat b)%nat.
@@ -39,7 +39,7 @@ Module N.
   Lemma shiftr_size : forall n bound, N.size_nat n <= bound ->
     N.shiftr_nat n bound = 0%N.
   Proof.
-    intros.
+    intros n bound H.
     rewrite <- (Nat2N.id bound).
     rewrite Nshiftr_nat_equiv.
     destruct (N.eq_dec n 0); subst; [apply N.shiftr_0_l|].
@@ -86,7 +86,7 @@ Module N.
     then S (2 * N.to_nat (N.shiftr_nat n (S i)))
     else (2 * N.to_nat (N.shiftr_nat n (S i))).
   Proof.
-    intros.
+    intros n i.
     rewrite Nshiftr_nat_S.
     case_eq (N.testbit_nat n i); intro testbit_i;
       pose proof (Nshiftr_nat_spec n i 0) as shiftr_n_odd;

--- a/src/Util/NatUtil.v
+++ b/src/Util/NatUtil.v
@@ -105,8 +105,8 @@ Ltac nat_beq_to_eq :=
 
 Lemma div_minus : forall a b, b <> 0 -> (a + b) / b = a / b + 1.
 Proof.
-  intros.
-  assert (b = 1 * b) by omega.
+  intros a b H.
+  assert (H0 : b = 1 * b) by omega.
   rewrite H0 at 1.
   rewrite <- Nat.div_add by auto.
   reflexivity.
@@ -114,7 +114,7 @@ Qed.
 
 Lemma pred_mod : forall m, (0 < m)%nat -> ((pred m) mod m)%nat = pred m.
 Proof.
-  intros; apply Nat.mod_small.
+  intros m H; apply Nat.mod_small.
   destruct m; try omega; rewrite Nat.pred_succ; auto.
 Qed.
 
@@ -141,7 +141,7 @@ Qed.
 Lemma divide2_1mod4_nat : forall c x, c = x / 4 -> x mod 4 = 1 -> exists y, 2 * y = (x / 2).
 Proof.
   assert (4 <> 0) as ne40 by omega.
-  induction c; intros; pose proof (div_mod x 4 ne40); rewrite <- H in H1. {
+  induction c; intros x H H0; pose proof (div_mod x 4 ne40) as H1; rewrite <- H in H1. {
     rewrite H0 in H1.
     simpl in H1.
     rewrite H1.
@@ -155,8 +155,8 @@ Proof.
     apply Nat.add_cancel_r in H.
     replace x with ((x - 4) + (1 * 4)) in H0 by omega.
     rewrite Nat.mod_add in H0 by auto.
-    pose proof (IHc _ H H0).
-    destruct H2.
+    pose proof (IHc _ H H0) as H2.
+    destruct H2 as [x0 H2].
     exists (x0 + 1).
     rewrite <- (Nat.sub_add 4 x) in H1 at 1 by auto.
     replace (4 * c + 4 + x mod 4) with (4 * c + x mod 4 + 4) in H1 by omega.
@@ -265,7 +265,7 @@ Hint Rewrite eq_nat_dec_refl : natsimplify.
 (** Helper to get around the lack of function extensionality *)
 Definition eq_nat_dec_right_val n m (pf0 : n <> m) : { pf | eq_nat_dec n m = right pf }.
 Proof.
-  revert dependent n; induction m; destruct n as [|n]; simpl;
+  revert dependent n; induction m as [|m IHm]; destruct n as [|n]; simpl;
     intro pf0;
     [ (exists pf0; exfalso; abstract congruence)
     | eexists; reflexivity

--- a/src/Util/Relations.v
+++ b/src/Util/Relations.v
@@ -38,7 +38,8 @@ Global Instance Equivalence_and {A B RA RB}
        {Equivalence_RB:@Equivalence B RB}
        : Equivalence (fun ab AB => RA (fst ab) (fst AB) /\ RB (snd ab) (snd AB)).
 Proof.
-  destruct Equivalence_RA as [], Equivalence_RB as []; cbv in *|-.
+  do 2 match goal with H : Equivalence _ |- _ => destruct H end;
+    cbv in *|-.
   repeat match goal with
            | _ => intro
            | _ => split

--- a/src/Util/Sum.v
+++ b/src/Util/Sum.v
@@ -10,10 +10,12 @@ Definition sumwise {A B} (RA:relation A) (RB : relation B) : relation (A + B)
                 | _, _ => False
                 end.
 
-Global Instance Equivalence_sumwise {A B} {RA:relation A} {RB:relation B}
-       {RA_equiv:Equivalence RA} {RB_equiv:Equivalence RB}
-  : Equivalence (sumwise RA RB).
+Global Instance Equivalence_sumwise
+  : forall {A B} {RA:relation A} {RB:relation B}
+           {RA_equiv:Equivalence RA} {RB_equiv:Equivalence RB},
+    Equivalence (sumwise RA RB).
 Proof.
+  intros A B RA RB RA_equiv RB_equiv.
   split; repeat intros [?|?]; simpl; trivial; destruct RA_equiv, RB_equiv; try tauto; eauto.
 Qed.
 

--- a/src/Util/ZUtil/Land.v
+++ b/src/Util/ZUtil/Land.v
@@ -5,7 +5,7 @@ Local Open Scope Z_scope.
 Module Z.
   Lemma land_same_r : forall a b, (a &' b) &' b = a &' b.
   Proof.
-    intros; apply Z.bits_inj'; intros.
+    intros a b; apply Z.bits_inj'; intros n H.
     rewrite !Z.land_spec.
     case_eq (Z.testbit b n); intros;
       rewrite ?Bool.andb_true_r, ?Bool.andb_false_r; reflexivity.

--- a/src/Util/ZUtil/Modulo.v
+++ b/src/Util/ZUtil/Modulo.v
@@ -14,38 +14,38 @@ Module Z.
   Hint Resolve elim_mod : zarith.
 
   Lemma mod_add_full : forall a b c, (a + b * c) mod c = a mod c.
-  Proof. intros; destruct (Z_zerop c); try subst; autorewrite with zsimplify; reflexivity. Qed.
+  Proof. intros a b c; destruct (Z_zerop c); try subst; autorewrite with zsimplify; reflexivity. Qed.
   Hint Rewrite mod_add_full : zsimplify.
 
   Lemma mod_add_l_full : forall a b c, (a * b + c) mod b = c mod b.
-  Proof. intros; rewrite (Z.add_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
+  Proof. intros a b c; rewrite (Z.add_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
   Hint Rewrite mod_add_l_full : zsimplify.
 
   Lemma mod_add'_full : forall a b c, (a + b * c) mod b = a mod b.
-  Proof. intros; rewrite (Z.mul_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
+  Proof. intros a b c; rewrite (Z.mul_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
   Lemma mod_add_l'_full : forall a b c, (a * b + c) mod a = c mod a.
-  Proof. intros; rewrite (Z.mul_comm _ b); autorewrite with zsimplify; reflexivity. Qed.
+  Proof. intros a b c; rewrite (Z.mul_comm _ b); autorewrite with zsimplify; reflexivity. Qed.
   Hint Rewrite mod_add'_full mod_add_l'_full : zsimplify.
 
   Lemma mod_add_l : forall a b c, b <> 0 -> (a * b + c) mod b = c mod b.
-  Proof. intros; rewrite (Z.add_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
+  Proof. intros a b c H; rewrite (Z.add_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
 
   Lemma mod_add' : forall a b c, b <> 0 -> (a + b * c) mod b = a mod b.
-  Proof. intros; rewrite (Z.mul_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
+  Proof. intros a b c H; rewrite (Z.mul_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
   Lemma mod_add_l' : forall a b c, a <> 0 -> (a * b + c) mod a = c mod a.
-  Proof. intros; rewrite (Z.mul_comm _ b); autorewrite with zsimplify; reflexivity. Qed.
+  Proof. intros a b c H; rewrite (Z.mul_comm _ b); autorewrite with zsimplify; reflexivity. Qed.
 
   Lemma add_pow_mod_l : forall a b c, a <> 0 -> 0 < b ->
                                       ((a ^ b) + c) mod a = c mod a.
   Proof.
-    intros; replace b with (b - 1 + 1) by ring;
+    intros a b c H H0; replace b with (b - 1 + 1) by ring;
       rewrite Z.pow_add_r, Z.pow_1_r by omega; auto using Z.mod_add_l.
   Qed.
 
   Lemma mod_exp_0 : forall a x m, x > 0 -> m > 1 -> a mod m = 0 ->
     a ^ x mod m = 0.
   Proof.
-    intros.
+    intros a x m H H0 H1.
     replace x with (Z.of_nat (Z.to_nat x)) in * by (apply Z2Nat.id; omega).
     induction (Z.to_nat x). {
       simpl in *; omega.
@@ -70,8 +70,8 @@ Module Z.
   Lemma mod_pow : forall (a m b : Z), (0 <= b) -> (m <> 0) ->
       a ^ b mod m = (a mod m) ^ b mod m.
   Proof.
-    intros; rewrite <- (Z2Nat.id b) by auto.
-    induction (Z.to_nat b); auto.
+    intros a m b H H0; rewrite <- (Z2Nat.id b) by auto.
+    induction (Z.to_nat b) as [|n IHn]; auto.
     rewrite Nat2Z.inj_succ.
     do 2 rewrite Z.pow_succ_r by apply Nat2Z.is_nonneg.
     rewrite Z.mul_mod by auto.
@@ -90,7 +90,7 @@ Module Z.
 
   Lemma mul_div_eq_full : forall a m, m <> 0 -> m * (a / m) = (a - a mod m).
   Proof.
-    intros. rewrite (Z_div_mod_eq_full a m) at 2 by auto. ring.
+    intros a m H. rewrite (Z_div_mod_eq_full a m) at 2 by auto. ring.
   Qed.
 
   Hint Rewrite mul_div_eq_full using zutil_arith : zdiv_to_mod.
@@ -126,14 +126,14 @@ Module Z.
 
   Lemma mul_div_eq : forall a m, m > 0 -> m * (a / m) = (a - a mod m).
   Proof.
-    intros.
+    intros a m H.
     rewrite (Z_div_mod_eq a m) at 2 by auto.
     ring.
   Qed.
 
   Lemma mul_div_eq' : (forall a m, m > 0 -> (a / m) * m = (a - a mod m))%Z.
   Proof.
-    intros.
+    intros a m H.
     rewrite (Z_div_mod_eq a m) at 2 by auto.
     ring.
   Qed.

--- a/src/Util/ZUtil/Testbit.v
+++ b/src/Util/ZUtil/Testbit.v
@@ -22,7 +22,7 @@ Module Z.
                                             then true
                                             else if Z_lt_dec m n then true else false.
   Proof.
-    intros.
+    intros n m.
     repeat (break_match || autorewrite with Ztestbit); try reflexivity; try omega.
     unfold Z.ones.
     rewrite <- Z.shiftr_opp_r, Z.shiftr_eq_0 by (simpl; omega); simpl.
@@ -34,7 +34,7 @@ Module Z.
   Lemma testbit_pow2_mod : forall a n i, 0 <= n ->
   Z.testbit (Z.pow2_mod a n) i = if Z_lt_dec i n then Z.testbit a i else false.
   Proof.
-  cbv [Z.pow2_mod]; intros; destruct (Z_le_dec 0 i);
+    cbv [Z.pow2_mod]; intros a n i H; destruct (Z_le_dec 0 i);
       repeat match goal with
           | |- _ => rewrite Z.testbit_neg_r by omega
           | |- _ => break_innermost_match_step
@@ -50,7 +50,7 @@ Module Z.
                                      then if Z_lt_dec i 0 then false else Z.testbit a i
                                      else if Z_lt_dec i n then Z.testbit a i else false.
   Proof.
-    intros; destruct (Z_lt_dec n 0); [ | apply testbit_pow2_mod; omega ].
+    intros a n i; destruct (Z_lt_dec n 0); [ | apply testbit_pow2_mod; omega ].
     unfold Z.pow2_mod.
     autorewrite with Ztestbit_full;
       repeat break_match;
@@ -80,7 +80,7 @@ Module Z.
   Lemma testbit_add_shiftl_low : forall i, (0 <= i) -> forall a b n, (i < n) ->
     Z.testbit (a + Z.shiftl b n) i = Z.testbit a i.
   Proof.
-    intros.
+    intros i H a b n H0.
     erewrite Z.testbit_low; eauto.
     rewrite Z.land_ones, Z.shiftl_mul_pow2 by omega.
     rewrite Z.mod_add by (pose proof (Z.pow_pos_nonneg 2 n); omega).


### PR DESCRIPTION
This fixes all of the private-names warnings emitted by compiling fiat-crypto with https://github.com/coq/coq/pull/268 (minus the ones in coqprime, which I didn't touch).

@ejgallego got me curious enough to try compiling fiat-crypto with that branch, and this was the result.