### PR TITLE
Hopefully fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,24 @@ addons:
 matrix:
   fast_finish: true
   include:
-    - env: COQ_VERSION="master" TARGETS="coq display test bench"         COQ_PACKAGE="coq"       PPA="ppa:jgross-h/coq-master-daily"
-    - env: COQ_VERSION="v8.7"   TARGETS="coq display test bench"         COQ_PACKAGE="coq"       PPA="ppa:jgross-h/coq-8.7-daily"
-    - env: COQ_VERSION="v8.6"   TARGETS="no-curves-proofs display bench" COQ_PACKAGE="coq"       PPA="ppa:jgross-h/coq-8.6-daily"
-    - env: COQ_VERSION="8.6.1"  TARGETS="no-curves-proofs display bench" COQ_PACKAGE="coq-8.6.1" PPA="ppa:jgross-h/many-coq-versions"
-    - env: TARGETS="printlite lite" COQ_VERSION="8.6.1"                  COQ_PACKAGE="coq-8.6.1" PPA="ppa:jgross-h/many-coq-versions"
+    - env: COQ_VERSION="master"    TARGETS="no-curves-proofs display test bench" COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-master-daily"
+    - env: COQ_VERSION="master"    TARGETS="curves-proofs"                       COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-master-daily"
+    - env: COQ_VERSION="v8.7"      TARGETS="no-curves-proofs display test bench" COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-8.7-daily"
+    - env: COQ_VERSION="v8.7"      TARGETS="curves-proofs"                       COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-8.7-daily"
+    - env: COQ_VERSION="v8.6"      TARGETS="no-curves-proofs display bench"      COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-8.6-daily"
+    - env: COQ_VERSION="v8.6"      TARGETS="curves-proofs"                       COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-8.6-daily"
+    - env: COQ_VERSION="8.7+beta1" TARGETS="no-curves-proofs display test bench" COQ_PACKAGE="coq-8.7+beta1" PPA="ppa:jgross-h/many-coq-versions"
+    - env: COQ_VERSION="8.7+beta1" TARGETS="curves-proofs"                       COQ_PACKAGE="coq-8.7+beta1" PPA="ppa:jgross-h/many-coq-versions"
+    - env: COQ_VERSION="8.6.1"     TARGETS="no-curves-proofs display bench"      COQ_PACKAGE="coq-8.6.1"     PPA="ppa:jgross-h/many-coq-versions"
+    - env: COQ_VERSION="8.6.1"     TARGETS="curves-proofs"                       COQ_PACKAGE="coq-8.6.1"     PPA="ppa:jgross-h/many-coq-versions"
+    - env: TARGETS="printlite lite" COQ_VERSION="8.6.1"                          COQ_PACKAGE="coq-8.6.1"     PPA="ppa:jgross-h/many-coq-versions"
   allow_failures:
-    - env: COQ_VERSION="master" TARGETS="coq display test bench"         COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-master-daily"
-    - env: COQ_VERSION="v8.7"   TARGETS="coq display test bench"         COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-8.7-daily"
-    - env: COQ_VERSION="v8.6"   TARGETS="no-curves-proofs display bench" COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-8.6-daily"
+    - env: COQ_VERSION="master"    TARGETS="no-curves-proofs display test bench" COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-master-daily"
+    - env: COQ_VERSION="master"    TARGETS="curves-proofs"                       COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-master-daily"
+    - env: COQ_VERSION="v8.7"      TARGETS="no-curves-proofs display test bench" COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-8.7-daily"
+    - env: COQ_VERSION="v8.7"      TARGETS="curves-proofs"                       COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-8.7-daily"
+    - env: COQ_VERSION="v8.6"      TARGETS="no-curves-proofs display bench"      COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-8.6-daily"
+    - env: COQ_VERSION="v8.6"      TARGETS="curves-proofs"                       COQ_PACKAGE="coq"           PPA="ppa:jgross-h/coq-8.6-daily"
 
 before_install:
   - if [ ! -z "$PPA" ]; then sudo add-apt-repository "$PPA" -y; fi


### PR DESCRIPTION
Travis was too slow to run all of the coq target, so we split off the
no-curves-proofs and the curves-proofs targets, and, while we're at it,
also add 8.7+beta1 tests.