### PR TITLE
[8.6.1] Less init plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 
 update-_CoqProject::
 	$(SHOW)'ECHO > _CoqProject'
-	$(HIDE)(echo '-R $(SRC_DIR) $(MOD_NAME)'; echo '-R Bedrock Bedrock'; echo '-arg "-compat 8.6"'; (git ls-files 'src/*.v' 'Bedrock/*.v' | $(SORT_COQPROJECT))) > _CoqProject
+	$(HIDE)(echo '-R $(SRC_DIR) $(MOD_NAME)'; echo '-R Bedrock Bedrock'; (git ls-files 'src/*.v' 'Bedrock/*.v' | $(SORT_COQPROJECT))) > _CoqProject
 
 $(VOFILES): | coqprime
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,5 @@
 -R src Crypto
 -R Bedrock Bedrock
--arg "-compat 8.6"
 Bedrock/Nomega.v
 Bedrock/Word.v
 src/Demo.v

--- a/src/Util/AdditionChainExponentiation.v
+++ b/src/Util/AdditionChainExponentiation.v
@@ -1,3 +1,4 @@
+Require Import Coq.funind.FunInd.
 Require Import Coq.Lists.List Coq.Lists.SetoidList. Import ListNotations.
 Require Import Coq.Numbers.BinNums Coq.NArith.BinNat.
 Require Import Crypto.Util.ListUtil.


### PR DESCRIPTION
This is the correct way to handle things, rather than `-compat 8.6`, when we're willing to move to requiring Coq 8.6.1 or Coq 8.7 (neither of which is currently released)