### PR TITLE
Allow subbing in alternate reification

### DIFF
--- a/src/Compilers/Reify.v
+++ b/src/Compilers/Reify.v
@@ -454,10 +454,15 @@ Ltac transitivity_tt term :=
         | transitivity (term tt)
         | let x := fresh in intro x; transitivity (term x); revert x  ].
 
-Ltac Reify_rhs_gen Reify prove_interp_compile_correct interp_op try_tac :=
-  Tuple.unfold_flat_interp_tuple ();
+Ltac pre_Reify_rhs _ :=
+  Tuple.unfold_flat_interp_tuple ().
+
+Ltac get_Reify_rhs_gen Reify :=
   let rhs := rhs_of_goal in
   let RHS := Reify rhs in
+  RHS.
+
+Ltac do_Reify_rhs_gen_from_reified prove_interp_compile_correct interp_op try_tac RHS :=
   let RHS' := (eval vm_compute in RHS) in
   transitivity_tt (Syntax.Interp interp_op RHS');
   [
@@ -493,6 +498,12 @@ Ltac Reify_rhs_gen Reify prove_interp_compile_correct interp_op try_tac :=
                       end;
                       subst_let;
                       cbv iota beta delta [InputSyntax.Interp interp_type interp_type_gen interp_type_gen_hetero interp_flat_type interp interpf InputSyntax.Fst InputSyntax.Snd]; reflexivity)) ] ] ].
+
+Ltac Reify_rhs_gen Reify prove_interp_compile_correct interp_op try_tac :=
+  pre_Reify_rhs ();
+  let RHS := get_Reify_rhs_gen Reify in
+  do_Reify_rhs_gen_from_reified
+    prove_interp_compile_correct interp_op try_tac RHS.
 
 Ltac prove_compile_correct_using tac :=
   fun _ => intros;

--- a/src/Compilers/Z/Bounds/Pipeline.v
+++ b/src/Compilers/Z/Bounds/Pipeline.v
@@ -20,9 +20,20 @@ Module Export Exports.
   Existing Instance DefaultedTypes.by_default.
 End Exports.
 
-Ltac refine_reflectively_gen allowable_bit_widths opts :=
+Ltac refine_prereflectively_gen allowable_bit_widths opts :=
   refine_to_reflective_glue allowable_bit_widths;
-  do_reflective_pipeline opts.
+  refine_with_pipeline_correct opts;
+  [ do_pre_reify () | .. ].
+Ltac get_reify _ :=
+  ReflectiveTactics.get_reify ().
+Ltac refine_with_reified RHS :=
+  ReflectiveTactics.do_post_reify RHS.
+Ltac refine_postreflectively _ :=
+  solve_post_reified_side_conditions.
+Ltac refine_reflectively_gen allowable_bit_widths opts :=
+  refine_prereflectively_gen allowable_bit_widths opts;
+  [ let RHS := get_reify () in refine_with_reified RHS | .. ];
+  refine_postreflectively ().
 
 Ltac refine_reflectively128_with opts := refine_reflectively_gen [128; 256] opts.
 Ltac refine_reflectively64_with opts := refine_reflectively_gen [64; 128] opts.

--- a/src/Compilers/Z/Bounds/Pipeline/ReflectiveTactics.v
+++ b/src/Compilers/Z/Bounds/Pipeline/ReflectiveTactics.v
@@ -59,13 +59,24 @@ End Exports.
 forall x, Interp _ ?e x = F
 >>
     by reifying [F]. *)
-Ltac do_reify :=
+(** It is split up into three stages, for ease of stubbing out the
+    reification bit. *)
+Ltac do_pre_reify _ :=
   unfold_second_arg Tuple.tuple;
   unfold_second_arg Tuple.tuple';
   cbv beta iota delta [Tuple.tuple Tuple.tuple'] in *;
   cbv beta iota delta [Syntax.interp_flat_type Syntax.interp_base_type];
   reify_context_variables;
-  Reify_rhs; reflexivity.
+  pre_Reify_rhs ().
+Ltac get_reify _ :=
+  get_Reify_rhs ().
+Ltac do_post_reify RHS :=
+  do_Reify_rhs_from_reified RHS;
+  reflexivity.
+Ltac do_reify :=
+  do_pre_reify ();
+  let RHS := get_reify () in
+  do_post_reify RHS.
 (** ** Input Boundedness Side-Conditions *)
 (** The tactic [handle_bounds_from_hyps] handles goals of the form
 <<

--- a/src/Compilers/Z/Reify.v
+++ b/src/Compilers/Z/Reify.v
@@ -77,6 +77,16 @@ Ltac prove_ExprEta_Compile_correct :=
      rewrite ?InterpExprEta;
      prove_compile_correct_using ltac:(fun _ => apply make_const_correct) ().
 
+Ltac pre_Reify_rhs _ :=
+  Compilers.Reify.pre_Reify_rhs ().
+
+Ltac get_Reify_rhs _ :=
+  Compilers.Reify.get_Reify_rhs_gen Reify.
+
+Ltac do_Reify_rhs_from_reified RHS :=
+  Compilers.Reify.do_Reify_rhs_gen_from_reified
+    prove_ExprEta_Compile_correct interp_op ltac:(fun tac => tac ()) RHS.
+
 Ltac Reify_rhs :=
   Compilers.Reify.Reify_rhs_gen Reify prove_ExprEta_Compile_correct interp_op ltac:(fun tac => tac ()).
 


### PR DESCRIPTION
For @andres-erbsen

This splits up the reification pipeline into pre-reification, reifying,
using the reified term, and post-reification stages.  To replace, e.g.,
a call to `synthesize_carry_mul ()` with alternate reification, use:
```coq
presynthesize_carry_carry_mul ().
let RHS := <alternate reification tactic to get_synthesized ()>
in refine_with_synthesized RHS.
all:finish_synthesis ().
```

Basically all the diff is boilerplate.