### PR TITLE
Fix warnings in gcc

### DIFF
--- a/src/Specific/NISTP256/AMD64/p256.h
+++ b/src/Specific/NISTP256/AMD64/p256.h
@@ -1,2 +1,3 @@
-void p256_jacobian_add_affine(long long unsigned int r[12], long long unsigned int j[12], long long unsigned int a[8]);
+#define uint64_t long long unsigned int
 
+void p256_jacobian_add_affine(uint64_t r[12], uint64_t j[12], uint64_t a[8]);


### PR DESCRIPTION
This closes #227, though I'm not entirely sure why.