### PR TITLE
[demo] Add reification in src/Experiments/SimplyTypedArithmetic.v

### DIFF
--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -487,9 +487,12 @@ Module Compilers.
     | forall x : ?T, _ => T
     end.
 
-  (** Template parameters (things whose type or codomain is [Type],
-      [Set] or [Prop]) get handled specially, because our PHOAS
-      representation does not support dependent types.  During
+  (** Forms of abstraction in Gallina that our reflective language
+      cannot handle get handled by specializing the code "template" to
+      each particular application of that abstraction. In particular,
+      type arguments (nat, Z, (λ _, nat), etc) get substituted into
+      lambdas and treated as a integral part of primitive operations
+      (such as [@List.app T], [@list_rect (λ _, nat)]).  During
       reification, we accumulate them in a right-associated tuple,
       using [tt] as the "nil" base case.  When we hit a λ or an
       identifier, we plug in the template parameters as necessary. *)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -520,8 +520,7 @@ Module Compilers.
   Ltac reify_helper var term ctx delayed_arguments :=
     let reify_rec term := reify_helper var term ctx delayed_arguments in
     (*let dummy := match goal with _ => idtac "reify_helper: attempting to reify:" term end in*)
-    match constr:(Set) with _ => let ret :=
-                                       lazymatch ctx with
+    lazymatch ctx with
     | context[@var_context.cons _ ?rT term ?v _]
       => constr:(@Var var rT v)
     | _
@@ -577,7 +576,7 @@ Module Compilers.
             let rf0 :=
                 constr:(
                   fun (x : T) (not_x : var rT)
-                  => match f with
+                  => match f return _ with (* c.f. COQBUG(https://github.com/coq/coq/issues/6252#issuecomment-347041995) for [return _] *)
                      | not_x2
                        => ltac:(
                             let f := (eval cbv delta [not_x2] in not_x2) in
@@ -599,13 +598,7 @@ Module Compilers.
              reify_op var term
         end
       end
-    end
-    in
-                                 (*let dummy := match goal with _ => idtac "success reifying" term "as" ret end in*)
-    ret
-  | _ => let dummy := match goal with _ => fail 1000000 "failure to reify" term end in
-         constr:(I : I)
-  end.
+    end.
   Ltac reify var term :=
     reify_helper var term (@var_context.nil var) tt.
   Ltac Reify term :=

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -5,6 +5,7 @@ Require Import Crypto.Util.Tuple Crypto.Util.Prod Crypto.Util.LetIn.
 Require Import Crypto.Util.ListUtil Coq.Lists.List Crypto.Util.NatUtil.
 Require Import QArith.QArith_base QArith.Qround Crypto.Util.QUtil.
 Require Import Crypto.Algebra.Ring Crypto.Util.Decidable.Bool2Prop.
+Require Import Crypto.Util.Notations.
 Import ListNotations. Local Open Scope Z_scope.
 
 Definition runtime_mul := Z.mul.
@@ -178,22 +179,435 @@ Module Positional. Section Positional.
   End mulmod.
 End Positional. End Positional.
 
-Import Associational Positional.
+Module Compilers.
+  Inductive type := Unit | Prod (A B : type) | Arrow (s d : type) | List (A : type) | TNat | TZ | TBool.
+  Delimit Scope ctype_scope with ctype.
+  Bind Scope ctype_scope with type.
+  Notation "()" := Unit : ctype_scope.
+  Notation "A * B" := (Prod A B) : ctype_scope.
+  Notation "A -> B" := (Arrow A B) : ctype_scope.
+  Fixpoint interp_type (t : type)
+    := match t with
+       | Unit => unit
+       | Prod A B => interp_type A * interp_type B
+       | Arrow A B => interp_type A -> interp_type B
+       | List A => list (interp_type A)
+       | TNat => nat
+       | TZ => Z
+       | TBool => bool
+       end%type.
+
+  Inductive op : type -> type -> Set :=
+  | OpConst {t} (v : interp_type t) : op Unit t
+  | NatS : op TNat TNat
+  | Nil {t} : op Unit (List t)
+  | Cons {t} : op (t * List t) (List t)
+  | Fst {A B} : op (A * B) A
+  | Snd {A B} : op (A * B) B
+  | BoolRect {T} : op (T * T * TBool) T
+  | NatRect {P} : op (P * (TNat -> P -> P) * TNat) P
+  | Seq : op (TNat * TNat) (List TNat)
+  | Repeat {A} : op (A * TNat) (List A)
+  | LetIn {tx tC} : op (tx * (tx -> tC)) tC
+  | Combine {A B} : op (List A * List B) (List (A * B))
+  | Map {A B} : op ((A -> B) * List A) (List B)
+  | FlatMap {A B} : op ((A -> List B) * List A) (List B)
+  | Partition {A} : op ((A -> TBool) * List A) (List A * List A)
+  | ListApp {A} : op (List A * List A) (List A)
+  | FoldRight {A B} : op ((B -> A -> A) * A * List B) A
+  | Pred : op TNat TNat
+  | UpdateNth {T} : op (TNat * (T -> T) * List T) (List T)
+  | RuntimeMul : op (TZ * TZ) TZ
+  | RuntimeAdd : op (TZ * TZ) TZ
+  | Zadd : op (TZ * TZ) TZ
+  | Zmul : op (TZ * TZ) TZ
+  | Zpow : op (TZ * TZ) TZ
+  | Zopp : op TZ TZ
+  | Zdiv : op (TZ * TZ) TZ
+  | Zmodulo : op (TZ * TZ) TZ
+  | Zeqb : op (TZ * TZ) TBool
+  | ZofNat : op TNat TZ
+  | App {s d} : op ((s -> d) * s) d.
+
+  Inductive expr {var : type -> Type} : type -> Type :=
+  | TT : expr Unit
+  | Pair {A B} (a : expr A) (b : expr B) : expr (A * B)
+  | Var {t} (v : var t) : expr t
+  | Op {s d} (opc : op s d) (args : expr s) : expr d
+  | Abs {s d} (f : var s -> expr d) : expr (s -> d).
+
+  Bind Scope expr_scope with expr.
+  Delimit Scope expr_scope with expr.
+  Notation "'λ'  x .. y , t" := (Abs (fun x => .. (Abs (fun y => t%expr)) ..)) : expr_scope.
+  Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
+  Notation "( )" := TT : expr_scope.
+  Notation "()" := TT : expr_scope.
+  Notation "'llet' x := A 'in' b" := (Op LetIn (Pair A%expr (Abs (fun x => b%expr)))) : expr_scope.
+  Notation "f ‘’ x" := (Op App (f, x)%expr) (at level 200) : expr_scope.
+
+  Definition Expr t := forall var, @expr var t.
+
+  Notation curry2 f
+    := (fun '(a, b) => f a b).
+  Notation curry3 f
+    := (fun '(a, b, c) => f a b c).
+
+  Definition interp_op {s d} (opc : op s d) : interp_type s -> interp_type d
+    := match opc in op s d return interp_type s -> interp_type d with
+       | OpConst t v => fun _ => v
+       | NatS => S
+       | Nil t => fun _ => @nil (interp_type t)
+       | Cons t => curry2 (@cons (interp_type t))
+       | BoolRect T => curry3 (@bool_rect (fun _ => interp_type T))
+       | Seq => curry2 seq
+       | LetIn tx tC => curry2 (@Let_In (interp_type tx) (fun _ => interp_type tC))
+       | Combine A B => curry2 (@combine (interp_type A) (interp_type B))
+       | Map A B => curry2 (@List.map (interp_type A) (interp_type B))
+       | Repeat A => curry2 (@List.repeat (interp_type A))
+       | FlatMap A B => curry2 (@List.flat_map (interp_type A) (interp_type B))
+       | Fst A B => @fst (interp_type A) (interp_type B)
+       | Snd A B => @snd (interp_type A) (interp_type B)
+       | Partition A => curry2 (@List.partition (interp_type A))
+       | ListApp A => curry2 (@List.app (interp_type A))
+       | FoldRight A B => curry3 (@List.fold_right (interp_type A) (interp_type B))
+       | NatRect P => curry3 (@nat_rect (fun _ => interp_type P))
+       | Pred => Nat.pred
+       | UpdateNth T => curry3 (@update_nth (interp_type T))
+       | RuntimeMul => curry2 runtime_mul
+       | RuntimeAdd => curry2 runtime_add
+       | Zadd => curry2 Z.add
+       | Zmul => curry2 Z.mul
+       | Zpow => curry2 Z.pow
+       | Zmodulo => curry2 Z.modulo
+       | Zopp => Z.opp
+       | Zdiv => curry2 Z.div
+       | Zeqb => curry2 Z.eqb
+       | ZofNat => Z.of_nat
+       | App s d => curry2 (fun (f : interp_type s -> interp_type d) (x : interp_type s)
+                            => f x)
+       end.
+
+  Fixpoint interp {t} (e : @expr interp_type t) : interp_type t
+    := match e with
+       | TT => tt
+       | Pair A B a b => (interp a, interp b)
+       | Var t v => v
+       | Op s d opc args => interp_op opc (interp args)
+       | Abs s d f => fun v => interp (f v)
+       end.
+
+  Definition Interp {t} (e : Expr t) := interp (e _).
+
+  Ltac reify_type term :=
+    lazymatch eval cbv beta in term with
+    | unit => Unit
+    | prod ?A ?B
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         constr:(Prod rA rB)
+    | ?A -> ?B
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         constr:(Arrow rA rB)
+    | list ?T
+      => let rT := reify_type T in
+         constr:(List rT)
+    | nat => TNat
+    | bool => TBool
+    | Z => TZ
+    end.
+
+  Ltac is_known_const_gen term on_success on_failure :=
+    let is_known_const term := is_known_const_gen term on_success on_failure in
+    lazymatch term with
+    | S ?term => is_known_const term
+    | O => on_success ()
+    | Z0 => on_success ()
+    | Zpos ?p => is_known_const p
+    | Zneg ?p => is_known_const p
+    | xI ?p => is_known_const p
+    | xO ?p => is_known_const p
+    | xH => on_success ()
+    | ?term => on_failure term
+    end.
+  Ltac is_known_const term :=
+    is_known_const_gen term ltac:(fun _ => idtac) ltac:(fun term => fail 0 "Not a known const:" term).
+  Ltac is_known_const_as_bool term :=
+    is_known_const_gen term ltac:(fun _ => true) ltac:(fun _ => false).
+
+  Definition Uncurry0 {A var} (opc : op Unit A) : @expr var A
+    := Op opc TT.
+  Definition Uncurry1 {A B var} (opc : op A B) : @expr var (A -> B)
+    := λ a, Op opc (Var a).
+  Definition Uncurry2 {A B C var} (opc : op (A * B) C) : @expr var (A -> B -> C)
+    := λ a b, Op opc (Var a, Var b).
+  Definition Uncurry3 {A B C D var} (opc : op (A * B * C) D) : @expr var (A -> B -> C -> D)
+    := λ a b c, Op opc (Var a, Var b, Var c).
+
+  Ltac reify_op var term :=
+    (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
+    let Uncurry0 x := constr:(Uncurry0 (var:=var) x) in
+    let Uncurry1 x := constr:(Uncurry1 (var:=var) x) in
+    let Uncurry2 x := constr:(Uncurry2 (var:=var) x) in
+    let Uncurry3 x := constr:(Uncurry3 (var:=var) x) in
+    lazymatch term with
+    | S => Uncurry1 NatS
+    | @nil ?T
+      => let rT := reify_type T in
+         Uncurry0 (@Nil rT)
+    | @cons ?T
+      => let rT := reify_type T in
+         Uncurry2 (@Cons rT)
+    | seq => Uncurry2 Seq
+    | @List.repeat ?A
+      => let rA := reify_type A in
+         Uncurry2 (@Repeat rA)
+    | @Let_In ?A (fun _ => ?B)
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         Uncurry2 (@LetIn rA rB)
+    | @combine ?A ?B
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         Uncurry2 (@Combine rA rB)
+    | @List.map ?A ?B
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         Uncurry2 (@Map rA rB)
+    | @List.flat_map ?A ?B
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         Uncurry2 (@FlatMap rA rB)
+    | @fst ?A ?B
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         Uncurry1 (@Fst rA rB)
+    | @snd ?A ?B
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         Uncurry1 (@Snd rA rB)
+    | @List.partition ?A
+      => let rA := reify_type A in
+         Uncurry2 (@Partition rA)
+    | @List.app ?A
+      => let rA := reify_type A in
+         Uncurry2 (@ListApp rA)
+    | @List.fold_right ?A ?B
+      => let rA := reify_type A in
+         let rB := reify_type B in
+         Uncurry3 (@FoldRight rA rB)
+    | pred => Uncurry1 Pred
+    | @update_nth ?T
+      => let rT := reify_type T in
+         Uncurry3 (@UpdateNth rT)
+    | runtime_mul => Uncurry2 RuntimeMul
+    | runtime_add => Uncurry2 RuntimeAdd
+    | Z.add => Uncurry2 Zadd
+    | Z.mul => Uncurry2 Zmul
+    | Z.pow => Uncurry2 Zpow
+    | Z.opp => Uncurry1 Zopp
+    | Z.div => Uncurry2 Zdiv
+    | Z.modulo => Uncurry2 Zmodulo
+    | Z.eqb => Uncurry2 Zeqb
+    | Z.of_nat => Uncurry1 ZofNat
+    | @nat_rect (fun _ => ?T)
+      => let rT := reify_type T in
+         Uncurry3 (@NatRect rT)
+    | @bool_rect (fun _ => ?T)
+      => let rT := reify_type T in
+         Uncurry3 (@BoolRect rT)
+    | _
+      => let assert_const := match goal with
+                             | _ => is_known_const term
+                             end in
+         let T := type of term in
+         let rT := reify_type T in
+         Uncurry0 (@OpConst rT term)
+    end.
+
+  Inductive context_var_map {var : type -> Type} :=
+  | cnil
+  | ccons {t} (gallina_v : interp_type t) (v : var t) (ctx : context_var_map).
+
+  Ltac refresh n :=
+    let n' := fresh n in
+    let n' := fresh n' in
+    let n' := fresh n' in
+    n'.
+
+  Ltac is_type_arg arg_ty :=
+    lazymatch eval cbv beta in arg_ty with
+    | Prop => true
+    | Set => true
+    | Type => true
+    | _ -> ?A => is_type_arg A
+    | _ => false
+    end.
+
+  Ltac build_dummy_delayed_arguments_for ty :=
+    lazymatch ty with
+    | forall x : ?T, ?P
+      => let not_x := refresh x in
+         let rest := constr:(
+                       fun x : T
+                       => match P with
+                          | not_x
+                            => ltac:(
+                                 let P := (eval cbv delta [not_x] in not_x) in
+                                 let v := build_dummy_delayed_arguments_for P in
+                                 exact v
+                               )
+                          end) in
+         lazymatch rest with
+         | (fun _ => ?rest)
+           => constr:((tt, rest))
+         end
+    | _ => tt
+    end.
+  Ltac check_delayed_arguments_dummy delayed_arguments if_dummy if_not_dummy :=
+    lazymatch delayed_arguments with
+    | tt => if_dummy ()
+    | (tt, ?delayed_arguments) => check_delayed_arguments_dummy delayed_arguments if_dummy if_not_dummy
+    | (_, _) => if_not_dummy ()
+    end.
+  Ltac plug_delayed_arguments f delayed_arguments :=
+    check_delayed_arguments_dummy
+      delayed_arguments
+      ltac:(fun _ => f)
+             ltac:(fun _ =>
+                     lazymatch delayed_arguments with
+                     | (tt, ?delayed_arguments)
+                       =>
+                       lazymatch type of f with
+                       | forall x : ?T, _
+                         => let x := refresh x in
+                            constr:(fun x : T
+                                    => ltac:(let v := plug_delayed_arguments (f x) delayed_arguments in
+                                             exact v))
+                       end
+                     | (?arg, ?delayed_arguments)
+                       => plug_delayed_arguments (f arg) delayed_arguments
+                     end).
+
+  Ltac reify_helper var term ctx delayed_arguments :=
+    let reify_rec term := reify_helper var term ctx delayed_arguments in
+    (*let dummy := match goal with _ => idtac "reify_helper: attempting to reify:" term end in*)
+    match constr:(Set) with _ => let ret :=
+                                       lazymatch ctx with
+    | context[@ccons _ ?rT term ?v _]
+      => constr:(@Var var rT v)
+    | _
+      =>
+      let term_is_known_const := is_known_const_as_bool term in
+      lazymatch term_is_known_const with
+      | true => reify_op var term
+      | false
+        =>
+        lazymatch term with
+        | tt => TT
+        | @pair ?A ?B ?a ?b
+          => let ra := reify_rec a in
+             let rb := reify_rec b in
+             constr:(Pair (var:=var) ra rb)
+        | match ?b with true => ?t | false => ?f end
+          => let T := type of t in
+             reify_rec (@bool_rect (fun _ => T) t f b)
+        | let x := ?a in @?b x
+          => let A := type of a in
+             let B := lazymatch type of b with forall x, @?B x => B end in
+             reify_rec (@Let_In A B a b)
+        | ?f ?x
+          =>
+          let x_ty := type of x in
+          let x_type_arg := is_type_arg x_ty in
+          lazymatch x_type_arg with
+          | true
+            => (* we can't reify things of type [Type], so we save it for later to plug in *)
+            reify_helper var f ctx (x, delayed_arguments)
+          | false
+            =>
+            let dummy_args := build_dummy_delayed_arguments_for x_ty in
+            let rx := reify_helper var x ctx dummy_args in
+            (* in rf's delayed_arguments, tt stands for "dummy" *)
+            let rf := reify_helper var f ctx (tt, delayed_arguments) in
+            constr:(Op (var:=var) App (Pair (var:=var) rf rx))
+          end
+        | (fun x : ?T => ?f)
+          =>
+          (*let dummy := match goal with _ => idtac "funcase delaying" delayed_arguments end in*)
+          lazymatch delayed_arguments with
+          | (tt, ?delayed_arguments)
+            => (* dummy, don't plug in *)
+            let rT := reify_type T in
+            let not_x := refresh x in
+            let not_x2 := refresh not_x in
+            let rf0 :=
+                constr:(
+                  fun (x : T) (not_x : var rT)
+                  => match f with
+                     | not_x2
+                       => ltac:(
+                            let f := (eval cbv delta [not_x2] in not_x2) in
+                            (*idtac "rec call" f "was" term;*)
+                            let rf := reify_helper var f (@ccons var rT x not_x ctx) delayed_arguments in
+                            exact rf)
+                     end) in
+            lazymatch rf0 with
+            | (fun _ => ?rf)
+              => constr:(@Abs var rT _ rf)
+            | _ => let dummy := match goal with
+                                | _ => fail 1 "Failure to eliminate functional dependencies of" rf0
+                                end in
+                   constr:(I : I)
+            end
+          | (?arg, ?delayed_arguments)
+            => (* we pull a trick with [match] to plug in [arg] without running cbv β *)
+            (*let fx := constr:(match arg with x => f end) in
+            let dummy := match goal with _ => idtac "testing beta1" fx end in*)
+            reify_helper var (match arg with x => f end) ctx delayed_arguments
+          end
+        | _
+          => let term := plug_delayed_arguments term delayed_arguments in
+             reify_op var term
+        end
+      end
+    end
+    in
+                                 (*let dummy := match goal with _ => idtac "success reifying" term "as" ret end in*)
+    ret
+  | _ => let dummy := match goal with _ => fail 1000000 "failure to reify" term end in
+         constr:(I : I)
+  end.
+  Ltac reify var term :=
+    let ty := type of term in
+    let dummy_args := build_dummy_delayed_arguments_for ty in
+    reify_helper var term (@cnil var) dummy_args.
+  Ltac Reify term :=
+    constr:(fun var : type -> Type
+            => ltac:(let r := reify var term in
+                     exact r)).
+  Ltac Reify_rhs _ :=
+    let RHS := lazymatch goal with |- _ = ?RHS => RHS end in
+    let R := Reify RHS in
+    transitivity (Interp R);
+    [ | cbv beta iota delta [Interp interp interp_op Uncurry0 Uncurry1 Uncurry2 Uncurry3 Let_In interp_type bool_rect];
+        reflexivity ].
+End Compilers.
+Import Associational Positional Compilers.
 Local Coercion Z.of_nat : nat >-> Z.
 Local Coercion QArith_base.inject_Z : Z >-> Q.
-
 Definition w (i:nat) : Z := 2^Qceiling((25+1/2)*i).
-
-Example base_25_5_mul (f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g8 g9 : Z)
+Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g8 g9 : Z)
         (f:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)
-        (g:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)
+        (g:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)*) (f g : list Z)
         (n:=10%nat)
+        (Hf : length f = n) (Hg : length g = n)
   : { fg : list Z | (eval w n fg) mod (2^255-19)
                     = (eval w n f * eval w n g) mod (2^255-19) }.
   (* manually assign names to limbs for pretty-printing *)
   eexists ?[fg].
   erewrite <-eval_mulmod with (s:=2^255) (c:=[(1,19)])
-      by (try eapply pow_ceil_mul_nat_nonzero; vm_decide).
+      by (try assumption; try eapply pow_ceil_mul_nat_nonzero; vm_decide).
 (*   eval w ?fg mod (2 ^ 255 - 19) = *)
 (*   eval w *)
 (*     (mulmod w (2^255) [(1, 19)] (f9,f8,f7,f6,f5,f4,f3,f2,f1,f0) *)
@@ -202,8 +616,14 @@ Example base_25_5_mul (f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g8 
 (*   ?fg = *)
 (*   mulmod w (2 ^ 255) [(1, 19)] (f9, f8, f7, f6, f5, f4, f3, f2, f1, f0) *)
 (*     (g9, g8, g7, g6, g5, g4, g3, g2, g1, g0) *)
-  cbv -[runtime_mul runtime_add]; cbv [runtime_mul runtime_add].
-  ring_simplify_subterms.
+  (*cbv [f g].*)
+  cbv [w Qceiling Qfloor Qopp Qnum Qdiv Qplus inject_Z Qmult Qinv Qden Pos.mul].
+  apply (f_equal (fun F => F f g)).
+  cbv [n].
+  cbv delta [mulmod w to_associational mul to_associational reduce from_associational add_to_nth zeros place split].
+  Reify_rhs ().
+  (*cbv -[runtime_mul runtime_add]; cbv [runtime_mul runtime_add].
+  ring_simplify_subterms.*)
 (* ?fg =
  (f0*g9+ f1*g8+    f2*g7+    f3*g6+    f4*g5+    f5*g4+    f6*g3+    f7*g2+    f8*g1+    f9*g0,
   f0*g8+ 2*f1*g7+  f2*g6+    2*f3*g5+  f4*g4+    2*f5*g3+  f6*g2+    2*f7*g1+  f8*g0+    38*f9*g9,
@@ -215,7 +635,8 @@ Example base_25_5_mul (f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g8 
   f0*g2+ 2*f1*g1+  f2*g0+    38*f3*g9+ 19*f4*g8+ 38*f5*g7+ 19*f6*g6+ 38*f7*g5+ 19*f8*g4+ 38*f9*g3,
   f0*g1+ f1*g0+    19*f2*g9+ 19*f3*g8+ 19*f4*g7+ 19*f5*g6+ 19*f6*g5+ 19*f7*g4+ 19*f8*g3+ 19*f9*g2,
   f0*g0+ 38*f1*g9+ 19*f2*g8+ 38*f3*g7+ 19*f4*g6+ 38*f5*g5+ 19*f6*g4+ 38*f7*g3+ 19*f8*g2+ 38*f9*g1) *)
-  trivial.
-Defined.
+  (*trivial.
+Defined.*)
+Abort.
 
 (* Eval cbv on this one would produce an ugly term due to the use of [destruct] *)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -480,12 +480,12 @@ Module Compilers.
     let n' := fresh n' in
     n'.
 
-  Ltac is_type_arg arg_ty :=
-    lazymatch eval cbv beta in arg_ty with
+  Ltac is_template_parameter parameter_type :=
+    lazymatch parameter_type with
     | Prop => true
     | Set => true
     | Type => true
-    | _ -> ?A => is_type_arg A
+    | _ -> ?A => is_template_parameter A
     | _ => false
     end.
 
@@ -564,7 +564,7 @@ Module Compilers.
         | ?f ?x
           =>
           let x_ty := type of x in
-          let x_type_arg := is_type_arg x_ty in
+          let x_type_arg := is_template_parameter x_ty in
           lazymatch x_type_arg with
           | true
             => (* we can't reify things of type [Type], so we save it for later to plug in *)


### PR DESCRIPTION
It's rather verbose, unfortunately.  The reification also doesn't have
any of the nice debugging features of the version of reification in
Compilers, because that's even more boilerplate.  Not sure if I should
add that back in, at the moment.

Also, for some strange reason, places where `constr`s fail to typecheck
seem to induce backtracking where I don't think they should, and I'm not
sure what's going on...