### PR TITLE
Reserve a printing-only notation for function application

### DIFF
--- a/src/Util/Notations.v
+++ b/src/Util/Notations.v
@@ -128,3 +128,4 @@ Reserved Notation "-- x" (at level 60, format "-- x").
 Reserved Notation "~> R" (at level 70).
 Reserved Notation "A ~> R" (at level 99).
 Reserved Notation "'return' x" (at level 70, format "'return'  x").
+Reserved Notation "f x" (only printing, at level 10, left associativity).


### PR DESCRIPTION
This sets the level and associativity in a common place, and will be useful for PHOAS application nodes.  Making a PR just to get travis to test the versions we care about.