### PR TITLE
Partial work on implementing partial reduction

### DIFF
--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -687,6 +687,51 @@ Module Compilers.
     | Z : arguments type.Z
     | bool : arguments type.bool.
 
+    Definition preinvertT (t : type) :=
+      match t with
+      | type.unit => Datatypes.unit
+      | type.prod A B => arguments A * arguments B
+      | type.arrow s d => arguments d
+      | type.list A => arguments A
+      | type.nat => Datatypes.unit
+      | type.Z => Datatypes.unit
+      | type.bool => Datatypes.unit
+      end%type.
+    Definition invertT (t : type) :=
+      option (* [None] means "generic" *) (preinvertT t).
+
+    Definition invert {t : type} (P : arguments t -> Type)
+               (generic_case : P generic)
+               (non_generic_cases
+                : forall v : preinvertT t,
+                   match t return forall v : preinvertT t, (arguments t -> Type) -> Type with
+                   | type.unit
+                     => fun v P => P unit
+                   | type.prod A B
+                     => fun '((a, b) : arguments A * arguments B) P
+                        => P (prod a b)
+                   | type.arrow s d => fun v P => P (arrow v)
+                   | type.list A => fun v P => P (list v)
+                   | type.nat => fun v P => P nat
+                   | type.Z => fun v P => P Z
+                   | type.bool => fun v P => P bool
+                   end v P)
+               (a : arguments t)
+      : P a.
+    Proof.
+      destruct a;
+        try specialize (fun a b => non_generic_cases (a, b));
+        cbn in *;
+        [ exact generic_case | apply non_generic_cases; apply tt .. ].
+    Defined.
+
+    Definition invert_arrow {s d} (a : arguments (type.arrow s d)) : arguments d
+      := @invert (type.arrow s d) (fun _ => arguments d) generic (fun ad => ad) a.
+
+    Definition invert_prod {A B} (a : arguments (type.prod A B)) : arguments A * arguments B
+      := @invert (type.prod A B) (fun _ => arguments A * arguments B)%type (generic, generic) (fun '(a, b) => (a, b)) a.
+
+
     Fixpoint ground {t : type} : arguments t
       := match t with
          | type.unit => unit
@@ -997,39 +1042,54 @@ Module Compilers.
   Section partial_reduce.
     Context {var : type -> Type}.
 
-    Fixpoint partial_reduce_cps {T} {t} (e : @expr (@expr var) t)
-      : (@expr var t -> @expr var T) -> @expr var T
-      := match e in expr t return (expr t -> expr T) -> expr T with
-         | TT => fun k => k TT
+    Local Notation partial_reduceT t a
+      := ((@expr var t * arguments.type.option.interp (@expr var) (@expr var) a)%type)
+           (only parsing).
+
+    Fixpoint partial_reduce' {t} (e : @expr (@expr var) t)
+      : forall a : arguments t, partial_reduceT t a
+      := match e in expr t return (forall a : arguments t, partial_reduceT t a) with
+         | TT
+           => arguments.invert
+                (fun a : arguments type.unit => partial_reduceT type.unit a)
+                (TT, TT)
+                (fun u => (TT, u))
          | Pair A B a b
-           => fun k
-              => @partial_reduce_cps
-                   T A a
-                   (fun a'
-                    => @partial_reduce_cps
-                         T B b
-                         (fun b' => k (Pair a' b')))
-         | Var t v => fun k => k v
-         | Abs s d f
-           => fun k
-              => k (Abs (fun x => @partial_reduce_cps _ d (f (Var x)) id))
+           => arguments.invert
+                (fun a => partial_reduceT (type.prod A B) a)
+                (let ab := (fst (@partial_reduce' A a arguments.generic),
+                            fst (@partial_reduce' B b arguments.generic))%expr in
+                 (ab, ab))
+                (fun '(aA, aB)
+                 => let '(a0, a1) := @partial_reduce' A a aA in
+                    let '(b0, b1) := @partial_reduce' B b aB in
+                    ((a0, b0)%expr, Some (a1, b1)))
+         | Var t v
+           => fun a => (v, arguments.expr.interp _ _ v)
          | Op s d opc args
-           => fun k
-              => @partial_reduce_cps
-                   T s args
-                   (fun args'
-                    => k
-                         match arguments.op.rewrite
-                                 opc
-                                 (arguments.expr.interp _ _ args')
-                         with
-                         | Some e => arguments.expr.reify _ _ e
-                         | None => Op opc args'
-                         end)
+           => let '(args0, args1) := @partial_reduce' s args (arguments.op.lookup_src opc) in
+              let e :=
+                  match arguments.op.rewrite opc args1 with
+                  | Some e => arguments.expr.reify _ _ e
+                  | None => Op opc args0
+                  end in
+              fun a => (e, arguments.expr.interp _ _ e)
+         | Abs s d f
+           => fun a
+              => let e' := Abs (fun x => fst (@partial_reduce' d (f (Var x)) (arguments.invert_arrow a))) in
+                 arguments.invert
+                   (fun a => partial_reduceT (type.arrow s d) a)
+                   (e', e')
+                   (fun ad
+                    => (e',
+                        (fun x =>
+                           snd (@partial_reduce' d (f x) ad))))
+                   a
          end.
 
+
     Definition partial_reduce {t} (e : @expr (@expr var) t) : @expr var t
-      := @partial_reduce_cps t t e id.
+      := snd (@partial_reduce' t e arguments.generic).
   End partial_reduce.
 
   Definition PartialReduce {t} (e : Expr t) : Expr t
@@ -1332,6 +1392,13 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
   apply (f_equal (fun F => F f g)).
   cbv [n].
   cbv delta [mulmod w to_associational mul to_associational reduce from_associational add_to_nth zeros place split].
+  assert True.
+  { let v := Reify ((fun x => 2^x) 255)%Z in
+    pose v as E.
+    vm_compute in E.
+    pose (PartialReduce E) as E'.
+    vm_compute in E'.
+    constructor. }
   Reify_rhs ().
   let e := match goal with |- _ = Interp ?e => e end in
   pose e as E.
@@ -1339,7 +1406,6 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
   Timeout 2 vm_compute in E.
   pose (PartialReduce E) as E'.
   Timeout 2 vm_compute in E'.
-
   (*cbv -[runtime_mul runtime_add]; cbv [runtime_mul runtime_add].
   ring_simplify_subterms.*)
 (* ?fg =

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -2311,7 +2311,7 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
 (*        (g9,g8,g7,g6,g5,g4,g3,g2,g1,g0)) mod (2^255 - 19) *)
   etransitivity; (* work around [rewrite] being stupid about evars *)
     [
-    | rewrite <- eval_chained_carries with (s:=2^255) (c:=[(1,19)]) (idxs:=(seq 0 (pred n) ++ [0; 1])%list%nat) (modulo:=fun x y => Z.modulo x y) (div:=fun x y => Z.div x y)
+    | rewrite <- eval_chained_carries with (s:=2^255) (c:=[(1,19)]) (idxs:=(seq 0 n ++ [0; 1])%list%nat) (modulo:=fun x y => Z.modulo x y) (div:=fun x y => Z.div x y)
       by (try assumption; auto using Z.div_mod; try (intros; eapply pow_ceil_mul_nat_divide_nonzero); try eapply pow_ceil_mul_nat_nonzero; try vm_decide);
       reflexivity ].
   eapply f_equal2; [|trivial]. eapply f_equal.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -138,8 +138,8 @@ Module Positional. Section Positional.
     rewrite <- (seq_length n 0) at 2.
     generalize dependent (List.seq 0 n); intro xs.
     induction xs; simpl; nsatz.                               Qed.
-  Definition add_to_nth i x : list Z -> list Z
-    := ListUtil.update_nth i (runtime_add x).
+  Definition add_to_nth i x (ls : list Z) : list Z
+    := ListUtil.update_nth i (fun y => runtime_add x y) ls.
   Lemma eval_add_to_nth (n:nat) (i:nat) (x:Z) (xs:list Z) (H:(i<length xs)%nat)
         (Hn : length xs = n) (* N.B. We really only need [i < Nat.min n (length xs)] *) :
     eval n (add_to_nth i x xs) = weight i * x + eval n xs.
@@ -179,9 +179,9 @@ Module Positional. Section Positional.
   Hint Rewrite weight_place : push_eval.
 
   Definition from_associational n (p:list (Z*Z)) :=
-    List.fold_right (fun t =>
+    List.fold_right (fun t ls =>
       let p := place t (pred n) in
-      add_to_nth (fst p) (snd p)    ) (zeros n) p.
+      add_to_nth (fst p) (snd p) ls ) (zeros n) p.
   Lemma eval_from_associational {n} p (n_nz:n<>O \/ p = nil) :
     eval n (from_associational n p) = Associational.eval p.
   Proof. destruct n_nz; [ induction p | subst p ];
@@ -254,7 +254,7 @@ Module Positional. Section Positional.
 
       will produce [fun a b c d => (a + (b + (c + d)))].*)
     Definition chained_carries {n} s c p (idxs : list nat) :=
-      fold_right (@carry_reduce n s c) p (rev idxs).
+      fold_right (fun a b => @carry_reduce n s c a b) p (rev idxs).
 
     Lemma eval_chained_carries {n} s c p idxs :
       (s <> 0) -> (s - Associational.eval c <> 0) -> (n <> 0%nat) ->
@@ -340,78 +340,122 @@ Module Compilers.
   End type.
   Export type.Notations.
 
-  Module expr.
-    Inductive expr {ident : type -> Type} {var : type -> Type} : type -> Type :=
-    | Var {t} (v : var t) : expr t
-    | Ident {t} (idc : ident t) : expr t
-    | App {s d} (f : expr (s -> d)) (x : expr s) : expr d
-    | Abs {s d} (f : var s -> expr d) : expr (s -> d).
+  Module Uncurried.
+    Module expr.
+      Inductive expr {ident : type -> type -> Type} {var : type -> Type} : type -> Type :=
+      | Var {t} (v : var t) : expr t
+      | TT : expr type.unit
+      | AppIdent {s d} (idc : ident s d) (args : expr s) : expr d
+      | App {s d} (f : expr (s -> d)) (x : expr s) : expr d
+      | Pair {A B} (a : expr A) (b : expr B) : expr (A * B)
+      | Abs {s d} (f : var s -> expr d) : expr (s -> d).
 
-    Module Export Notations.
-      Bind Scope expr_scope with expr.
-      Delimit Scope expr_scope with expr.
+      Module Export Notations.
+        Bind Scope expr_scope with expr.
+        Delimit Scope expr_scope with expr.
 
-      Infix "@" := App : expr_scope.
-      Notation "'λ'  x .. y , t" := (Abs (fun x => .. (Abs (fun y => t%expr)) ..)) : expr_scope.
-    End Notations.
+        Infix "@" := App : expr_scope.
+        Infix "@@" := AppIdent : expr_scope.
+        Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
+        Notation "( )" := TT : expr_scope.
+        Notation "()" := TT : expr_scope.
+        Notation "'λ'  x .. y , t" := (Abs (fun x => .. (Abs (fun y => t%expr)) ..)) : expr_scope.
+      End Notations.
 
-    Definition Expr {ident : type -> Type} t := forall var, @expr ident var t.
+      Definition Expr {ident : type -> type -> Type} t := forall var, @expr ident var t.
 
-    Section with_ident.
-      Context {ident : type -> Type}
-              (interp_ident : forall t, ident t -> type.interp t).
+      Section unexpr.
+        Context {ident : type -> type -> Type}
+                {var : type -> Type}.
 
-      Fixpoint interp {t} (e : @expr ident type.interp t) : type.interp t
-        := match e with
-           | Var t v => v
-           | Ident t idc => interp_ident t idc
-           | App s d f x => interp f (interp x)
-           | Abs s d f => fun v => interp (f v)
-           end.
+        Fixpoint unexpr {t} (e : @expr ident (@expr ident var) t) : @expr ident var t
+          := match e in expr t return expr t with
+             | Var t v => v
+             | TT => TT
+             | AppIdent s d idc args => AppIdent idc (unexpr args)
+             | App s d f x => App (unexpr f) (unexpr x)
+             | Pair A B a b => Pair (unexpr a) (unexpr b)
+             | Abs s d f => Abs (fun x => unexpr (f (Var x)))
+             end.
+      End unexpr.
 
-      Definition Interp {t} (e : Expr t) := interp (e _).
-    End with_ident.
+      Section with_ident.
+        Context {ident : type -> type -> Type}
+                (interp_ident : forall s d, ident s d -> type.interp s -> type.interp d).
 
-    Ltac is_primitive_const_cps2 term on_success on_failure :=
-      let recurse term := is_primitive_const_cps2 term on_success on_failure in
-      lazymatch term with
-      | S ?n => recurse n
-      | O => on_success ()
-      | true => on_success ()
-      | false => on_success ()
-      | tt => on_success ()
-      | Z0 => on_success ()
-      | Zpos ?p => recurse p
-      | Zneg ?p => recurse p
-      | xI ?p => recurse p
-      | xO ?p => recurse p
-      | xH => on_success ()
-      | ?term => on_failure term
-      end.
-    Ltac require_primitive_const term :=
-      is_primitive_const_cps2 term ltac:(fun _ => idtac) ltac:(fun term => fail 0 "Not a known const:" term).
-    Ltac is_primitive_const term :=
-      is_primitive_const_cps2 term ltac:(fun _ => true) ltac:(fun _ => false).
+        Fixpoint interp {t} (e : @expr ident type.interp t) : type.interp t
+          := match e with
+             | Var t v => v
+             | TT => tt
+             | AppIdent s d idc args => interp_ident s d idc (@interp s args)
+             | App s d f x => @interp _ f (@interp _ x)
+             | Pair A B a b => (@interp A a, @interp B b)
+             | Abs s d f => fun v => interp (f v)
+             end.
 
-    Module var_context.
-      Inductive list {var : type -> Type} :=
-      | nil
-      | cons {t} (gallina_v : type.interp t) (v : var t) (ctx : list).
-    End var_context.
+        Definition Interp {t} (e : Expr t) := interp (e _).
+      End with_ident.
 
-    (* cf COQBUG(https://github.com/coq/coq/issues/5448) , COQBUG(https://github.com/coq/coq/issues/6315) *)
-    Ltac refresh n :=
-      let n' := fresh n in
-      let n' := fresh n in
-      n'.
+      Ltac is_primitive_const_cps2 term on_success on_failure :=
+        let recurse term := is_primitive_const_cps2 term on_success on_failure in
+        lazymatch term with
+        | S ?n => recurse n
+        | O => on_success ()
+        | true => on_success ()
+        | false => on_success ()
+        | tt => on_success ()
+        | Z0 => on_success ()
+        | Zpos ?p => recurse p
+        | Zneg ?p => recurse p
+        | xI ?p => recurse p
+        | xO ?p => recurse p
+        | xH => on_success ()
+        | ?term => on_failure term
+        end.
+      Ltac require_primitive_const term :=
+        is_primitive_const_cps2 term ltac:(fun _ => idtac) ltac:(fun term => fail 0 "Not a known const:" term).
+      Ltac is_primitive_const term :=
+        is_primitive_const_cps2 term ltac:(fun _ => true) ltac:(fun _ => false).
 
-    Ltac type_of_first_argument_of f :=
-      let f_ty := type of f in
-      lazymatch eval hnf in f_ty with
-      | forall x : ?T, _ => T
-      end.
+      Module var_context.
+        Inductive list {var : type -> Type} :=
+        | nil
+        | cons {t} (gallina_v : type.interp t) (v : var t) (ctx : list).
+      End var_context.
 
-    (** Forms of abstraction in Gallina that our reflective language
+      (* cf COQBUG(https://github.com/coq/coq/issues/5448) , COQBUG(https://github.com/coq/coq/issues/6315) , COQBUG(https://github.com/coq/coq/issues/6559) *)
+      Ltac require_same_var n1 n2 :=
+        (*idtac n1 n2;*)
+        let c1 := constr:(fun n1 n2 : Set => ltac:(exact n1)) in
+        let c2 := constr:(fun n1 n2 : Set => ltac:(exact n2)) in
+        (*idtac c1 c2;*)
+        first [ constr_eq c1 c2 | fail 1 "Not the same var:" n1 "and" n2 "(via constr_eq" c1 c2 ")" ].
+      Ltac is_same_var n1 n2 :=
+        match goal with
+        | _ => let check := match goal with _ => require_same_var n1 n2 end in
+               true
+        | _ => false
+        end.
+      Ltac is_underscore v :=
+        let v' := fresh v in
+        let v' := fresh v' in
+        is_same_var v v'.
+      Ltac refresh n fresh_tac :=
+        let n_is_underscore := is_underscore n in
+        let n' := lazymatch n_is_underscore with
+                  | true => fresh
+                  | false => fresh_tac n
+                  end in
+        let n' := fresh_tac n' in
+        n'.
+
+      Ltac type_of_first_argument_of f :=
+        let f_ty := type of f in
+        lazymatch eval hnf in f_ty with
+        | forall x : ?T, _ => T
+        end.
+
+      (** Forms of abstraction in Gallina that our reflective language
       cannot handle get handled by specializing the code "template" to
       each particular application of that abstraction. In particular,
       type arguments (nat, Z, (λ _, nat), etc) get substituted into
@@ -420,74 +464,74 @@ Module Compilers.
       reification, we accumulate them in a right-associated tuple,
       using [tt] as the "nil" base case.  When we hit a λ or an
       identifier, we plug in the template parameters as necessary. *)
-    Ltac require_template_parameter parameter_type :=
-      first [ unify parameter_type Prop
-            | unify parameter_type Set
-            | unify parameter_type Type
-            | lazymatch eval hnf in parameter_type with
-              | forall x : ?T, @?P x
-                => let check := constr:(fun x : T
-                                        => ltac:(require_template_parameter (P x);
-                                                 exact I)) in
-                   idtac
-              end ].
-    Ltac is_template_parameter parameter_type :=
-      is_success_run_tactic ltac:(fun _ => require_template_parameter parameter_type).
-    Ltac plug_template_ctx f template_ctx :=
-      lazymatch template_ctx with
-      | tt => f
-      | (?arg, ?template_ctx')
-        =>
-        let T := type_of_first_argument_of f in
-        let x_is_template_parameter := is_template_parameter T in
-        lazymatch x_is_template_parameter with
-        | true
-          => plug_template_ctx (f arg) template_ctx'
-        | false
-          => constr:(fun x : T
-                     => ltac:(let v := plug_template_ctx (f x) template_ctx in
-                              exact v))
-        end
-      end.
+      Ltac require_template_parameter parameter_type :=
+        first [ unify parameter_type Prop
+              | unify parameter_type Set
+              | unify parameter_type Type
+              | lazymatch eval hnf in parameter_type with
+                | forall x : ?T, @?P x
+                  => let check := constr:(fun x : T
+                                          => ltac:(require_template_parameter (P x);
+                                                   exact I)) in
+                     idtac
+                end ].
+      Ltac is_template_parameter parameter_type :=
+        is_success_run_tactic ltac:(fun _ => require_template_parameter parameter_type).
+      Ltac plug_template_ctx f template_ctx :=
+        lazymatch template_ctx with
+        | tt => f
+        | (?arg, ?template_ctx')
+          =>
+          let T := type_of_first_argument_of f in
+          let x_is_template_parameter := is_template_parameter T in
+          lazymatch x_is_template_parameter with
+          | true
+            => plug_template_ctx (f arg) template_ctx'
+          | false
+            => constr:(fun x : T
+                       => ltac:(let v := plug_template_ctx (f x) template_ctx in
+                                exact v))
+          end
+        end.
 
-    Ltac reify_helper ident reify_ident var term value_ctx template_ctx :=
-      let reify_rec_gen term value_ctx template_ctx := reify_helper ident reify_ident var term value_ctx template_ctx in
-      let reify_rec term := reify_rec_gen term value_ctx template_ctx in
-      (*let dummy := match goal with _ => idtac "reify_helper: attempting to reify:" term end in*)
-      lazymatch value_ctx with
-      | context[@var_context.cons _ ?rT term ?v _]
-        => constr:(@Var ident var rT v)
-      | _
-        =>
-        let term_is_primitive_const := is_primitive_const term in
-        lazymatch term_is_primitive_const with
-        | true
-          => let rv := reify_ident term in
-             constr:(Ident (var:=var) rv)
-        | false
+      Ltac reify_helper ident reify_ident var term value_ctx template_ctx :=
+        let reify_rec_gen term value_ctx template_ctx := reify_helper ident reify_ident var term value_ctx template_ctx in
+        let reify_rec term := reify_rec_gen term value_ctx template_ctx in
+        let reify_rec_not_head term := reify_rec_gen term value_ctx tt in
+        let mkAppIdent idc args
+            := let rargs := reify_rec_not_head args in
+               constr:(@AppIdent ident var _ _ idc rargs) in
+        let do_reify_ident term else_tac
+            := let term_is_primitive_const := is_primitive_const term in
+               reify_ident
+                 mkAppIdent
+                 term_is_primitive_const
+                 term
+                 else_tac in
+        (*let dummy := match goal with _ => idtac "reify_helper: attempting to reify:" term end in*)
+        lazymatch value_ctx with
+        | context[@var_context.cons _ ?rT term ?v _]
+          => constr:(@Var ident var rT v)
+        | _
           =>
           lazymatch term with
           | match ?b with true => ?t | false => ?f end
             => let T := type of t in
                reify_rec (@bool_rect (fun _ => T) t f b)
+          | match ?x with Datatypes.pair a b => ?f end
+            => reify_rec (match Datatypes.fst x, Datatypes.snd x return _ with
+                          | a, b => f
+                          end)
           | let x := ?a in @?b x
             => let A := type of a in
                let B := lazymatch type of b with forall x, @?B x => B end in
                reify_rec (@Let_In A B a b)
-          | ?f ?x
-            =>
-            let ty := type_of_first_argument_of f in
-            let x_is_template_parameter := is_template_parameter ty in
-            lazymatch x_is_template_parameter with
-            | true
-              => (* we can't reify things of type [Type], so we save it for later to plug in *)
-              reify_rec_gen f value_ctx (x, template_ctx)
-            | false
-              =>
-              let rx := reify_rec_gen x value_ctx tt in
-              let rf := reify_rec_gen f value_ctx template_ctx in
-              constr:(App (var:=var) rf rx)
-            end
+          | Datatypes.pair ?x ?y
+            => let rx := reify_rec x in
+               let ry := reify_rec y in
+               constr:(Pair (ident:=ident) (var:=var) rx ry)
+          | tt
+            => constr:(@TT ident var)
           | (fun x : ?T => ?f)
             =>
             let x_is_template_parameter := is_template_parameter T in
@@ -502,9 +546,10 @@ Module Compilers.
             | false
               =>
               let rT := type.reify T in
-              let not_x := refresh x in
-              let not_x2 := refresh not_x in
-              let not_x3 := refresh not_x2 in
+              let not_x := refresh x ltac:(fun n => fresh n) in
+              let not_x2 := refresh not_x ltac:(fun n => fresh n) in
+              let not_x3 := refresh not_x2 ltac:(fun n => fresh n) in
+              (*let dummy := match goal with _ => idtac "reify_helper: λ case:" term "using vars:" not_x not_x2 not_x3 end in*)
               let rf0 :=
                   constr:(
                     fun (x : T) (not_x : var rT)
@@ -535,593 +580,703 @@ Module Compilers.
               end
             end
           | _
-            => let term := plug_template_ctx term template_ctx in
-               let idc := reify_ident term in
-               constr:(Ident (var:=var) idc)
+            =>
+            do_reify_ident
+              term
+              ltac:(
+              fun _
+              =>
+                lazymatch term with
+                | ?f ?x
+                  =>
+                  let ty := type_of_first_argument_of f in
+                  let x_is_template_parameter := is_template_parameter ty in
+                  lazymatch x_is_template_parameter with
+                  | true
+                    => (* we can't reify things of type [Type], so we save it for later to plug in *)
+                    reify_rec_gen f value_ctx (x, template_ctx)
+                  | false
+                    => let rx := reify_rec_gen x value_ctx tt in
+                       let rf := reify_rec_gen f value_ctx template_ctx in
+                       constr:(App (ident:=ident) (var:=var) rf rx)
+                  end
+                | _
+                  => let term := plug_template_ctx term template_ctx in
+                     do_reify_ident
+                       term
+                       ltac:(fun _
+                             => let dummy := match goal with
+                                             | _ => fail 1 "Unrecognized term:" term
+                                             end in
+                                constr:(I : I))
+                end)
           end
-        end
-      end.
-    Ltac reify ident reify_ident var term :=
-      reify_helper ident reify_ident var term (@var_context.nil var) tt.
-    Ltac Reify ident reify_ident term :=
-      constr:(fun var : type -> Type
-              => ltac:(let r := reify ident reify_ident var term in
-                       exact r)).
-    Ltac Reify_rhs ident reify_ident interp_ident _ :=
-      let RHS := lazymatch goal with |- _ = ?RHS => RHS end in
-      let R := Reify ident reify_ident RHS in
-      transitivity (@Interp ident interp_ident _ R);
-      [ | cbv beta iota delta [Interp interp interp_ident Let_In type.interp bool_rect];
-          reflexivity ].
+        end.
+      Ltac reify ident reify_ident var term :=
+        reify_helper ident reify_ident var term (@var_context.nil var) tt.
+      Ltac Reify ident reify_ident term :=
+        constr:(fun var : type -> Type
+                => ltac:(let r := reify ident reify_ident var term in
+                         exact r)).
+      Ltac Reify_rhs ident reify_ident interp_ident _ :=
+        let RHS := lazymatch goal with |- _ = ?RHS => RHS end in
+        let R := Reify ident reify_ident RHS in
+        transitivity (@Interp ident interp_ident _ R);
+        [ | cbv beta iota delta [Interp interp interp_ident Let_In type.interp bool_rect];
+            reflexivity ].
 
-    Module for_reification.
-      Module ident.
-        Import type.
-        Inductive ident : type -> Set :=
-        | primitive {t:type.primitive} (v : interp t) : ident t
-        | Let_In {tx tC} : ident (tx -> (tx -> tC) -> tC)
-        | Nat_succ : ident (nat -> nat)
-        | nil {t} : ident (list t)
-        | cons {t} : ident (t -> list t -> list t)
-        | pair {A B} : ident (A -> B -> A * B)
-        | fst {A B} : ident (A * B -> A)
-        | snd {A B} : ident (A * B -> B)
-        | bool_rect {T} : ident (T -> T -> bool -> T)
-        | nat_rect {P} : ident (P -> (nat -> P -> P) -> nat -> P)
-        | pred : ident (nat -> nat)
-        | List_seq : ident (nat -> nat -> list nat)
-        | List_repeat {A} : ident (A -> nat -> list A)
-        | List_combine {A B} : ident (list A -> list B -> list (A * B))
-        | List_map {A B} : ident ((A -> B) -> list A -> list B)
-        | List_flat_map {A B} : ident ((A -> list B) -> list A -> list B)
-        | List_partition {A} : ident ((A -> bool) -> list A -> list A * list A)
-        | List_app {A} : ident (list A -> list A -> list A)
-        | List_rev {A} : ident (list A -> list A)
-        | List_fold_right {A B} : ident ((B -> A -> A) -> A -> list B -> A)
-        | List_update_nth {T} : ident (nat -> (T -> T) -> list T -> list T)
-        | List_nth_default {T} : ident (T -> list T -> nat -> T)
-        | Z_runtime_mul : ident (Z -> Z -> Z)
-        | Z_runtime_add : ident (Z -> Z -> Z)
-        | Z_add : ident (Z -> Z -> Z)
-        | Z_mul : ident (Z -> Z -> Z)
-        | Z_pow : ident (Z -> Z -> Z)
-        | Z_opp : ident (Z -> Z)
-        | Z_div : ident (Z -> Z -> Z)
-        | Z_modulo : ident (Z -> Z -> Z)
-        | Z_eqb : ident (Z -> Z -> bool)
-        | Z_of_nat : ident (nat -> Z).
+      Module for_reification.
+        Module ident.
+          Import type.
+          Inductive ident : type -> type -> Set :=
+          | primitive {t:type.primitive} (v : interp t) : ident () t
+          | Let_In {tx tC} : ident (tx * (tx -> tC)) tC
+          | Nat_succ : ident nat nat
+          | nil {t} : ident () (list t)
+          | cons {t} : ident (t * list t) (list t)
+          | fst {A B} : ident (A * B) A
+          | snd {A B} : ident (A * B) B
+          | bool_rect {T} : ident (T * T * bool) T
+          | nat_rect {P} : ident (P * (nat * P -> P) * nat) P
+          | pred : ident nat nat
+          | List_seq : ident (nat * nat) (list nat)
+          | List_repeat {A} : ident (A * nat) (list A)
+          | List_combine {A B} : ident (list A * list B) (list (A * B))
+          | List_map {A B} : ident ((A -> B) * list A) (list B)
+          | List_flat_map {A B} : ident ((A -> list B) * list A) (list B)
+          | List_partition {A} : ident ((A -> bool) * list A) (list A * list A)
+          | List_app {A} : ident (list A * list A) (list A)
+          | List_rev {A} : ident (list A) (list A)
+          | List_fold_right {A B} : ident ((B * A -> A) * A * list B) A
+          | List_update_nth {T} : ident (nat * (T -> T) * list T) (list T)
+          | List_nth_default {T} : ident (T * list T * nat) T
+          | Z_runtime_mul : ident (Z * Z) Z
+          | Z_runtime_add : ident (Z * Z) Z
+          | Z_add : ident (Z * Z) Z
+          | Z_mul : ident (Z * Z) Z
+          | Z_pow : ident (Z * Z) Z
+          | Z_opp : ident Z Z
+          | Z_div : ident (Z * Z) Z
+          | Z_modulo : ident (Z * Z) Z
+          | Z_eqb : ident (Z * Z) bool
+          | Z_of_nat : ident nat Z.
 
-        Definition interp {t} (idc : ident t) : type.interp t
-          := match idc in ident t return type.interp t with
-             | primitive _ v => v
-             | Let_In tx tC => @LetIn.Let_In (type.interp tx) (fun _ => type.interp tC)
-             | Nat_succ => Nat.succ
-             | nil t => @Datatypes.nil (type.interp t)
-             | cons t => @Datatypes.cons (type.interp t)
-             | pair A B => @Datatypes.pair (type.interp A) (type.interp B)
-             | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
-             | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
-             | bool_rect T => @Datatypes.bool_rect (fun _ => type.interp T)
-             | nat_rect P => @Datatypes.nat_rect (fun _ => type.interp P)
-             | pred => Nat.pred
-             | List_seq => List.seq
-             | List_combine A B => @List.combine (type.interp A) (type.interp B)
-             | List_map A B => @List.map (type.interp A) (type.interp B)
-             | List_repeat A => @List.repeat (type.interp A)
-             | List_flat_map A B => @List.flat_map (type.interp A) (type.interp B)
-             | List_partition A => @List.partition (type.interp A)
-             | List_app A => @List.app (type.interp A)
-             | List_rev A => @List.rev (type.interp A)
-             | List_fold_right A B => @List.fold_right (type.interp A) (type.interp B)
-             | List_update_nth T => @update_nth (type.interp T)
-             | List_nth_default T => @List.nth_default (type.interp T)
-             | Z_runtime_mul => runtime_mul
-             | Z_runtime_add => runtime_add
-             | Z_add => Z.add
-             | Z_mul => Z.mul
-             | Z_pow => Z.pow
-             | Z_modulo => Z.modulo
-             | Z_opp => Z.opp
-             | Z_div => Z.div
-             | Z_eqb => Z.eqb
-             | Z_of_nat => Z.of_nat
-             end.
+          Notation curry0 f
+            := (fun 'tt => f).
+          Notation curry2 f
+            := (fun '(a, b) => f a b).
+          Notation curry3 f
+            := (fun '(a, b, c) => f a b c).
+          Notation uncurry2 f
+            := (fun a b => f (a, b)).
+          Notation curry3_1 f
+            := (fun '(a, b, c) => f (uncurry2 a) b c).
+          Notation curry3_2 f
+            := (fun '(a, b, c) => f a (uncurry2 b) c).
 
-        Ltac reify term :=
-          (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
-          lazymatch term with
-          | Nat.succ => Nat_succ
-          | S => Nat_succ
-          | @Datatypes.nil ?T
-            => let rT := type.reify T in
-               constr:(@ident.nil rT)
-          | @Datatypes.cons ?T
-            => let rT := type.reify T in
-               constr:(@ident.cons rT)
-          | @Datatypes.pair ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.pair rA rB)
-          | @Datatypes.fst ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.fst rA rB)
-          | @Datatypes.snd ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.snd rA rB)
-          | @Datatypes.bool_rect (fun _ => ?T)
-            => let rT := type.reify T in
-               constr:(@ident.bool_rect rT)
-          | @Datatypes.nat_rect (fun _ => ?T)
-            => let rT := type.reify T in
-               constr:(@ident.nat_rect rT)
-          | Nat.pred => ident.pred
-          | List.seq => ident.List_seq
-          | @List.repeat ?A
-            => let rA := type.reify A in
-               constr:(@ident.List_repeat rA)
-          | @LetIn.Let_In ?A (fun _ => ?B)
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.Let_In rA rB)
-          | @LetIn.Let_In ?A ?B
-            => let dummy := match goal with _ => fail 1 "Let_In contains a dependent type λ as its second argument:" B end in
-               constr:(I : I)
-          | @combine ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.List_combine rA rB)
-          | @List.map ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.List_map rA rB)
-          | @List.flat_map ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.List_flat_map rA rB)
-          | @List.partition ?A
-            => let rA := type.reify A in
-               constr:(@ident.List_partition rA)
-          | @List.app ?A
-            => let rA := type.reify A in
-               constr:(@ident.List_app rA)
-          | @List.rev ?A
-            => let rA := type.reify A in
-               constr:(@ident.List_rev rA)
-          | @List.fold_right ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.List_fold_right rA rB)
-          | @update_nth ?T
-            => let rT := type.reify T in
-               constr:(@ident.List_update_nth rT)
-          | @List.nth_default ?T
-            => let rT := type.reify T in
-               constr:(@ident.List_nth_default rT)
-          | runtime_mul => ident.Z_runtime_mul
-          | runtime_add => ident.Z_runtime_add
-          | Z.add => ident.Z_add
-          | Z.mul => ident.Z_mul
-          | Z.pow => ident.Z_pow
-          | Z.opp => ident.Z_opp
-          | Z.div => ident.Z_div
-          | Z.modulo => ident.Z_modulo
-          | Z.eqb => ident.Z_eqb
-          | Z.of_nat => ident.Z_of_nat
-          | _
-            => let assert_const := match goal with
-                                   | _ => require_primitive_const term
-                                   end in
-               let T := type of term in
-               let rT := type.reify_primitive T in
-               constr:(@ident.primitive rT term)
-          end.
+          Definition interp {s d} (idc : ident s d) : type.interp s -> type.interp d
+            := match idc in ident s d return type.interp s -> type.interp d with
+               | primitive _ v => curry0 v
+               | Let_In tx tC => curry2 (@LetIn.Let_In (type.interp tx) (fun _ => type.interp tC))
+               | Nat_succ => Nat.succ
+               | nil t => curry0 (@Datatypes.nil (type.interp t))
+               | cons t => curry2 (@Datatypes.cons (type.interp t))
+               | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
+               | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
+               | bool_rect T => curry3 (@Datatypes.bool_rect (fun _ => type.interp T))
+               | nat_rect P => curry3_2 (@Datatypes.nat_rect (fun _ => type.interp P))
+               | pred => Nat.pred
+               | List_seq => curry2 List.seq
+               | List_combine A B => curry2 (@List.combine (type.interp A) (type.interp B))
+               | List_map A B => curry2 (@List.map (type.interp A) (type.interp B))
+               | List_repeat A => curry2 (@List.repeat (type.interp A))
+               | List_flat_map A B => curry2 (@List.flat_map (type.interp A) (type.interp B))
+               | List_partition A => curry2 (@List.partition (type.interp A))
+               | List_app A => curry2 (@List.app (type.interp A))
+               | List_rev A => @List.rev (type.interp A)
+               | List_fold_right A B => curry3_1 (@List.fold_right (type.interp A) (type.interp B))
+               | List_update_nth T => curry3 (@update_nth (type.interp T))
+               | List_nth_default T => curry3 (@List.nth_default (type.interp T))
+               | Z_runtime_mul => curry2 runtime_mul
+               | Z_runtime_add => curry2 runtime_add
+               | Z_add => curry2 Z.add
+               | Z_mul => curry2 Z.mul
+               | Z_pow => curry2 Z.pow
+               | Z_modulo => curry2 Z.modulo
+               | Z_opp => Z.opp
+               | Z_div => curry2 Z.div
+               | Z_eqb => curry2 Z.eqb
+               | Z_of_nat => Z.of_nat
+               end.
 
-        Module List.
-          Notation seq := List_seq.
-          Notation repeat := List_repeat.
-          Notation combine := List_combine.
-          Notation map := List_map.
-          Notation flat_map := List_flat_map.
-          Notation partition := List_partition.
-          Notation app := List_app.
-          Notation rev := List_rev.
-          Notation fold_right := List_fold_right.
-          Notation update_nth := List_update_nth.
-          Notation nth_default := List_nth_default.
-        End List.
+          Ltac reify
+               mkAppIdent
+               term_is_primitive_const
+               term
+               else_tac :=
+            (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
+            lazymatch term with
+            | Nat.succ ?x => mkAppIdent Nat_succ x
+            | S ?x => mkAppIdent Nat_succ x
+            | @Datatypes.nil ?T
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.nil rT) tt
+            | @Datatypes.cons ?T ?x ?xs
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.cons rT) (x, xs)
+            | @Datatypes.fst ?A ?B ?x
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.fst rA rB) x
+            | @Datatypes.snd ?A ?B ?x
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.snd rA rB) x
+            | @Datatypes.bool_rect (fun _ => ?T) ?Ptrue ?Pfalse ?b
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.bool_rect rT) (Ptrue, Pfalse, b)
+            | @Datatypes.nat_rect (fun _ => ?T) ?P0 (fun (n' : Datatypes.nat) Pn => ?PS) ?n
+              => let rT := type.reify T in
+                 let pat := fresh "pat" in (* fresh for COQBUG(https://github.com/coq/coq/issues/6562) *)
+                 mkAppIdent (@ident.nat_rect rT) (P0,
+                                                  (fun pat : Datatypes.nat * T
+                                                   => let '(n', Pn) := pat in PS),
+                                                  n)
+            | @Datatypes.nat_rect (fun _ => ?T) ?P0 ?PS ?n
+              => let dummy := match goal with _ => fail 1 "nat_rect successor case is not syntactically a function of two arguments:" PS end in
+                 constr:(I : I)
+            | Nat.pred ?x => mkAppIdent ident.pred x
+            | List.seq ?x ?y  => mkAppIdent ident.List_seq (x, y)
+            | @List.repeat ?A ?x ?y
+              => let rA := type.reify A in
+                 mkAppIdent (@ident.List_repeat rA) (x, y)
+            | @LetIn.Let_In ?A (fun _ => ?B) ?x ?f
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.Let_In rA rB) (x, f)
+            | @LetIn.Let_In ?A ?B ?x ?f
+              => let dummy := match goal with _ => fail 1 "Let_In contains a dependent type λ as its second argument:" B end in
+                 constr:(I : I)
+            | @combine ?A ?B ?ls1 ?ls2
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.List_combine rA rB) (ls1, ls2)
+            | @List.map ?A ?B ?f ?ls
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.List_map rA rB) (f, ls)
+            | @List.flat_map ?A ?B ?f ?ls
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.List_flat_map rA rB) (f, ls)
+            | @List.partition ?A ?f ?ls
+              => let rA := type.reify A in
+                 mkAppIdent (@ident.List_partition rA) (f, ls)
+            | @List.app ?A ?ls1 ?ls2
+              => let rA := type.reify A in
+                 mkAppIdent (@ident.List_app rA) (ls1, ls2)
+            | @List.rev ?A ?ls
+              => let rA := type.reify A in
+                 mkAppIdent (@ident.List_rev rA) ls
+            | @List.fold_right ?A ?B (fun b a => ?f) ?a0 ?ls
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 let pat := fresh "pat" in (* fresh for COQBUG(https://github.com/coq/coq/issues/6562) *)
+                 mkAppIdent (@ident.List_fold_right rA rB) ((fun pat : B * A => let '(b, a) := pat in f), a0, ls)
+            | @List.fold_right ?A ?B ?f ?a0 ?ls
+              => let dummy := match goal with _ => fail 1 "List.fold_right function argument is not syntactically a function of two arguments:" f end in
+                 constr:(I : I)
+            | @update_nth ?T ?n ?f ?ls
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.List_update_nth rT) (n, f, ls)
+            | @List.nth_default ?T ?d ?ls ?n
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.List_nth_default rT) (d, ls, n)
+            | runtime_mul ?x ?y => mkAppIdent ident.Z_runtime_mul (x, y)
+            | runtime_add ?x ?y => mkAppIdent ident.Z_runtime_add (x, y)
+            | Z.add ?x ?y => mkAppIdent ident.Z_add (x, y)
+            | Z.mul ?x ?y => mkAppIdent ident.Z_mul (x, y)
+            | Z.pow ?x ?y => mkAppIdent ident.Z_pow (x, y)
+            | Z.opp ?x => mkAppIdent ident.Z_opp x
+            | Z.div ?x ?y => mkAppIdent ident.Z_div (x, y)
+            | Z.modulo ?x ?y => mkAppIdent ident.Z_modulo (x, y)
+            | Z.eqb ?x ?y => mkAppIdent ident.Z_eqb (x, y)
+            | Z.of_nat ?x => mkAppIdent ident.Z_of_nat x
+            | _
+              => lazymatch term_is_primitive_const with
+                 | true
+                   =>
+                   let assert_const := match goal with
+                                       | _ => require_primitive_const term
+                                       end in
+                   let T := type of term in
+                   let rT := type.reify_primitive T in
+                   mkAppIdent (@ident.primitive rT term) tt
+                 | false => else_tac ()
+                 end
+            end.
 
-        Module Z.
-          Notation runtime_mul := Z_runtime_mul.
-          Notation runtime_add := Z_runtime_add.
-          Notation add := Z_add.
-          Notation mul := Z_mul.
-          Notation pow := Z_pow.
-          Notation opp := Z_opp.
-          Notation div := Z_div.
-          Notation modulo := Z_modulo.
-          Notation eqb := Z_eqb.
-          Notation of_nat := Z_of_nat.
-        End Z.
+          Module List.
+            Notation seq := List_seq.
+            Notation repeat := List_repeat.
+            Notation combine := List_combine.
+            Notation map := List_map.
+            Notation flat_map := List_flat_map.
+            Notation partition := List_partition.
+            Notation app := List_app.
+            Notation rev := List_rev.
+            Notation fold_right := List_fold_right.
+            Notation update_nth := List_update_nth.
+            Notation nth_default := List_nth_default.
+          End List.
 
-        Module Nat.
-          Notation succ := Nat_succ.
-        End Nat.
+          Module Z.
+            Notation runtime_mul := Z_runtime_mul.
+            Notation runtime_add := Z_runtime_add.
+            Notation add := Z_add.
+            Notation mul := Z_mul.
+            Notation pow := Z_pow.
+            Notation opp := Z_opp.
+            Notation div := Z_div.
+            Notation modulo := Z_modulo.
+            Notation eqb := Z_eqb.
+            Notation of_nat := Z_of_nat.
+          End Z.
 
-        Module Export Notations.
-          Notation ident := ident.
+          Module Nat.
+            Notation succ := Nat_succ.
+          End Nat.
+
+          Module Export Notations.
+            Notation ident := ident.
+          End Notations.
+        End ident.
+
+        Module Notations.
+          Include ident.Notations.
+          Notation expr := (@expr ident).
+          Notation Expr := (@Expr ident).
+          Notation interp := (@interp ident (@ident.interp)).
+          Notation Interp := (@Interp ident (@ident.interp)).
+
+          (*Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.*)
+          Notation "'expr_let' x := A 'in' b" := (AppIdent ident.Let_In (Pair A%expr (Abs (fun x => b%expr)))) : expr_scope.
+          Notation "[ ]" := (AppIdent ident.nil _) : expr_scope.
+          Notation "x :: xs" := (AppIdent ident.cons (Pair x%expr xs%expr)) : expr_scope.
+          Notation "x" := (AppIdent (ident.primitive x) _) (only printing, at level 9) : expr_scope.
+          Notation "ls [[ n ]]"
+            := (AppIdent ident.List.nth_default (_, ls, AppIdent (ident.primitive n%nat) _)%expr)
+               : expr_scope.
+
+          Module Reification.
+            Ltac reify var term := expr.reify ident ident.reify var term.
+            Ltac Reify term := expr.Reify ident ident.reify term.
+            Ltac Reify_rhs _ :=
+              expr.Reify_rhs ident ident.reify ident.interp ().
+          End Reification.
+          Include Reification.
         End Notations.
-      End ident.
+        Include Notations.
+      End for_reification.
 
-      Module Notations.
-        Include ident.Notations.
-        Notation expr := (@expr ident).
-        Notation Expr := (@Expr ident).
-        Notation interp := (@interp ident (@ident.interp)).
-        Notation Interp := (@Interp ident (@ident.interp)).
+      Module Export default.
+        Module ident.
+          Import type.
+          Inductive ident : type -> type -> Set :=
+          | primitive {t : type.primitive} (v : interp t) : ident () t
+          | Let_In {tx tC} : ident (tx * (tx -> tC)) tC
+          | Nat_succ : ident nat nat
+          | nil {t} : ident () (list t)
+          | cons {t} : ident (t * list t) (list t)
+          | fst {A B} : ident (A * B) A
+          | snd {A B} : ident (A * B) B
+          | bool_rect {T} : ident (T * T * bool) T
+          | nat_rect {P} : ident (P * (nat * P -> P) * nat) P
+          | pred : ident nat nat
+          | list_rect {A P} : ident (P * (A * list A * P -> P) * list A) P
+          | List_nth_default {T} : ident (T * list T * nat) T
+          | Z_runtime_mul : ident (Z * Z) Z
+          | Z_runtime_add : ident (Z * Z) Z
+          | Z_add : ident (Z * Z) Z
+          | Z_mul : ident (Z * Z) Z
+          | Z_pow : ident (Z * Z) Z
+          | Z_opp : ident Z Z
+          | Z_div : ident (Z * Z) Z
+          | Z_modulo : ident (Z * Z) Z
+          | Z_eqb : ident (Z * Z) bool
+          | Z_of_nat : ident nat Z.
 
-        Notation Pair x y := (App (App (Ident ident.pair) x) y).
+          Notation curry0 f
+            := (fun 'tt => f).
+          Notation curry2 f
+            := (fun '(a, b) => f a b).
+          Notation curry3 f
+            := (fun '(a, b, c) => f a b c).
+          Notation uncurry2 f
+            := (fun a b => f (a, b)).
+          Notation uncurry3 f
+            := (fun a b c => f (a, b, c)).
+          Notation curry3_23 f
+            := (fun '(a, b, c) => f a (uncurry3 b) c).
+          Notation curry3_2 f
+            := (fun '(a, b, c) => f a (uncurry2 b) c).
 
-        Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
-        Notation "'expr_let' x := A 'in' b" := (App (App (Ident ident.Let_In) A%expr) (Abs (fun x => b%expr))) : expr_scope.
-        Notation "[ ]" := (Ident ident.nil) : expr_scope.
-        Notation "x :: xs" := (App (App (Ident ident.cons) x%expr) xs%expr) : expr_scope.
-        Notation "x" := (Ident (ident.primitive x)) (only printing, at level 9) : expr_scope.
-        Notation "ls [[ n ]]"
-          := (App (App (App (Ident ident.List.nth_default) _) ls%expr) (Ident (ident.primitive n%nat)))
-             : expr_scope.
+          Definition interp {s d} (idc : ident s d) : type.interp s -> type.interp d
+            := match idc in ident s d return type.interp s -> type.interp d with
+               | primitive _ v => curry0 v
+               | Let_In tx tC => curry2 (@LetIn.Let_In (type.interp tx) (fun _ => type.interp tC))
+               | Nat_succ => Nat.succ
+               | nil t => curry0 (@Datatypes.nil (type.interp t))
+               | cons t => curry2 (@Datatypes.cons (type.interp t))
+               | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
+               | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
+               | bool_rect T => curry3 (@Datatypes.bool_rect (fun _ => type.interp T))
+               | nat_rect P => curry3_2 (@Datatypes.nat_rect (fun _ => type.interp P))
+               | pred => Nat.pred
+               | list_rect A P => curry3_23 (@Datatypes.list_rect (type.interp A) (fun _ => type.interp P))
+               | List_nth_default T => curry3 (@List.nth_default (type.interp T))
+               | Z_runtime_mul => curry2 runtime_mul
+               | Z_runtime_add => curry2 runtime_add
+               | Z_add => curry2 Z.add
+               | Z_mul => curry2 Z.mul
+               | Z_pow => curry2 Z.pow
+               | Z_modulo => curry2 Z.modulo
+               | Z_opp => Z.opp
+               | Z_div => curry2 Z.div
+               | Z_eqb => curry2 Z.eqb
+               | Z_of_nat => Z.of_nat
+               end.
 
-        Module Reification.
+          Ltac reify
+               mkAppIdent
+               term_is_primitive_const
+               term
+               else_tac :=
+            (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
+            lazymatch term with
+            | Nat.succ ?x => mkAppIdent Nat_succ x
+            | S ?x => mkAppIdent Nat_succ x
+            | @Datatypes.nil ?T
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.nil rT) tt
+            | @Datatypes.cons ?T ?x ?xs
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.cons rT) (x, xs)
+            | @Datatypes.fst ?A ?B ?x
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.fst rA rB) x
+            | @Datatypes.snd ?A ?B ?x
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.snd rA rB) x
+            | @Datatypes.bool_rect (fun _ => ?T) ?Ptrue ?Pfalse ?b
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.bool_rect rT) (Ptrue, Pfalse, b)
+            | @Datatypes.nat_rect (fun _ => ?T) ?P0 (fun (n' : Datatypes.nat) Pn => ?PS) ?n
+              => let rT := type.reify T in
+                 let pat := fresh "pat" in (* fresh for COQBUG(https://github.com/coq/coq/issues/6562) *)
+                 mkAppIdent (@ident.nat_rect rT) (P0,
+                                                  (fun pat : Datatypes.nat * T
+                                                   => let '(n', Pn) := pat in PS),
+                                                  n)
+            | @Datatypes.nat_rect (fun _ => ?T) ?P0 ?PS ?n
+              => let dummy := match goal with _ => fail 1 "nat_rect successor case is not syntactically a function of two arguments:" PS end in
+                 constr:(I : I)
+            | Nat.pred ?x => mkAppIdent ident.pred x
+            | @LetIn.Let_In ?A (fun _ => ?B) ?x ?f
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 mkAppIdent (@ident.Let_In rA rB) (x, f)
+            | @LetIn.Let_In ?A ?B ?x ?f
+              => let dummy := match goal with _ => fail 1 "Let_In contains a dependent type λ as its second argument:" B end in
+                 constr:(I : I)
+            | @Datatypes.list_rect ?A (fun _ => ?B) ?Pnil (fun x xs rec => ?Pcons) ?ls
+              => let rA := type.reify A in
+                 let rB := type.reify B in
+                 let pat := fresh "pat" in (* fresh for COQBUG(https://github.com/coq/coq/issues/6562) *)
+                 let pat' := fresh "pat" in (* fresh for COQBUG(https://github.com/coq/coq/issues/6562) (must also not overlap with [rec], but I think [fresh] handles that correctly, at least) *)
+                 mkAppIdent (@ident.list_rect rA rB)
+                            (Pnil,
+                             (fun pat : A * Datatypes.list A * B
+                              => let '(pat', rec) := pat in
+                                 let '(x, xs) := pat' in
+                                 Pcons),
+                             ls)
+            | @Datatypes.list_rect ?A (fun _ => ?B) ?Pnil ?Pcons ?ls
+              => let dummy := match goal with _ => fail 1 "list_rect cons case is not syntactically a function of three arguments:" Pcons end in
+                 constr:(I : I)
+            | @List.nth_default ?T ?d ?ls ?n
+              => let rT := type.reify T in
+                 mkAppIdent (@ident.List_nth_default rT) (d, ls, n)
+            | runtime_mul ?x ?y => mkAppIdent ident.Z_runtime_mul (x, y)
+            | runtime_add ?x ?y => mkAppIdent ident.Z_runtime_add (x, y)
+            | Z.add ?x ?y => mkAppIdent ident.Z_add (x, y)
+            | Z.mul ?x ?y => mkAppIdent ident.Z_mul (x, y)
+            | Z.pow ?x ?y => mkAppIdent ident.Z_pow (x, y)
+            | Z.opp ?x => mkAppIdent ident.Z_opp x
+            | Z.div ?x ?y => mkAppIdent ident.Z_div (x, y)
+            | Z.modulo ?x ?y => mkAppIdent ident.Z_modulo (x, y)
+            | Z.eqb ?x ?y => mkAppIdent ident.Z_eqb (x, y)
+            | Z.of_nat ?x => mkAppIdent ident.Z_of_nat x
+            | _
+              => lazymatch term_is_primitive_const with
+                 | true
+                   =>
+                   let assert_const := match goal with
+                                       | _ => require_primitive_const term
+                                       end in
+                   let T := type of term in
+                   let rT := type.reify_primitive T in
+                   mkAppIdent (@ident.primitive rT term) tt
+                 | _ => else_tac ()
+                 end
+            end.
+
+          Module List.
+            Notation nth_default := List_nth_default.
+          End List.
+
+          Module Z.
+            Notation runtime_mul := Z_runtime_mul.
+            Notation runtime_add := Z_runtime_add.
+            Notation add := Z_add.
+            Notation mul := Z_mul.
+            Notation pow := Z_pow.
+            Notation opp := Z_opp.
+            Notation div := Z_div.
+            Notation modulo := Z_modulo.
+            Notation eqb := Z_eqb.
+            Notation of_nat := Z_of_nat.
+          End Z.
+
+          Module Nat.
+            Notation succ := Nat_succ.
+          End Nat.
+
+          Module Export Notations.
+            Notation ident := ident.
+          End Notations.
+        End ident.
+
+        Module Notations.
+          Include ident.Notations.
+          Notation expr := (@expr ident).
+          Notation Expr := (@Expr ident).
+          Notation interp := (@interp ident (@ident.interp)).
+          Notation Interp := (@Interp ident (@ident.interp)).
+
+          (*Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.*)
+          Notation "'expr_let' x := A 'in' b" := (AppIdent ident.Let_In (Pair A%expr (Abs (fun x => b%expr)))) : expr_scope.
+          Notation "[ ]" := (AppIdent ident.nil _) : expr_scope.
+          Notation "x :: xs" := (AppIdent ident.cons (Pair x%expr xs%expr)) : expr_scope.
+          Notation "x" := (AppIdent (ident.primitive x) _) (only printing, at level 9) : expr_scope.
+          Notation "ls [[ n ]]"
+            := (AppIdent ident.List.nth_default (_, ls, AppIdent (ident.primitive n%nat) _)%expr)
+               : expr_scope.
+
           Ltac reify var term := expr.reify ident ident.reify var term.
           Ltac Reify term := expr.Reify ident ident.reify term.
           Ltac Reify_rhs _ :=
             expr.Reify_rhs ident ident.reify ident.interp ().
-        End Reification.
-        Include Reification.
         End Notations.
-      Include Notations.
-    End for_reification.
+        Include Notations.
+      End default.
+    End expr.
 
-    Module Export default.
+    Module canonicalize_list_recursion.
+      Import expr.
+      Import expr.default.
       Module ident.
-        Import type.
-        Inductive ident : type -> Set :=
-        | primitive {t : type.primitive} (v : interp t) : ident t
-        | Let_In {tx tC} : ident (tx -> (tx -> tC) -> tC)
-        | Nat_succ : ident (nat -> nat)
-        | nil {t} : ident (list t)
-        | cons {t} : ident (t -> list t -> list t)
-        | pair {A B} : ident (A -> B -> A * B)
-        | fst {A B} : ident (A * B -> A)
-        | snd {A B} : ident (A * B -> B)
-        | bool_rect {T} : ident (T -> T -> bool -> T)
-        | nat_rect {P} : ident (P -> (nat -> P -> P) -> nat -> P)
-        | pred : ident (nat -> nat)
-        | list_rect {A P} : ident (P -> (A -> list A -> P -> P) -> list A -> P)
-        | List_nth_default {T} : ident (T -> list T -> nat -> T)
-        | Z_runtime_mul : ident (Z -> Z -> Z)
-        | Z_runtime_add : ident (Z -> Z -> Z)
-        | Z_add : ident (Z -> Z -> Z)
-        | Z_mul : ident (Z -> Z -> Z)
-        | Z_pow : ident (Z -> Z -> Z)
-        | Z_opp : ident (Z -> Z)
-        | Z_div : ident (Z -> Z -> Z)
-        | Z_modulo : ident (Z -> Z -> Z)
-        | Z_eqb : ident (Z -> Z -> bool)
-        | Z_of_nat : ident (nat -> Z).
-
-        Definition interp {t} (idc : ident t) : type.interp t
-          := match idc in ident t return type.interp t with
-             | primitive _ v => v
-             | Let_In tx tC => @LetIn.Let_In (type.interp tx) (fun _ => type.interp tC)
-             | Nat_succ => Nat.succ
-             | nil t => @Datatypes.nil (type.interp t)
-             | cons t => @Datatypes.cons (type.interp t)
-             | pair A B => @Datatypes.pair (type.interp A) (type.interp B)
-             | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
-             | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
-             | bool_rect T => @Datatypes.bool_rect (fun _ => type.interp T)
-             | nat_rect P => @Datatypes.nat_rect (fun _ => type.interp P)
-             | pred => Nat.pred
-             | list_rect A P => @Datatypes.list_rect (type.interp A) (fun _ => type.interp P)
-             | List_nth_default T => @nth_default (type.interp T)
-             | Z_runtime_mul => runtime_mul
-             | Z_runtime_add => runtime_add
-             | Z_add => Z.add
-             | Z_mul => Z.mul
-             | Z_pow => Z.pow
-             | Z_modulo => Z.modulo
-             | Z_opp => Z.opp
-             | Z_div => Z.div
-             | Z_eqb => Z.eqb
-             | Z_of_nat => Z.of_nat
-             end.
-
-        Ltac reify term :=
-          (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
+        Local Ltac SmartApp term :=
           lazymatch term with
-          | Nat.succ => ident.Nat_succ
-          | S => ident.Nat_succ
-          | @Datatypes.nil ?T
-            => let rT := type.reify T in
-               constr:(@ident.nil rT)
-          | @Datatypes.cons ?T
-            => let rT := type.reify T in
-               constr:(@ident.cons rT)
-          | @Datatypes.pair ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.pair rA rB)
-          | @Datatypes.fst ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.fst rA rB)
-          | @Datatypes.snd ?A ?B
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.snd rA rB)
-          | @Datatypes.bool_rect (fun _ => ?T)
-            => let rT := type.reify T in
-               constr:(@ident.bool_rect rT)
-          | @Datatypes.nat_rect (fun _ => ?T)
-            => let rT := type.reify T in
-               constr:(@ident.nat_rect rT)
-          | Nat.pred => ident.pred
-          | @LetIn.Let_In ?A (fun _ => ?B)
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.Let_In rA rB)
-          | @LetIn.Let_In ?A ?B
-            => let dummy := match goal with _ => fail 1 "Let_In contains a dependent type λ as its second argument:" B end in
+          | Abs (fun x : @expr ?var ?T => ?f)
+            => eval cbv [unexpr] in (fun x : @expr var T => @unexpr ident.ident var _ f)
+          | Abs (fun x : ?T => ?f)
+            => let dummy := match goal with _ => fail 1 "Invalid var type:" T end in
                constr:(I : I)
-          | @Datatypes.list_rect ?A (fun _ => ?B)
-            => let rA := type.reify A in
-               let rB := type.reify B in
-               constr:(@ident.list_rect rA rB)
-          | @nth_default ?T
-            => let rT := type.reify T in
-               constr:(@ident.List_nth_default rT)
-          | runtime_mul => ident.Z_runtime_mul
-          | runtime_add => ident.Z_runtime_add
-          | Z.add => ident.Z_add
-          | Z.mul => ident.Z_mul
-          | Z.pow => ident.Z_pow
-          | Z.opp => ident.Z_opp
-          | Z.div => ident.Z_div
-          | Z.modulo => ident.Z_modulo
-          | Z.eqb => ident.Z_eqb
-          | Z.of_nat => ident.Z_of_nat
-          | _
-            => let assert_const := match goal with
-                                   | _ => require_primitive_const term
-                                   end in
-               let T := type of term in
-               let rT := type.reify_primitive T in
-               constr:(@ident.primitive rT term)
           end.
 
-        Module List.
-          Notation nth_default := List_nth_default.
-        End List.
-
-        Module Z.
-          Notation runtime_mul := Z_runtime_mul.
-          Notation runtime_add := Z_runtime_add.
-          Notation add := Z_add.
-          Notation mul := Z_mul.
-          Notation pow := Z_pow.
-          Notation opp := Z_opp.
-          Notation div := Z_div.
-          Notation modulo := Z_modulo.
-          Notation eqb := Z_eqb.
-          Notation of_nat := Z_of_nat.
-        End Z.
-
-        Module Nat.
-          Notation succ := Nat_succ.
-        End Nat.
-
-        Module Export Notations.
-          Notation ident := ident.
-        End Notations.
-      End ident.
-
-      Module Notations.
-        Include ident.Notations.
-        Notation expr := (@expr ident).
-        Notation Expr := (@Expr ident).
-        Notation interp := (@interp ident (@ident.interp)).
-        Notation Interp := (@Interp ident (@ident.interp)).
-
-        Notation Pair x y := (App (App (Ident ident.pair) x) y).
-
-        Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
-        Notation "'expr_let' x := A 'in' b" := (App (App (Ident ident.Let_In) A%expr) (Abs (fun x => b%expr))) : expr_scope.
-        Notation "[ ]" := (Ident ident.nil) : expr_scope.
-        Notation "x :: xs" := (App (App (Ident ident.cons) x%expr) xs%expr) : expr_scope.
-        Notation "x" := (Ident (ident.primitive x)) (only printing, at level 9) : expr_scope.
-        Notation "ls [[ n ]]"
-          := (App (App (App (Ident ident.List.nth_default) _) ls%expr) (Ident (ident.primitive n%nat)))
-             : expr_scope.
-
-        Ltac reify var term := expr.reify ident ident.reify var term.
-        Ltac Reify term := expr.Reify ident ident.reify term.
-        Ltac Reify_rhs _ :=
-          expr.Reify_rhs ident ident.reify ident.interp ().
-      End Notations.
-      Include Notations.
-    End default.
-  End expr.
-
-  Module canonicalize_list_recursion.
-    Import expr.
-    Import expr.default.
-    Module ident.
-      Definition transfer {var} {t} (idc : for_reification.ident t) : @expr var t
-        := let List_app A :=
-               list_rect
-                 (fun _ => list (type.interp A) -> list (type.interp A))
-                 (fun m => m)
-                 (fun a l1 app_l1 m => a :: app_l1 m) in
-           match idc with
-           | for_reification.ident.Let_In tx tC
-             => Ident ident.Let_In
-           | for_reification.ident.Nat_succ
-             => Ident ident.Nat_succ
-           | for_reification.ident.nil t
-             => Ident ident.nil
-           | for_reification.ident.cons t
-             => Ident ident.cons
-           | for_reification.ident.pair A B
-             => Ident ident.pair
-           | for_reification.ident.fst A B
-             => Ident ident.fst
-           | for_reification.ident.snd A B
-             => Ident ident.snd
-           | for_reification.ident.bool_rect T
-             => Ident ident.bool_rect
-           | for_reification.ident.nat_rect P
-             => Ident ident.nat_rect
-           | for_reification.ident.pred
-             => Ident ident.pred
-           | for_reification.ident.primitive t v
-             => Ident (ident.primitive v)
-           | for_reification.ident.Z_runtime_mul
-             => Ident ident.Z.runtime_mul
-           | for_reification.ident.Z_runtime_add
-             => Ident ident.Z.runtime_add
-           | for_reification.ident.Z_add
-             => Ident ident.Z.add
-           | for_reification.ident.Z_mul
-             => Ident ident.Z.mul
-           | for_reification.ident.Z_pow
-             => Ident ident.Z.pow
-           | for_reification.ident.Z_opp
-             => Ident ident.Z.opp
-           | for_reification.ident.Z_div
-             => Ident ident.Z.div
-           | for_reification.ident.Z_modulo
-             => Ident ident.Z.modulo
-           | for_reification.ident.Z_eqb
-             => Ident ident.Z.eqb
-           | for_reification.ident.Z_of_nat
-             => Ident ident.Z.of_nat
-           | for_reification.ident.List_seq
-             => ltac:(
-                  let v := reify
-                             var
-                             (fun start len : nat
-                              => nat_rect
-                                   (fun _ => nat -> list nat)
-                                   (fun _ => nil)
-                                   (fun len seq_len start => cons start (seq_len (S start)))
-                                   len start)
-                  in exact v)
-           | for_reification.ident.List_repeat A
-             => ltac:(
-                  let v := reify
-                             var
-                             (fun (x : type.interp A)
-                              => nat_rect
-                                   (fun _ => list (type.interp A))
-                                   nil
-                                   (fun k repeat_k => cons x repeat_k)) in
-                  exact v)
-           | for_reification.ident.List_combine A B
-             => ltac:(
-                  let v := reify
-                             var
-                             (list_rect
-                                (fun _ => list (type.interp B) -> list (type.interp A * type.interp B))
-                                (fun l' => nil)
-                                (fun x tl combine_tl
-                                 => list_rect
-                                      (fun _ => list (type.interp A * type.interp B))
-                                      nil
-                                      (fun y tl' REIFICATION_STACK_OVERFLOWS_IF_THIS_IS_NAMED_UNDERSCORE (* CODBUG(https://github.com/coq/coq/issues/5448) *)
-                                       => (x, y) :: combine_tl tl'))) in
-                  exact v)
-           | for_reification.ident.List_map A B
-             => ltac:(
-                  let v := reify
-                             var
-                             (fun f : type.interp A -> type.interp B
-                              => list_rect
-                                   (fun _ => list (type.interp B))
-                                   nil
-                                   (fun a t map_t => f a :: map_t)) in
-                  exact v)
-           | for_reification.ident.List_flat_map A B
-             => ltac:(
-                  let List_app := (eval cbv [List_app] in (List_app B)) in
-                  let v := reify
-                             var
-                             (fun f : type.interp A -> list (type.interp B)
-                              => list_rect
-                                   (fun _ => list (type.interp B))
-                                   nil
-                                   (fun x t flat_map_t => List_app (f x) flat_map_t)) in
-                  exact v)
-           | for_reification.ident.List_partition A
-             => ltac:(
-                  let v := reify
-                             var
-                             (fun f : type.interp A -> bool
-                              => list_rect
-                                   (fun _ => list (type.interp A) * list (type.interp A))%type
-                                   (nil, nil)
-                                   (fun x tl partition_tl
-                                    => let g := fst partition_tl in
-                                       let d := snd partition_tl in
-                                       if f x then (x :: g, d) else (g, x :: d))) in
-                  exact v)
-           | for_reification.ident.List_app A
-             => ltac:(
-                  let List_app := (eval cbv [List_app] in (List_app A)) in
-                  let v := reify var List_app in
-                  exact v)
-           | for_reification.ident.List_rev A
-             => ltac:(
-                  let List_app := (eval cbv [List_app] in (List_app A)) in
-                  let v := reify
-                             var
-                             (list_rect
-                                (fun _ => list (type.interp A))
-                                nil
-                                (fun x l' rev_l' => List_app rev_l' [x])) in
-                  exact v)
-           | for_reification.ident.List_fold_right A B
-             => ltac:(
-                  let v := reify
-                             var
-                             (fun (f : type.interp B -> type.interp A -> type.interp A) (a0 : type.interp A)
-                              => list_rect
-                                   (fun _ => type.interp A)
-                                   a0
-                                   (fun b t fold_right_t => f b fold_right_t)) in
-                  exact v)
-           | for_reification.ident.List_update_nth T
-             => ltac:(
-                  let v := reify
-                             var
-                             (fun (n : nat) (f : type.interp T -> type.interp T)
-                              => nat_rect
-                                   (fun _ => list (type.interp T) -> list (type.interp T))
-                                   (list_rect
-                                      (fun _ => list (type.interp T))
-                                      nil
-                                      (fun x' xs' __ => f x' :: xs'))
-                                   (fun n' update_nth_n'
-                                    => list_rect
-                                         (fun _ => list (type.interp T))
-                                         nil
-                                         (fun x' xs' __ => x' :: update_nth_n' xs'))
-                                   n) in
-                  exact v)
-           | for_reification.ident.List_nth_default T
-             => Ident ident.List_nth_default
-           (*ltac:(
+        Definition transfer {var} {s d} (idc : for_reification.ident s d) : @expr var s -> @expr var d
+          := let List_app A :=
+                 list_rect
+                   (fun _ => list (type.interp A) -> list (type.interp A))
+                   (fun m => m)
+                   (fun a l1 app_l1 m => a :: app_l1 m) in
+             match idc in for_reification.ident s d return @expr var s -> @expr var d with
+             | for_reification.ident.Let_In tx tC
+               => AppIdent ident.Let_In
+             | for_reification.ident.Nat_succ
+               => AppIdent ident.Nat_succ
+             | for_reification.ident.nil t
+               => AppIdent ident.nil
+             | for_reification.ident.cons t
+               => AppIdent ident.cons
+             | for_reification.ident.fst A B
+               => AppIdent ident.fst
+             | for_reification.ident.snd A B
+               => AppIdent ident.snd
+             | for_reification.ident.bool_rect T
+               => AppIdent ident.bool_rect
+             | for_reification.ident.nat_rect P
+               => AppIdent ident.nat_rect
+             | for_reification.ident.pred
+               => AppIdent ident.pred
+             | for_reification.ident.primitive t v
+               => AppIdent (ident.primitive v)
+             | for_reification.ident.Z_runtime_mul
+               => AppIdent ident.Z.runtime_mul
+             | for_reification.ident.Z_runtime_add
+               => AppIdent ident.Z.runtime_add
+             | for_reification.ident.Z_add
+               => AppIdent ident.Z.add
+             | for_reification.ident.Z_mul
+               => AppIdent ident.Z.mul
+             | for_reification.ident.Z_pow
+               => AppIdent ident.Z.pow
+             | for_reification.ident.Z_opp
+               => AppIdent ident.Z.opp
+             | for_reification.ident.Z_div
+               => AppIdent ident.Z.div
+             | for_reification.ident.Z_modulo
+               => AppIdent ident.Z.modulo
+             | for_reification.ident.Z_eqb
+               => AppIdent ident.Z.eqb
+             | for_reification.ident.Z_of_nat
+               => AppIdent ident.Z.of_nat
+             | for_reification.ident.List_seq
+               => ltac:(
+                    let v
+                        :=
+                        reify
+                          (@expr var)
+                          (fun start_len : nat * nat
+                           => nat_rect
+                                (fun _ => nat -> list nat)
+                                (fun _ => nil)
+                                (fun len seq_len start => cons start (seq_len (S start)))
+                                (snd start_len) (fst start_len)) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_repeat A
+               => ltac:(
+                    let v := reify
+                               (@expr var)
+                               (fun (xn : type.interp A * nat)
+                                => nat_rect
+                                     (fun _ => list (type.interp A))
+                                     nil
+                                     (fun k repeat_k => cons (fst xn) repeat_k)
+                                     (snd xn)) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_combine A B
+               => ltac:(
+                    let v := reify
+                               (@expr var)
+                               (fun '((ls1, ls2) : list (type.interp A) * list (type.interp B))
+                                => list_rect
+                                     (fun _ => list (type.interp B) -> list (type.interp A * type.interp B))
+                                     (fun l' => nil)
+                                     (fun x tl combine_tl rest
+                                      => list_rect
+                                           (fun _ => list (type.interp A * type.interp B))
+                                           nil
+                                           (fun y tl' _
+                                            => (x, y) :: combine_tl tl')
+                                           rest)
+                                     ls1
+                                     ls2) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_map A B
+               => ltac:(
+                    let v := reify
+                               (@expr var)
+                               (fun '((f, ls) : (type.interp A -> type.interp B) * Datatypes.list (type.interp A))
+                                => list_rect
+                                     (fun _ => list (type.interp B))
+                                     nil
+                                     (fun a t map_t => f a :: map_t)
+                                     ls) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_flat_map A B
+               => ltac:(
+                    let List_app := (eval cbv [List_app] in (List_app B)) in
+                    let v := reify
+                               (@expr var)
+                               (fun '((f, ls) : (type.interp A -> list (type.interp B)) * list (type.interp A))
+                                => list_rect
+                                     (fun _ => list (type.interp B))
+                                     nil
+                                     (fun x t flat_map_t => List_app (f x) flat_map_t)
+                                     ls) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_partition A
+               => ltac:(
+                    let v := reify
+                               (@expr var)
+                               (fun '((f, ls) : (type.interp A -> bool) * list (type.interp A))
+                                => list_rect
+                                     (fun _ => list (type.interp A) * list (type.interp A))%type
+                                     (nil, nil)
+                                     (fun x tl partition_tl
+                                      => let g := fst partition_tl in
+                                         let d := snd partition_tl in
+                                         if f x then (x :: g, d) else (g, x :: d))
+                                     ls) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_app A
+               => ltac:(
+                    let List_app := (eval cbv [List_app] in (List_app A)) in
+                    let v := reify (@expr var) (fun '(ls1, ls2) => List_app ls1 ls2) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_rev A
+               => ltac:(
+                    let List_app := (eval cbv [List_app] in (List_app A)) in
+                    let v := reify
+                               (@expr var)
+                               (fun ls
+                                => list_rect
+                                     (fun _ => list (type.interp A))
+                                     nil
+                                     (fun x l' rev_l' => List_app rev_l' [x])
+                                     ls) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_fold_right A B
+               => ltac:(
+                    let v := reify
+                               (@expr var)
+                               (fun '((f, a0, ls)
+                                      : (type.interp B * type.interp A -> type.interp A) * type.interp A * list (type.interp B))
+                                => list_rect
+                                     (fun _ => type.interp A)
+                                     a0
+                                     (fun b t fold_right_t => f (b, fold_right_t))
+                                     ls) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_update_nth T
+               => ltac:(
+                    let v := reify
+                               (@expr var)
+                               (fun '((n, f, ls) : nat * (type.interp T -> type.interp T) * list (type.interp T))
+                                => nat_rect
+                                     (fun _ => list (type.interp T) -> list (type.interp T))
+                                     (fun ls
+                                      => list_rect
+                                           (fun _ => list (type.interp T))
+                                           nil
+                                           (fun x' xs' __ => f x' :: xs')
+                                           ls)
+                                     (fun n' update_nth_n' ls
+                                      => list_rect
+                                           (fun _ => list (type.interp T))
+                                           nil
+                                           (fun x' xs' __ => x' :: update_nth_n' xs')
+                                           ls)
+                                     n
+                                     ls) in
+                    let v := SmartApp v in exact v)
+             | for_reification.ident.List_nth_default T
+               => AppIdent ident.List_nth_default
+             (*ltac:(
                   let v := reify
                              var
                              (fun (default : type.interp T) (l : list (type.interp T)) (n : nat)
@@ -1139,252 +1294,578 @@ Module Compilers.
                                    n
                                    l) in
                   exact v)*)
-           end%expr.
-    End ident.
+             end%expr.
+      End ident.
 
-    Module expr.
-      Section with_var.
-        Context {var : type -> Type}.
+      Module expr.
+        Section with_var.
+          Context {var : type -> Type}.
 
-        Fixpoint transfer {t} (e : @for_reification.Notations.expr var t)
-          : @expr var t
-          := match e  with
-             | Var t v => Var v
-             | Ident t idc => @ident.transfer var t idc
-             | App s d f x => App (@transfer _ f) (@transfer _ x)
-             | Abs s d f => Abs (fun x => @transfer d (f x))
-             end.
-      End with_var.
+          Fixpoint transfer {t} (e : @for_reification.Notations.expr var t)
+            : @expr var t
+            := match e  with
+               | Var t v => Var v
+               | TT => TT
+               | Pair A B a b => Pair (@transfer A a) (@transfer B b)
+               | AppIdent s d idc args => @ident.transfer var s d idc (@transfer _ args)
+               | App s d f x => App (@transfer _ f) (@transfer _ x)
+               | Abs s d f => Abs (fun x => @transfer d (f x))
+               end.
+        End with_var.
 
-      Definition Transfer {t} (e : for_reification.Notations.Expr t) : Expr t
-        := fun var => transfer (e _).
-    End expr.
-  End canonicalize_list_recursion.
-  Notation canonicalize_list_recursion := canonicalize_list_recursion.expr.Transfer.
-  Import expr.
-  Import expr.default.
+        Definition Transfer {t} (e : for_reification.Notations.Expr t) : Expr t
+          := fun var => transfer (e _).
+      End expr.
+    End canonicalize_list_recursion.
+    Notation canonicalize_list_recursion := canonicalize_list_recursion.expr.Transfer.
+    Export expr.
+    Export expr.default.
+  End Uncurried.
 
   Module CPS.
+    Import Uncurried.
+    Module Import Output.
+      Module type.
+        Import Compilers.type.
+        Inductive type := type_primitive (_:primitive) | prod (A B : type) | continuation (A : type) | list (A : type).
+        Module Export Coercions.
+          Global Coercion type_primitive : primitive >-> type.
+        End Coercions.
+
+        Module Export Notations.
+          Export Coercions.
+          Delimit Scope cpstype_scope with cpstype.
+          Bind Scope cpstype_scope with type.
+          Notation "()" := unit : cpstype_scope.
+          Notation "A * B" := (prod A B) : cpstype_scope.
+          Notation "A --->" := (continuation A) : cpstype_scope.
+          Notation type := type.
+        End Notations.
+
+        Section interp.
+          Context (R : Type).
+          Fixpoint interp (t : type)
+            := match t return Type with
+               | type_primitive t => Compilers.type.interp t
+               | prod A B => interp A * interp B
+               | continuation A => interp A -> R
+               | list A => Datatypes.list (interp A)
+               end%type.
+        End interp.
+      End type.
+      Export type.Notations.
+
+      Module expr.
+        Section expr.
+          Context {ident : type -> Type} {var : type -> Type} {R : type}.
+
+          Inductive expr :=
+          | Halt (v : var R)
+          | App {A} (f : var (A --->)) (x : var A)
+          | Bind {A} (x : primop A) (f : var A -> expr)
+          with
+          primop : type -> Type :=
+          | Var {t} (v : var t) : primop t
+          | Abs {t} (f : var t -> expr) : primop (t --->)
+          | Pair {A B} (x : var A) (y : var B) : primop (A * B)
+          | Fst {A B} (x : var (A * B)) : primop A
+          | Snd {A B} (x : var (A * B)) : primop B
+          | TT : primop ()
+          | Ident {t} (idc : ident t) : primop t.
+        End expr.
+        Global Arguments expr {ident var} R.
+        Global Arguments primop {ident var} R _.
+
+        Definition Expr {ident : type -> Type} R := forall var, @expr ident var R.
+
+        Section with_ident.
+          Context {ident : type -> Type}
+                  (r : type)
+                  (R : Type)
+                  (interp_ident
+                   : forall t, ident t -> type.interp R t).
+
+          Fixpoint interp (e : @expr ident (type.interp R) r) (k : type.interp R r -> R)
+                   {struct e}
+            : R
+            := match e with
+               | Halt v => k v
+               | App A f x => f x
+               | Bind A x f => interp (f (@interp_primop _ x k)) k
+               end
+          with interp_primop {t} (e : @primop ident (type.interp R) r t) (k : type.interp R r -> R)
+                             {struct e}
+               : type.interp R t
+               := match e with
+                  | Var t v => v
+                  | Abs t f => fun x : type.interp _ t => interp (f x) k
+                  | Pair A B x y => (x, y)
+                  | Fst A B x => fst x
+                  | Snd A B x => snd x
+                  | TT => tt
+                  | Ident t idc => interp_ident t idc
+                  end.
+
+          Definition Interp (e : Expr r) (k : type.interp R r -> R) : R := interp (e _) k.
+        End with_ident.
+
+        Module Export Notations.
+          Delimit Scope cpsexpr_scope with cpsexpr.
+          Bind Scope cpsexpr_scope with expr.
+          Bind Scope cpsexpr_scope with primop.
+
+          Infix "@" := App : cpsexpr_scope.
+          Notation "v <- x ; f" := (Bind x (fun v => f)) : cpsexpr_scope.
+          Notation "'λ'  x .. y , t" := (Abs (fun x => .. (Abs (fun y => t%cpsexpr)) ..)) : cpsexpr_scope.
+          Notation "( x , y , .. , z )" := (Pair .. (Pair x%cpsexpr y%cpsexpr) .. z%cpsexpr) : cpsexpr_scope.
+        Notation "( )" := TT : cpsexpr_scope.
+        Notation "()" := TT : cpsexpr_scope.
+        End Notations.
+      End expr.
+      Export expr.Notations.
+    End Output.
+
     Module type.
-      Import Compilers.type.
       Section translate.
-        Context (R : type).
-        Fixpoint translate (t : type) : type
+        Fixpoint translate (t : Compilers.type.type) : type
           := match t with
-             | A * B => translate A * translate B
-             | s -> d => translate s -> (translate d -> R) -> R
-             | list A => list (translate A)
-             | type_primitive _ as t
+             | A * B => (translate A * translate B)%cpstype
+             | s -> d => (translate s * (translate d --->) --->)%cpstype
+             | Compilers.type.list A => type.list (translate A)
+             | Compilers.type.type_primitive t
                => t
              end%ctype.
+        Fixpoint untranslate (R : Compilers.type.type) (t : type)
+          : Compilers.type.type
+          := match t with
+             | type.type_primitive t => t
+             | A * B => (untranslate R A * untranslate R B)%ctype
+             | (t --->)
+               => (untranslate R t -> R)%ctype
+             | type.list A => Compilers.type.list (untranslate R A)
+             end%cpstype.
       End translate.
     End type.
 
-    Module ident.
-      Section with_var.
-        Context {var : type -> Type}.
-        Let Ident' := @Ident ident var.
-        Local Coercion Ident' : ident >-> expr.
-
-        Definition translate {t} {R}
-                 (idc : ident t)
-                 (k : @expr var (type.translate R t) -> @expr var R)
-          : @expr var R
-          := match idc in ident.ident t return (expr (type.translate R t) -> expr R) -> expr R with
-             | ident.primitive _ _ as idc
-               => fun k => k idc
-             | ident.nil t
-               => fun k => k (@ident.nil (type.translate R t))
-             | ident.Let_In tx tC as idc
-               => fun k
-                  => k (λ (x : var (type.translate R tx))
-                          (xk :
-                             (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (((type.translate _ tx -> ((type.translate _ tC -> R) -> R)) -> ((type.translate _ tC -> R) -> R)) -> R)) ,
-                        Var xk @ (λ f fk,
-                                  ident.Let_In
-                                    @ Var x
-                                    @ (λ x, Var f @ Var x @ Var fk)))
-             | ident.Nat_succ as idc
-             | ident.pred as idc
-             | ident.Z_opp as idc
-             | ident.Z_of_nat as idc
-               => fun k
-                  => k (λ x k, Var k @ (idc @ Var x))
-             | ident.cons t as idc
-               => fun k
-                  => k (λ (x : var (type.translate R t))
-                          (xk :
-                             (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var ((type.list (type.translate _ t) -> ((type.list (type.translate _ t) -> R) -> R)) -> R)),
-                        Var xk @ (λ xs k,
-                                  Var k @ (ident.cons @ Var x @ Var xs)))
-             | ident.pair A B
-               => fun k
-                  => k (λ (x : var (type.translate R A))
-                          (xk :
-                             (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var ((type.translate _ B -> ((type.translate _ A * type.translate _ B -> R) -> R)) -> R)),
-                        Var xk @ (λ y k,
-                                  Var k @ (Var x, Var y)))
-             | ident.fst A B
-               => fun k
-                  => k (λ (x : var (type.translate R A * type.translate R B))
-                          (k : var (type.translate _ A -> R)),
-                        Var k @ (ident.fst @ Var x))
-             | ident.snd A B
-               => fun k
-                  => k (λ (x : var (type.translate R A * type.translate R B))
-                          (k : var (type.translate _ B -> R)),
-                        Var k @ (ident.snd @ Var x))
-             | ident.bool_rect T
-               => fun k
-                  => k (λ (true_case : var (type.translate R T))
-                          (k0 :
-                             (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var ((type.translate R T -> ((type.bool -> (type.translate R T -> R) -> R) -> R) -> R) -> R)),
-                        Var k0 @ (λ false_case k1,
-                                  Var k1 @ (λ b k,
-                                            ident.bool_rect
-                                              @ (Var k @ Var true_case)
-                                              @ (Var k @ Var false_case)
-                                              @ Var b)))
-             | ident.nat_rect P
-               => fun k
-                  => k (λ (O_case : var (type.translate R P))
-                          (k0 :
-                             (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (((type.nat -> ((type.translate R P -> (type.translate R P -> R) -> R) -> R) -> R) -> ((type.nat -> (type.translate R P -> R) -> R) -> R) -> R) -> R)),
-                        Var k0 @ (λ S_case k1,
-                                  Var k1 @ (λ n k,
-                                            (@ident.nat_rect ((type.translate R P -> R) -> R))
-                                              @ (λ k, Var k @ Var O_case)
-                                              @ (λ n' rec k,
-                                                 (Var rec)
-                                                   @ (λ rec,
-                                                      (Var S_case)
-                                                        @ (Var n')
-                                                        @ (λ K, Var K @ Var rec @ Var k)))
-                                              @ (Var n)
-                                              @ (Var k))))
-             | ident.list_rect A P
-               => fun k
-                  => k (λ (nil_case : var (type.translate R P))
-                          (k0 :
-                             (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (((type.translate R A -> ((type.list (type.translate R A) -> ((type.translate R P -> (type.translate R P -> R) -> R) -> R) -> R) -> R) -> R) -> ((type.list (type.translate R A) -> (type.translate R P -> R) -> R) -> R) -> R) -> R)),
-                        (Var k0)
-                          @ (λ cons_case k1,
-                             (Var k1)
-                               @ (λ ls k,
-                                  (@ident.list_rect _ ((type.translate R P -> R) -> R))
-                                    @ (λ k, Var k @ Var nil_case)
-                                    @ (λ x xs rec k,
-                                       (Var rec)
-                                         @ (λ rec,
-                                            (Var cons_case)
-                                              @ (Var x)
-                                              @ (λ K,
-                                                 (Var K)
-                                                   @ (Var xs)
-                                                   @ (λ K, Var K @ Var rec @ Var k))))
-                                    @ (Var ls)
-                                    @ (Var k))))
-             | ident.List_nth_default A
-               => fun k
-                  => k (λ (default : var (type.translate R A))
-                          (k0 :
-                             (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var ((type.list (type.translate R A) -> ((type.nat -> (type.translate R A -> R) -> R) -> R) -> R) -> R)),
-                        (Var k0)
-                          @ (λ ls k1,
-                             (Var k1)
-                               @ (λ n k,
-                                  Var k @ (ident.List.nth_default @ Var default @ Var ls @ Var n))))
-             | ident.Z_runtime_mul as idc
-             | ident.Z_runtime_add as idc
-             | ident.Z_add as idc
-             | ident.Z_mul as idc
-             | ident.Z_pow as idc
-             | ident.Z_div as idc
-             | ident.Z_modulo as idc
-             | ident.Z_eqb as idc
-               => fun k
-                  => k (λ x xk,
-                        (Var xk)
-                          @ (λ y yk,
-                             (Var yk @ (idc @ Var x @ Var y))))
-             end%expr k.
-      End with_var.
-    End ident.
-
     Module expr.
-      Section with_var.
-        Context {var : type -> Type}.
-        Notation var' R := (fun t => var (type.translate R t)).
-        Section with_R.
-          Context {R : type}.
+      Import Output.expr.
+      Import Output.expr.Notations.
+      Import Compilers.type.
+      Import Compilers.Uncurried.expr.
+      Section with_ident.
+        Context {ident : Output.type.type -> Type}
+                {ident' : type -> type -> Type}
+                {var : Output.type.type -> Type}
+                (translate_ident : forall s d, ident' s d -> ident (type.translate (s -> d))).
+        Notation var' := (fun t => var (type.translate t)).
+        Local Notation oexpr := (@Output.expr.expr ident var).
 
-          Fixpoint translate {t}
-                   (e : @expr (var' R) t)
-                   (k : @expr var (type.translate R t) -> @expr var R)
-                   {struct e}
-            : @expr var R
-            := match e in expr.expr t return (expr (type.translate R t) -> expr R) -> expr R with
-               | Var t v
-                 => fun k => k (Var v)
-               | Ident t idc => ident.translate idc
-               | App s d f x
-                 => fun k
-                    => @translate
-                         _ f
-                         (fun fv
-                          => @translate
-                               _ x
-                               (fun xv
-                                => App (App fv xv) (Abs (fun v => k (Var v)))))
-               | Abs s d f
-                 => fun k
-                    => k (Abs (fun (x : var (type.translate R s))
-                               => Abs (fun (k : var (type.translate _ _ -> _))
-                                       => @translate
-                                            _ (f x)
-                                            (fun v => App (Var k) v))))
-               end k.
+        Section splice.
+          Context {r1 r2 : Output.type.type}.
+          Fixpoint splice  (e1 : oexpr r1) (e2 : var r1 -> oexpr r2)
+                   {struct e1}
+            : oexpr r2
+            := match e1 with
+               | Halt v => e2 v
+               | f @ x => f @ x
+               | Bind A x f => v <- @splice_primop _ x e2; @splice (f v) e2
+               end%cpsexpr
+          with
+          splice_primop {t} (f : @primop ident var r1 t) (e2 : var r1 -> oexpr r2)
+                        {struct f}
+          : @primop ident var r2 t
+          := match f with
+             | Output.expr.Var t v => Output.expr.Var v
+             | Output.expr.Pair A B x y as e => Output.expr.Pair x y
+             | Output.expr.Fst A B x => Output.expr.Fst x
+             | Output.expr.Snd A B x => Output.expr.Snd x
+             | Output.expr.TT => Output.expr.TT
+             | Output.expr.Ident t idc => Output.expr.Ident idc
+             | Output.expr.Abs t f
+               => Output.expr.Abs (fun x => @splice (f x) e2)
+             end.
+        End splice.
 
-          Fixpoint collect_translation_function_types t
-            := match t return Type with
-               | type.arrow s d
-                 => collect_translation_function_types d
-                    * (var s -> var (type.translate R s))
-               | _ => unit
-               end%type.
-        End with_R.
+        Local Notation "x <-- e1 ; e2" := (splice e1 (fun x => e2%cpsexpr)) : cpsexpr_scope.
 
-        Fixpoint translate_under_binders {t}
-                 (R:=type.final_codomain t)
-                 (e : @expr (var' R) t)
-                 (k_vars : @collect_translation_function_types (type.final_codomain t) t)
-                 (k : @expr var (type.translate R (type.final_codomain t)) -> @expr var R)
-                 {struct t}
-          : @expr var t
-          := match t return @expr (var' (type.final_codomain t)) t -> (collect_translation_function_types t) -> (expr (type.translate _ (type.final_codomain t)) -> expr (type.final_codomain t)) -> expr t with
-             | type.arrow s d
-               => fun e '((k_vars, ks) : collect_translation_function_types d * _) k
-                  => Abs (fun x : var s
-                          => @translate_under_binders d (e @ Var (ks x))%expr k_vars k)
-             | t
-               => fun e _ k
-                  => @translate (type.final_codomain t) t e k
-             end e k_vars k.
-      End with_var.
+        Fixpoint translate {t}
+                 (e : @Compilers.Uncurried.expr.expr ident' var' t)
+          : @Output.expr.expr ident var (type.translate t)
+          := match e with
+             | Var t v => Halt v
+             | TT => x <- () ; Halt x
+             | AppIdent s d idc args
+               => (args' <-- @translate _ args;
+                     k <- Output.expr.Abs (fun r => Halt r);
+                     p <- (args', k);
+                     f <- Output.expr.Ident (translate_ident s d idc);
+                     f @ p)
+             | Pair A B a b
+               => (a' <-- @translate _ a;
+                     b' <-- @translate _ b;
+                     p <- (a', b');
+                     Halt p)
+             | App s d e1 e2
+               => (f <-- @translate _ e1;
+                     x <-- @translate _ e2;
+                     k <- Output.expr.Abs (fun r => Halt r);
+                     p <- (x, k);
+                     f @ p)
+             | Abs s d f
+               => f <- (Output.expr.Abs
+                          (fun p
+                           => x <- Fst p;
+                                k <- Snd p;
+                                r <-- @translate _ (f x);
+                                k @ r));
+                    Halt f
+             end%cpsexpr.
+      End with_ident.
 
-      Definition Translate {R t} (e : Expr t) (k : forall var, @expr var (type.translate R t) -> @expr var R)
-        : Expr R
-        := fun var => @translate var R t (e _) (k _).
+      Definition Translate
+                 {ident : Output.type.type -> Type}
+                 {ident' : type -> type -> Type}
+                 (translate_ident : forall s d, ident' s d -> ident (type.translate (s -> d)))
+                 {t} (e : @Compilers.Uncurried.expr.Expr ident' t)
+        : @Output.expr.Expr ident (type.translate t)
+        := fun var => translate translate_ident (e _).
 
-      Definition TranslateUnderBinders {t} (e : Expr t)
-                 (k : forall var,
-                     @collect_translation_function_types var (type.final_codomain t) t
-                     * (@expr var (type.translate (type.final_codomain t) (type.final_codomain t)) -> @expr var (type.final_codomain t)))
-        : Expr t
-        := fun var => @translate_under_binders var t (e _) (fst (k _)) (snd (k _)).
+      Section call_with_cont.
+        Context {ident' : Output.type.type -> Type}
+                {ident : type -> type -> Type}
+                {var : type -> Type}
+                {r : Output.type.type}
+                {R : type}.
+        Notation ucexpr := (@Compilers.Uncurried.expr.expr ident var).
+        Notation ucexprut t := (ucexpr (type.untranslate R t)) (only parsing).
+        Notation var' := (fun t => ucexprut t).
+        Context (untranslate_ident : forall t, ident' t -> ucexprut t)
+                (ifst : forall A B, ident (A * B)%ctype A)
+                (isnd : forall A B, ident (A * B)%ctype B).
+
+        Fixpoint call_with_continuation
+                 (e : @Output.expr.expr ident' var' r)
+                 (k : ucexprut r -> ucexpr R)
+                 {struct e}
+          : ucexpr R
+          := match e with
+             | Halt v => k v
+             | expr.App A f x
+               => @App _ _ (type.untranslate R A) R
+                       f x
+             | Bind A x f
+               => @call_with_continuation
+                    (f (@call_primop_with_continuation A x k))
+                    k
+             end%expr
+        with
+        call_primop_with_continuation
+          {t}
+          (e : @Output.expr.primop ident' var' r t)
+          (k : ucexprut r -> ucexpr R)
+          {struct e}
+        : ucexprut t
+        := match e in Output.expr.primop _ t return ucexprut t with
+           | expr.Var t v => v
+           | expr.Abs t f => Abs (fun x : var (type.untranslate _ _)
+                                  => @call_with_continuation
+                                       (f (Var x)) k)
+           | expr.Pair A B x y => (x, y)
+           | Fst A B x => ifst (type.untranslate _ A) (type.untranslate _ B)
+                               @@ x
+           | Snd A B x => isnd (type.untranslate _ A) (type.untranslate _ B)
+                               @@ x
+           | expr.TT => TT
+           | Ident t idc => untranslate_ident t idc
+           end%expr.
+      End call_with_cont.
+
+      Definition CallWithContinuation
+                 {ident' : Output.type.type -> Type}
+                 {ident : type -> type -> Type}
+                 {R : type}
+                 (untranslate_ident : forall t, ident' t -> @Compilers.Uncurried.expr.Expr ident (type.untranslate R t))
+                 (ifst : forall A B, ident (A * B)%ctype A)
+                 (isnd : forall A B, ident (A * B)%ctype B)
+                 {t} (e : @Output.expr.Expr ident' t)
+                 (k : forall var, @Uncurried.expr.expr ident var (type.untranslate R t) -> @Uncurried.expr.expr ident var R)
+        : @Compilers.Uncurried.expr.Expr ident R
+        := fun var => call_with_continuation
+                        (fun t idc => untranslate_ident t idc _) ifst isnd (e _) (k _).
     End expr.
+
+    Module ident.
+      Import CPS.Output.type.
+      Inductive ident : type -> Set :=
+      | wrap {s d} (idc : Uncurried.expr.default.ident s d) : ident (type.translate (s -> d)).
+
+      Notation cps_of f
+        := (fun x k => k (f x)).
+      Notation curry0 f
+        := (fun 'tt => f).
+      Notation curry2 f
+        := (fun '(a, b) => f a b).
+      Notation curry3 f
+        := (fun '(a, b, c) => f a b c).
+      Notation uncurry2 f
+        := (fun a b => f (a, b)).
+      Notation uncurry3 f
+        := (fun a b c => f (a, b, c)).
+      Notation curry3_23 f
+        := (fun '(a, b, c) => f a (uncurry3 b) c).
+      Notation curry3_2 f
+        := (fun '(a, b, c) => f a (uncurry2 b) c).
+
+      Definition interp {R} {t} (idc : ident t) : type.interp R t
+        := match idc in ident t return type.interp R t with
+           | wrap s d idc
+             => fun '((x, k) : type.interp R (type.translate s) * (type.interp R (type.translate d) -> R))
+                =>
+                  match idc in Uncurried.expr.default.ident s d return type.interp R (type.translate s) -> (type.interp R (type.translate d) -> R) -> R with
+                  | ident.primitive _ _ as idc
+                  | ident.Nat_succ as idc
+                  | ident.pred as idc
+                  | ident.Z_runtime_mul as idc
+                  | ident.Z_runtime_add as idc
+                  | ident.Z_add as idc
+                  | ident.Z_mul as idc
+                  | ident.Z_pow as idc
+                  | ident.Z_opp as idc
+                  | ident.Z_div as idc
+                  | ident.Z_modulo as idc
+                  | ident.Z_eqb as idc
+                  | ident.Z_of_nat as idc
+                    => cps_of (Uncurried.expr.default.ident.interp idc)
+                  | ident.Let_In tx tC
+                    => fun '((x, f) : (interp R (type.translate tx)
+                                       * (interp R (type.translate tx) * (interp R (type.translate tC) -> R) -> R)))
+                           (k : interp R (type.translate tC) -> R)
+                       => @LetIn.Let_In
+                            (type.interp R (type.translate tx)) (fun _ => R)
+                            x
+                            (fun v => f (v, k))
+                  | ident.nil t
+                    => cps_of (curry0 (@Datatypes.nil (interp R (type.translate t))))
+                  | ident.cons t
+                    => cps_of (curry2 (@Datatypes.cons (interp R (type.translate t))))
+                  | ident.fst A B
+                    => cps_of (@Datatypes.fst (interp R (type.translate A)) (interp R (type.translate B)))
+                  | ident.snd A B
+                    => cps_of (@Datatypes.snd (interp R (type.translate A)) (interp R (type.translate B)))
+                  | ident.bool_rect T
+                    => fun '((tc, fc, b) :
+                               (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) type.interp R (type.translate T) * type.interp R (type.translate T) * bool)
+                           k
+                       => @Datatypes.bool_rect
+                            (fun _ => R)
+                            (k tc)
+                            (k fc)
+                            b
+                  | ident.nat_rect P
+                    => fun '((PO, PS, n) :
+                               (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) interp R (type.translate P) * (nat * interp R (type.translate P) * (interp R (type.translate P) -> R) -> R) * nat)
+                           k
+                       => @Datatypes.nat_rect
+                            (fun _ => (interp R (type.translate P) -> R) -> R)
+                            (fun k => k PO)
+                            (fun n' rec k
+                             => rec (fun rec => PS (n', rec, k)))
+                            n
+                            k
+                  | ident.list_rect A P
+                    => fun '((Pnil, Pcons, ls) :
+                               (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) interp R (type.translate P) * (interp R (type.translate A) * Datatypes.list (interp R (type.translate A)) * interp R (type.translate P) * (interp R (type.translate P) -> R) -> R) * Datatypes.list (interp R (type.translate A)))
+                           k
+                       => @Datatypes.list_rect
+                            (interp R (type.translate A))
+                            (fun _ => (interp R (type.translate P) -> R) -> R)
+                            (fun k => k Pnil)
+                            (fun x xs rec k
+                             => rec (fun rec => Pcons (x, xs, rec, k)))
+                            ls
+                            k
+                  | ident.List_nth_default T
+                    => cps_of (curry3 (@List.nth_default (interp R (type.translate T))))
+                  end x k
+           end.
+
+      Local Notation var_eta x := (ident.fst @@ x, ident.snd @@ x)%core%expr.
+
+      Definition untranslate {R} {t} (idc : ident t)
+        : @Compilers.Uncurried.expr.Expr Uncurried.expr.default.ident (type.untranslate R t)
+        := fun var
+           => match idc in ident t return Compilers.Uncurried.expr.expr (type.untranslate _ t) with
+              | wrap s d idc
+                =>
+                match idc in default.ident s d return Compilers.Uncurried.expr.expr (type.untranslate _ (type.translate (s -> d))) with
+                | ident.primitive t v
+                  => λ (_k :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (() * (t -> R))%ctype) ,
+                     (ident.snd @@ (Var _k))
+                       @ (ident.primitive v @@ TT)
+                | ident.Let_In tx tC
+                  => λ (xyk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate tx) * (type.untranslate _ (type.translate tx) * (type.untranslate _ (type.translate tC) -> R) -> R) * (type.untranslate _ (type.translate tC) -> R))%ctype) ,
+                     ident.Let_In
+                       @@ (ident.fst @@ (ident.fst @@ (Var xyk)),
+                           (λ (x :
+                                 (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate tx))) ,
+                            (ident.snd @@ (ident.fst @@ (Var xyk)))
+                              @ (Var x, ident.snd @@ Var xyk)))
+                | ident.nat_rect P
+                  => λ (PO_PS_n_k :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate P) * (type.nat * type.untranslate _ (type.translate P) * (type.untranslate _ (type.translate P) -> R) -> R) * type.nat * (type.untranslate _ (type.translate P) -> R))%ctype) ,
+                     let (PO_PS_n, k) := var_eta (Var PO_PS_n_k) in
+                     let (PO_PS, n) := var_eta PO_PS_n in
+                     let (PO, PS) := var_eta PO_PS in
+                     ((@ident.nat_rect ((type.untranslate _ (type.translate P) -> R) -> R))
+                        @@ ((λ k , Var k @ PO),
+                            (λ n'rec k ,
+                             let (n', rec) := var_eta (Var n'rec) in
+                             rec @ (λ rec , PS @ (n', Var rec, Var k))),
+                            n))
+                       @ k
+                | ident.list_rect A P
+                  => λ (Pnil_Pcons_ls_k :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate P) * (type.untranslate _ (type.translate A) * Compilers.type.list (type.untranslate _ (type.translate A)) * type.untranslate _ (type.translate P) * (type.untranslate _ (type.translate P) -> R) -> R) * Compilers.type.list (type.untranslate _ (type.translate A)) * (type.untranslate _ (type.translate P) -> R))%ctype) ,
+                     let (Pnil_Pcons_ls, k) := var_eta (Var Pnil_Pcons_ls_k) in
+                     let (Pnil_Pcons, ls) := var_eta Pnil_Pcons_ls in
+                     let (Pnil, Pcons) := var_eta Pnil_Pcons in
+                     ((@ident.list_rect
+                         (type.untranslate _ (type.translate A))
+                         ((type.untranslate _ (type.translate P) -> R) -> R))
+                        @@ ((λ k, Var k @ Pnil),
+                            (λ x_xs_rec k,
+                             let (x_xs, rec) := var_eta (Var x_xs_rec) in
+                             let (x, xs) := var_eta x_xs in
+                             rec @ (λ rec , Pcons @ (x, xs, Var rec, Var k))),
+                            ls))
+                       @ k
+                | ident.List_nth_default T
+                  => λ (xyzk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate T) * Compilers.type.list (type.untranslate _ (type.translate T)) * type.nat * (type.untranslate _ (type.translate T) -> R))%ctype) ,
+                     (ident.snd @@ Var xyzk)
+                       @ (ident.List_nth_default @@ (ident.fst @@ Var xyzk))
+                | ident.bool_rect T
+                  => λ (xyzk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate T) * type.untranslate _ (type.translate T) * type.bool * (type.untranslate _ (type.translate T) -> R))%ctype) ,
+                     ident.bool_rect
+                       @@ ((ident.snd @@ (Var xyzk))
+                             @ (ident.fst @@ (ident.fst @@ (ident.fst @@ (Var xyzk)))),
+                           (ident.snd @@ (Var xyzk))
+                             @ (ident.snd @@ (ident.fst @@ (ident.fst @@ (Var xyzk)))),
+                           ident.snd @@ (ident.fst @@ (Var xyzk)))
+                | ident.nil t
+                  => λ (_k :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (() * (Compilers.type.list (type.untranslate _ (type.translate t)) -> R))%ctype) ,
+                     (ident.snd @@ (Var _k))
+                       @ (ident.nil @@ TT)
+                | ident.cons t
+                  => λ (xyk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate t) * Compilers.type.list (type.untranslate _ (type.translate t)) * (Compilers.type.list (type.untranslate _ (type.translate t)) -> R))%ctype) ,
+                     (ident.snd @@ (Var xyk))
+                       @ (ident.cons
+                            @@ (ident.fst @@ (Var xyk)))
+                | ident.fst A B
+                  => λ (xk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate A) * type.untranslate _ (type.translate B) * (type.untranslate _ (type.translate A) -> R))%ctype) ,
+                     (ident.snd @@ (Var xk))
+                       @ (ident.fst
+                            @@ (ident.fst @@ (Var xk)))
+                | ident.snd A B
+                  => λ (xk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.untranslate _ (type.translate A) * type.untranslate _ (type.translate B) * (type.untranslate _ (type.translate B) -> R))%ctype) ,
+                     (ident.snd @@ (Var xk))
+                       @ (ident.snd
+                            @@ (ident.fst @@ (Var xk)))
+                | ident.Nat_succ as idc
+                | ident.pred as idc
+                  => λ (xyk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.nat * (type.nat -> R))%ctype) ,
+                     (ident.snd @@ (Var xyk))
+                       @ ((idc : default.ident _ type.nat)
+                            @@ (ident.fst @@ (Var xyk)))
+                | ident.Z_opp as idc
+                  => λ (xyk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.Z * (type.Z -> R))%ctype) ,
+                     (ident.snd @@ (Var xyk))
+                       @ ((idc : default.ident _ type.Z)
+                            @@ (ident.fst @@ (Var xyk)))
+                | ident.Z_runtime_mul as idc
+                | ident.Z_runtime_add as idc
+                | ident.Z_add as idc
+                | ident.Z_mul as idc
+                | ident.Z_pow as idc
+                | ident.Z_div as idc
+                | ident.Z_modulo as idc
+                  => λ (xyk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.Z * type.Z * (type.Z -> R))%ctype) ,
+                     (ident.snd @@ (Var xyk))
+                       @ ((idc : default.ident _ type.Z)
+                            @@ (ident.fst @@ (Var xyk)))
+                | ident.Z_eqb as idc
+                  => λ (xyk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.Z * type.Z * (type.bool -> R))%ctype) ,
+                     (ident.snd @@ (Var xyk))
+                       @ ((idc : default.ident _ type.bool)
+                            @@ (ident.fst @@ (Var xyk)))
+                | ident.Z_of_nat as idc
+                  => λ (xyk :
+                          (* ignore this line; it's to work around lack of fixpoint refolding in type inference *) var (type.nat * (type.Z -> R))%ctype) ,
+                     (ident.snd @@ (Var xyk))
+                       @ ((idc : default.ident _ type.Z)
+                            @@ (ident.fst @@ (Var xyk)))
+                end%expr
+              end.
+    End ident.
+    Notation ident := ident.ident.
+
+    Module default.
+      Notation expr := (@Output.expr.expr ident).
+      Notation Expr := (@Output.expr.Expr ident).
+
+      Definition Translate
+                 {t} (e : @Compilers.Uncurried.expr.default.Expr t)
+        : Expr (type.translate t)
+        := expr.Translate (@ident.wrap) e.
+
+      Definition call_with_continuation
+                 {var}
+                 {R : Compilers.type.type}
+                 {t} (e : @expr _ t)
+                 (k : @Uncurried.expr.default.expr var (type.untranslate R t) -> @Uncurried.expr.default.expr var R)
+        : @Compilers.Uncurried.expr.default.expr var R
+        := expr.call_with_continuation (fun t idc => @ident.untranslate _ t idc _) (@ident.fst) (@ident.snd) e k.
+
+      Definition CallWithContinuation
+                 {R : Compilers.type.type}
+                 {t} (e : Expr t)
+                 (k : forall var, @Uncurried.expr.default.expr var (type.untranslate R t) -> @Uncurried.expr.default.expr var R)
+        : @Compilers.Uncurried.expr.default.Expr R
+        := expr.CallWithContinuation (@ident.untranslate _) (@ident.fst) (@ident.snd) e k.
+
+      Definition CallFunWithIdContinuation'
+                 {R}
+                 {s d} (e : Expr (type.translate (s -> d)))
+                 (k : forall var, var (type.untranslate R (type.translate d)) -> var R)
+        : @Compilers.Uncurried.expr.default.Expr (type.untranslate R (type.translate s) -> R)
+        := fun var
+           => Abs (fun x => @call_with_continuation
+                              var R _ (e _)
+                              (fun e : expr.default.expr (type.untranslate _ (type.translate s) * (type.untranslate _ (type.translate d) -> _) -> _)
+                               => e @ (Var x, λ v , Var (k _ v)))%expr).
+      Notation CallFunWithIdContinuation e
+        := (@CallFunWithIdContinuation'
+              ((fun s d (e' : Expr (type.translate (s -> d))) => d) _ _ e)
+              _ _
+              e
+              (fun _ => id))
+             (only parsing).
+    End default.
+    Include default.
   End CPS.
 
+  Import Uncurried.
   Section invert.
     Context {var : type -> Type}.
 
@@ -1401,6 +1882,11 @@ Module Compilers.
                    end) (only parsing).
     Local Notation if_arrow_s f := (if_arrow (fun s d => f s)) (only parsing).
     Local Notation if_arrow_d f := (if_arrow (fun s d => f d)) (only parsing).
+    Local Notation if_prod f
+      := (fun t => match t return Type with
+                   | type.prod A B => f A B
+                   | _ => True
+                   end).
 
     Definition invert_Abs {s d} (e : @expr var (type.arrow s d)) : option (var s -> @expr var d)
       := match e in expr.expr t return option (if_arrow (fun _ _ => _) t) with
@@ -1414,20 +1900,11 @@ Module Compilers.
          | _ => None
          end.
 
-    Definition invert_Ident {t} (e : @expr var t) : option (ident t)
+    Definition invert_AppIdent {d} (e : @expr var d) : option { s : _ & @ident s d * @expr var s }%type
       := match e with
-         | Ident t idc => Some idc
+         | AppIdent s d idc args
+           => Some (existT _ s (idc, args))
          | _ => None
-         end.
-
-    Definition invert_AppIdent {d} (e : @expr var d) : option { s : _ & @ident (s -> d) * @expr var s }%type
-      := match invert_App e with
-         | Some (existT s (f, x))
-           => match invert_Ident f with
-              | Some f' => Some (existT _ s (f', x))
-              | None => None
-              end
-         | None => None
          end.
 
     Definition invert_App2 {d} (e : @expr var d) : option { s1s2 : _ * _ & @expr var (fst s1s2 -> snd s1s2 -> d) * @expr var (fst s1s2) * @expr var (snd s1s2) }%type
@@ -1448,30 +1925,19 @@ Module Compilers.
                    end) (only parsing).
 
     Definition invert_Pair {A B} (e : @expr var (type.prod A B)) : option (@expr var A * @expr var B)
-      := match invert_App2 e with
-         | Some (existT (s1, s2) (f, x, y))
-           => match invert_Ident f with
-              | Some idc
-                => match idc in ident t
-                         return if_arrow_s expr t
-                                -> if_arrow_d (if_arrow_s expr) t
-                                -> option (if_arrow_d (if_arrow_d expr_prod) t)
-                   with
-                   | ident.pair A B => fun x y => Some (x, y)
-                   | _ => fun _ _ => None
-                   end x y
-              | None => None
-              end
-         | None => None
+      := match e in expr.expr t return option (if_prod (fun A B => expr A * expr B)%type t) with
+         | Pair A B a b
+           => Some (a, b)
+         | _ => None
          end.
 
     (* if we want more code for the below, I would suggest [reify_base_type] and [reflect_base_type] *)
     Definition reify_primitive {t} (v : type.interp (type.type_primitive t)) : @expr var (type.type_primitive t)
-      := Ident (ident.primitive v).
+      := AppIdent (ident.primitive v) TT.
     Definition reflect_primitive {t} (e : @expr var (type.type_primitive t)) : option (type.interp (type.type_primitive t))
-      := match invert_Ident e with
-         | Some idc
-           => match idc in ident t return option (type.interp t) with
+      := match invert_AppIdent e with
+         | Some (existT s (idc, args))
+           => match idc in ident _ t return option (type.interp t) with
               | ident.primitive _ v => Some v
               | _ => None
               end
@@ -1488,29 +1954,30 @@ Module Compilers.
     Fixpoint reflect_list {t} (e : @expr var (type.list t))
       : option (list (@expr var t))
       := match e in expr.expr t return option (list_expr t) with
-         | Ident t idc
-           => match idc in ident t return option (list_expr t) with
-              | ident.nil _ => Some nil
-              | _ => None
-              end
-         | App (type.list s) d f xs
-               (* WHY reflect xs before x? *)
-           => match @reflect_list s xs return _ with
-              | Some xs
-                => match invert_AppIdent f return option (list_expr d) with
-                   | Some (existT s' (idc, x))
-                     => match idc in ident t
-                              return if_arrow_s expr t
-                                     -> if_arrow_d (if_arrow_s list_expr) t
-                                     -> option (if_arrow_d (if_arrow_d list_expr) t)
-                        with
-                        | ident.cons A => fun x xs => Some (cons x xs)
-                        | _ => fun _ _ => None
-                        end x xs
-                   | _ => None
+         | AppIdent s (type.list t) idc x_xs
+           => match x_xs in expr.expr s return ident s (type.list t) -> option (list (expr t)) with
+              | Pair A (type.list B) x xs
+                => match @reflect_list B xs with
+                   | Some xs
+                     => fun idc
+                        => match idc in ident s d
+                                 return if_prod (fun A B => expr A) s
+                                        -> if_prod (fun A B => list_expr B) s
+                                        -> option (list_expr d)
+                           with
+                           | ident.cons A
+                             => fun x xs => Some (cons x xs)
+                           | _ => fun _ _ => None
+                           end x xs
+                   | None => fun _ => None
                    end
-              | None => None
-              end
+              | _
+                => fun idc
+                   => match idc in ident _ t return option (list_expr t) with
+                      | ident.nil _ => Some nil
+                      | _ => None
+                      end
+              end idc
          | _ => None
          end.
   End invert.
@@ -1520,8 +1987,8 @@ Module Compilers.
     Definition reify_list {t} (ls : list (@expr var t)) : @expr var (type.list t)
       := list_rect
            (fun _ => _)
-           (Ident ident.nil)
-           (fun x _ xs => App (App (Ident ident.cons) x) xs)
+           (ident.nil @@ TT)%expr
+           (fun x _ xs => ident.cons @@ (x, xs))%expr
            ls.
   End gallina_reify.
 
@@ -1575,8 +2042,8 @@ Module Compilers.
                => fun x : expr t + type.interp t
                   => match x with
                      | inl v => v
-                     | inr v => Ident (ident.primitive v)
-                     end
+                     | inr v => ident.primitive v @@ TT
+                     end%expr
              end
         with reflect {t : type}
              : @expr var t -> value var t
@@ -1636,71 +2103,71 @@ Module Compilers.
                      | inr v => f (inr v) (* FIXME: do not substitute [S (big stuck term)] *)
                      end
              end.
-        Definition interp {t} (idc : ident t) : value var t
-          := match idc in ident t return value var t with
-             | ident.Let_In tx tC
-               => interp_let_in
-             | ident.nil t
-               => inr (@nil (value var t))
-             | ident.primitive t v
-               => inr v
-             | ident.cons t as idc
-               => fun x (xs : expr (type.list t) + list (value var t))
-                  => match xs return expr (type.list t) + list (value var t) with
-                     | inr xs => inr (cons x xs)
-                     | _ => expr.reflect (Ident idc) x xs
+        Definition interp {s d} (idc : ident s d) : value var (s -> d)
+          := match idc in ident s d return value var (s -> d) with
+             | ident.Let_In tx tC as idc
+               => fun (xf : expr (tx * (tx -> tC)) + value var tx * value var (tx -> tC))
+                  => match xf with
+                     | inr (x, f) => interp_let_in x f
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=tx * (tx -> tC)) xf))
                      end
-             | ident.pair A B as idc
-               => fun x y => @inr _ (value var A * value var B) (x, y)
+             | ident.nil t
+               => fun _ => inr (@nil (value var t))
+             | ident.primitive t v
+               => fun _ => inr v
+             | ident.cons t as idc
+               => fun (x_xs : expr (t * type.list t) + value var t * (expr (type.list t) + list (value var t)))
+                  => match x_xs return expr (type.list t) + list (value var t) with
+                     | inr (x, inr xs) => inr (cons x xs)
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=t * type.list t) x_xs))
+                     end
              | ident.fst A B as idc
                => fun x : expr (A * B) + value var A * value var B
                   => match x with
                      | inr x => fst x
-                     | _ => expr.reflect (Ident idc) x
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=A*B) x))
                      end
              | ident.snd A B as idc
                => fun x : expr (A * B) + value var A * value var B
                   => match x with
                      | inr x => snd x
-                     | _ => expr.reflect (Ident idc) x
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=A*B) x))
                      end
              | ident.bool_rect T as idc
-               => fun true_case false_case (b : expr type.bool + bool)
-                  => match b with
-                     | inr b => @bool_rect (fun _ => value var T) true_case false_case b
-                     | _ => expr.reflect (Ident idc) true_case false_case b
+               => fun (true_case_false_case_b : expr (T * T * type.bool) + (expr (T * T) + value var T * value var T) * (expr type.bool + bool))
+                  => match true_case_false_case_b with
+                     | inr (inr (true_case, false_case), inr b)
+                       => @bool_rect (fun _ => value var T) true_case false_case b
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=T*T*type.bool) true_case_false_case_b))
                      end
              | ident.nat_rect P as idc
-               => fun (O_case : value var P)
-                      (S_case : expr type.nat + nat -> value var P -> value var P)
-                      (n : expr type.nat + nat)
-                  => match n with
-                     | inr n => @nat_rect (fun _ => value var P)
-                                          O_case
-                                          (fun n' => S_case (inr n'))
-                                          n
-                     | _ => expr.reflect (Ident idc) O_case S_case n
+               => fun (O_case_S_case_n : expr (P * (type.nat * P -> P) * type.nat) + (expr (P * (type.nat * P -> P)) + value var P * value var (type.nat * P -> P)) * (expr type.nat + nat))
+                  => match O_case_S_case_n with
+                     | inr (inr (O_case, S_case), inr n)
+                       => @nat_rect (fun _ => value var P)
+                                    O_case
+                                    (fun n' rec => S_case (inr (inr n', rec)))
+                                    n
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=P * (type.nat * P -> P) * type.nat) O_case_S_case_n))
                      end
              | ident.list_rect A P as idc
-               => fun (nil_case : value var P)
-                      (cons_case : value var A -> expr (type.list A) + list (value var A) -> value var P -> value var P)
-                      (ls : expr (type.list A) + list (value var A))
-                  => match ls with
-                     | inr ls => @list_rect
-                                   (value var A)
-                                   (fun _ => value var P)
-                                   nil_case
-                                   (fun x xs rec => cons_case x (inr xs) rec)
-                                   ls
-                     | _ => expr.reflect (Ident idc) nil_case cons_case ls
+               => fun (nil_case_cons_case_ls : expr (P * (A * type.list A * P -> P) * type.list A) + (expr (P * (A * type.list A * P -> P)) + value var P * value var (A * type.list A * P -> P)) * (expr (type.list A) + list (value var A)))
+                  => match nil_case_cons_case_ls with
+                     | inr (inr (nil_case, cons_case), inr ls)
+                       => @list_rect
+                            (value var A)
+                            (fun _ => value var P)
+                            nil_case
+                            (fun x xs rec => cons_case (inr (inr (x, inr xs), rec)))
+                            ls
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=P * (A * type.list A * P -> P) * type.list A) nil_case_cons_case_ls))
                      end
              | ident.List.nth_default A as idc
-               => fun (default : value var A)
-                      (ls : expr _ + list (value var A))
-                      (idx : expr _ + nat)
-                  => match ls, idx return value var A with
-                     | inr ls, inr idx => List.nth_default default ls idx
-                     | _, _ => expr.reflect (Ident idc) default ls idx
+               => fun (default_ls_idx : expr (A * type.list A * type.nat) + (expr (A * type.list A) + value var A * (expr (type.list A) + list (value var A))) * (expr type.nat + nat))
+                  => match default_ls_idx with
+                     | inr (inr (default, inr ls), inr idx)
+                       => List.nth_default default ls idx
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=A * type.list A * type.nat) default_ls_idx))
                      end
              | ident.pred as idc
              | ident.Nat_succ as idc
@@ -1709,7 +2176,7 @@ Module Compilers.
                => fun x : expr _ + type.interp _
                   => match x return expr _ + type.interp _ with
                      | inr x => inr (ident.interp idc x)
-                     | _ => expr.reflect (Ident idc) x
+                     | inl x => expr.reflect (AppIdent idc x)
                      end
              | ident.Z_add as idc
              | ident.Z_mul as idc
@@ -1717,38 +2184,38 @@ Module Compilers.
              | ident.Z_div as idc
              | ident.Z_modulo as idc
              | ident.Z_eqb as idc
-               => fun (x y : expr _ + type.interp _)
-                  => match x, y return expr _ + type.interp _ with
-                     | inr x, inr y => inr (ident.interp idc x y)
-                     | _, _ => expr.reflect (Ident idc) x y
+               => fun (x_y : expr (_ * _) + (expr _ + type.interp _) * (expr _ + type.interp _))
+                  => match x_y return expr _ + type.interp _ with
+                     | inr (inr x, inr y) => inr (ident.interp idc (x, y))
+                     | _ => expr.reflect (AppIdent idc (expr.reify (t:=_*_) x_y))
                      end
              | ident.Z_runtime_mul as idc
-               => fun (x y : expr _ + type.interp _)
-                  => let default := expr.reflect (Ident idc) x y in
-                     match x, y return expr _ + type.interp _ with
-                     | inr x, inr y => inr (ident.interp idc x y)
-                     | inr x, inl e
-                     | inl e, inr x
+               => fun (x_y : expr (_ * _) + (expr _ + type.interp _) * (expr _ + type.interp _))
+                  => let default := expr.reflect (AppIdent idc (expr.reify (t:=_*_) x_y)) in
+                     match x_y return expr _ + type.interp _ with
+                     | inr (inr x, inr y) => inr (ident.interp idc (x, y))
+                     | inr (inr x, inl e)
+                     | inr (inl e, inr x)
                        => if Z.eqb x 0
                           then inr 0%Z
                           else if Z.eqb x 1
                                then inl e
                                else default
-                     | inl _, inl _ => default
+                     | inr (inl _, inl _) | inl _ => default
                      end
              | ident.Z_runtime_add as idc
-               => fun (x y : expr _ + type.interp _)
-                  => let default := expr.reflect (Ident idc) x y in
-                     match x, y return expr _ + type.interp _ with
-                     | inr x, inr y => inr (ident.interp idc x y)
-                     | inr x, inl e
-                     | inl e, inr x
+               => fun (x_y : expr (_ * _) + (expr _ + type.interp _) * (expr _ + type.interp _))
+                  => let default := expr.reflect (AppIdent idc (expr.reify (t:=_*_) x_y)) in
+                     match x_y return expr _ + type.interp _ with
+                     | inr (inr x, inr y) => inr (ident.interp idc (x, y))
+                     | inr (inr x, inl e)
+                     | inr (inl e, inr x)
                        => if Z.eqb x 0
                           then inl e
                           else default
-                     | inl _, inl _ => default
+                     | inr (inl _, inl _) | inl _ => default
                      end
-                 end.
+             end.
       End interp.
     End ident.
   End partial.
@@ -1760,7 +2227,9 @@ Module Compilers.
       : partial.value var t
       := match e in expr.expr t return partial.value var t with
          | Var t v => v
-         | Ident t idc => partial.ident.interp idc
+         | TT => inr tt
+         | AppIdent s d idc args => partial.ident.interp idc (@partial_reduce' _ args)
+         | Pair A B a b => inr (@partial_reduce' A a, @partial_reduce' B b)
          | App s d f x => @partial_reduce' _ f (@partial_reduce' _ x)
          | Abs s d f => fun x => @partial_reduce' d (f x)
          end.
@@ -1810,20 +2279,21 @@ Proof.
 Qed.
 
 Delimit Scope RT_expr_scope with RT_expr.
+Import Uncurried.
 Import expr.
 Import for_reification.Notations.Reification.
 
 Notation "x + y"
-  := (App (App (Ident ident.Z.runtime_add) x%RT_expr) y%RT_expr)
+  := (AppIdent ident.Z.runtime_add (x%RT_expr, y%RT_expr)%expr)
      : RT_expr_scope.
 Notation "x * y"
-  := (App (App (Ident ident.Z.runtime_mul) x%RT_expr) y%RT_expr)
+  := (AppIdent ident.Z.runtime_mul (x%RT_expr, y%RT_expr)%expr)
      : RT_expr_scope.
 Notation "x + y"
-  := (App (App (Ident ident.Z.runtime_add) x%RT_expr) y%RT_expr)
+  := (AppIdent ident.Z.runtime_add (x%RT_expr, y%RT_expr)%expr)
      : expr_scope.
 Notation "x * y"
-  := (App (App (Ident ident.Z.runtime_mul) x%RT_expr) y%RT_expr)
+  := (AppIdent ident.Z.runtime_mul (x%RT_expr, y%RT_expr)%expr)
      : expr_scope.
 Notation "x" := (Var x) (only printing, at level 9) : expr_scope.
 Open Scope RT_expr_scope.
@@ -1834,7 +2304,8 @@ Require Import AdmitAxiom.
 Definition w (i:nat) : Z := 2^Qceiling(51*i).
 Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g8 g9 : Z)
         (f:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)
-        (g:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)*) (f g : list Z)
+        (g:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)*) (fg : list Z * list Z)
+        (f := fst fg) (g := snd fg)
         (n:=5%nat)
         (Hf : length f = n) (Hg : length g = n)
   : { fg : list Z | (eval w n fg) mod (2^255-19)
@@ -1849,7 +2320,7 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
 (*        (g9,g8,g7,g6,g5,g4,g3,g2,g1,g0)) mod (2^255 - 19) *)
   etransitivity; (* work around [rewrite] being stupid about evars *)
     [
-    | rewrite <- eval_chained_carries with (s:=2^255) (c:=[(1,19)]) (idxs:=(seq 0 (pred n) ++ [0; 1])%list%nat) (modulo:=Z.modulo) (div:=Z.div)
+    | rewrite <- eval_chained_carries with (s:=2^255) (c:=[(1,19)]) (idxs:=(seq 0 (pred n) ++ [0; 1])%list%nat) (modulo:=fun x y => Z.modulo x y) (div:=fun x y => Z.div x y)
       by (try assumption; auto using Z.div_mod; try (intros; eapply pow_ceil_mul_nat_divide_nonzero); try eapply pow_ceil_mul_nat_nonzero; try vm_decide);
       reflexivity ].
   eapply f_equal2; [|trivial]. eapply f_equal.
@@ -1863,11 +2334,11 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
   rewrite <- (expand_list_correct n (-1)%Z f), <- (expand_list_correct n (-1)%Z g) by assumption; subst e.
   etransitivity.
   Focus 2.
-  {
-    repeat match goal with H : _ |- _ => clear H end; revert f g.
+  { subst f g.
+    repeat match goal with H : _ |- _ => clear H end; revert fg.
     lazymatch goal with
-    | [ |- forall f g, ?ev = @?RHS f g ]
-      => refine (fun f g => f_equal (fun F => F f g) (_ : _ = RHS))
+    | [ |- forall fg, ?ev = @?RHS fg ]
+      => refine (fun fg => f_equal (fun F => F fg) (_ : _ = RHS))
     end.
     cbv [n expand_list expand_list_helper].
     cbv delta [chained_carries carry carry_reduce Associational.carry carryterm mulmod w to_associational mul to_associational reduce from_associational add_to_nth zeros place split].
@@ -1879,7 +2350,7 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
       pose (PartialReduce (canonicalize_list_recursion E)) as E'.
       vm_compute in E'.
       lazymatch (eval cbv delta [E'] in E') with
-      | (fun var => Ident (ident.primitive ?v)) => idtac
+      | (fun var => AppIdent (ident.primitive ?v) TT) => idtac
       end.
       constructor. }
     assert True.
@@ -1910,9 +2381,11 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
                          (z * z)%RT) in
       pose v as E.
       vm_compute in E.
-      pose (PartialReduce (CPS.expr.TranslateUnderBinders (canonicalize_list_recursion E) (fun var => (tt, id, id)))) as E'.
+      pose (CPS.CallFunWithIdContinuation (CPS.Translate (canonicalize_list_recursion E))) as E'.
       vm_compute in E'.
-      lazymatch (eval cbv delta [E'] in E') with
+      pose (PartialReduce E') as E''.
+      lazy in E''.
+      lazymatch (eval cbv delta [E''] in E'') with
       | (fun var : type -> Type =>
            (λ x : var (type.type_primitive type.Z),
                   expr_let x0 := Var x * Var x in
@@ -1927,12 +2400,12 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
     reflexivity.
   } Unfocus.
   cbv beta.
-  let e := match goal with |- _ = expr.Interp _ ?e _ _ => e end in
+  let e := match goal with |- _ = expr.Interp _ ?e _ => e end in
   set (E := e).
-  Time let E' := constr:(PartialReduce (CPS.expr.TranslateUnderBinders (canonicalize_list_recursion E) (fun var => (tt, id, id, id)))) in
+  Time let E' := constr:(PartialReduce (CPS.CallFunWithIdContinuation (CPS.Translate (canonicalize_list_recursion E)))) in
        let E' := (eval lazy in E') in
        pose E' as E''.
-  transitivity (Interp E'' f g); [ clear E | admit ].
+  transitivity (Interp E'' fg); [ clear E | admit ].
   reflexivity.
   (*cbv -[runtime_mul runtime_add]; cbv [runtime_mul runtime_add].
   ring_simplify_subterms.*)
@@ -1949,154 +2422,169 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
   f0*g0+ 38*f1*g9+ 19*f2*g8+ 38*f3*g7+ 19*f4*g6+ 38*f5*g5+ 19*f6*g4+ 38*f7*g3+ 19*f8*g2+ 38*f9*g1) *)
   (*trivial.*)
 Defined.
-Eval cbv [proj1_sig base_51_carry_mul] in (fun f g Hf Hg => proj1_sig (base_51_carry_mul f g Hf Hg)).
-(*     = fun (f g : list Z) (_ : length f = 5%nat) (_ : length g = 5%nat) =>
-       expr.Interp (@ident.interp)
+Import ident.
+Eval cbv [proj1_sig base_51_carry_mul] in (fun fg Hf Hg => proj1_sig (base_51_carry_mul fg Hf Hg)).
+(*     = fun (fg : list Z * list Z) (_ : length (Datatypes.fst fg) = 5%nat)
+         (_ : length (Datatypes.snd fg) = 5%nat) =>
+       expr.Interp (@interp)
          (fun var : type -> Type =>
-          (λ x x0 : var (type.list type.Z),
-           expr_let y := x [[0]] * x0 [[4]] +
-                         (x [[1]] * x0 [[3]] +
-                          (x [[2]] * x0 [[2]] +
-                           (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]]))) in
-           expr_let _ := Ident ident.Z.div @ y @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y @ 2251799813685248 in
-           expr_let y2 := x [[0]] * x0 [[3]] +
-                          (x [[1]] * x0 [[2]] +
-                           (x [[2]] * x0 [[1]] +
-                            (x [[3]] * x0 [[0]] + 19 * (x [[4]] * x0 [[4]])))) in
-           expr_let _ := Ident ident.Z.div @ y2 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y2 @ 2251799813685248 in
-           expr_let y5 := x [[0]] * x0 [[2]] +
-                          (x [[1]] * x0 [[1]] +
-                           (x [[2]] * x0 [[0]] +
-                            (19 * (x [[3]] * x0 [[4]]) + 19 * (x [[4]] * x0 [[3]])))) in
-           expr_let _ := Ident ident.Z.div @ y5 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y5 @ 2251799813685248 in
-           expr_let y8 := x [[0]] * x0 [[1]] +
-                          (x [[1]] * x0 [[0]] +
-                           (19 * (x [[2]] * x0 [[4]]) +
-                            (19 * (x [[3]] * x0 [[3]]) + 19 * (x [[4]] * x0 [[2]])))) in
-           expr_let _ := Ident ident.Z.div @ y8 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y8 @ 2251799813685248 in
-           expr_let y11 := x [[0]] * x0 [[0]] +
-                           (19 * (x [[1]] * x0 [[4]]) +
-                            (19 * (x [[2]] * x0 [[3]]) +
-                             (19 * (x [[3]] * x0 [[2]]) +
-                              19 * (x [[4]] * x0 [[1]])))) in
-           expr_let y12 := Ident ident.Z.div @ y11 @ 2251799813685248 in
-           expr_let y13 := Ident ident.Z.modulo @ y11 @ 2251799813685248 in
-           expr_let y14 := x [[0]] * x0 [[4]] +
-                           (x [[1]] * x0 [[3]] +
-                            (x [[2]] * x0 [[2]] +
-                             (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]]))) in
-           expr_let _ := Ident ident.Z.div @ y14 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y14 @ 2251799813685248 in
-           expr_let y17 := x [[0]] * x0 [[3]] +
-                           (x [[1]] * x0 [[2]] +
-                            (x [[2]] * x0 [[1]] +
-                             (x [[3]] * x0 [[0]] + 19 * (x [[4]] * x0 [[4]])))) in
-           expr_let _ := Ident ident.Z.div @ y17 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y17 @ 2251799813685248 in
-           expr_let y20 := x [[0]] * x0 [[2]] +
-                           (x [[1]] * x0 [[1]] +
-                            (x [[2]] * x0 [[0]] +
-                             (19 * (x [[3]] * x0 [[4]]) +
-                              19 * (x [[4]] * x0 [[3]])))) in
-           expr_let _ := Ident ident.Z.div @ y20 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y20 @ 2251799813685248 in
+          (λ x : var (type.list type.Z * type.list type.Z)%ctype,
+           expr_let y := fst @@ x [[0]] * snd @@ x [[4]] +
+                         (fst @@ x [[1]] * snd @@ x [[3]] +
+                          (fst @@ x [[2]] * snd @@ x [[2]] +
+                           (fst @@ x [[3]] * snd @@ x [[1]] +
+                            fst @@ x [[4]] * snd @@ x [[0]]))) in
+           expr_let _ := Z.div @@ (y, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y, 2251799813685248) in
+           expr_let y2 := fst @@ x [[0]] * snd @@ x [[3]] +
+                          (fst @@ x [[1]] * snd @@ x [[2]] +
+                           (fst @@ x [[2]] * snd @@ x [[1]] +
+                            (fst @@ x [[3]] * snd @@ x [[0]] +
+                             19 * (fst @@ x [[4]] * snd @@ x [[4]])))) in
+           expr_let _ := Z.div @@ (y2, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y2, 2251799813685248) in
+           expr_let y5 := fst @@ x [[0]] * snd @@ x [[2]] +
+                          (fst @@ x [[1]] * snd @@ x [[1]] +
+                           (fst @@ x [[2]] * snd @@ x [[0]] +
+                            (19 * (fst @@ x [[3]] * snd @@ x [[4]]) +
+                             19 * (fst @@ x [[4]] * snd @@ x [[3]])))) in
+           expr_let _ := Z.div @@ (y5, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y5, 2251799813685248) in
+           expr_let y8 := fst @@ x [[0]] * snd @@ x [[1]] +
+                          (fst @@ x [[1]] * snd @@ x [[0]] +
+                           (19 * (fst @@ x [[2]] * snd @@ x [[4]]) +
+                            (19 * (fst @@ x [[3]] * snd @@ x [[3]]) +
+                             19 * (fst @@ x [[4]] * snd @@ x [[2]])))) in
+           expr_let _ := Z.div @@ (y8, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y8, 2251799813685248) in
+           expr_let y11 := fst @@ x [[0]] * snd @@ x [[0]] +
+                           (19 * (fst @@ x [[1]] * snd @@ x [[4]]) +
+                            (19 * (fst @@ x [[2]] * snd @@ x [[3]]) +
+                             (19 * (fst @@ x [[3]] * snd @@ x [[2]]) +
+                              19 * (fst @@ x [[4]] * snd @@ x [[1]])))) in
+           expr_let y12 := Z.div @@ (y11, 2251799813685248) in
+           expr_let y13 := Z.modulo @@ (y11, 2251799813685248) in
+           expr_let y14 := fst @@ x [[0]] * snd @@ x [[4]] +
+                           (fst @@ x [[1]] * snd @@ x [[3]] +
+                            (fst @@ x [[2]] * snd @@ x [[2]] +
+                             (fst @@ x [[3]] * snd @@ x [[1]] +
+                              fst @@ x [[4]] * snd @@ x [[0]]))) in
+           expr_let _ := Z.div @@ (y14, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y14, 2251799813685248) in
+           expr_let y17 := fst @@ x [[0]] * snd @@ x [[3]] +
+                           (fst @@ x [[1]] * snd @@ x [[2]] +
+                            (fst @@ x [[2]] * snd @@ x [[1]] +
+                             (fst @@ x [[3]] * snd @@ x [[0]] +
+                              19 * (fst @@ x [[4]] * snd @@ x [[4]])))) in
+           expr_let _ := Z.div @@ (y17, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y17, 2251799813685248) in
+           expr_let y20 := fst @@ x [[0]] * snd @@ x [[2]] +
+                           (fst @@ x [[1]] * snd @@ x [[1]] +
+                            (fst @@ x [[2]] * snd @@ x [[0]] +
+                             (19 * (fst @@ x [[3]] * snd @@ x [[4]]) +
+                              19 * (fst @@ x [[4]] * snd @@ x [[3]])))) in
+           expr_let _ := Z.div @@ (y20, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y20, 2251799813685248) in
            expr_let y23 := y12 +
-                           (x [[0]] * x0 [[1]] +
-                            (x [[1]] * x0 [[0]] +
-                             (19 * (x [[2]] * x0 [[4]]) +
-                              (19 * (x [[3]] * x0 [[3]]) +
-                               19 * (x [[4]] * x0 [[2]]))))) in
-           expr_let y24 := Ident ident.Z.div @ y23 @ 2251799813685248 in
-           expr_let y25 := Ident ident.Z.modulo @ y23 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y13 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y13 @ 2251799813685248 in
-           expr_let y28 := x [[0]] * x0 [[4]] +
-                           (x [[1]] * x0 [[3]] +
-                            (x [[2]] * x0 [[2]] +
-                             (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]]))) in
-           expr_let _ := Ident ident.Z.div @ y28 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y28 @ 2251799813685248 in
-           expr_let y31 := x [[0]] * x0 [[3]] +
-                           (x [[1]] * x0 [[2]] +
-                            (x [[2]] * x0 [[1]] +
-                             (x [[3]] * x0 [[0]] + 19 * (x [[4]] * x0 [[4]])))) in
-           expr_let _ := Ident ident.Z.div @ y31 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y31 @ 2251799813685248 in
+                           (fst @@ x [[0]] * snd @@ x [[1]] +
+                            (fst @@ x [[1]] * snd @@ x [[0]] +
+                             (19 * (fst @@ x [[2]] * snd @@ x [[4]]) +
+                              (19 * (fst @@ x [[3]] * snd @@ x [[3]]) +
+                               19 * (fst @@ x [[4]] * snd @@ x [[2]]))))) in
+           expr_let y24 := Z.div @@ (y23, 2251799813685248) in
+           expr_let y25 := Z.modulo @@ (y23, 2251799813685248) in
+           expr_let _ := Z.div @@ (y13, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y13, 2251799813685248) in
+           expr_let y28 := fst @@ x [[0]] * snd @@ x [[4]] +
+                           (fst @@ x [[1]] * snd @@ x [[3]] +
+                            (fst @@ x [[2]] * snd @@ x [[2]] +
+                             (fst @@ x [[3]] * snd @@ x [[1]] +
+                              fst @@ x [[4]] * snd @@ x [[0]]))) in
+           expr_let _ := Z.div @@ (y28, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y28, 2251799813685248) in
+           expr_let y31 := fst @@ x [[0]] * snd @@ x [[3]] +
+                           (fst @@ x [[1]] * snd @@ x [[2]] +
+                            (fst @@ x [[2]] * snd @@ x [[1]] +
+                             (fst @@ x [[3]] * snd @@ x [[0]] +
+                              19 * (fst @@ x [[4]] * snd @@ x [[4]])))) in
+           expr_let _ := Z.div @@ (y31, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y31, 2251799813685248) in
            expr_let y34 := y24 +
-                           (x [[0]] * x0 [[2]] +
-                            (x [[1]] * x0 [[1]] +
-                             (x [[2]] * x0 [[0]] +
-                              (19 * (x [[3]] * x0 [[4]]) +
-                               19 * (x [[4]] * x0 [[3]]))))) in
-           expr_let y35 := Ident ident.Z.div @ y34 @ 2251799813685248 in
-           expr_let y36 := Ident ident.Z.modulo @ y34 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y25 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y25 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y13 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y13 @ 2251799813685248 in
-           expr_let y41 := x [[0]] * x0 [[4]] +
-                           (x [[1]] * x0 [[3]] +
-                            (x [[2]] * x0 [[2]] +
-                             (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]]))) in
-           expr_let _ := Ident ident.Z.div @ y41 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y41 @ 2251799813685248 in
+                           (fst @@ x [[0]] * snd @@ x [[2]] +
+                            (fst @@ x [[1]] * snd @@ x [[1]] +
+                             (fst @@ x [[2]] * snd @@ x [[0]] +
+                              (19 * (fst @@ x [[3]] * snd @@ x [[4]]) +
+                               19 * (fst @@ x [[4]] * snd @@ x [[3]]))))) in
+           expr_let y35 := Z.div @@ (y34, 2251799813685248) in
+           expr_let y36 := Z.modulo @@ (y34, 2251799813685248) in
+           expr_let _ := Z.div @@ (y25, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y25, 2251799813685248) in
+           expr_let _ := Z.div @@ (y13, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y13, 2251799813685248) in
+           expr_let y41 := fst @@ x [[0]] * snd @@ x [[4]] +
+                           (fst @@ x [[1]] * snd @@ x [[3]] +
+                            (fst @@ x [[2]] * snd @@ x [[2]] +
+                             (fst @@ x [[3]] * snd @@ x [[1]] +
+                              fst @@ x [[4]] * snd @@ x [[0]]))) in
+           expr_let _ := Z.div @@ (y41, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y41, 2251799813685248) in
            expr_let y44 := y35 +
-                           (x [[0]] * x0 [[3]] +
-                            (x [[1]] * x0 [[2]] +
-                             (x [[2]] * x0 [[1]] +
-                              (x [[3]] * x0 [[0]] + 19 * (x [[4]] * x0 [[4]]))))) in
-           expr_let y45 := Ident ident.Z.div @ y44 @ 2251799813685248 in
-           expr_let y46 := Ident ident.Z.modulo @ y44 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y36 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y36 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y25 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y25 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y13 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y13 @ 2251799813685248 in
+                           (fst @@ x [[0]] * snd @@ x [[3]] +
+                            (fst @@ x [[1]] * snd @@ x [[2]] +
+                             (fst @@ x [[2]] * snd @@ x [[1]] +
+                              (fst @@ x [[3]] * snd @@ x [[0]] +
+                               19 * (fst @@ x [[4]] * snd @@ x [[4]]))))) in
+           expr_let y45 := Z.div @@ (y44, 2251799813685248) in
+           expr_let y46 := Z.modulo @@ (y44, 2251799813685248) in
+           expr_let _ := Z.div @@ (y36, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y36, 2251799813685248) in
+           expr_let _ := Z.div @@ (y25, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y25, 2251799813685248) in
+           expr_let _ := Z.div @@ (y13, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y13, 2251799813685248) in
            expr_let y53 := y45 +
-                           (x [[0]] * x0 [[4]] +
-                            (x [[1]] * x0 [[3]] +
-                             (x [[2]] * x0 [[2]] +
-                              (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]])))) in
-           expr_let _ := Ident ident.Z.div @ y53 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y53 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y46 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y46 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y36 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y36 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y25 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y25 @ 2251799813685248 in
-           expr_let y62 := Ident ident.Z.div @ y13 @ 2251799813685248 in
-           expr_let y63 := Ident ident.Z.modulo @ y13 @ 2251799813685248 in
+                           (fst @@ x [[0]] * snd @@ x [[4]] +
+                            (fst @@ x [[1]] * snd @@ x [[3]] +
+                             (fst @@ x [[2]] * snd @@ x [[2]] +
+                              (fst @@ x [[3]] * snd @@ x [[1]] +
+                               fst @@ x [[4]] * snd @@ x [[0]])))) in
+           expr_let _ := Z.div @@ (y53, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y53, 2251799813685248) in
+           expr_let _ := Z.div @@ (y46, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y46, 2251799813685248) in
+           expr_let _ := Z.div @@ (y36, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y36, 2251799813685248) in
+           expr_let _ := Z.div @@ (y25, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y25, 2251799813685248) in
+           expr_let y62 := Z.div @@ (y13, 2251799813685248) in
+           expr_let y63 := Z.modulo @@ (y13, 2251799813685248) in
            expr_let y64 := y45 +
-                           (x [[0]] * x0 [[4]] +
-                            (x [[1]] * x0 [[3]] +
-                             (x [[2]] * x0 [[2]] +
-                              (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]])))) in
-           expr_let _ := Ident ident.Z.div @ y64 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y64 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y46 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y46 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y36 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y36 @ 2251799813685248 in
+                           (fst @@ x [[0]] * snd @@ x [[4]] +
+                            (fst @@ x [[1]] * snd @@ x [[3]] +
+                             (fst @@ x [[2]] * snd @@ x [[2]] +
+                              (fst @@ x [[3]] * snd @@ x [[1]] +
+                               fst @@ x [[4]] * snd @@ x [[0]])))) in
+           expr_let _ := Z.div @@ (y64, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y64, 2251799813685248) in
+           expr_let _ := Z.div @@ (y46, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y46, 2251799813685248) in
+           expr_let _ := Z.div @@ (y36, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y36, 2251799813685248) in
            expr_let y71 := y62 + y25 in
-           expr_let y72 := Ident ident.Z.div @ y71 @ 2251799813685248 in
-           expr_let y73 := Ident ident.Z.modulo @ y71 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.div @ y63 @ 2251799813685248 in
-           expr_let _ := Ident ident.Z.modulo @ y63 @ 2251799813685248 in
+           expr_let y72 := Z.div @@ (y71, 2251799813685248) in
+           expr_let y73 := Z.modulo @@ (y71, 2251799813685248) in
+           expr_let _ := Z.div @@ (y63, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y63, 2251799813685248) in
            y63
            :: y73
               :: y72 + y36
                  :: y46
                     :: y45 +
-                       (x [[0]] * x0 [[4]] +
-                        (x [[1]] * x0 [[3]] +
-                         (x [[2]] * x0 [[2]] +
-                          (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]])))) :: [])%expr)
-         f g
-     : forall f g : list Z, length f = 5%nat -> length g = 5%nat -> list Z
-*)
+                       (fst @@ x [[0]] * snd @@ x [[4]] +
+                        (fst @@ x [[1]] * snd @@ x [[3]] +
+                         (fst @@ x [[2]] * snd @@ x [[2]] +
+                          (fst @@ x [[3]] * snd @@ x [[1]] +
+                           fst @@ x [[4]] * snd @@ x [[0]])))) :: [])%expr) fg
+     : forall fg : list Z * list Z,
+       length (Datatypes.fst fg) = 5%nat ->
+       length (Datatypes.snd fg) = 5%nat -> list Z *)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -1326,43 +1326,6 @@ Module Compilers.
     End expr.
   End CPS.
 
-  Section option_partition.
-    Context {A : Type} (f : A -> option Datatypes.bool).
-    Fixpoint option_partition (l : list A) : option (list A * list A)
-      := match l with
-         | nil => Some (nil, nil)
-         | cons x tl
-           => match option_partition tl, f x with
-              | Some (g, d), Some fx
-                => Some (if fx then (x :: g, d) else (g, x :: d))
-              | _, _ => None
-              end
-         end.
-  End option_partition.
-  Section option_flat_map.
-    Context {A B : Type} (f : A -> option (list B)).
-    Fixpoint option_flat_map (l : list A) : option (list B)
-      := match l with
-         | nil => Some nil
-         | cons x t => match f x, option_flat_map t with
-                       | Some fx, Some ft
-                         => Some (fx ++ ft)
-                       | _, _ => None
-                       end
-         end.
-  End option_flat_map.
-
-  Definition lift_option_list {A} (ls : list (option A)) : option (list A)
-    := list_rect
-         (fun _ => _)
-         (Some nil)
-         (fun x _ xs
-          => match x, xs with
-             | Some x, Some xs => Some (cons x xs)
-             | _, _ => None
-             end)
-         ls.
-
   Section invert.
     Context {var : type -> Type}.
 

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -90,9 +90,9 @@ Module Associational.
 
     Definition carryterm (w fw:Z) (t:Z * Z) :=
       if (Z.eqb (fst t) w)
-      then dlet t2 := snd t in
-           dlet d2 := div t2 fw in
-           dlet m2 := modulo t2 fw in
+      then dlet_nd t2 := snd t in
+           dlet_nd d2 := div t2 fw in
+           dlet_nd m2 := modulo t2 fw in
            [(w * fw, d2);(w,m2)]
       else [t].
 
@@ -661,11 +661,13 @@ Module Compilers.
           | @List.repeat ?A
             => let rA := type.reify A in
                constr:(@ident.List_repeat rA)
-          | @LetIn.Let_In ?A ?B
-            => let B := lazymatch (eval cbv beta in B) with fun _ => ?B => B end in
-               let rA := type.reify A in
+          | @LetIn.Let_In ?A (fun _ => ?B)
+            => let rA := type.reify A in
                let rB := type.reify B in
                constr:(@ident.Let_In rA rB)
+          | @LetIn.Let_In ?A ?B
+            => let dummy := match goal with _ => fail 1 "Let_In contains a dependent type λ as its second argument:" B end in
+               constr:(I : I)
           | @combine ?A ?B
             => let rA := type.reify A in
                let rB := type.reify B in
@@ -866,11 +868,13 @@ Module Compilers.
             => let rT := type.reify T in
                constr:(@ident.nat_rect rT)
           | Nat.pred => ident.pred
-          | @LetIn.Let_In ?A ?B
-            => let B := lazymatch (eval cbv beta in B) with fun _ => ?B => B end in
-               let rA := type.reify A in
+          | @LetIn.Let_In ?A (fun _ => ?B)
+            => let rA := type.reify A in
                let rB := type.reify B in
                constr:(@ident.Let_In rA rB)
+          | @LetIn.Let_In ?A ?B
+            => let dummy := match goal with _ => fail 1 "Let_In contains a dependent type λ as its second argument:" B end in
+               constr:(I : I)
           | @Datatypes.list_rect ?A (fun _ => ?B)
             => let rA := type.reify A in
                let rB := type.reify B in

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -2413,118 +2413,119 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
   f0*g0+ 38*f1*g9+ 19*f2*g8+ 38*f3*g7+ 19*f4*g6+ 38*f5*g5+ 19*f6*g4+ 38*f7*g3+ 19*f8*g2+ 38*f9*g1) *)
   (*trivial.*)
 Defined.
+
 Import ident.
 Eval cbv [proj1_sig base_51_carry_mul] in (fun fg Hf Hg => proj1_sig (base_51_carry_mul fg Hf Hg)).
-(*     = fun (fg : list Z * list Z) (_ : length (Datatypes.fst fg) = 5%nat)
+(*   = fun (fg : list Z * list Z) (_ : length (Datatypes.fst fg) = 5%nat)
          (_ : length (Datatypes.snd fg) = 5%nat) =>
        expr.Interp (@interp)
          (fun var : type -> Type =>
           (λ x : var (type.list type.Z * type.list type.Z)%ctype,
-           expr_let y := fst @@ x [[0]] * snd @@ x [[4]] +
-                         (fst @@ x [[1]] * snd @@ x [[3]] +
-                          (fst @@ x [[2]] * snd @@ x [[2]] +
-                           (fst @@ x [[3]] * snd @@ x [[1]] +
-                            fst @@ x [[4]] * snd @@ x [[0]]))) in
+           expr_let y := (fst @@ x [[0]] * snd @@ x [[4]])%expr +
+                         ((fst @@ x [[1]] * snd @@ x [[3]])%expr +
+                          ((fst @@ x [[2]] * snd @@ x [[2]])%expr +
+                           ((fst @@ x [[3]] * snd @@ x [[1]])%expr +
+                            (fst @@ x [[4]] * snd @@ x [[0]])%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y, 2251799813685248) in
-           expr_let y2 := fst @@ x [[0]] * snd @@ x [[3]] +
-                          (fst @@ x [[1]] * snd @@ x [[2]] +
-                           (fst @@ x [[2]] * snd @@ x [[1]] +
-                            (fst @@ x [[3]] * snd @@ x [[0]] +
-                             19 * (fst @@ x [[4]] * snd @@ x [[4]])))) in
+           expr_let y2 := (fst @@ x [[0]] * snd @@ x [[3]])%expr +
+                          ((fst @@ x [[1]] * snd @@ x [[2]])%expr +
+                           ((fst @@ x [[2]] * snd @@ x [[1]])%expr +
+                            ((fst @@ x [[3]] * snd @@ x [[0]])%expr +
+                             (19 * (fst @@ x [[4]] * snd @@ x [[4]])%expr)%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y2, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y2, 2251799813685248) in
-           expr_let y5 := fst @@ x [[0]] * snd @@ x [[2]] +
-                          (fst @@ x [[1]] * snd @@ x [[1]] +
-                           (fst @@ x [[2]] * snd @@ x [[0]] +
-                            (19 * (fst @@ x [[3]] * snd @@ x [[4]]) +
-                             19 * (fst @@ x [[4]] * snd @@ x [[3]])))) in
+           expr_let y5 := (fst @@ x [[0]] * snd @@ x [[2]])%expr +
+                          ((fst @@ x [[1]] * snd @@ x [[1]])%expr +
+                           ((fst @@ x [[2]] * snd @@ x [[0]])%expr +
+                            ((19 * (fst @@ x [[3]] * snd @@ x [[4]])%expr)%expr +
+                             (19 * (fst @@ x [[4]] * snd @@ x [[3]])%expr)%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y5, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y5, 2251799813685248) in
-           expr_let y8 := fst @@ x [[0]] * snd @@ x [[1]] +
-                          (fst @@ x [[1]] * snd @@ x [[0]] +
-                           (19 * (fst @@ x [[2]] * snd @@ x [[4]]) +
-                            (19 * (fst @@ x [[3]] * snd @@ x [[3]]) +
-                             19 * (fst @@ x [[4]] * snd @@ x [[2]])))) in
+           expr_let y8 := (fst @@ x [[0]] * snd @@ x [[1]])%expr +
+                          ((fst @@ x [[1]] * snd @@ x [[0]])%expr +
+                           ((19 * (fst @@ x [[2]] * snd @@ x [[4]])%expr)%expr +
+                            ((19 * (fst @@ x [[3]] * snd @@ x [[3]])%expr)%expr +
+                             (19 * (fst @@ x [[4]] * snd @@ x [[2]])%expr)%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y8, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y8, 2251799813685248) in
-           expr_let y11 := fst @@ x [[0]] * snd @@ x [[0]] +
-                           (19 * (fst @@ x [[1]] * snd @@ x [[4]]) +
-                            (19 * (fst @@ x [[2]] * snd @@ x [[3]]) +
-                             (19 * (fst @@ x [[3]] * snd @@ x [[2]]) +
-                              19 * (fst @@ x [[4]] * snd @@ x [[1]])))) in
+           expr_let y11 := (fst @@ x [[0]] * snd @@ x [[0]])%expr +
+                           ((19 * (fst @@ x [[1]] * snd @@ x [[4]])%expr)%expr +
+                            ((19 * (fst @@ x [[2]] * snd @@ x [[3]])%expr)%expr +
+                             ((19 * (fst @@ x [[3]] * snd @@ x [[2]])%expr)%expr +
+                              (19 * (fst @@ x [[4]] * snd @@ x [[1]])%expr)%expr)%expr)%expr)%expr in
            expr_let y12 := Z.div @@ (y11, 2251799813685248) in
            expr_let y13 := Z.modulo @@ (y11, 2251799813685248) in
-           expr_let y14 := fst @@ x [[0]] * snd @@ x [[4]] +
-                           (fst @@ x [[1]] * snd @@ x [[3]] +
-                            (fst @@ x [[2]] * snd @@ x [[2]] +
-                             (fst @@ x [[3]] * snd @@ x [[1]] +
-                              fst @@ x [[4]] * snd @@ x [[0]]))) in
+           expr_let y14 := (fst @@ x [[0]] * snd @@ x [[4]])%expr +
+                           ((fst @@ x [[1]] * snd @@ x [[3]])%expr +
+                            ((fst @@ x [[2]] * snd @@ x [[2]])%expr +
+                             ((fst @@ x [[3]] * snd @@ x [[1]])%expr +
+                              (fst @@ x [[4]] * snd @@ x [[0]])%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y14, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y14, 2251799813685248) in
-           expr_let y17 := fst @@ x [[0]] * snd @@ x [[3]] +
-                           (fst @@ x [[1]] * snd @@ x [[2]] +
-                            (fst @@ x [[2]] * snd @@ x [[1]] +
-                             (fst @@ x [[3]] * snd @@ x [[0]] +
-                              19 * (fst @@ x [[4]] * snd @@ x [[4]])))) in
+           expr_let y17 := (fst @@ x [[0]] * snd @@ x [[3]])%expr +
+                           ((fst @@ x [[1]] * snd @@ x [[2]])%expr +
+                            ((fst @@ x [[2]] * snd @@ x [[1]])%expr +
+                             ((fst @@ x [[3]] * snd @@ x [[0]])%expr +
+                              (19 * (fst @@ x [[4]] * snd @@ x [[4]])%expr)%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y17, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y17, 2251799813685248) in
-           expr_let y20 := fst @@ x [[0]] * snd @@ x [[2]] +
-                           (fst @@ x [[1]] * snd @@ x [[1]] +
-                            (fst @@ x [[2]] * snd @@ x [[0]] +
-                             (19 * (fst @@ x [[3]] * snd @@ x [[4]]) +
-                              19 * (fst @@ x [[4]] * snd @@ x [[3]])))) in
+           expr_let y20 := (fst @@ x [[0]] * snd @@ x [[2]])%expr +
+                           ((fst @@ x [[1]] * snd @@ x [[1]])%expr +
+                            ((fst @@ x [[2]] * snd @@ x [[0]])%expr +
+                             ((19 * (fst @@ x [[3]] * snd @@ x [[4]])%expr)%expr +
+                              (19 * (fst @@ x [[4]] * snd @@ x [[3]])%expr)%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y20, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y20, 2251799813685248) in
            expr_let y23 := y12 +
-                           (fst @@ x [[0]] * snd @@ x [[1]] +
-                            (fst @@ x [[1]] * snd @@ x [[0]] +
-                             (19 * (fst @@ x [[2]] * snd @@ x [[4]]) +
-                              (19 * (fst @@ x [[3]] * snd @@ x [[3]]) +
-                               19 * (fst @@ x [[4]] * snd @@ x [[2]]))))) in
+                           ((fst @@ x [[0]] * snd @@ x [[1]])%expr +
+                            ((fst @@ x [[1]] * snd @@ x [[0]])%expr +
+                             ((19 * (fst @@ x [[2]] * snd @@ x [[4]])%expr)%expr +
+                              ((19 * (fst @@ x [[3]] * snd @@ x [[3]])%expr)%expr +
+                               (19 * (fst @@ x [[4]] * snd @@ x [[2]])%expr)%expr)%expr)%expr)%expr)%expr in
            expr_let y24 := Z.div @@ (y23, 2251799813685248) in
            expr_let y25 := Z.modulo @@ (y23, 2251799813685248) in
            expr_let _ := Z.div @@ (y13, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y13, 2251799813685248) in
-           expr_let y28 := fst @@ x [[0]] * snd @@ x [[4]] +
-                           (fst @@ x [[1]] * snd @@ x [[3]] +
-                            (fst @@ x [[2]] * snd @@ x [[2]] +
-                             (fst @@ x [[3]] * snd @@ x [[1]] +
-                              fst @@ x [[4]] * snd @@ x [[0]]))) in
+           expr_let y28 := (fst @@ x [[0]] * snd @@ x [[4]])%expr +
+                           ((fst @@ x [[1]] * snd @@ x [[3]])%expr +
+                            ((fst @@ x [[2]] * snd @@ x [[2]])%expr +
+                             ((fst @@ x [[3]] * snd @@ x [[1]])%expr +
+                              (fst @@ x [[4]] * snd @@ x [[0]])%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y28, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y28, 2251799813685248) in
-           expr_let y31 := fst @@ x [[0]] * snd @@ x [[3]] +
-                           (fst @@ x [[1]] * snd @@ x [[2]] +
-                            (fst @@ x [[2]] * snd @@ x [[1]] +
-                             (fst @@ x [[3]] * snd @@ x [[0]] +
-                              19 * (fst @@ x [[4]] * snd @@ x [[4]])))) in
+           expr_let y31 := (fst @@ x [[0]] * snd @@ x [[3]])%expr +
+                           ((fst @@ x [[1]] * snd @@ x [[2]])%expr +
+                            ((fst @@ x [[2]] * snd @@ x [[1]])%expr +
+                             ((fst @@ x [[3]] * snd @@ x [[0]])%expr +
+                              (19 * (fst @@ x [[4]] * snd @@ x [[4]])%expr)%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y31, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y31, 2251799813685248) in
            expr_let y34 := y24 +
-                           (fst @@ x [[0]] * snd @@ x [[2]] +
-                            (fst @@ x [[1]] * snd @@ x [[1]] +
-                             (fst @@ x [[2]] * snd @@ x [[0]] +
-                              (19 * (fst @@ x [[3]] * snd @@ x [[4]]) +
-                               19 * (fst @@ x [[4]] * snd @@ x [[3]]))))) in
+                           ((fst @@ x [[0]] * snd @@ x [[2]])%expr +
+                            ((fst @@ x [[1]] * snd @@ x [[1]])%expr +
+                             ((fst @@ x [[2]] * snd @@ x [[0]])%expr +
+                              ((19 * (fst @@ x [[3]] * snd @@ x [[4]])%expr)%expr +
+                               (19 * (fst @@ x [[4]] * snd @@ x [[3]])%expr)%expr)%expr)%expr)%expr)%expr in
            expr_let y35 := Z.div @@ (y34, 2251799813685248) in
            expr_let y36 := Z.modulo @@ (y34, 2251799813685248) in
            expr_let _ := Z.div @@ (y25, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y25, 2251799813685248) in
            expr_let _ := Z.div @@ (y13, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y13, 2251799813685248) in
-           expr_let y41 := fst @@ x [[0]] * snd @@ x [[4]] +
-                           (fst @@ x [[1]] * snd @@ x [[3]] +
-                            (fst @@ x [[2]] * snd @@ x [[2]] +
-                             (fst @@ x [[3]] * snd @@ x [[1]] +
-                              fst @@ x [[4]] * snd @@ x [[0]]))) in
+           expr_let y41 := (fst @@ x [[0]] * snd @@ x [[4]])%expr +
+                           ((fst @@ x [[1]] * snd @@ x [[3]])%expr +
+                            ((fst @@ x [[2]] * snd @@ x [[2]])%expr +
+                             ((fst @@ x [[3]] * snd @@ x [[1]])%expr +
+                              (fst @@ x [[4]] * snd @@ x [[0]])%expr)%expr)%expr)%expr in
            expr_let _ := Z.div @@ (y41, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y41, 2251799813685248) in
            expr_let y44 := y35 +
-                           (fst @@ x [[0]] * snd @@ x [[3]] +
-                            (fst @@ x [[1]] * snd @@ x [[2]] +
-                             (fst @@ x [[2]] * snd @@ x [[1]] +
-                              (fst @@ x [[3]] * snd @@ x [[0]] +
-                               19 * (fst @@ x [[4]] * snd @@ x [[4]]))))) in
+                           ((fst @@ x [[0]] * snd @@ x [[3]])%expr +
+                            ((fst @@ x [[1]] * snd @@ x [[2]])%expr +
+                             ((fst @@ x [[2]] * snd @@ x [[1]])%expr +
+                              ((fst @@ x [[3]] * snd @@ x [[0]])%expr +
+                               (19 * (fst @@ x [[4]] * snd @@ x [[4]])%expr)%expr)%expr)%expr)%expr)%expr in
            expr_let y45 := Z.div @@ (y44, 2251799813685248) in
            expr_let y46 := Z.modulo @@ (y44, 2251799813685248) in
            expr_let _ := Z.div @@ (y36, 2251799813685248) in
@@ -2534,48 +2535,99 @@ Eval cbv [proj1_sig base_51_carry_mul] in (fun fg Hf Hg => proj1_sig (base_51_ca
            expr_let _ := Z.div @@ (y13, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y13, 2251799813685248) in
            expr_let y53 := y45 +
-                           (fst @@ x [[0]] * snd @@ x [[4]] +
-                            (fst @@ x [[1]] * snd @@ x [[3]] +
-                             (fst @@ x [[2]] * snd @@ x [[2]] +
-                              (fst @@ x [[3]] * snd @@ x [[1]] +
-                               fst @@ x [[4]] * snd @@ x [[0]])))) in
-           expr_let _ := Z.div @@ (y53, 2251799813685248) in
-           expr_let _ := Z.modulo @@ (y53, 2251799813685248) in
+                           ((fst @@ x [[0]] * snd @@ x [[4]])%expr +
+                            ((fst @@ x [[1]] * snd @@ x [[3]])%expr +
+                             ((fst @@ x [[2]] * snd @@ x [[2]])%expr +
+                              ((fst @@ x [[3]] * snd @@ x [[1]])%expr +
+                               (fst @@ x [[4]] * snd @@ x [[0]])%expr)%expr)%expr)%expr)%expr in
+           expr_let y54 := Z.div @@ (y53, 2251799813685248) in
+           expr_let y55 := Z.modulo @@ (y53, 2251799813685248) in
            expr_let _ := Z.div @@ (y46, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y46, 2251799813685248) in
            expr_let _ := Z.div @@ (y36, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y36, 2251799813685248) in
            expr_let _ := Z.div @@ (y25, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y25, 2251799813685248) in
-           expr_let y62 := Z.div @@ (y13, 2251799813685248) in
-           expr_let y63 := Z.modulo @@ (y13, 2251799813685248) in
-           expr_let y64 := y45 +
-                           (fst @@ x [[0]] * snd @@ x [[4]] +
-                            (fst @@ x [[1]] * snd @@ x [[3]] +
-                             (fst @@ x [[2]] * snd @@ x [[2]] +
-                              (fst @@ x [[3]] * snd @@ x [[1]] +
-                               fst @@ x [[4]] * snd @@ x [[0]])))) in
-           expr_let _ := Z.div @@ (y64, 2251799813685248) in
-           expr_let _ := Z.modulo @@ (y64, 2251799813685248) in
+           expr_let _ := Z.div @@ (y13, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y13, 2251799813685248) in
+           expr_let _ := Z.div @@ (y55, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y55, 2251799813685248) in
            expr_let _ := Z.div @@ (y46, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y46, 2251799813685248) in
            expr_let _ := Z.div @@ (y36, 2251799813685248) in
            expr_let _ := Z.modulo @@ (y36, 2251799813685248) in
-           expr_let y71 := y62 + y25 in
-           expr_let y72 := Z.div @@ (y71, 2251799813685248) in
-           expr_let y73 := Z.modulo @@ (y71, 2251799813685248) in
-           expr_let _ := Z.div @@ (y63, 2251799813685248) in
-           expr_let _ := Z.modulo @@ (y63, 2251799813685248) in
-           y63
-           :: y73
-              :: y72 + y36
-                 :: y46
-                    :: y45 +
-                       (fst @@ x [[0]] * snd @@ x [[4]] +
-                        (fst @@ x [[1]] * snd @@ x [[3]] +
-                         (fst @@ x [[2]] * snd @@ x [[2]] +
-                          (fst @@ x [[3]] * snd @@ x [[1]] +
-                           fst @@ x [[4]] * snd @@ x [[0]])))) :: [])%expr) fg
+           expr_let _ := Z.div @@ (y25, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y25, 2251799813685248) in
+           expr_let y72 := y13 + (19 * y54)%expr in
+           expr_let y73 := Z.div @@ (y72, 2251799813685248) in
+           expr_let y74 := Z.modulo @@ (y72, 2251799813685248) in
+           expr_let _ := Z.div @@ (y55, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y55, 2251799813685248) in
+           expr_let _ := Z.div @@ (y46, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y46, 2251799813685248) in
+           expr_let _ := Z.div @@ (y36, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y36, 2251799813685248) in
+           expr_let y81 := y73 + y25 in
+           expr_let y82 := Z.div @@ (y81, 2251799813685248) in
+           expr_let y83 := Z.modulo @@ (y81, 2251799813685248) in
+           expr_let _ := Z.div @@ (y74, 2251799813685248) in
+           expr_let _ := Z.modulo @@ (y74, 2251799813685248) in
+           y74 :: y83 :: y82 + y36 :: y46 :: y55 :: [])%expr) fg
      : forall fg : list Z * list Z,
        length (Datatypes.fst fg) = 5%nat ->
-       length (Datatypes.snd fg) = 5%nat -> list Z *)
+       length (Datatypes.snd fg) = 5%nat -> list Z
+*)
+
+(* after manual dead code elimination: *)
+(*    = fun (fg : list Z * list Z) (_ : length (Datatypes.fst fg) = 5%nat)
+         (_ : length (Datatypes.snd fg) = 5%nat) =>
+       expr.Interp (@interp)
+         (fun var : type -> Type =>
+          (λ x : var (type.list type.Z * type.list type.Z)%ctype,
+           expr_let y11 := (fst @@ x [[0]] * snd @@ x [[0]])%expr +
+                           ((19 * (fst @@ x [[1]] * snd @@ x [[4]])%expr)%expr +
+                            ((19 * (fst @@ x [[2]] * snd @@ x [[3]])%expr)%expr +
+                             ((19 * (fst @@ x [[3]] * snd @@ x [[2]])%expr)%expr +
+                              (19 * (fst @@ x [[4]] * snd @@ x [[1]])%expr)%expr)%expr)%expr)%expr in
+           expr_let y12 := Z.div @@ (y11, 2251799813685248) in
+           expr_let y13 := Z.modulo @@ (y11, 2251799813685248) in
+           expr_let y23 := y12 +
+                           ((fst @@ x [[0]] * snd @@ x [[1]])%expr +
+                            ((fst @@ x [[1]] * snd @@ x [[0]])%expr +
+                             ((19 * (fst @@ x [[2]] * snd @@ x [[4]])%expr)%expr +
+                              ((19 * (fst @@ x [[3]] * snd @@ x [[3]])%expr)%expr +
+                               (19 * (fst @@ x [[4]] * snd @@ x [[2]])%expr)%expr)%expr)%expr)%expr)%expr in
+           expr_let y24 := Z.div @@ (y23, 2251799813685248) in
+           expr_let y25 := Z.modulo @@ (y23, 2251799813685248) in
+           expr_let y34 := y24 +
+                           ((fst @@ x [[0]] * snd @@ x [[2]])%expr +
+                            ((fst @@ x [[1]] * snd @@ x [[1]])%expr +
+                             ((fst @@ x [[2]] * snd @@ x [[0]])%expr +
+                              ((19 * (fst @@ x [[3]] * snd @@ x [[4]])%expr)%expr +
+                               (19 * (fst @@ x [[4]] * snd @@ x [[3]])%expr)%expr)%expr)%expr)%expr)%expr in
+           expr_let y35 := Z.div @@ (y34, 2251799813685248) in
+           expr_let y36 := Z.modulo @@ (y34, 2251799813685248) in
+           expr_let y44 := y35 +
+                           ((fst @@ x [[0]] * snd @@ x [[3]])%expr +
+                            ((fst @@ x [[1]] * snd @@ x [[2]])%expr +
+                             ((fst @@ x [[2]] * snd @@ x [[1]])%expr +
+                              ((fst @@ x [[3]] * snd @@ x [[0]])%expr +
+                               (19 * (fst @@ x [[4]] * snd @@ x [[4]])%expr)%expr)%expr)%expr)%expr)%expr in
+           expr_let y45 := Z.div @@ (y44, 2251799813685248) in
+           expr_let y46 := Z.modulo @@ (y44, 2251799813685248) in
+           expr_let y53 := y45 +
+                           ((fst @@ x [[0]] * snd @@ x [[4]])%expr +
+                            ((fst @@ x [[1]] * snd @@ x [[3]])%expr +
+                             ((fst @@ x [[2]] * snd @@ x [[2]])%expr +
+                              ((fst @@ x [[3]] * snd @@ x [[1]])%expr +
+                               (fst @@ x [[4]] * snd @@ x [[0]])%expr)%expr)%expr)%expr)%expr in
+           expr_let y54 := Z.div @@ (y53, 2251799813685248) in
+           expr_let y55 := Z.modulo @@ (y53, 2251799813685248) in
+           expr_let y72 := y13 + (19 * y54)%expr in
+           expr_let y73 := Z.div @@ (y72, 2251799813685248) in
+           expr_let y74 := Z.modulo @@ (y72, 2251799813685248) in
+           expr_let y81 := y73 + y25 in
+           expr_let y82 := Z.div @@ (y81, 2251799813685248) in
+           expr_let y83 := Z.modulo @@ (y81, 2251799813685248) in
+           y74 :: y83 :: y82 + y36 :: y46 :: y55 :: [])%expr) fg
+*)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -1522,7 +1522,6 @@ Module Compilers.
   End gallina_reify.
 
   Module partial.
-    (** TODO: pick a better name for this (partial_expr?) *)
     Section value.
       Context (var : type -> Type).
       Definition value_prestep (value : type -> Type) (t : type)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -649,8 +649,9 @@ Module Compilers.
           | @List.repeat ?A
             => let rA := type.reify A in
                constr:(@ident.List_repeat rA)
-          | @LetIn.Let_In ?A (fun _ => ?B)
-            => let rA := type.reify A in
+          | @LetIn.Let_In ?A ?B
+            => let B := lazymatch (eval cbv beta in B) with fun _ => ?B => B end in
+               let rA := type.reify A in
                let rB := type.reify B in
                constr:(@ident.Let_In rA rB)
           | @combine ?A ?B
@@ -853,8 +854,9 @@ Module Compilers.
             => let rT := type.reify T in
                constr:(@ident.nat_rect rT)
           | Nat.pred => ident.pred
-          | @LetIn.Let_In ?A (fun _ => ?B)
-            => let rA := type.reify A in
+          | @LetIn.Let_In ?A ?B
+            => let B := lazymatch (eval cbv beta in B) with fun _ => ?B => B end in
+               let rA := type.reify A in
                let rB := type.reify B in
                constr:(@ident.Let_In rA rB)
           | @Datatypes.list_rect ?A (fun _ => ?B)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -316,79 +316,78 @@ Module Compilers.
   End type.
   Export type.Notations.
 
-  Module op.
+  Module ident.
     Import type.
-    Inductive op : type -> type -> Set :=
-    | Const {t} (v : interp t) : op unit t
-    | Let_In {tx tC} : op (tx * (tx -> tC)) tC
-    | App {s d} : op ((s -> d) * s) d
-    | S : op nat nat
-    | nil {t} : op unit (list t)
-    | cons {t} : op (t * list t) (list t)
-    | fst {A B} : op (A * B) A
-    | snd {A B} : op (A * B) B
-    | bool_rect {T} : op (T * T * bool) T
-    | nat_rect {P} : op (P * (nat -> P -> P) * nat) P
-    | pred : op nat nat
-    | List_seq : op (nat * nat) (list nat)
-    | List_repeat {A} : op (A * nat) (list A)
-    | List_combine {A B} : op (list A * list B) (list (A * B))
-    | List_map {A B} : op ((A -> B) * list A) (list B)
-    | List_flat_map {A B} : op ((A -> list B) * list A) (list B)
-    | List_partition {A} : op ((A -> bool) * list A) (list A * list A)
-    | List_app {A} : op (list A * list A) (list A)
-    | List_fold_right {A B} : op ((B -> A -> A) * A * list B) A
-    | List_update_nth {T} : op (nat * (T -> T) * list T) (list T)
-    | Z_runtime_mul : op (Z * Z) Z
-    | Z_runtime_add : op (Z * Z) Z
-    | Z_add : op (Z * Z) Z
-    | Z_mul : op (Z * Z) Z
-    | Z_pow : op (Z * Z) Z
-    | Z_opp : op Z Z
-    | Z_div : op (Z * Z) Z
-    | Z_modulo : op (Z * Z) Z
-    | Z_eqb : op (Z * Z) bool
-    | Z_of_nat : op nat Z.
+    Inductive ident : type -> Set :=
+    | Const {t} (v : interp t) : ident t
+    | Let_In {tx tC} : ident (tx -> (tx -> tC) -> tC)
+    | S : ident (nat -> nat)
+    | nil {t} : ident (list t)
+    | cons {t} : ident (t -> list t -> list t)
+    | pair {A B} : ident (A -> B -> A * B)
+    | fst {A B} : ident (A * B -> A)
+    | snd {A B} : ident (A * B -> B)
+    | bool_rect {T} : ident (T -> T -> bool -> T)
+    | nat_rect {P} : ident (P -> (nat -> P -> P) -> nat -> P)
+    | pred : ident (nat -> nat)
+    | List_seq : ident (nat -> nat -> list nat)
+    | List_repeat {A} : ident (A -> nat -> list A)
+    | List_combine {A B} : ident (list A -> list B -> list (A * B))
+    | List_map {A B} : ident ((A -> B) -> list A -> list B)
+    | List_flat_map {A B} : ident ((A -> list B) -> list A -> list B)
+    | List_partition {A} : ident ((A -> bool) -> list A -> list A * list A)
+    | List_app {A} : ident (list A -> list A -> list A)
+    | List_rev {A} : ident (list A -> list A)
+    | List_fold_right {A B} : ident ((B -> A -> A) -> A -> list B -> A)
+    | List_update_nth {T} : ident (nat -> (T -> T) -> list T -> list T)
+    | List_nth_default {T} : ident (T -> list T -> nat -> T)
+    | Z_runtime_mul : ident (Z -> Z -> Z)
+    | Z_runtime_add : ident (Z -> Z -> Z)
+    | Z_add : ident (Z -> Z -> Z)
+    | Z_mul : ident (Z -> Z -> Z)
+    | Z_pow : ident (Z -> Z -> Z)
+    | Z_opp : ident (Z -> Z)
+    | Z_div : ident (Z -> Z -> Z)
+    | Z_modulo : ident (Z -> Z -> Z)
+    | Z_eqb : ident (Z -> Z -> bool)
+    | Z_of_nat : ident (nat -> Z)
+    | Nat_sub : ident (nat -> nat -> nat).
 
-    Notation curry2 f
-      := (fun '(a, b) => f a b).
-    Notation curry3 f
-      := (fun '(a, b, c) => f a b c).
-
-    Definition interp {s d} (opc : op s d) : type.interp s -> type.interp d
-      := match opc in op s d return type.interp s -> type.interp d with
-         | Const t v => fun _ => v
-         | Let_In tx tC => curry2 (@LetIn.Let_In (type.interp tx) (fun _ => type.interp tC))
-         | App s d
-           => fun '((f, x) : (type.interp s -> type.interp d) * type.interp s)
-              => f x
+    Definition interp {t} (idc : ident t) : type.interp t
+      := match idc in ident t return type.interp t with
+         | Const t v => v
+         | Let_In tx tC => @LetIn.Let_In (type.interp tx) (fun _ => type.interp tC)
          | S => Datatypes.S
-         | nil t => fun _ => @Datatypes.nil (type.interp t)
-         | cons t => curry2 (@Datatypes.cons (type.interp t))
+         | nil t => @Datatypes.nil (type.interp t)
+         | cons t => @Datatypes.cons (type.interp t)
+         | pair A B => @Datatypes.pair (type.interp A) (type.interp B)
          | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
          | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
-         | bool_rect T => curry3 (@Datatypes.bool_rect (fun _ => type.interp T))
-         | nat_rect P => curry3 (@Datatypes.nat_rect (fun _ => type.interp P))
+         | bool_rect T => @Datatypes.bool_rect (fun _ => type.interp T)
+         | nat_rect P => @Datatypes.nat_rect (fun _ => type.interp P)
          | pred => Nat.pred
-         | List_seq => curry2 List.seq
-         | List_combine A B => curry2 (@List.combine (type.interp A) (type.interp B))
-         | List_map A B => curry2 (@List.map (type.interp A) (type.interp B))
-         | List_repeat A => curry2 (@List.repeat (type.interp A))
-         | List_flat_map A B => curry2 (@List.flat_map (type.interp A) (type.interp B))
-         | List_partition A => curry2 (@List.partition (type.interp A))
-         | List_app A => curry2 (@List.app (type.interp A))
-         | List_fold_right A B => curry3 (@List.fold_right (type.interp A) (type.interp B))
-         | List_update_nth T => curry3 (@update_nth (type.interp T))
-         | Z_runtime_mul => curry2 runtime_mul
-         | Z_runtime_add => curry2 runtime_add
-         | Z_add => curry2 Z.add
-         | Z_mul => curry2 Z.mul
-         | Z_pow => curry2 Z.pow
-         | Z_modulo => curry2 Z.modulo
+         | List_seq => List.seq
+         | List_combine A B => @List.combine (type.interp A) (type.interp B)
+         | List_map A B => @List.map (type.interp A) (type.interp B)
+         | List_repeat A => @List.repeat (type.interp A)
+         | List_flat_map A B => @List.flat_map (type.interp A) (type.interp B)
+         | List_partition A => @List.partition (type.interp A)
+         | List_app A => @List.app (type.interp A)
+         | List_rev A => @List.rev (type.interp A)
+         | List_fold_right A B => @List.fold_right (type.interp A) (type.interp B)
+         | List_update_nth T => @update_nth (type.interp T)
+         | List_nth_default T => @List.nth_default (type.interp T)
+         | Z_runtime_mul => runtime_mul
+         | Z_runtime_add => runtime_add
+         | Z_add => Z.add
+         | Z_mul => Z.mul
+         | Z_pow => Z.pow
+         | Z_modulo => Z.modulo
          | Z_opp => Z.opp
-         | Z_div => curry2 Z.div
-         | Z_eqb => curry2 Z.eqb
+         | Z_div => Z.div
+         | Z_eqb => Z.eqb
          | Z_of_nat => Z.of_nat
+         | Nat_sub => Nat.sub
          end.
 
     Module List.
@@ -399,8 +398,10 @@ Module Compilers.
       Notation flat_map := List_flat_map.
       Notation partition := List_partition.
       Notation app := List_app.
+      Notation rev := List_rev.
       Notation fold_right := List_fold_right.
       Notation update_nth := List_update_nth.
+      Notation nth_default := List_nth_default.
     End List.
 
     Module Z.
@@ -416,43 +417,50 @@ Module Compilers.
       Notation of_nat := Z_of_nat.
     End Z.
 
+    Module Nat.
+      Notation sub := Nat_sub.
+    End Nat.
+
     Module Export Notations.
-      Notation op := op.
+      Notation ident := ident.
     End Notations.
-  End op.
-  Export op.Notations.
+  End ident.
+  Export ident.Notations.
 
   Inductive expr {var : type -> Type} : type -> Type :=
-  | TT : expr ()
-  | Pair {A B} (a : expr A) (b : expr B) : expr (A * B)
   | Var {t} (v : var t) : expr t
-  | Op {s d} (opc : op s d) (args : expr s) : expr d
+  | Ident {t} (idc : ident t) : expr t
+  | App {s d} (f : expr (s -> d)) (x : expr s) : expr d
   | Abs {s d} (f : var s -> expr d) : expr (s -> d).
+
+  Notation TT := (Ident (@ident.Const type.unit tt)).
+  Notation Pair x y := (App (App (Ident ident.pair) x) y).
 
   Bind Scope expr_scope with expr.
   Delimit Scope expr_scope with expr.
+  Notation "f x" := (App f x) (only printing) : expr_scope.
   Notation "'λ'  x .. y , t" := (Abs (fun x => .. (Abs (fun y => t%expr)) ..)) : expr_scope.
   Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
   Notation "( )" := TT : expr_scope.
   Notation "()" := TT : expr_scope.
-  Notation "'expr_let' x := A 'in' b" := (Op op.Let_In (Pair A%expr (Abs (fun x => b%expr)))) : expr_scope.
-  Notation "f x" := (Op op.App (f, x)%expr) (only printing) : expr_scope.
+  Notation "'expr_let' x := A 'in' b" := (App (App (Ident ident.Let_In) A%expr) (Abs (fun x => b%expr))) : expr_scope.
+  Notation "[ ]" := (Ident ident.nil) : expr_scope.
+  Notation "x :: xs" := (App (App (Ident ident.cons) x%expr) xs%expr) : expr_scope.
 
   Definition Expr t := forall var, @expr var t.
 
   Fixpoint interp {t} (e : @expr type.interp t) : type.interp t
     := match e with
-       | TT => tt
-       | Pair A B a b => (interp a, interp b)
        | Var t v => v
-       | Op s d opc args => op.interp opc (interp args)
+       | Ident t idc => ident.interp idc
+       | App s d f x => interp f (interp x)
        | Abs s d f => fun v => interp (f v)
        end.
 
   Definition Interp {t} (e : Expr t) := interp (e _).
 
   Definition const {var t} (v : type.interp t) : @expr var t
-    := Op (op.Const v) TT.
+    := Ident (ident.Const v).
 
   Section option_partition.
     Context {A : Type} (f : A -> option Datatypes.bool).
@@ -509,48 +517,102 @@ Module Compilers.
          | _ => None
          end.
 
-    Definition invert_Pair {A B} (e : @expr var (type.prod A B)) : option (@expr var A * @expr var B)
-      := match e in expr t return option match t with
-                                         | type.prod _ _ => _
-                                         | _ => True
-                                         end with
-         | Pair _ _ a b => Some (a, b)
-         | _ => None
-         end.
-
-    Definition invert_Op {t} (e : @expr var t) : option { s : _ & op s t * @expr var s }%type
+    Definition invert_App {d} (e : @expr var d) : option { s : _ & @expr var (s -> d) * @expr var s }%type
       := match e with
-         | Op s d opc args => Some (existT _ s (opc, args))
+         | App s d f x => Some (existT _ s (f, x))
          | _ => None
          end.
 
-    Definition invert_OpConst {t} (e : @expr var t) : option (type.interp t)
-      := match invert_Op e with
-         | Some (existT s (opc, args))
-           => match opc with
-              | op.Const t v => Some v
+    Definition invert_Ident {t} (e : @expr var t) : option (ident t)
+      := match e with
+         | Ident t idc => Some idc
+         | _ => None
+         end.
+
+    Definition invert_Const {t} (e : @expr var t) : option (type.interp t)
+      := match invert_Ident e with
+         | Some idc
+           => match idc with
+              | ident.Const t v => Some v
               | _ => None
               end
          | None => None
          end.
 
-    Definition invert_op_S (e : @expr var type.nat) : option (@expr var type.nat)
-      := match invert_Op e with
-         | Some (existT s (opc, args))
-           => match opc in op s d return expr s -> option (expr type.nat) with
-              | op.S => fun args => Some args
-              | _ => fun _ => None
-              end args
+    Definition invert_AppIdent {d} (e : @expr var d) : option { s : _ & @ident (s -> d) * @expr var s }%type
+      := match invert_App e with
+         | Some (existT s (f, x))
+           => match invert_Ident f with
+              | Some f' => Some (existT _ s (f', x))
+              | None => None
+              end
          | None => None
          end.
 
-    Definition invert_Z (e : @expr var type.Z) : option Z := invert_OpConst e.
-    Definition invert_bool (e : @expr var type.bool) : option bool := invert_OpConst e.
+    Definition invert_App2 {d} (e : @expr var d) : option { s1s2 : _ * _ & @expr var (fst s1s2 -> snd s1s2 -> d) * @expr var (fst s1s2) * @expr var (snd s1s2) }%type
+      := match invert_App e with
+         | Some (existT s (f, y))
+           => match invert_App f with
+              | Some (existT s' (f', x))
+                => Some (existT _ (s', s) (f', x, y))
+              | None => None
+              end
+         | None => None
+         end.
+
+    Definition invert_Pair {A B} (e : @expr var (type.prod A B)) : option (@expr var A * @expr var B)
+      := match invert_App2 e with
+         | Some (existT (s1, s2) (f, x, y))
+           => match invert_Ident f with
+              | Some idc
+                => match idc in ident t
+                         return match t return Type with
+                                | (A -> B -> _)%ctype
+                                  => expr A
+                                | _ => True
+                                end
+                                -> match t return Type with
+                                   | (A -> B -> _)%ctype
+                                     => expr B
+                                   | _ => True
+                                   end
+                                -> option match t with
+                                          | (_ -> _ -> A * B)%ctype
+                                            => expr A * expr B
+                                          | _ => True
+                                          end
+                   with
+                   | ident.pair A B => fun x y => Some (x, y)
+                   | _ => fun _ _ => None
+                   end x y
+              | None => None
+              end
+         | None => None
+         end.
+
+    Definition invert_S (e : @expr var type.nat) : option (@expr var type.nat)
+      := match invert_AppIdent e with
+         | Some (existT s (idc, x))
+           => match idc in ident t
+                    return match t return Type with
+                           | (s -> d)%ctype => expr s
+                           | _ => True
+                           end
+                           -> option (expr type.nat)
+              with
+              | ident.S => fun args => Some args
+              | _ => fun _ => None
+              end x
+         | None => None
+         end.
+
+    Definition invert_Z (e : @expr var type.Z) : option Z := invert_Const e.
+    Definition invert_bool (e : @expr var type.bool) : option bool := invert_Const e.
     Fixpoint invert_nat_full (e : @expr var type.nat) : option nat
-      := match e with
-         | Op _ _ op.S args
+      := match e return option nat with
+         | App type.nat _ (Ident _ ident.S) args
            => option_map S (invert_nat_full args)
-         | Op _ _ (op.Const type.nat v) _
+         | Ident _ (ident.Const type.nat v)
            => Some v
          | _ => None
          end.
@@ -562,37 +624,69 @@ Module Compilers.
                                          | _ => True
                                          end
          with
-         | Op s d opc args
-           => match opc in op s d
-                    return option match s with
-                                  | type.prod A (type.list B) => expr A * list (expr B)
+         | Ident t idc
+           => match idc in ident t
+                    return option match t return Type with
+                                  | type.list A => list (expr A)
                                   | _ => True
                                   end
-                           -> option match d with
-                                     | type.list t => list (expr t)
-                                     | _ => True
-                                     end
               with
-              | op.Const (type.list _) v => fun _ => Some (List.map const v)
-              | op.cons _ => option_map (fun '(x, xs) => cons x xs)
-              | op.nil _ => fun _ => Some nil
-              | _ => fun _ => None
+              | ident.Const (type.list _) v => Some (List.map const v)
+              | ident.nil _ => Some nil
+              | _ => None
               end
-                (match args in expr t
-                       return option match t with
-                                     | type.prod A (type.list B) => expr A * list (expr B)
+         | App (type.list s) d f xs
+           => match @invert_list_full s xs return _ with
+              | Some xs
+                => match invert_AppIdent f
+                         return option match d return Type with
+                                       | type.list t => list (expr t)
+                                       | _ => True
+                                       end
+                   with
+                   | Some (existT s' (idc, x))
+                     => match idc in ident t
+                              return match t return Type with
+                                     | (s' -> d')%ctype => expr s'
                                      | _ => True
                                      end
-                 with
-                 | Pair _ (type.list _) x xs
-                   => match @invert_list_full _ xs with
-                      | Some xs => Some (x, xs)
-                      | None => None
-                      end
-                 | _ => None
-                 end)
+                                     -> match t return Type with
+                                        | (s' -> type.list s -> _)%ctype => list (expr s)
+                                        | _ => list (@expr var s)
+                                        end
+                                     -> option match t return Type with
+                                               | (_ -> _ -> type.list d)%ctype => list (expr d)
+                                               | _ => True
+                                               end
+                        with
+                        | ident.cons A => fun x xs => Some (cons x xs)
+                        | _ => fun _ _ => None
+                        end x xs
+                   | _ => None
+                   end
+              | None => None
+              end
          | _ => None
          end.
+
+    (** TODO: figure out a better name for this *)
+    Definition Smart_invert_Pair {A B} (e : @expr var (type.prod A B)) : option (@expr var A * @expr var B)
+      := match invert_Pair e, invert_Var e, invert_Const e with
+         | Some ab, _, _ => Some ab
+         | _, Some v, _ => Some (App (Ident ident.fst) (Var v), App (Ident ident.snd) (Var v))
+         | _, _, Some v => Some (@const var A (fst v), @const var B (snd v))
+         | None, None, None => None
+         end.
+
+    (** TODO: figure out a better name for this *)
+    Definition Smart_invert_list_full {A} (e : @expr var (type.list A)) : option (list (@expr var A))
+      := match invert_Const e, invert_list_full e with
+         | Some ls, _ => Some (List.map (@const var A) ls)
+         | _, Some ls => Some ls
+         | None, None => None
+         end.
+
+
     (*Section with_map.
       (* oh, the horrors of not being able to use non-linear deep
          pattern matches.  Luckily Coq's guard checker unfolds things,
@@ -634,17 +728,17 @@ Module Compilers.
         : forall d : extra_dataT t, option (list (U t d))
       := match e in expr t return list_to_forall_data_option_list t
            with
-           | Op s d opc args
-             => match opc in op s d
+           | Op s d idc args
+             => match idc in op s d
                       return (prod_list_to_forall_data_option_list s
                               -> list_to_forall_data_option_list d)
                 with
-                | op.Const (type.list _) v
+                | ident.Const (type.list _) v
                   => fun _ data => Some (List.map (f _ data) (List.map const v))
-                | op.cons _
+                | ident.cons _
                   => fun xs data
                      => option_map (fun '(x, xs) => cons (f _ data x) xs) (xs data)
-                | op.nil _
+                | ident.nil _
                   => fun _ _ => Some nil
                 | _ => fun _ _ => None
                 end
@@ -669,23 +763,260 @@ Module Compilers.
     Definition reify_list {t} (ls : list (@expr var t)) : @expr var (type.list t)
       := list_rect
            (fun _ => _)
-           (Op op.nil TT)
-           (fun x _ xs => Op op.cons (x, xs))
+           (Ident ident.nil)
+           (fun x _ xs => App (App (Ident ident.cons) x) xs)
+           ls.
+
+    Definition reify_list_by_app {t} (ls : list (@expr var (type.list t))) : @expr var (type.list t)
+      := list_rect
+           (fun _ => _)
+           (Ident ident.nil)
+           (fun ls1 _ ls2 => App (App (Ident ident.List.app) ls1) ls2)
            ls.
   End gallina_reify.
 
-
+  (** TODO: should this even be named [arguments]? *)
   Module arguments.
-    Inductive arguments : type -> Set :=
-    | generic {T} : arguments T
-    (*| cps {T} (aT : arguments T) : arguments T*)
-    | arrow {A B} (aB : arguments B) : arguments (A -> B)
-    | unit : arguments type.unit
-    | prod {A B} (aA : arguments A) (aB : arguments B) : arguments (A * B)
-    | list {T} (aT : arguments T) : arguments (type.list T)
-    | nat : arguments type.nat
-    | Z : arguments type.Z
-    | bool : arguments type.bool.
+    (*Module rec.*)
+    (** TODO: pick a better name for this (partial_expr?) *)
+    Section interp.
+      Context (var : type -> Type).
+      Definition interp_prestep (interp : type -> Type) (t : type)
+        := match t return Type with
+           | type.prod A B as t => interp A * interp B
+           | type.arrow s d => interp s -> interp d
+           | type.list A => list (interp A)
+           | type.unit as t
+           | type.Z as t
+           | type.nat as t
+           | type.bool as t
+             => type.interp t
+           end%type.
+      Definition interp_step (interp : type -> Type) (t : type)
+        := match t return Type with
+           | type.unit as t
+           | type.arrow _ _ as t
+             => interp_prestep interp t
+           | type.prod _ _ as t
+           | type.list _ as t
+           | type.Z as t
+           | type.nat as t
+           | type.bool as t
+             => @expr var t + interp_prestep interp t
+           end%type.
+      Fixpoint interp (t : type)
+        := interp_step interp t.
+
+      Definition unprestep {t : type} : interp_prestep interp t -> interp t
+        := match t return interp_prestep interp t -> interp t with
+           | type.unit as t
+           | type.arrow _ _ as t
+             => id
+           | type.prod _ _ as t
+           | type.list _ as t
+           | type.Z as t
+           | type.nat as t
+           | type.bool as t
+             => @inr _ (interp_prestep interp t)
+           end%type.
+
+      Definition unprestep2 {t : type}
+        : interp_prestep (interp_prestep interp) t
+          -> match t with
+             | type.arrow _ _ => interp_prestep (interp_prestep interp) t
+             | t => interp_prestep interp t
+             end
+        := match t
+                 return (interp_prestep (interp_prestep interp) t
+                         -> match t with
+                            | type.arrow _ _ => interp_prestep (interp_prestep interp) t
+                            | t => interp_prestep interp t
+                            end)
+           with
+           | type.prod A B
+             => fun '((a, b) : interp_prestep interp A * interp_prestep interp B)
+                => (@unprestep A a, @unprestep B b)
+           | type.list A as t
+             => List.map (@unprestep A)
+           | type.arrow _ _ as t
+           | type.unit as t
+           | type.Z as t
+           | type.nat as t
+           | type.bool as t
+             => id
+           end%type.
+    End interp.
+    Arguments unprestep {var t} _.
+    Arguments unprestep2 {var t} _.
+
+
+      (*Definition invert1 {var} {t : type}
+        : interp var t -> (var t + interp_step (interp var) t)
+        := match t with
+           | type.unit
+           | _
+             => id
+           end.
+
+      Definition generic {var : type -> Type} {t : type} : var t -> interp var t
+        := match t with
+           | type.unit
+           | _
+             => @inl _ _
+           end.*)
+
+      Notation expr_const := const.
+
+      Module expr.
+        Section reify.
+          Context {var : type -> Type}.
+          (** TODO: figure out if these names are good; [eta_expand] is maybe better called [reflect]?  or [expand]? *)
+          Fixpoint reify {t : type} {struct t}
+            : interp var t -> @expr var t
+            := match t return interp var t -> expr t with
+               | type.unit as t => expr_const (t:=t)
+               | type.prod A B as t
+                 => fun x : expr t + interp var A * interp var B
+                    => match x with
+                       | inl v => v
+                       | inr (a, b) => (@reify A a, @reify B b)%expr
+                       end
+               | type.arrow s d
+                 => fun (f : interp var s -> interp var d)
+                    => Abs (fun x
+                            => @reify d (f (@eta_expand s (Var x))))
+               | type.list A as t
+                 => fun x : expr t + list (interp var A)
+                    => match x with
+                       | inl v => v
+                       | inr v => reify_list (List.map (@reify A) v)
+                       end
+               | type.nat as t
+               | type.Z as t
+               | type.bool as t
+                 => fun x : expr t + type.interp t
+                    => match x with
+                       | inl v => v
+                       | inr v => expr_const (t:=t) v
+                       end
+               end
+          with eta_expand {t : type}
+               : @expr var t -> interp var t
+               := match t return expr t -> interp var t with
+                  | type.arrow s d
+                    => fun (f : expr (s -> d)) (x : interp var s)
+                       => @eta_expand d (App f (@reify s x))
+                  | type.unit => fun _ => tt
+                  | type.prod A B as t
+                    => fun v : expr t
+                       => let inr := @inr (expr t) (interp_prestep (interp var) t) in
+                          let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                          match Smart_invert_Pair v with
+                          | Some (a, b)
+                            => inr (@eta_expand A a, @eta_expand B b)
+                          | None
+                            => inl v
+                          end
+                  | type.list A as t
+                    => fun v : expr t
+                       => let inr := @inr (expr t) (interp_prestep (interp var) t) in
+                          let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                          match Smart_invert_list_full v with
+                          | Some ls
+                            => inr (List.map (@eta_expand A) ls)
+                          | None
+                            => inl v
+                          end
+                  | type.nat as t
+                    => fun v : expr t
+                       => let inr := @inr (expr t) (interp_prestep (interp var) t) in
+                          let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                          match invert_nat_full v with
+                          | Some v => inr v
+                          | None => inl v
+                          end
+                  | type.Z as t
+                  | type.bool as t
+                    => fun v : expr t
+                       => let inr := @inr (expr t) (interp_prestep (interp var) t) in
+                          let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                          match invert_Const v with
+                          | Some v => inr v
+                          | None => inl v
+                          end
+                  end.
+        End reify.
+
+        Section SmartLetIn.
+          Context {var : type -> Type} {tC : type}.
+          (** TODO: Find a better name for this *)
+          (** N.B. This always inlines functions; not sure if this is the right thing to do *)
+          (** TODO: should we handle let-bound pairs, let-bound lists?  What should we do with them?  Here, I make the decision to always inline them; not sure if this is right *)
+          Fixpoint SmartLetIn {tx : type} : interp var tx -> (interp var tx -> interp var tC) -> interp var tC
+            := match tx return interp var tx -> (interp var tx -> interp var tC) -> interp var tC with
+               | type.unit => fun _ f => f tt
+               | type.arrow _ _
+               | type.prod _ _
+               | type.list _
+                 => fun x f => f x
+               | type.nat as t
+               | type.Z as t
+               | type.bool as t
+                 => fun (x : expr t + type.interp t) (f : expr t + type.interp t -> interp var tC)
+                    => match x with
+                       | inl e
+                         => match invert_Var e, invert_Const e with
+                            | Some v, _ => f (inl (Var v))
+                            | _, Some v => f (inr v)
+                            | None, None => eta_expand (expr_let y := e in reify (f (inl (Var y))))%expr
+                            end
+                       | inr v => f (inr v)
+                       end
+               end.
+        End SmartLetIn.
+      End expr.
+      (*
+      Section const.
+        Context {var : type -> Type} (const_var_arrow : forall s d,
+                                         type.interp (s -> d) -> var (s -> d)%ctype).
+        Fixpoint const {t : type} : type.interp t -> interp var t.
+          refine match t return type.interp t -> interp var t with
+             | type.prod A B as t
+               => fun '((a, b) : type.interp A * type.interp B)
+                  => @inr
+                       (expr t) (interp var A * interp var B)
+                       (@const A a, @const B b)
+             | type.arrow s d
+               => fun (f : type.interp s -> type.interp d) (x : interp var s)
+                  => _ : interp var d
+             | type.list A as t
+               => fun ls : list (type.interp A)
+                  => @inr (expr t) (list (interp var A))
+                          (List.map (@const A) ls)
+             | type.unit as t
+               => id
+             | type.nat as t
+             | type.Z as t
+             | type.bool as t
+               => @inr (expr t) (type.interp t)
+                 end.
+          cbn.
+      End const.
+*)
+  (*End rec.*)
+
+      (*Module ind.
+      Module arguments.
+        Inductive arguments : type -> Set :=
+        | generic {T} : arguments T
+        (*| cps {T} (aT : arguments T) : arguments T*)
+        | arrow {A B} (aB : arguments B) : arguments (A -> B)
+        | unit : arguments type.unit
+        | prod {A B} (aA : arguments A) (aB : arguments B) : arguments (A * B)
+        | list {T} (aT : arguments T) : arguments (type.list T)
+        | nat : arguments type.nat
+        | Z : arguments type.Z
+        | bool : arguments type.bool.
 
     Definition preinvertT (t : type) :=
       match t with
@@ -859,7 +1190,40 @@ Module Compilers.
       End option.
     End type.
 
-    Module expr.
+     Module expr.
++      Section reify.
++        Context {var : type -> Type}.
++        Fixpoint reify {t : type} (v : interp (@expr var) t) {struct t}
++          : @expr var t
++          := match invert1 v with
++             | inl e => e
++             | inr e
++               => match t return interp_step (interp expr) t -> expr t with
++                  | type.prod A B
++                    => fun '((a, b) : interp expr A * interp expr B)
++                       => Pair (@reify A a) (@reify B b)
++                  | type.arrow s d
++                    => fun f
++                       => Abs (fun x => @reify d (f (generic (Var x))))
++                  | type.list A
++                    => fun e
++                       => list_rect
++                            (fun _ => expr (type.list A))
++                            (Ident ident.nil)
++                            (fun x _ xs
++                             => App (App (Ident ident.cons) x) xs)
++                            (List.map (@reify A) e)
++                  | type.unit as t
++                  | type.nat as t
++                  | type.Z as t
++                  | type.bool as t
++                    => expr_const (t:=t)
++                  end e
++             end.
++      End reify.
++
+    End ind.*)
+      (*
       Section interp.
         Context (var : type -> Type).
         Fixpoint interp {t} (a : arguments t)
@@ -873,7 +1237,7 @@ Module Compilers.
                        B aB
                        match invert_Abs e, invert_Var arg with
                        | Some f, Some arg => f arg
-                       | _, _ => Op op.App (e, arg)
+                       | _, _ => Op ident.App (e, arg)
                        end
              | unit => fun _ => tt
              | prod A B aA aB
@@ -910,58 +1274,411 @@ Module Compilers.
              | Z => @const var type.Z
              | bool => @const var type.bool
              end.
-      End reify.
-    End expr.
-
+      End reify.*)
+    (*End expr.*)
+    (*
     Module Export Notations.
       Delimit Scope arguments_scope with arguments.
-      Bind Scope arguments_scope with arguments.
-      Notation "()" := unit : arguments_scope.
+      Bind Scope arguments_scope with interp.
+      Notation "()" := (inr tt) : arguments_scope.
       Notation "A * B" := (prod A B) : arguments_scope.
       Notation "A -> B" := (@arrow A _ B) (only printing) : arguments_scope.
       Notation "A -> B" := (arrow B) (only parsing) : arguments_scope.
       Global Coercion generic : type.type >-> arguments.
       Notation arguments := arguments.
     End Notations.
+     *)
 
-    Module op.
-      Local Open Scope arguments_scope.
-      Definition lookup {s d} (opc : op s d) : arguments s * arguments d
-        := match opc in op s d return arguments s * arguments d with
-           | op.Const t v => (generic, ground)
-           | op.Let_In tx tC => (tx * (tx -> tC), generic)
-           | op.App s d => ((s -> d) * s, generic)
-           | op.S => (ground, ground)
-           | op.nil t => (generic, ground)
-           | op.cons t => (t * list t, list t)
-           | op.fst A B => (A * B, generic)
-           | op.snd A B => (A * B, generic)
-           | op.bool_rect T => (T * T * bool, generic)
-           | op.nat_rect P => (P * (nat -> P -> P) * nat, generic)
-           | op.pred => (nat, ground)
-           | op.List_seq => (nat * nat, ground)
-           | op.List_repeat A => (A * nat, list A)
-           | op.List_combine A B => (list A * list B, list (A * B))
-           | op.List_map A B => ((A -> B) * list A, list B)
-           | op.List_flat_map A B => ((A -> list B) * list A, list B)
-           | op.List_partition A => ((A -> bool) * list A, list A * list A)
-           | op.List_app A => (list A * list A, list A)
-           | op.List_fold_right A B => ((B -> A -> A) * A * list B, generic)
-           | op.List_update_nth T => (nat * (T -> T) * list T, list T)
-           | op.Z_runtime_mul => (Z * Z, Z)
-           | op.Z_runtime_add => (Z * Z, Z)
-           | op.Z_add => (Z * Z, Z)
-           | op.Z_mul => (Z * Z, Z)
-           | op.Z_pow => (Z * Z, Z)
-           | op.Z_opp => (Z, Z)
-           | op.Z_div => (Z * Z, Z)
-           | op.Z_modulo => (Z * Z, Z)
-           | op.Z_eqb => (Z * Z, bool)
-           | op.Z_of_nat => (nat, Z)
+    Definition sum_arrow {A A' B B'} (f : A -> A') (g : B -> B')
+               (v : A + B)
+      : A' + B'
+      := match v with
+         | inl v => inl (f v)
+         | inr v => inr (g v)
+         end.
+    Infix "+" := sum_arrow : function_scope.
+
+    Module ident.
+      (*Local Open Scope arguments_scope.*)
+      Section interp.
+        Context {var : type -> Type}.
+        (*Notation default_App0 idc
+          := (inr (ident.interp idc))
+               (only parsing).
+        Notation default_App1 idc
+          := (inr (App (Ident idc) + ident.interp idc)%function)
+               (only parsing).
+        Notation default_App2 idc
+          := (inr (App (Ident idc)
+                   + (fun x
+                      => App (App (Ident idc) (expr_const x))
+                         + ident.interp idc x))%function)
+               (only parsing).
+
+        Let default_App1e {A B}
+            (f : interp (@expr var) A -> interp (@expr var) B)
+          : interp (@expr var) (A -> B)
+          := inr f.
+        Let default_App2e {A B C}
+            (f : interp (@expr var) A -> interp (@expr var) B -> interp (@expr var) C)
+          : interp (@expr var) (A -> B -> C)
+          := inr (fun x => inr (f x)).
+         *)
+        Let defaulted_App_p_e {A B} (idc : ident (A -> B))
+            (F : interp_prestep (interp var) A
+                 -> interp var B)
+          : @expr var A + interp_prestep (interp var) A
+            -> interp var B
+          := fun x
+             => match x with
+                | inl e => expr.eta_expand (App (Ident idc) e)
+                | inr x => F x
+                end.
+        Let defaulted_App_p_p {A B} (idc : ident (A -> B))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) B)
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var B + interp_prestep (interp var) B
+          := (App (Ident idc) + F)%function.
+        Let defaulted_App_ep_p {A B C} (idc : ident (A -> B -> C))
+            (F : interp var A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp var) C)
+          : interp var A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x
+             => (App (App (Ident idc) (expr.reify x))
+                 + (F x))%function.
+        Let defaulted_App_eep_e {A B C D} (idc : ident (A -> B -> C -> D))
+            (F : interp var A
+                 -> interp var B
+                 -> interp_prestep (interp var) C
+                 -> interp var D)
+          : interp var A
+            -> interp var B
+            -> @expr var C + interp_prestep (interp var) C
+            -> interp var D
+          := fun x y z
+             => match z with
+                | inl z => expr.eta_expand (App (App (App (Ident idc) (expr.reify x)) (expr.reify y)) z)
+                | inr z => F x y z
+                end.
+        Let defaulted_App_pe_p {A B C} (idc : ident (A -> B -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp var B
+                 -> interp_prestep (interp var) C)
+          : @expr var A + interp_prestep (interp var) A
+            -> interp var B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x y
+             => match x with
+                | inl x => inl (App (App (Ident idc) x) (expr.reify y))
+                | inr x => inr (F x y)
+                end.
+        Let defaulted_App_pep_p {A B C D} (idc : ident (A -> B -> C -> D))
+            (F : interp_prestep (interp var) A
+                 -> interp var B
+                 -> interp_prestep (interp var) C
+                 -> interp_prestep (interp var) D)
+          : @expr var A + interp_prestep (interp var) A
+            -> interp var B
+            -> @expr var C + interp_prestep (interp var) C
+            -> @expr var D + interp_prestep (interp var) D
+          := fun x y z
+             => let xz
+                    := match x, z with
+                       | inl x, inl z => inl (x, z)
+                       | inr x, inl z => inl (expr.reify (unprestep x), z)
+                       | inl x, inr z => inl (x, expr.reify (unprestep z))
+                       | inr x, inr z => inr (x, z)
+                       end in
+                match xz with
+                | inl (x, z) => inl (App (App (App (Ident idc) x) (expr.reify y)) z)
+                | inr (x, z) => inr (F x y z)
+                end.
+        Let defaulted_App_pp_p {A B C} (idc : ident (A -> B -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp var) C)
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x y
+             => let xy
+                    := match x, y with
+                       | inl x, inl y => inl (x, y)
+                       | inr x, inl y => inl (expr.reify (unprestep x), y)
+                       | inl x, inr y => inl (x, expr.reify (unprestep y))
+                       | inr x, inr y => inr (x, y)
+                       end in
+                match xy with
+                | inl (x, y) => inl (App (App (Ident idc) x) y)
+                | inr (x, y) => inr (F x y)
+                end.
+        Let defaulted_App_pp_p_or_pe_e_or_ep_e {A B C} (idc : ident (A -> B -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp var) C)
+            (F1 : interp_prestep (interp var) A
+                 -> @expr var B
+                 -> option (@expr var C + interp_prestep (interp var) C))
+            (F2 : @expr var A
+                 -> interp_prestep (interp var) B
+                 -> option (@expr var C + interp_prestep (interp var) C))
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x y
+             => let default := defaulted_App_pp_p idc F x y in
+                match x, y with
+                | inl x, inl y => inl (App (App (Ident idc) x) y)
+                | inl x, inr y => match F2 x y with
+                                  | Some Fxy => Fxy
+                                  | None => default
+                                  end
+                | inr x, inl y => match F1 x y with
+                                  | Some Fxy => Fxy
+                                  | None => default
+                                  end
+                | inr x, inr y => inr (F x y)
+                end.
+        Let defaulted_App_pp_p_or_pe_e_comm {A C} (idc : ident (A -> A -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) A
+                 -> interp_prestep (interp var) C)
+            (F1 : interp_prestep (interp var) A
+                 -> @expr var A
+                 -> option (@expr var C + interp_prestep (interp var) C))
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var A + interp_prestep (interp var) A
+            -> @expr var C + interp_prestep (interp var) C
+          := defaulted_App_pp_p_or_pe_e_or_ep_e
+               idc
+               F
+               F1
+               (fun x y => F1 y x).
+        Let defaulted_App_epp_e {A B C D} (idc : ident (A -> B -> C -> D))
+            (F : interp var A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp var) C
+                 -> interp var D)
+          : interp var A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + interp_prestep (interp var) C
+            -> interp var D
+          := fun x y z
+             => let yz
+                    := match y, z with
+                       | inl y, inl z => inl (y, z)
+                       | inr y, inl z => inl (expr.reify (unprestep y), z)
+                       | inl y, inr z => inl (y, expr.reify (unprestep z))
+                       | inr y, inr z => inr (y, z)
+                       end in
+                match yz with
+                | inl (y, z) => expr.eta_expand (App (App (App (Ident idc) (expr.reify x)) y) z)
+                | inr (y, z) => F x y z
+                end.
+        Let defaulted_App_pp_p2 {A B C} (idc : ident (A -> B -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp_prestep (interp var)) C)
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + match C with
+                             | type.arrow s d => interp_prestep (interp_prestep (interp var)) C
+                             | C => interp_prestep (interp var) C
+                             end
+          := fun x y
+             => let xy
+                    := match x, y with
+                       | inl x, inl y => inl (x, y)
+                       | inr x, inl y => inl (expr.reify (unprestep x), y)
+                       | inl x, inr y => inl (x, expr.reify (unprestep y))
+                       | inr x, inr y => inr (x, y)
+                       end in
+                match xy with
+                | inl (x, y) => inl (App (App (Ident idc) x) y)
+                | inr (x, y) => inr (unprestep2 (F x y))
+                end.
+        Let defaulted_App_ep_p2o {A B C} (idc : ident (A -> B -> C))
+            (F : interp var A
+                 -> interp_prestep (interp var) B
+                 -> option (interp_prestep (interp_prestep (interp var)) C))
+          : interp var A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + match C with
+                             | type.arrow s d => interp_prestep (interp_prestep (interp var)) C
+                             | C => interp_prestep (interp var) C
+                             end
+          := fun x y
+             => match y with
+                | inl y => inl (App (App (Ident idc) (expr.reify x)) y)
+                | inr y
+                  => match F x y with
+                     | Some Fxy => inr (unprestep2 Fxy)
+                     | None
+                       => inl (App (App (Ident idc) (expr.reify x)) (expr.reify (unprestep y)))
+                     end
+                end.
+
+
+
+        Let defaulted_App_ee_p {A B C} (idc : ident (A -> B -> C))
+            (F : interp var A
+                 -> interp var B
+                 -> interp_prestep (interp var) C)
+          : interp var A
+            -> interp var B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x y => inr (F x y).
+
+        Definition interp {t} (idc : ident t) : interp var t
+          := match idc in ident t return interp var t with
+             | ident.Const t v as idc
+               => expr.eta_expand (Ident idc)
+             | ident.Let_In tx tC
+               => expr.SmartLetIn
+             | ident.nil t
+               => inr (@nil (interp var t))
+             | ident.cons t as idc
+               => defaulted_App_ep_p idc (@cons (interp var t))
+             | ident.pair A B as idc
+               => defaulted_App_ee_p idc (@pair (interp var A) (interp var B))
+             | ident.fst A B as idc
+               => defaulted_App_p_e idc (@fst (interp var A) (interp var B))
+             | ident.snd A B as idc
+               => defaulted_App_p_e idc (@snd (interp var A) (interp var B))
+             | ident.bool_rect T as idc
+               => defaulted_App_eep_e idc (@bool_rect (fun _ => interp var T))
+             | ident.nat_rect P as idc
+               => defaulted_App_eep_e
+                    idc
+                    (fun O_case S_case n
+                     => @nat_rect
+                          (fun _ => interp var P)
+                          O_case
+                          (fun n' => S_case (inr n'))
+                          n)
+             | ident.List_seq as idc
+               => defaulted_App_pp_p2 idc List.seq
+             | ident.List_repeat A as idc
+               => defaulted_App_ep_p idc (@List.repeat (interp var A))
+             | ident.List_combine A B as idc
+               => defaulted_App_pp_p2 idc (@List.combine (interp var A) (interp var B))
+             | ident.List_map A B as idc
+               => defaulted_App_ep_p idc (@List.map (interp var A) (interp var B))
+             | ident.List_flat_map A B as idc
+               => fun (f : interp var A -> expr (type.list B) + list (interp var B))
+                      (ls : expr (type.list A) + list (interp var A))
+                  => match ls return expr (type.list B) + list (interp var B) with
+                     | inl lse
+                       => inl (App (App (Ident idc) (expr.reify (t:=A->type.list B) f)) lse)
+                     | inr ls
+                       => match option_flat_map
+                                  (fun x => match f x with
+                                            | inl _ => None
+                                            | inr v => Some v
+                                            end)
+                                  ls
+                          with
+                          | Some res => inr res
+                          | None
+                            => let ls'
+                                   := List.map
+                                        (fun x => match f x with
+                                                  | inl e => e
+                                                  | inr v => reify_list (List.map expr.reify v)
+                                                  end)
+                                        ls in
+                               inl (reify_list_by_app ls')
+                          end
+                     end
+             | ident.List_partition A as idc
+               => defaulted_App_ep_p2o
+                    idc
+                    (fun f => option_partition (fun x => match f x with
+                                                         | inl _ => None
+                                                         | inr b => Some b
+                                                         end))
+             | ident.List_app A as idc
+               => defaulted_App_pp_p idc (@List.app (interp var A))
+             | ident.List_rev A as idc
+               => defaulted_App_p_p idc (@List.rev (interp var A))
+             | ident.List_fold_right A B as idc
+               => defaulted_App_eep_e idc (@List.fold_right (interp var A) (interp var B))
+             | ident.List_update_nth T as idc
+               => defaulted_App_pep_p idc (@update_nth (interp var T))
+             | ident.List_nth_default T as idc
+               => defaulted_App_epp_e idc (@List.nth_default (interp var T))
+             | ident.pred as idc
+             | ident.S as idc
+             | ident.Z_of_nat as idc
+             | ident.Z_opp as idc
+               => defaulted_App_p_p idc (ident.interp idc)
+             | ident.Z_runtime_mul as idc
+               => defaulted_App_pp_p_or_pe_e_comm
+                    idc (ident.interp idc)
+                    (fun x e
+                     => if Z.eqb x 0
+                        then Some (inr 0%Z)
+                        else if Z.eqb x 1
+                             then Some (inl e)
+                             else None)
+             | ident.Z_runtime_add as idc
+               => defaulted_App_pp_p_or_pe_e_comm
+                    idc (ident.interp idc)
+                    (fun x e
+                     => if Z.eqb x 0
+                        then Some (inl e)
+                        else None)
+             | ident.Z_add as idc
+             | ident.Z_mul as idc
+             | ident.Z_pow as idc
+             | ident.Z_div as idc
+             | ident.Z_modulo as idc
+             | ident.Z_eqb as idc
+             | ident.Nat_sub as idc
+               => defaulted_App_pp_p idc (ident.interp idc)
+             end.
+      End interp. (*
+
+      Definition lookup {s d} (idc : op s d) : arguments s * arguments d
+        := match idc in op s d return arguments s * arguments d with
+           | ident.Const t v => (generic, ground)
+           | ident.Let_In tx tC => (tx * (tx -> tC), generic)
+           | ident.App s d => ((s -> d) * s, generic)
+           | ident.S => (ground, ground)
+           | ident.nil t => (generic, ground)
+           | ident.cons t => (t * list t, list t)
+           | ident.fst A B => (A * B, generic)
+           | ident.snd A B => (A * B, generic)
+           | ident.bool_rect T => (T * T * bool, generic)
+           | ident.nat_rect P => (P * (nat -> P -> P) * nat, generic)
+           | ident.pred => (nat, ground)
+           | ident.List_seq => (nat * nat, ground)
+           | ident.List_repeat A => (A * nat, list A)
+           | ident.List_combine A B => (list A * list B, list (A * B))
+           | ident.List_map A B => ((A -> B) * list A, list B)
+           | ident.List_flat_map A B => ((A -> list B) * list A, list B)
+           | ident.List_partition A => ((A -> bool) * list A, list A * list A)
+           | ident.List_app A => (list A * list A, list A)
+           | ident.List_fold_right A B => ((B -> A -> A) * A * list B, generic)
+           | ident.List_update_nth T => (nat * (T -> T) * list T, list T)
+           | ident.Z_runtime_mul => (Z * Z, Z)
+           | ident.Z_runtime_add => (Z * Z, Z)
+           | ident.Z_add => (Z * Z, Z)
+           | ident.Z_mul => (Z * Z, Z)
+           | ident.Z_pow => (Z * Z, Z)
+           | ident.Z_opp => (Z, Z)
+           | ident.Z_div => (Z * Z, Z)
+           | ident.Z_modulo => (Z * Z, Z)
+           | ident.Z_eqb => (Z * Z, bool)
+           | ident.Z_of_nat => (nat, Z)
            end.
 
-      Definition lookup_src {s d} opc := fst (@lookup s d opc).
-      Definition lookup_dst {s d} opc := snd (@lookup s d opc).
+      Definition lookup_src {s d} idc := fst (@lookup s d idc).
+      Definition lookup_dst {s d} idc := snd (@lookup s d idc).
 
       Definition option_map_prod {A B C} (f : A -> B -> C) (v : option (option A * option B))
         : option C
@@ -974,122 +1691,88 @@ Module Compilers.
 
       Definition rewrite
                  {var : type -> Type}
-                 {s d} (opc : op s d)
-                 (exploded_arguments : type.option.interp (@expr var) (@expr var) (lookup_src opc))
-        : option (type.interp var (@expr var) (lookup_dst opc))
-        := match opc in op s d
+                 {s d} (idc : op s d)
+                 (exploded_arguments : type.option.interp (@expr var) (@expr var) (lookup_src idc))
+        : option (type.interp var (@expr var) (lookup_dst idc))
+        := match idc in op s d
                  return
-                 (forall (exploded_arguments' : option (type.option.interp_to_arrow_or_generic expr expr (lookup_src opc))),
-                     option (type.interp var expr (lookup_dst opc)))
+                 (forall (exploded_arguments' : option (type.option.interp_to_arrow_or_generic expr expr (lookup_src idc))),
+                     option (type.interp var expr (lookup_dst idc)))
            with
-           | op.Const t v => fun _ => arguments.type.const_of_ground v
-           | op.Let_In tx tC
+           | ident.Const t v => fun _ => arguments.type.const_of_ground v
+           | ident.Let_In tx tC
              => option_map
                   (fun '(ex, eC)
-                   => match invert_Var ex, invert_OpConst ex with
+                   => match invert_Var ex, invert_Idconst ex with
                       | Some v, _ => eC ex
                       | None, Some v => eC ex
-                      | None, None => Op op.Let_In (ex, Abs (fun v => eC (Var v)))
+                      | None, None => Op ident.Let_In (ex, Abs (fun v => eC (Var v)))
                       end)
-           | op.App s d => option_map (fun '(f, x) => f x)
-           | op.S as opc
-           | op.pred as opc
-           | op.Z_runtime_mul as opc
-           | op.Z_runtime_add as opc
-           | op.Z_add as opc
-           | op.Z_mul as opc
-           | op.Z_pow as opc
-           | op.Z_opp as opc
-           | op.Z_div as opc
-           | op.Z_modulo as opc
-           | op.Z_eqb as opc
-           | op.Z_of_nat as opc
-             => option_map (op.interp opc)
-           | op.nil t => fun _ => Some (@nil (type.interp _ _ ground))
-           | op.cons t => option_map (op.curry2 cons)
-           | op.fst A B => option_map (@fst (expr A) (expr B))
-           | op.snd A B => option_map (@snd (expr A) (expr B))
-           | op.bool_rect T => option_map (op.curry3 (bool_rect (fun _ => _)))
-           | op.nat_rect P
+           | ident.App s d => option_map (fun '(f, x) => f x)
+           | ident.S as idc
+           | ident.pred as idc
+           | ident.Z_runtime_mul as idc
+           | ident.Z_runtime_add as idc
+           | ident.Z_add as idc
+           | ident.Z_mul as idc
+           | ident.Z_pow as idc
+           | ident.Z_opp as idc
+           | ident.Z_div as idc
+           | ident.Z_modulo as idc
+           | ident.Z_eqb as idc
+           | ident.Z_of_nat as idc
+             => option_map (ident.interp idc)
+           | ident.nil t => fun _ => Some (@nil (type.interp _ _ ground))
+           | ident.cons t => option_map (ident.curry2 cons)
+           | ident.fst A B => option_map (@fst (expr A) (expr B))
+           | ident.snd A B => option_map (@snd (expr A) (expr B))
+           | ident.bool_rect T => option_map (ident.curry3 (bool_rect (fun _ => _)))
+           | ident.nat_rect P
              => option_map
                   (fun '(O_case, S_case, v)
                    => nat_rect (fun _ => expr P) O_case (fun n (v : expr P) => S_case (@const _ type.nat n) v) v)
-           | op.List_seq => option_map (op.curry2 List.seq)
-           | op.List_repeat A => option_map (op.curry2 (@List.repeat (expr A)))
-           | op.List_combine A B => option_map (op.curry2 (@List.combine (expr A) (expr B)))
-           | op.List_map A B => option_map (op.curry2 (@List.map (expr A) (expr B)))
-           | op.List_flat_map A B
+           | ident.List_seq => option_map (ident.curry2 List.seq)
+           | ident.List_repeat A => option_map (ident.curry2 (@List.repeat (expr A)))
+           | ident.List_combine A B => option_map (ident.curry2 (@List.combine (expr A) (expr B)))
+           | ident.List_map A B => option_map (ident.curry2 (@List.map (expr A) (expr B)))
+           | ident.List_flat_map A B
              => fun args : option ((expr A -> option (Datatypes.list (expr B))) * Datatypes.list (expr A))
                 => match args with
                    | Some (f, ls) => option_flat_map f ls
                    | None => None
                    end
-           | op.List_partition A
+           | ident.List_partition A
              => fun args : option ((expr A -> option Datatypes.bool) * Datatypes.list (expr A))
                 => match args with
                    | Some (f, ls) => option_partition f ls
                    | None => None
                    end
-           | op.List_app A => option_map (op.curry2 (@List.app (expr A)))
-           | op.List_fold_right A B => option_map (op.curry3 (@List.fold_right (expr A) (expr B)))
-           | op.List_update_nth T => option_map (op.curry3 (@update_nth (expr T)))
+           | ident.List_app A => option_map (ident.curry2 (@List.app (expr A)))
+           | ident.List_fold_right A B => option_map (ident.curry3 (@List.fold_right (expr A) (expr B)))
+           | ident.List_update_nth T => option_map (ident.curry3 (@update_nth (expr T)))
            end
-             (type.option.lift_interp exploded_arguments).
-    End op.
+             (type.option.lift_interp exploded_arguments).*)
+    End ident.
   End arguments.
-  Export arguments.Notations.
+  (*Export arguments.Notations.*)
 
   Section partial_reduce.
     Context {var : type -> Type}.
 
-    Local Notation partial_reduceT t a
-      := ((@expr var t * arguments.type.option.interp (@expr var) (@expr var) a)%type)
-           (only parsing).
-
-    Fixpoint partial_reduce' {t} (e : @expr (@expr var) t)
-      : forall a : arguments t, partial_reduceT t a
-      := match e in expr t return (forall a : arguments t, partial_reduceT t a) with
-         | TT
-           => arguments.invert
-                (fun a : arguments type.unit => partial_reduceT type.unit a)
-                (TT, TT)
-                (fun u => (TT, u))
-         | Pair A B a b
-           => arguments.invert
-                (fun a => partial_reduceT (type.prod A B) a)
-                (let ab := (fst (@partial_reduce' A a arguments.generic),
-                            fst (@partial_reduce' B b arguments.generic))%expr in
-                 (ab, ab))
-                (fun '(aA, aB)
-                 => let '(a0, a1) := @partial_reduce' A a aA in
-                    let '(b0, b1) := @partial_reduce' B b aB in
-                    ((a0, b0)%expr, Some (a1, b1)))
-         | Var t v
-           => fun a => (v, arguments.expr.interp _ _ v)
-         | Op s d opc args
-           => let '(args0, args1) := @partial_reduce' s args (arguments.op.lookup_src opc) in
-              let e :=
-                  match arguments.op.rewrite opc args1 with
-                  | Some e => arguments.expr.reify _ _ e
-                  | None => Op opc args0
-                  end in
-              fun a => (e, arguments.expr.interp _ _ e)
+    Fixpoint partial_reduce' {t} (e : @expr (arguments.interp var) t)
+      : arguments.interp var t
+      := match e in expr t return arguments.interp var t with
+         | Var t v => v
+         | Ident t idc => arguments.ident.interp idc
+         | App s d f x
+           => @partial_reduce' _ f (@partial_reduce' _ x)
          | Abs s d f
-           => fun a
-              => let e' := Abs (fun x => fst (@partial_reduce' d (f (Var x)) (arguments.invert_arrow a))) in
-                 arguments.invert
-                   (fun a => partial_reduceT (type.arrow s d) a)
-                   (e', e')
-                   (fun ad
-                    => (e',
-                        (fun x =>
-                           snd (@partial_reduce' d (f x) ad))))
-                   a
+           => fun x
+              => @partial_reduce' d (f x)
          end.
 
-
-    Definition partial_reduce {t} (e : @expr (@expr var) t) : @expr var t
-      := snd (@partial_reduce' t e arguments.generic).
+    Definition partial_reduce {t} (e : @expr (arguments.interp var) t) : @expr var t
+      := arguments.expr.reify (@partial_reduce' t e).
   End partial_reduce.
 
   Definition PartialReduce {t} (e : Expr t) : Expr t
@@ -1098,6 +1781,8 @@ Module Compilers.
   Ltac is_known_const_cps2 term on_success on_failure :=
     let recurse term := is_known_const_cps2 term on_success on_failure in
     lazymatch term with
+    | tt => on_success ()
+    | @nil _ => on_success ()
     | S ?term => recurse term
     | O => on_success ()
     | Z0 => on_success ()
@@ -1113,94 +1798,93 @@ Module Compilers.
   Ltac is_known_const term :=
     is_known_const_cps2 term ltac:(fun _ => true) ltac:(fun _ => false).
 
-  Definition Uncurry0 {A var} (opc : op type.unit A) : @expr var A
-    := Op opc TT.
-  Definition Uncurry1 {A B var} (opc : op A B) : @expr var (A -> B)
-    := λ a, Op opc (Var a).
-  Definition Uncurry2 {A B C var} (opc : op (A * B) C) : @expr var (A -> B -> C)
-    := λ a b, Op opc (Var a, Var b).
-  Definition Uncurry3 {A B C D var} (opc : op (A * B * C) D) : @expr var (A -> B -> C -> D)
-    := λ a b c, Op opc (Var a, Var b, Var c).
-
-  Ltac reify_op var term :=
+  Print ident.ident.
+  Ltac reify_ident term :=
     (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
-    let Uncurry0 x := constr:(Uncurry0 (var:=var) x) in
-    let Uncurry1 x := constr:(Uncurry1 (var:=var) x) in
-    let Uncurry2 x := constr:(Uncurry2 (var:=var) x) in
-    let Uncurry3 x := constr:(Uncurry3 (var:=var) x) in
     lazymatch term with
-    | S => Uncurry1 op.S
+    | S => ident.S
     | @nil ?T
       => let rT := type.reify T in
-         Uncurry0 (@op.nil rT)
+         constr:(@ident.nil rT)
     | @cons ?T
       => let rT := type.reify T in
-         Uncurry2 (@op.cons rT)
-    | seq => Uncurry2 op.List.seq
-    | @List.repeat ?A
-      => let rA := type.reify A in
-         Uncurry2 (@op.List.repeat rA)
-    | @Let_In ?A (fun _ => ?B)
+         constr:(@ident.cons rT)
+    | @pair ?A ?B
       => let rA := type.reify A in
          let rB := type.reify B in
-         Uncurry2 (@op.Let_In rA rB)
-    | @combine ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         Uncurry2 (@op.List.combine rA rB)
-    | @List.map ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         Uncurry2 (@op.List.map rA rB)
-    | @List.flat_map ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         Uncurry2 (@op.List.flat_map rA rB)
+         constr:(@ident.pair rA rB)
     | @fst ?A ?B
       => let rA := type.reify A in
          let rB := type.reify B in
-         Uncurry1 (@op.fst rA rB)
+         constr:(@ident.fst rA rB)
     | @snd ?A ?B
       => let rA := type.reify A in
          let rB := type.reify B in
-         Uncurry1 (@op.snd rA rB)
+         constr:(@ident.snd rA rB)
+    | @bool_rect (fun _ => ?T)
+      => let rT := type.reify T in
+         constr:(@ident.bool_rect rT)
+    | @nat_rect (fun _ => ?T)
+      => let rT := type.reify T in
+         constr:(@ident.nat_rect rT)
+    | pred => ident.pred
+    | seq => ident.List.seq
+    | @List.repeat ?A
+      => let rA := type.reify A in
+         constr:(@ident.List.repeat rA)
+    | @Let_In ?A (fun _ => ?B)
+      => let rA := type.reify A in
+         let rB := type.reify B in
+         constr:(@ident.Let_In rA rB)
+    | @combine ?A ?B
+      => let rA := type.reify A in
+         let rB := type.reify B in
+         constr:(@ident.List.combine rA rB)
+    | @List.map ?A ?B
+      => let rA := type.reify A in
+         let rB := type.reify B in
+         constr:(@ident.List.map rA rB)
+    | @List.flat_map ?A ?B
+      => let rA := type.reify A in
+         let rB := type.reify B in
+         constr:(@ident.List.flat_map rA rB)
     | @List.partition ?A
       => let rA := type.reify A in
-         Uncurry2 (@op.List.partition rA)
+         constr:(@ident.List.partition rA)
     | @List.app ?A
       => let rA := type.reify A in
-         Uncurry2 (@op.List.app rA)
+         constr:(@ident.List.app rA)
+    | @List.rev ?A
+      => let rA := type.reify A in
+         constr:(@ident.List.rev rA)
     | @List.fold_right ?A ?B
       => let rA := type.reify A in
          let rB := type.reify B in
-         Uncurry3 (@op.List.fold_right rA rB)
-    | pred => Uncurry1 op.pred
+         constr:(@ident.List.fold_right rA rB)
     | @update_nth ?T
       => let rT := type.reify T in
-         Uncurry3 (@op.List.update_nth rT)
-    | runtime_mul => Uncurry2 op.Z.runtime_mul
-    | runtime_add => Uncurry2 op.Z.runtime_add
-    | Z.add => Uncurry2 op.Z.add
-    | Z.mul => Uncurry2 op.Z.mul
-    | Z.pow => Uncurry2 op.Z.pow
-    | Z.opp => Uncurry1 op.Z.opp
-    | Z.div => Uncurry2 op.Z.div
-    | Z.modulo => Uncurry2 op.Z.modulo
-    | Z.eqb => Uncurry2 op.Z.eqb
-    | Z.of_nat => Uncurry1 op.Z.of_nat
-    | @nat_rect (fun _ => ?T)
+         constr:(@ident.List.update_nth rT)
+    | @List.nth_default ?T
       => let rT := type.reify T in
-         Uncurry3 (@op.nat_rect rT)
-    | @bool_rect (fun _ => ?T)
-      => let rT := type.reify T in
-         Uncurry3 (@op.bool_rect rT)
+         constr:(@ident.List.nth_default rT)
+    | runtime_mul => ident.Z.runtime_mul
+    | runtime_add => ident.Z.runtime_add
+    | Z.add => ident.Z.add
+    | Z.mul => ident.Z.mul
+    | Z.pow => ident.Z.pow
+    | Z.opp => ident.Z.opp
+    | Z.div => ident.Z.div
+    | Z.modulo => ident.Z.modulo
+    | Z.eqb => ident.Z.eqb
+    | Z.of_nat => ident.Z.of_nat
+    | Nat.sub => ident.Nat.sub
     | _
       => let assert_const := match goal with
                              | _ => require_known_const term
                              end in
          let T := type of term in
          let rT := type.reify T in
-         Uncurry0 (@op.Const rT term)
+         constr:(@ident.Const rT term)
     end.
 
   Module var_context.
@@ -1209,11 +1893,10 @@ Module Compilers.
     | cons {t} (gallina_v : type.interp t) (v : var t) (ctx : list).
   End var_context.
 
-  (* cf COQBUG(https://github.com/coq/coq/issues/5448) *)
+  (* cf COQBUG(https://github.com/coq/coq/issues/5448) , COQBUG(https://github.com/coq/coq/issues/6315) *)
   Ltac refresh n :=
     let n' := fresh n in
-    let n' := fresh n' in
-    let n' := fresh n' in
+    let n' := fresh n in
     n'.
 
   Ltac type_of_first_argument_of f :=
@@ -1271,15 +1954,12 @@ Module Compilers.
       =>
       let term_is_known_const := is_known_const term in
       lazymatch term_is_known_const with
-      | true => reify_op var term
+      | true
+        => let rv := reify_ident term in
+           constr:(Ident (var:=var) rv)
       | false
         =>
         lazymatch term with
-        | tt => TT
-        | @pair ?A ?B ?a ?b
-          => let ra := reify_rec a in
-             let rb := reify_rec b in
-             constr:(Pair (var:=var) ra rb)
         | match ?b with true => ?t | false => ?f end
           => let T := type of t in
              reify_rec (@bool_rect (fun _ => T) t f b)
@@ -1299,7 +1979,7 @@ Module Compilers.
             =>
             let rx := reify_helper var x value_ctx tt in
             let rf := reify_helper var f value_ctx template_ctx in
-            constr:(Op (var:=var) op.App (Pair (var:=var) rf rx))
+            constr:(App (var:=var) rf rx)
           end
         | (fun x : ?T => ?f)
           =>
@@ -1317,15 +1997,17 @@ Module Compilers.
             let rT := type.reify T in
             let not_x := refresh x in
             let not_x2 := refresh not_x in
+            let not_x3 := refresh not_x2 in
             let rf0 :=
                 constr:(
                   fun (x : T) (not_x : var rT)
-                  => match f return _ with (* c.f. COQBUG(https://github.com/coq/coq/issues/6252#issuecomment-347041995) for [return _] *)
-                     | not_x2
+                  => match f, @var_context.cons var rT x not_x value_ctx return _ with (* c.f. COQBUG(https://github.com/coq/coq/issues/6252#issuecomment-347041995) for [return _] *)
+                     | not_x2, not_x3
                        => ltac:(
                             let f := (eval cbv delta [not_x2] in not_x2) in
+                            let var_ctx := (eval cbv delta [not_x3] in not_x3) in
                             (*idtac "rec call" f "was" term;*)
-                            let rf := reify_helper var f (@var_context.cons var rT x not_x value_ctx) template_ctx in
+                            let rf := reify_helper var f var_ctx template_ctx in
                             exact rf)
                      end) in
             lazymatch rf0 with
@@ -1347,7 +2029,8 @@ Module Compilers.
           end
         | _
           => let term := plug_template_ctx term template_ctx in
-             reify_op var term
+             let idc := reify_ident term in
+             constr:(Ident (var:=var) idc)
         end
       end
     end.
@@ -1361,13 +2044,63 @@ Module Compilers.
     let RHS := lazymatch goal with |- _ = ?RHS => RHS end in
     let R := Reify RHS in
     transitivity (Interp R);
-    [ | cbv beta iota delta [Interp interp op.interp Uncurry0 Uncurry1 Uncurry2 Uncurry3 Let_In type.interp bool_rect];
+    [ | cbv beta iota delta [Interp interp ident.interp Let_In type.interp bool_rect];
         reflexivity ].
 End Compilers.
 Import Associational Positional Compilers.
 Local Coercion Z.of_nat : nat >-> Z.
 Local Coercion QArith_base.inject_Z : Z >-> Q.
 Definition w (i:nat) : Z := 2^Qceiling((25+1/2)*i).
+
+(* TODO: is this the right way to do things? *)
+Definition expand_list_helper {A} (default : A) (ls : list A) (n : nat) (idx : nat) : list A
+  := nat_rect
+       (fun _ => nat -> list A)
+       (fun _ => nil)
+       (fun n' rec_call idx
+        => cons (List.nth_default default ls idx) (rec_call (S idx)))
+       n
+       idx.
+Definition expand_list {A} (default : A) (ls : list A) (n : nat) : list A
+  := expand_list_helper default ls n 0.
+Require Import Coq.micromega.Lia.
+(* TODO: MOVE ME *)
+Lemma expand_list_helper_correct {A} (default : A) (ls : list A) (n idx : nat) (H : (idx + n <= length ls)%nat)
+  : expand_list_helper default ls n idx
+    = List.firstn n (List.skipn idx ls).
+Proof.
+  cbv [expand_list_helper]; revert idx H.
+  induction n as [|n IHn]; cbn; intros.
+  { reflexivity. }
+  { rewrite IHn by omega.
+    erewrite (@skipn_nth_default _ idx ls) by omega.
+    reflexivity. }
+Qed.
+
+Lemma expand_list_correct (n : nat) {A} (default : A) (ls : list A) (H : List.length ls = n)
+  : expand_list default ls n = ls.
+Proof.
+  subst; cbv [expand_list]; rewrite expand_list_helper_correct by reflexivity.
+  rewrite skipn_0, firstn_all; reflexivity.
+Qed.
+
+Delimit Scope RT_expr_scope with RT_expr.
+Notation "ls _{ n }"
+  := (App (App (App (Ident ident.List.nth_default) _) ls%expr) (Ident (ident.Const n%nat)))
+       (at level 20, format "ls _{ n }")
+     : expr_scope.
+Print Grammar constr.
+Notation "x + y"
+  := (App (App (Ident ident.Z.runtime_add) x%RT_expr) y%RT_expr)
+     : RT_expr_scope.
+Notation "x * y"
+  := (App (App (Ident ident.Z.runtime_mul) x%RT_expr) y%RT_expr)
+     : RT_expr_scope.
+Notation "x" := (Ident (ident.Const x)) (only printing, at level 10) : expr_scope.
+Notation "x" := (Var x) (only printing, at level 10) : expr_scope.
+
+Require Import AdmitAxiom.
+
 Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g8 g9 : Z)
         (f:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)
         (g:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)*) (f g : list Z)
@@ -1389,23 +2122,59 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
 (*     (g9, g8, g7, g6, g5, g4, g3, g2, g1, g0) *)
   (*cbv [f g].*)
   cbv [w Qceiling Qfloor Qopp Qnum Qdiv Qplus inject_Z Qmult Qinv Qden Pos.mul].
-  apply (f_equal (fun F => F f g)).
-  cbv [n].
-  cbv delta [mulmod w to_associational mul to_associational reduce from_associational add_to_nth zeros place split].
-  assert True.
-  { let v := Reify ((fun x => 2^x) 255)%Z in
-    pose v as E.
-    vm_compute in E.
-    pose (PartialReduce E) as E'.
-    vm_compute in E'.
-    constructor. }
-  Reify_rhs ().
-  let e := match goal with |- _ = Interp ?e => e end in
-  pose e as E.
-  exfalso.
-  Timeout 2 vm_compute in E.
-  pose (PartialReduce E) as E'.
-  Timeout 2 vm_compute in E'.
+  let ev := match goal with |- ?ev = _ => ev end in
+  set (e := ev).
+  rewrite <- (expand_list_correct n (-1)%Z f), <- (expand_list_correct n (-1)%Z g) by assumption; subst e.
+  etransitivity.
+  Focus 2.
+  {
+    repeat match goal with H : _ |- _ => clear H end; revert f g.
+    lazymatch goal with
+    | [ |- forall f g, ?ev = @?RHS f g ]
+      => refine (fun f g => f_equal (fun F => F f g) (_ : _ = RHS))
+    end.
+    cbv [n expand_list expand_list_helper].
+    cbv delta [mulmod w to_associational mul to_associational reduce from_associational add_to_nth zeros place split].
+    assert True.
+    { let v := Reify ((fun x => 2^x) 255)%Z in
+      pose v as E.
+      vm_compute in E.
+      pose (PartialReduce E) as E'.
+      vm_compute in E'.
+      lazymatch (eval cbv delta [E'] in E') with
+      | (fun var => Ident (ident.Const ?v)) => idtac
+      end.
+      constructor. }
+    assert True.
+    { let v := Reify (fun y : Z
+                      => (fun k : Z * Z -> Z * Z
+                          => let x := (y * y)%RT in
+                             let z := (x * x)%RT in
+                             k (z, z))
+                           (fun v => v)) in
+      pose v as E.
+      vm_compute in E.
+      pose (PartialReduce E) as E'.
+      vm_compute in E'.
+      lazymatch (eval cbv delta [E'] in E') with
+      | (fun var : type -> Type =>
+           (λ x : var type.Z,
+                  expr_let x0 := (Var x * Var x)%RT_expr in
+                expr_let x1 := (Var x0 * Var x0)%RT_expr in
+                (Var x1, Var x1))%expr) => idtac
+      end.
+      constructor. }
+    Reify_rhs ().
+    reflexivity.
+  } Unfocus.
+  cbv beta.
+  let e := match goal with |- _ = Interp ?e _ _ => e end in
+  set (E := e).
+  let E' := constr:(PartialReduce E) in
+  let E' := (eval vm_compute in E') in
+  pose E' as E''.
+  transitivity (Interp E'' f g); [ clear E | admit ].
+  reflexivity.
   (*cbv -[runtime_mul runtime_add]; cbv [runtime_mul runtime_add].
   ring_simplify_subterms.*)
 (* ?fg =
@@ -1419,8 +2188,101 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
   f0*g2+ 2*f1*g1+  f2*g0+    38*f3*g9+ 19*f4*g8+ 38*f5*g7+ 19*f6*g6+ 38*f7*g5+ 19*f8*g4+ 38*f9*g3,
   f0*g1+ f1*g0+    19*f2*g9+ 19*f3*g8+ 19*f4*g7+ 19*f5*g6+ 19*f6*g5+ 19*f7*g4+ 19*f8*g3+ 19*f9*g2,
   f0*g0+ 38*f1*g9+ 19*f2*g8+ 38*f3*g7+ 19*f4*g6+ 38*f5*g5+ 19*f6*g4+ 38*f7*g3+ 19*f8*g2+ 38*f9*g1) *)
-  (*trivial.
-Defined.*)
-Abort.
+  (*trivial.*)
+Defined.
 
-(* Eval cbv on this one would produce an ugly term due to the use of [destruct] *)
+Eval cbv [proj1_sig base_25_5_mul] in (fun f g Hf Hg => proj1_sig (base_25_5_mul f g Hf Hg)).
+(*      = fun (f g : list Z) (_ : length f = 10%nat) (_ : length g = 10%nat) =>
+       Interp
+         (fun var : type -> Type =>
+          (λ x x0 : var (type.list type.Z),
+           (x_{0} * x0_{0} +
+            (2 * (19 * (x_{1} * x0_{9})) +
+             (19 * (x_{2} * x0_{8}) +
+              (2 * (19 * (x_{3} * x0_{7})) +
+               (19 * (x_{4} * x0_{6}) +
+                (2 * (19 * (x_{5} * x0_{5})) +
+                 (19 * (x_{6} * x0_{4}) +
+                  (2 * (19 * (x_{7} * x0_{3})) +
+                   (19 * (x_{8} * x0_{2}) + 2 * (19 * (x_{9} * x0_{1})))))))))))%RT_expr
+           :: (x_{0} * x0_{1} +
+               (x_{1} * x0_{0} +
+                (19 * (x_{2} * x0_{9}) +
+                 (19 * (x_{3} * x0_{8}) +
+                  (19 * (x_{4} * x0_{7}) +
+                   (19 * (x_{5} * x0_{6}) +
+                    (19 * (x_{6} * x0_{5}) +
+                     (19 * (x_{7} * x0_{4}) + (19 * (x_{8} * x0_{3}) + 19 * (x_{9} * x0_{2}))))))))))%RT_expr
+              :: (x_{0} * x0_{2} +
+                  (2 * (x_{1} * x0_{1}) +
+                   (x_{2} * x0_{0} +
+                    (2 * (19 * (x_{3} * x0_{9})) +
+                     (19 * (x_{4} * x0_{8}) +
+                      (2 * (19 * (x_{5} * x0_{7})) +
+                       (19 * (x_{6} * x0_{6}) +
+                        (2 * (19 * (x_{7} * x0_{5})) +
+                         (19 * (x_{8} * x0_{4}) + 2 * (19 * (x_{9} * x0_{3})))))))))))%RT_expr
+                 :: (x_{0} * x0_{3} +
+                     (x_{1} * x0_{2} +
+                      (x_{2} * x0_{1} +
+                       (x_{3} * x0_{0} +
+                        (19 * (x_{4} * x0_{9}) +
+                         (19 * (x_{5} * x0_{8}) +
+                          (19 * (x_{6} * x0_{7}) +
+                           (19 * (x_{7} * x0_{6}) +
+                            (19 * (x_{8} * x0_{5}) + 19 * (x_{9} * x0_{4}))))))))))%RT_expr
+                    :: (x_{0} * x0_{4} +
+                        (2 * (x_{1} * x0_{3}) +
+                         (x_{2} * x0_{2} +
+                          (2 * (x_{3} * x0_{1}) +
+                           (x_{4} * x0_{0} +
+                            (2 * (19 * (x_{5} * x0_{9})) +
+                             (19 * (x_{6} * x0_{8}) +
+                              (2 * (19 * (x_{7} * x0_{7})) +
+                               (19 * (x_{8} * x0_{6}) + 2 * (19 * (x_{9} * x0_{5})))))))))))%RT_expr
+                       :: (x_{0} * x0_{5} +
+                           (x_{1} * x0_{4} +
+                            (x_{2} * x0_{3} +
+                             (x_{3} * x0_{2} +
+                              (x_{4} * x0_{1} +
+                               (x_{5} * x0_{0} +
+                                (19 * (x_{6} * x0_{9}) +
+                                 (19 * (x_{7} * x0_{8}) +
+                                  (19 * (x_{8} * x0_{7}) + 19 * (x_{9} * x0_{6}))))))))))%RT_expr
+                          :: (x_{0} * x0_{6} +
+                              (2 * (x_{1} * x0_{5}) +
+                               (x_{2} * x0_{4} +
+                                (2 * (x_{3} * x0_{3}) +
+                                 (x_{4} * x0_{2} +
+                                  (2 * (x_{5} * x0_{1}) +
+                                   (x_{6} * x0_{0} +
+                                    (2 * (19 * (x_{7} * x0_{9})) +
+                                     (19 * (x_{8} * x0_{8}) + 2 * (19 * (x_{9} * x0_{7})))))))))))%RT_expr
+                             :: (x_{0} * x0_{7} +
+                                 (x_{1} * x0_{6} +
+                                  (x_{2} * x0_{5} +
+                                   (x_{3} * x0_{4} +
+                                    (x_{4} * x0_{3} +
+                                     (x_{5} * x0_{2} +
+                                      (x_{6} * x0_{1} +
+                                       (x_{7} * x0_{0} +
+                                        (19 * (x_{8} * x0_{9}) + 19 * (x_{9} * x0_{8}))))))))))%RT_expr
+                                :: (x_{0} * x0_{8} +
+                                    (2 * (x_{1} * x0_{7}) +
+                                     (x_{2} * x0_{6} +
+                                      (2 * (x_{3} * x0_{5}) +
+                                       (x_{4} * x0_{4} +
+                                        (2 * (x_{5} * x0_{3}) +
+                                         (x_{6} * x0_{2} +
+                                          (2 * (x_{7} * x0_{1}) +
+                                           (x_{8} * x0_{0} + 2 * (19 * (x_{9} * x0_{9})))))))))))%RT_expr
+                                   :: (x_{0} * x0_{9} +
+                                       (x_{1} * x0_{8} +
+                                        (x_{2} * x0_{7} +
+                                         (x_{3} * x0_{6} +
+                                          (x_{4} * x0_{5} +
+                                           (x_{5} * x0_{4} +
+                                            (x_{6} * x0_{3} +
+                                             (x_{7} * x0_{2} + (x_{8} * x0_{1} + x_{9} * x0_{0})))))))))%RT_expr
+                                      :: [])%expr) f g
+     : forall f g : list Z, length f = 10%nat -> length g = 10%nat -> list Z *)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -616,7 +616,7 @@ Module Compilers.
            => Some v
          | _ => None
          end.
-    (* oh, the horrors of not being able to use non-linear deep pattern matches *)
+    (* oh, the horrors of not being able to use non-linear deep pattern matches.  c.f. COQBUG(https://github.com/coq/coq/issues/6320) *)
     Fixpoint invert_list_full {t} (e : @expr var (type.list t))
       : option (list (@expr var t))
       := match e in expr t return option match t with

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -303,6 +303,7 @@ Module Compilers.
       | Datatypes.nat => nat
       | Datatypes.bool => bool
       | BinInt.Z => Z
+      | type.interp ?T => T
       end.
 
     Module Export Notations.
@@ -316,151 +317,805 @@ Module Compilers.
   End type.
   Export type.Notations.
 
-  Module ident.
-    Import type.
-    Inductive ident : type -> Set :=
-    | Const {t} (v : interp t) : ident t
-    | Let_In {tx tC} : ident (tx -> (tx -> tC) -> tC)
-    | S : ident (nat -> nat)
-    | nil {t} : ident (list t)
-    | cons {t} : ident (t -> list t -> list t)
-    | pair {A B} : ident (A -> B -> A * B)
-    | fst {A B} : ident (A * B -> A)
-    | snd {A B} : ident (A * B -> B)
-    | bool_rect {T} : ident (T -> T -> bool -> T)
-    | nat_rect {P} : ident (P -> (nat -> P -> P) -> nat -> P)
-    | pred : ident (nat -> nat)
-    | List_seq : ident (nat -> nat -> list nat)
-    | List_repeat {A} : ident (A -> nat -> list A)
-    | List_combine {A B} : ident (list A -> list B -> list (A * B))
-    | List_map {A B} : ident ((A -> B) -> list A -> list B)
-    | List_flat_map {A B} : ident ((A -> list B) -> list A -> list B)
-    | List_partition {A} : ident ((A -> bool) -> list A -> list A * list A)
-    | List_app {A} : ident (list A -> list A -> list A)
-    | List_rev {A} : ident (list A -> list A)
-    | List_fold_right {A B} : ident ((B -> A -> A) -> A -> list B -> A)
-    | List_update_nth {T} : ident (nat -> (T -> T) -> list T -> list T)
-    | List_nth_default {T} : ident (T -> list T -> nat -> T)
-    | Z_runtime_mul : ident (Z -> Z -> Z)
-    | Z_runtime_add : ident (Z -> Z -> Z)
-    | Z_add : ident (Z -> Z -> Z)
-    | Z_mul : ident (Z -> Z -> Z)
-    | Z_pow : ident (Z -> Z -> Z)
-    | Z_opp : ident (Z -> Z)
-    | Z_div : ident (Z -> Z -> Z)
-    | Z_modulo : ident (Z -> Z -> Z)
-    | Z_eqb : ident (Z -> Z -> bool)
-    | Z_of_nat : ident (nat -> Z)
-    | Nat_sub : ident (nat -> nat -> nat).
-
-    Definition interp {t} (idc : ident t) : type.interp t
-      := match idc in ident t return type.interp t with
-         | Const t v => v
-         | Let_In tx tC => @LetIn.Let_In (type.interp tx) (fun _ => type.interp tC)
-         | S => Datatypes.S
-         | nil t => @Datatypes.nil (type.interp t)
-         | cons t => @Datatypes.cons (type.interp t)
-         | pair A B => @Datatypes.pair (type.interp A) (type.interp B)
-         | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
-         | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
-         | bool_rect T => @Datatypes.bool_rect (fun _ => type.interp T)
-         | nat_rect P => @Datatypes.nat_rect (fun _ => type.interp P)
-         | pred => Nat.pred
-         | List_seq => List.seq
-         | List_combine A B => @List.combine (type.interp A) (type.interp B)
-         | List_map A B => @List.map (type.interp A) (type.interp B)
-         | List_repeat A => @List.repeat (type.interp A)
-         | List_flat_map A B => @List.flat_map (type.interp A) (type.interp B)
-         | List_partition A => @List.partition (type.interp A)
-         | List_app A => @List.app (type.interp A)
-         | List_rev A => @List.rev (type.interp A)
-         | List_fold_right A B => @List.fold_right (type.interp A) (type.interp B)
-         | List_update_nth T => @update_nth (type.interp T)
-         | List_nth_default T => @List.nth_default (type.interp T)
-         | Z_runtime_mul => runtime_mul
-         | Z_runtime_add => runtime_add
-         | Z_add => Z.add
-         | Z_mul => Z.mul
-         | Z_pow => Z.pow
-         | Z_modulo => Z.modulo
-         | Z_opp => Z.opp
-         | Z_div => Z.div
-         | Z_eqb => Z.eqb
-         | Z_of_nat => Z.of_nat
-         | Nat_sub => Nat.sub
-         end.
-
-    Module List.
-      Notation seq := List_seq.
-      Notation repeat := List_repeat.
-      Notation combine := List_combine.
-      Notation map := List_map.
-      Notation flat_map := List_flat_map.
-      Notation partition := List_partition.
-      Notation app := List_app.
-      Notation rev := List_rev.
-      Notation fold_right := List_fold_right.
-      Notation update_nth := List_update_nth.
-      Notation nth_default := List_nth_default.
-    End List.
-
-    Module Z.
-      Notation runtime_mul := Z_runtime_mul.
-      Notation runtime_add := Z_runtime_add.
-      Notation add := Z_add.
-      Notation mul := Z_mul.
-      Notation pow := Z_pow.
-      Notation opp := Z_opp.
-      Notation div := Z_div.
-      Notation modulo := Z_modulo.
-      Notation eqb := Z_eqb.
-      Notation of_nat := Z_of_nat.
-    End Z.
-
-    Module Nat.
-      Notation sub := Nat_sub.
-    End Nat.
+  Module expr.
+    Inductive expr {ident : type -> Type} {var : type -> Type} : type -> Type :=
+    | Var {t} (v : var t) : expr t
+    | Ident {t} (idc : ident t) : expr t
+    | App {s d} (f : expr (s -> d)) (x : expr s) : expr d
+    | Abs {s d} (f : var s -> expr d) : expr (s -> d).
 
     Module Export Notations.
-      Notation ident := ident.
+      Bind Scope expr_scope with expr.
+      Delimit Scope expr_scope with expr.
+
+      Notation "f x" := (App f x) (only printing) : expr_scope.
+      Notation "'λ'  x .. y , t" := (Abs (fun x => .. (Abs (fun y => t%expr)) ..)) : expr_scope.
     End Notations.
-  End ident.
-  Export ident.Notations.
 
-  Inductive expr {var : type -> Type} : type -> Type :=
-  | Var {t} (v : var t) : expr t
-  | Ident {t} (idc : ident t) : expr t
-  | App {s d} (f : expr (s -> d)) (x : expr s) : expr d
-  | Abs {s d} (f : var s -> expr d) : expr (s -> d).
+    Definition Expr {ident : type -> Type} t := forall var, @expr ident var t.
 
-  Notation TT := (Ident (@ident.Const type.unit tt)).
-  Notation Pair x y := (App (App (Ident ident.pair) x) y).
+    Section with_ident.
+      Context {ident : type -> Type}
+              (interp_ident : forall t, ident t -> type.interp t).
 
-  Bind Scope expr_scope with expr.
-  Delimit Scope expr_scope with expr.
-  Notation "f x" := (App f x) (only printing) : expr_scope.
-  Notation "'λ'  x .. y , t" := (Abs (fun x => .. (Abs (fun y => t%expr)) ..)) : expr_scope.
-  Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
-  Notation "( )" := TT : expr_scope.
-  Notation "()" := TT : expr_scope.
-  Notation "'expr_let' x := A 'in' b" := (App (App (Ident ident.Let_In) A%expr) (Abs (fun x => b%expr))) : expr_scope.
-  Notation "[ ]" := (Ident ident.nil) : expr_scope.
-  Notation "x :: xs" := (App (App (Ident ident.cons) x%expr) xs%expr) : expr_scope.
+      Fixpoint interp {t} (e : @expr ident type.interp t) : type.interp t
+        := match e with
+           | Var t v => v
+           | Ident t idc => interp_ident t idc
+           | App s d f x => interp f (interp x)
+           | Abs s d f => fun v => interp (f v)
+           end.
 
-  Definition Expr t := forall var, @expr var t.
+      Definition Interp {t} (e : Expr t) := interp (e _).
+    End with_ident.
 
-  Fixpoint interp {t} (e : @expr type.interp t) : type.interp t
-    := match e with
-       | Var t v => v
-       | Ident t idc => ident.interp idc
-       | App s d f x => interp f (interp x)
-       | Abs s d f => fun v => interp (f v)
-       end.
+    Ltac is_known_const_cps2 term on_success on_failure :=
+      let recurse term := is_known_const_cps2 term on_success on_failure in
+      lazymatch term with
+      | tt => on_success ()
+      | @nil _ => on_success ()
+      | S ?term => recurse term
+      | O => on_success ()
+      | Z0 => on_success ()
+      | Zpos ?p => recurse p
+      | Zneg ?p => recurse p
+      | xI ?p => recurse p
+      | xO ?p => recurse p
+      | xH => on_success ()
+      | ?term => on_failure term
+      end.
+    Ltac require_known_const term :=
+      is_known_const_cps2 term ltac:(fun _ => idtac) ltac:(fun term => fail 0 "Not a known const:" term).
+    Ltac is_known_const term :=
+      is_known_const_cps2 term ltac:(fun _ => true) ltac:(fun _ => false).
 
-  Definition Interp {t} (e : Expr t) := interp (e _).
+    Module var_context.
+      Inductive list {var : type -> Type} :=
+      | nil
+      | cons {t} (gallina_v : type.interp t) (v : var t) (ctx : list).
+    End var_context.
 
-  Definition const {var t} (v : type.interp t) : @expr var t
-    := Ident (ident.Const v).
+    (* cf COQBUG(https://github.com/coq/coq/issues/5448) , COQBUG(https://github.com/coq/coq/issues/6315) *)
+    Ltac refresh n :=
+      let n' := fresh n in
+      let n' := fresh n in
+      n'.
+
+    Ltac type_of_first_argument_of f :=
+      let f_ty := type of f in
+      lazymatch eval hnf in f_ty with
+      | forall x : ?T, _ => T
+      end.
+
+    (** Forms of abstraction in Gallina that our reflective language
+      cannot handle get handled by specializing the code "template" to
+      each particular application of that abstraction. In particular,
+      type arguments (nat, Z, (λ _, nat), etc) get substituted into
+      lambdas and treated as a integral part of primitive operations
+      (such as [@List.app T], [@list_rect (λ _, nat)]).  During
+      reification, we accumulate them in a right-associated tuple,
+      using [tt] as the "nil" base case.  When we hit a λ or an
+      identifier, we plug in the template parameters as necessary. *)
+    Ltac require_template_parameter parameter_type :=
+      first [ unify parameter_type Prop
+            | unify parameter_type Set
+            | unify parameter_type Type
+            | lazymatch eval hnf in parameter_type with
+              | forall x : ?T, @?P x
+                => let check := constr:(fun x : T
+                                        => ltac:(require_template_parameter (P x);
+                                                 exact I)) in
+                   idtac
+              end ].
+    Ltac is_template_parameter parameter_type :=
+      is_success_run_tactic ltac:(fun _ => require_template_parameter parameter_type).
+    Ltac plug_template_ctx f template_ctx :=
+      lazymatch template_ctx with
+      | tt => f
+      | (?arg, ?template_ctx')
+        =>
+        let T := type_of_first_argument_of f in
+        let x_is_template_parameter := is_template_parameter T in
+        lazymatch x_is_template_parameter with
+        | true
+          => plug_template_ctx (f arg) template_ctx'
+        | false
+          => constr:(fun x : T
+                     => ltac:(let v := plug_template_ctx (f x) template_ctx in
+                              exact v))
+        end
+      end.
+
+    Ltac reify_helper ident reify_ident var term value_ctx template_ctx :=
+      let reify_rec_gen term value_ctx template_ctx := reify_helper ident reify_ident var term value_ctx template_ctx in
+      let reify_rec term := reify_rec_gen term value_ctx template_ctx in
+      (*let dummy := match goal with _ => idtac "reify_helper: attempting to reify:" term end in*)
+      lazymatch value_ctx with
+      | context[@var_context.cons _ ?rT term ?v _]
+        => constr:(@Var ident var rT v)
+      | _
+        =>
+        let term_is_known_const := is_known_const term in
+        lazymatch term_is_known_const with
+        | true
+          => let rv := reify_ident term in
+             constr:(Ident (var:=var) rv)
+        | false
+          =>
+          lazymatch term with
+          | match ?b with true => ?t | false => ?f end
+            => let T := type of t in
+               reify_rec (@bool_rect (fun _ => T) t f b)
+          | let x := ?a in @?b x
+            => let A := type of a in
+               let B := lazymatch type of b with forall x, @?B x => B end in
+               reify_rec (@Let_In A B a b)
+          | ?f ?x
+            =>
+            let ty := type_of_first_argument_of f in
+            let x_is_template_parameter := is_template_parameter ty in
+            lazymatch x_is_template_parameter with
+            | true
+              => (* we can't reify things of type [Type], so we save it for later to plug in *)
+              reify_rec_gen f value_ctx (x, template_ctx)
+            | false
+              =>
+              let rx := reify_rec_gen x value_ctx tt in
+              let rf := reify_rec_gen f value_ctx template_ctx in
+              constr:(App (var:=var) rf rx)
+            end
+          | (fun x : ?T => ?f)
+            =>
+            let x_is_template_parameter := is_template_parameter T in
+            lazymatch x_is_template_parameter with
+            | true
+              =>
+              lazymatch template_ctx with
+              | (?arg, ?template_ctx)
+                => (* we pull a trick with [match] to plug in [arg] without running cbv β *)
+                reify_rec_gen (match arg with x => f end) value_ctx template_ctx
+              end
+            | false
+              =>
+              let rT := type.reify T in
+              let not_x := refresh x in
+              let not_x2 := refresh not_x in
+              let not_x3 := refresh not_x2 in
+              let rf0 :=
+                  constr:(
+                    fun (x : T) (not_x : var rT)
+                    => match f, @var_context.cons var rT x not_x value_ctx return _ with (* c.f. COQBUG(https://github.com/coq/coq/issues/6252#issuecomment-347041995) for [return _] *)
+                       | not_x2, not_x3
+                         => ltac:(
+                              let f := (eval cbv delta [not_x2] in not_x2) in
+                              let var_ctx := (eval cbv delta [not_x3] in not_x3) in
+                              (*idtac "rec call" f "was" term;*)
+                              let rf := reify_rec_gen f var_ctx template_ctx in
+                              exact rf)
+                       end) in
+              lazymatch rf0 with
+              | (fun _ => ?rf)
+                => constr:(@Abs ident var rT _ rf)
+              | _
+                => (* This will happen if the reified term still
+              mentions the non-var variable.  By chance, [cbv delta]
+              strips type casts, which are only places that I can
+              think of where such dependency might remain.  However,
+              if this does come up, having a distinctive error message
+              is much more useful for debugging than the generic "no
+              matching clause" *)
+                let dummy := match goal with
+                             | _ => fail 1 "Failure to eliminate functional dependencies of" rf0
+                             end in
+                constr:(I : I)
+              end
+            end
+          | _
+            => let term := plug_template_ctx term template_ctx in
+               let idc := reify_ident term in
+               constr:(Ident (var:=var) idc)
+          end
+        end
+      end.
+    Ltac reify ident reify_ident var term :=
+      reify_helper ident reify_ident var term (@var_context.nil var) tt.
+    Ltac Reify ident reify_ident term :=
+      constr:(fun var : type -> Type
+              => ltac:(let r := reify ident reify_ident var term in
+                       exact r)).
+    Ltac Reify_rhs ident reify_ident interp_ident _ :=
+      let RHS := lazymatch goal with |- _ = ?RHS => RHS end in
+      let R := Reify ident reify_ident RHS in
+      transitivity (@Interp ident interp_ident _ R);
+      [ | cbv beta iota delta [Interp interp interp_ident Let_In type.interp bool_rect];
+          reflexivity ].
+
+    Module for_reification.
+      Module ident.
+        Import type.
+        Inductive ident : type -> Set :=
+        | Const {t} (v : interp t) : ident t
+        | Let_In {tx tC} : ident (tx -> (tx -> tC) -> tC)
+        | S : ident (nat -> nat)
+        | nil {t} : ident (list t)
+        | cons {t} : ident (t -> list t -> list t)
+        | pair {A B} : ident (A -> B -> A * B)
+        | fst {A B} : ident (A * B -> A)
+        | snd {A B} : ident (A * B -> B)
+        | bool_rect {T} : ident (T -> T -> bool -> T)
+        | nat_rect {P} : ident (P -> (nat -> P -> P) -> nat -> P)
+        | pred : ident (nat -> nat)
+        | List_seq : ident (nat -> nat -> list nat)
+        | List_repeat {A} : ident (A -> nat -> list A)
+        | List_combine {A B} : ident (list A -> list B -> list (A * B))
+        | List_map {A B} : ident ((A -> B) -> list A -> list B)
+        | List_flat_map {A B} : ident ((A -> list B) -> list A -> list B)
+        | List_partition {A} : ident ((A -> bool) -> list A -> list A * list A)
+        | List_app {A} : ident (list A -> list A -> list A)
+        | List_rev {A} : ident (list A -> list A)
+        | List_fold_right {A B} : ident ((B -> A -> A) -> A -> list B -> A)
+        | List_update_nth {T} : ident (nat -> (T -> T) -> list T -> list T)
+        | List_nth_default {T} : ident (T -> list T -> nat -> T)
+        | Z_runtime_mul : ident (Z -> Z -> Z)
+        | Z_runtime_add : ident (Z -> Z -> Z)
+        | Z_add : ident (Z -> Z -> Z)
+        | Z_mul : ident (Z -> Z -> Z)
+        | Z_pow : ident (Z -> Z -> Z)
+        | Z_opp : ident (Z -> Z)
+        | Z_div : ident (Z -> Z -> Z)
+        | Z_modulo : ident (Z -> Z -> Z)
+        | Z_eqb : ident (Z -> Z -> bool)
+        | Z_of_nat : ident (nat -> Z).
+
+        Definition interp {t} (idc : ident t) : type.interp t
+          := match idc in ident t return type.interp t with
+             | Const t v => v
+             | Let_In tx tC => @LetIn.Let_In (type.interp tx) (fun _ => type.interp tC)
+             | S => Datatypes.S
+             | nil t => @Datatypes.nil (type.interp t)
+             | cons t => @Datatypes.cons (type.interp t)
+             | pair A B => @Datatypes.pair (type.interp A) (type.interp B)
+             | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
+             | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
+             | bool_rect T => @Datatypes.bool_rect (fun _ => type.interp T)
+             | nat_rect P => @Datatypes.nat_rect (fun _ => type.interp P)
+             | pred => Nat.pred
+             | List_seq => List.seq
+             | List_combine A B => @List.combine (type.interp A) (type.interp B)
+             | List_map A B => @List.map (type.interp A) (type.interp B)
+             | List_repeat A => @List.repeat (type.interp A)
+             | List_flat_map A B => @List.flat_map (type.interp A) (type.interp B)
+             | List_partition A => @List.partition (type.interp A)
+             | List_app A => @List.app (type.interp A)
+             | List_rev A => @List.rev (type.interp A)
+             | List_fold_right A B => @List.fold_right (type.interp A) (type.interp B)
+             | List_update_nth T => @update_nth (type.interp T)
+             | List_nth_default T => @List.nth_default (type.interp T)
+             | Z_runtime_mul => runtime_mul
+             | Z_runtime_add => runtime_add
+             | Z_add => Z.add
+             | Z_mul => Z.mul
+             | Z_pow => Z.pow
+             | Z_modulo => Z.modulo
+             | Z_opp => Z.opp
+             | Z_div => Z.div
+             | Z_eqb => Z.eqb
+             | Z_of_nat => Z.of_nat
+             end.
+
+        Ltac reify term :=
+          (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
+          lazymatch term with
+          | Datatypes.S => ident.S
+          | @Datatypes.nil ?T
+            => let rT := type.reify T in
+               constr:(@ident.nil rT)
+          | @Datatypes.cons ?T
+            => let rT := type.reify T in
+               constr:(@ident.cons rT)
+          | @Datatypes.pair ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.pair rA rB)
+          | @Datatypes.fst ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.fst rA rB)
+          | @Datatypes.snd ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.snd rA rB)
+          | @Datatypes.bool_rect (fun _ => ?T)
+            => let rT := type.reify T in
+               constr:(@ident.bool_rect rT)
+          | @Datatypes.nat_rect (fun _ => ?T)
+            => let rT := type.reify T in
+               constr:(@ident.nat_rect rT)
+          | Nat.pred => ident.pred
+          | List.seq => ident.List_seq
+          | @List.repeat ?A
+            => let rA := type.reify A in
+               constr:(@ident.List_repeat rA)
+          | @LetIn.Let_In ?A (fun _ => ?B)
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.Let_In rA rB)
+          | @combine ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.List_combine rA rB)
+          | @List.map ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.List_map rA rB)
+          | @List.flat_map ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.List_flat_map rA rB)
+          | @List.partition ?A
+            => let rA := type.reify A in
+               constr:(@ident.List_partition rA)
+          | @List.app ?A
+            => let rA := type.reify A in
+               constr:(@ident.List_app rA)
+          | @List.rev ?A
+            => let rA := type.reify A in
+               constr:(@ident.List_rev rA)
+          | @List.fold_right ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.List_fold_right rA rB)
+          | @update_nth ?T
+            => let rT := type.reify T in
+               constr:(@ident.List_update_nth rT)
+          | @List.nth_default ?T
+            => let rT := type.reify T in
+               constr:(@ident.List_nth_default rT)
+          | runtime_mul => ident.Z_runtime_mul
+          | runtime_add => ident.Z_runtime_add
+          | Z.add => ident.Z_add
+          | Z.mul => ident.Z_mul
+          | Z.pow => ident.Z_pow
+          | Z.opp => ident.Z_opp
+          | Z.div => ident.Z_div
+          | Z.modulo => ident.Z_modulo
+          | Z.eqb => ident.Z_eqb
+          | Z.of_nat => ident.Z_of_nat
+          | _
+            => let assert_const := match goal with
+                                   | _ => require_known_const term
+                                   end in
+               let T := type of term in
+               let rT := type.reify T in
+               constr:(@ident.Const rT term)
+          end.
+
+        Module List.
+          Notation seq := List_seq.
+          Notation repeat := List_repeat.
+          Notation combine := List_combine.
+          Notation map := List_map.
+          Notation flat_map := List_flat_map.
+          Notation partition := List_partition.
+          Notation app := List_app.
+          Notation rev := List_rev.
+          Notation fold_right := List_fold_right.
+          Notation update_nth := List_update_nth.
+          Notation nth_default := List_nth_default.
+        End List.
+
+        Module Z.
+          Notation runtime_mul := Z_runtime_mul.
+          Notation runtime_add := Z_runtime_add.
+          Notation add := Z_add.
+          Notation mul := Z_mul.
+          Notation pow := Z_pow.
+          Notation opp := Z_opp.
+          Notation div := Z_div.
+          Notation modulo := Z_modulo.
+          Notation eqb := Z_eqb.
+          Notation of_nat := Z_of_nat.
+        End Z.
+
+        Module Export Notations.
+          Notation ident := ident.
+        End Notations.
+      End ident.
+
+      Module Notations.
+        Include ident.Notations.
+        Notation expr := (@expr ident).
+        Notation Expr := (@Expr ident).
+        Notation interp := (@interp ident (@ident.interp)).
+        Notation Interp := (@Interp ident (@ident.interp)).
+
+        Notation TT := (Ident (@ident.Const type.unit tt)).
+        Notation Pair x y := (App (App (Ident ident.pair) x) y).
+
+        Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
+        Notation "( )" := TT : expr_scope.
+        Notation "()" := TT : expr_scope.
+        Notation "'expr_let' x := A 'in' b" := (App (App (Ident ident.Let_In) A%expr) (Abs (fun x => b%expr))) : expr_scope.
+        Notation "[ ]" := (Ident ident.nil) : expr_scope.
+        Notation "x :: xs" := (App (App (Ident ident.cons) x%expr) xs%expr) : expr_scope.
+
+        Definition const {var t} (v : type.interp t) : @expr var t
+          := Ident (ident.Const v).
+        Module Reification.
+          Ltac reify var term := expr.reify ident ident.reify var term.
+          Ltac Reify term := expr.Reify ident ident.reify term.
+          Ltac Reify_rhs _ :=
+            expr.Reify_rhs ident ident.reify ident.interp ().
+        End Reification.
+        Include Reification.
+        End Notations.
+      Include Notations.
+    End for_reification.
+
+    Module Export default.
+      Module ident.
+        Import type.
+        Inductive ident : type -> Set :=
+        | Const {t} (v : interp t) : ident t
+        | Let_In {tx tC} : ident (tx -> (tx -> tC) -> tC)
+        | S : ident (nat -> nat)
+        | nil {t} : ident (list t)
+        | cons {t} : ident (t -> list t -> list t)
+        | pair {A B} : ident (A -> B -> A * B)
+        | fst {A B} : ident (A * B -> A)
+        | snd {A B} : ident (A * B -> B)
+        | bool_rect {T} : ident (T -> T -> bool -> T)
+        | nat_rect {P} : ident (P -> (nat -> P -> P) -> nat -> P)
+        | pred : ident (nat -> nat)
+        | list_rect {A P} : ident (P -> (A -> list A -> P -> P) -> list A -> P)
+        | Z_runtime_mul : ident (Z -> Z -> Z)
+        | Z_runtime_add : ident (Z -> Z -> Z)
+        | Z_add : ident (Z -> Z -> Z)
+        | Z_mul : ident (Z -> Z -> Z)
+        | Z_pow : ident (Z -> Z -> Z)
+        | Z_opp : ident (Z -> Z)
+        | Z_div : ident (Z -> Z -> Z)
+        | Z_modulo : ident (Z -> Z -> Z)
+        | Z_eqb : ident (Z -> Z -> bool)
+        | Z_of_nat : ident (nat -> Z).
+
+        Definition interp {t} (idc : ident t) : type.interp t
+          := match idc in ident t return type.interp t with
+             | Const t v => v
+             | Let_In tx tC => @LetIn.Let_In (type.interp tx) (fun _ => type.interp tC)
+             | S => Datatypes.S
+             | nil t => @Datatypes.nil (type.interp t)
+             | cons t => @Datatypes.cons (type.interp t)
+             | pair A B => @Datatypes.pair (type.interp A) (type.interp B)
+             | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
+             | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
+             | bool_rect T => @Datatypes.bool_rect (fun _ => type.interp T)
+             | nat_rect P => @Datatypes.nat_rect (fun _ => type.interp P)
+             | pred => Nat.pred
+             | list_rect A P => @Datatypes.list_rect (type.interp A) (fun _ => type.interp P)
+             | Z_runtime_mul => runtime_mul
+             | Z_runtime_add => runtime_add
+             | Z_add => Z.add
+             | Z_mul => Z.mul
+             | Z_pow => Z.pow
+             | Z_modulo => Z.modulo
+             | Z_opp => Z.opp
+             | Z_div => Z.div
+             | Z_eqb => Z.eqb
+             | Z_of_nat => Z.of_nat
+             end.
+
+        Ltac reify term :=
+          (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
+          lazymatch term with
+          | Datatypes.S => ident.S
+          | @Datatypes.nil ?T
+            => let rT := type.reify T in
+               constr:(@ident.nil rT)
+          | @Datatypes.cons ?T
+            => let rT := type.reify T in
+               constr:(@ident.cons rT)
+          | @Datatypes.pair ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.pair rA rB)
+          | @Datatypes.fst ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.fst rA rB)
+          | @Datatypes.snd ?A ?B
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.snd rA rB)
+          | @Datatypes.bool_rect (fun _ => ?T)
+            => let rT := type.reify T in
+               constr:(@ident.bool_rect rT)
+          | @Datatypes.nat_rect (fun _ => ?T)
+            => let rT := type.reify T in
+               constr:(@ident.nat_rect rT)
+          | Nat.pred => ident.pred
+          | @LetIn.Let_In ?A (fun _ => ?B)
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.Let_In rA rB)
+          | @Datatypes.list_rect ?A (fun _ => ?B)
+            => let rA := type.reify A in
+               let rB := type.reify B in
+               constr:(@ident.list_rect rA rB)
+          | runtime_mul => ident.Z_runtime_mul
+          | runtime_add => ident.Z_runtime_add
+          | Z.add => ident.Z_add
+          | Z.mul => ident.Z_mul
+          | Z.pow => ident.Z_pow
+          | Z.opp => ident.Z_opp
+          | Z.div => ident.Z_div
+          | Z.modulo => ident.Z_modulo
+          | Z.eqb => ident.Z_eqb
+          | Z.of_nat => ident.Z_of_nat
+          | _
+            => let assert_const := match goal with
+                                   | _ => require_known_const term
+                                   end in
+               let T := type of term in
+               let rT := type.reify T in
+               constr:(@ident.Const rT term)
+          end.
+
+        Module Z.
+          Notation runtime_mul := Z_runtime_mul.
+          Notation runtime_add := Z_runtime_add.
+          Notation add := Z_add.
+          Notation mul := Z_mul.
+          Notation pow := Z_pow.
+          Notation opp := Z_opp.
+          Notation div := Z_div.
+          Notation modulo := Z_modulo.
+          Notation eqb := Z_eqb.
+          Notation of_nat := Z_of_nat.
+        End Z.
+
+        Module Export Notations.
+          Notation ident := ident.
+        End Notations.
+      End ident.
+
+      Module Notations.
+        Include ident.Notations.
+        Notation expr := (@expr ident).
+        Notation Expr := (@Expr ident).
+        Notation interp := (@interp ident (@ident.interp)).
+        Notation Interp := (@Interp ident (@ident.interp)).
+
+        Notation TT := (Ident (@ident.Const type.unit tt)).
+        Notation Pair x y := (App (App (Ident ident.pair) x) y).
+
+        Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
+        Notation "( )" := TT : expr_scope.
+        Notation "()" := TT : expr_scope.
+        Notation "'expr_let' x := A 'in' b" := (App (App (Ident ident.Let_In) A%expr) (Abs (fun x => b%expr))) : expr_scope.
+        Notation "[ ]" := (Ident ident.nil) : expr_scope.
+        Notation "x :: xs" := (App (App (Ident ident.cons) x%expr) xs%expr) : expr_scope.
+
+        Definition const {var t} (v : type.interp t) : @expr var t
+          := Ident (ident.Const v).
+
+        Ltac reify var term := expr.reify ident ident.reify var term.
+        Ltac Reify term := expr.Reify ident ident.reify term.
+        Ltac Reify_rhs _ :=
+          expr.Reify_rhs ident ident.reify ident.interp ().
+      End Notations.
+      Include Notations.
+    End default.
+  End expr.
+
+  Module canonicalize_list_recursion.
+    Import expr.
+    Import expr.default.
+    Module ident.
+      Definition transfer {var} {t} (idc : for_reification.ident t) : @expr var t
+        := let List_app A :=
+               list_rect
+                 (fun _ => list (type.interp A) -> list (type.interp A))
+                 (fun m => m)
+                 (fun a l1 app_l1 m => a :: app_l1 m) in
+           match idc with
+           | for_reification.ident.Const t v
+             => Ident (ident.Const v)
+           | for_reification.ident.Let_In tx tC
+             => Ident ident.Let_In
+           | for_reification.ident.S
+             => Ident ident.S
+           | for_reification.ident.nil t
+             => Ident ident.nil
+           | for_reification.ident.cons t
+             => Ident ident.cons
+           | for_reification.ident.pair A B
+             => Ident ident.pair
+           | for_reification.ident.fst A B
+             => Ident ident.fst
+           | for_reification.ident.snd A B
+             => Ident ident.snd
+           | for_reification.ident.bool_rect T
+             => Ident ident.bool_rect
+           | for_reification.ident.nat_rect P
+             => Ident ident.nat_rect
+           | for_reification.ident.pred
+             => Ident ident.pred
+           | for_reification.ident.Z_runtime_mul
+             => Ident ident.Z.runtime_mul
+           | for_reification.ident.Z_runtime_add
+             => Ident ident.Z.runtime_add
+           | for_reification.ident.Z_add
+             => Ident ident.Z.add
+           | for_reification.ident.Z_mul
+             => Ident ident.Z.mul
+           | for_reification.ident.Z_pow
+             => Ident ident.Z.pow
+           | for_reification.ident.Z_opp
+             => Ident ident.Z.opp
+           | for_reification.ident.Z_div
+             => Ident ident.Z.div
+           | for_reification.ident.Z_modulo
+             => Ident ident.Z.modulo
+           | for_reification.ident.Z_eqb
+             => Ident ident.Z.eqb
+           | for_reification.ident.Z_of_nat
+             => Ident ident.Z.of_nat
+           | for_reification.ident.List_seq
+             => ltac:(
+                  let v := reify
+                             var
+                             (fun start len : nat
+                              => nat_rect
+                                   (fun _ => nat -> list nat)
+                                   (fun _ => nil)
+                                   (fun len seq_len start => cons start (seq_len (S start)))
+                                   len start)
+                  in exact v)
+           | for_reification.ident.List_repeat A
+             => ltac:(
+                  let v := reify
+                             var
+                             (fun (x : type.interp A)
+                              => nat_rect
+                                   (fun _ => list (type.interp A))
+                                   nil
+                                   (fun k repeat_k => cons x repeat_k)) in
+                  exact v)
+           | for_reification.ident.List_combine A B
+             => ltac:(
+                  let v := reify
+                             var
+                             (list_rect
+                                (fun _ => list (type.interp B) -> list (type.interp A * type.interp B))
+                                (fun l' => nil)
+                                (fun x tl combine_tl
+                                 => list_rect
+                                      (fun _ => list (type.interp A * type.interp B))
+                                      nil
+                                      (fun y tl' REIFICATION_STACK_OVERFLOWS_IF_THIS_IS_NAMED_UNDERSCORE (* CODBUG(https://github.com/coq/coq/issues/5448) *)
+                                       => (x, y) :: combine_tl tl'))) in
+                  exact v)
+           | for_reification.ident.List_map A B
+             => ltac:(
+                  let v := reify
+                             var
+                             (fun f : type.interp A -> type.interp B
+                              => list_rect
+                                   (fun _ => list (type.interp B))
+                                   nil
+                                   (fun a t map_t => f a :: map_t)) in
+                  exact v)
+           | for_reification.ident.List_flat_map A B
+             => ltac:(
+                  let List_app := (eval cbv [List_app] in (List_app B)) in
+                  let v := reify
+                             var
+                             (fun f : type.interp A -> list (type.interp B)
+                              => list_rect
+                                   (fun _ => list (type.interp B))
+                                   nil
+                                   (fun x t flat_map_t => List_app (f x) flat_map_t)) in
+                  exact v)
+           | for_reification.ident.List_partition A
+             => ltac:(
+                  let v := reify
+                             var
+                             (fun f : type.interp A -> bool
+                              => list_rect
+                                   (fun _ => list (type.interp A) * list (type.interp A))%type
+                                   (nil, nil)
+                                   (fun x tl partition_tl
+                                    => let g := fst partition_tl in
+                                       let d := snd partition_tl in
+                                       if f x then (x :: g, d) else (g, x :: d))) in
+                  exact v)
+           | for_reification.ident.List_app A
+             => ltac:(
+                  let List_app := (eval cbv [List_app] in (List_app A)) in
+                  let v := reify var List_app in
+                  exact v)
+           | for_reification.ident.List_rev A
+             => ltac:(
+                  let List_app := (eval cbv [List_app] in (List_app A)) in
+                  let v := reify
+                             var
+                             (list_rect
+                                (fun _ => list (type.interp A))
+                                nil
+                                (fun x l' rev_l' => List_app rev_l' [x])) in
+                  exact v)
+           | for_reification.ident.List_fold_right A B
+             => ltac:(
+                  let v := reify
+                             var
+                             (fun (f : type.interp B -> type.interp A -> type.interp A) (a0 : type.interp A)
+                              => list_rect
+                                   (fun _ => type.interp A)
+                                   a0
+                                   (fun b t fold_right_t => f b fold_right_t)) in
+                  exact v)
+           | for_reification.ident.List_update_nth T
+             => ltac:(
+                  let v := reify
+                             var
+                             (fun (n : nat) (f : type.interp T -> type.interp T)
+                              => nat_rect
+                                   (fun _ => list (type.interp T) -> list (type.interp T))
+                                   (list_rect
+                                      (fun _ => list (type.interp T))
+                                      nil
+                                      (fun x' xs' __ => f x' :: xs'))
+                                   (fun n' update_nth_n'
+                                    => list_rect
+                                         (fun _ => list (type.interp T))
+                                         nil
+                                         (fun x' xs' __ => x' :: update_nth_n' xs'))
+                                   n) in
+                  exact v)
+           | for_reification.ident.List_nth_default T
+             => ltac:(
+                  let v := reify
+                             var
+                             (fun (default : type.interp T) (l : list (type.interp T)) (n : nat)
+                              => nat_rect
+                                   (fun _ => list (type.interp T) -> type.interp T)
+                                   (list_rect
+                                      (fun _ => type.interp T)
+                                      default
+                                      (fun x __ __ => x))
+                                   (fun n nth_error_n
+                                    => list_rect
+                                         (fun _ => type.interp T)
+                                         default
+                                         (fun __ l __ => nth_error_n l))
+                                   n
+                                   l) in
+                  exact v)
+           end%expr.
+    End ident.
+
+    Module expr.
+      Section with_var.
+        Context {var : type -> Type}.
+
+        Fixpoint transfer {t} (e : @for_reification.Notations.expr var t)
+          : @expr var t
+          := match e  with
+             | Var t v => Var v
+             | Ident t idc => @ident.transfer var t idc
+             | App s d f x => App (@transfer _ f) (@transfer _ x)
+             | Abs s d f => Abs (fun x => @transfer d (f x))
+             end.
+      End with_var.
+
+      Definition Transfer {t} (e : for_reification.Notations.Expr t) : Expr t
+        := fun var => transfer (e _).
+    End expr.
+  End canonicalize_list_recursion.
+  Notation canonicalize_list_recursion := canonicalize_list_recursion.expr.Transfer.
+  Import expr.
+  Import expr.default.
 
   Section option_partition.
     Context {A : Type} (f : A -> option Datatypes.bool).
@@ -517,7 +1172,7 @@ Module Compilers.
     Local Notation if_arrow_d f := (if_arrow (fun s d => f d)) (only parsing).
 
     Definition invert_Abs {s d} (e : @expr var (type.arrow s d)) : option (var s -> @expr var d)
-      := match e in expr t return option (if_arrow (fun _ _ => _) t) with
+      := match e in expr.expr t return option (if_arrow (fun _ _ => _) t) with
          | Abs s d f => Some f
          | _ => None
          end.
@@ -621,7 +1276,7 @@ Module Compilers.
     (* oh, the horrors of not being able to use non-linear deep pattern matches.  c.f. COQBUG(https://github.com/coq/coq/issues/6320) *)
     Fixpoint invert_list_full {t} (e : @expr var (type.list t))
       : option (list (@expr var t))
-      := match e in expr t return option (list_expr t) with
+      := match e in expr.expr t return option (list_expr t) with
          | Ident t idc
            => match idc in ident t return option (list_expr t) with
               | ident.Const (type.list _) v => Some (List.map const v)
@@ -673,13 +1328,6 @@ Module Compilers.
            (fun _ => _)
            (Ident ident.nil)
            (fun x _ xs => App (App (Ident ident.cons) x) xs)
-           ls.
-
-    Definition reify_list_by_app {t} (ls : list (@expr var (type.list t))) : @expr var (type.list t)
-      := list_rect
-           (fun _ => _)
-           (Ident ident.nil)
-           (fun ls1 _ ls2 => App (App (Ident ident.List.app) ls1) ls2)
            ls.
   End gallina_reify.
 
@@ -877,215 +1525,6 @@ Module Compilers.
     Module ident.
       Section interp.
         Context {var : type -> Type}.
-        Let defaulted_App_p_e {A B} (idc : ident (A -> B))
-            (F : interp_prestep (interp var) A
-                 -> interp var B)
-          : @expr var A + interp_prestep (interp var) A
-            -> interp var B
-          := fun x
-             => match x with
-                | inl e => expr.reflect (App (Ident idc) e)
-                | inr x => F x
-                end.
-        Let defaulted_App_p_p {A B} (idc : ident (A -> B))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) B)
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var B + interp_prestep (interp var) B
-          := (App (Ident idc) + F)%function.
-        Let defaulted_App_ep_p {A B C} (idc : ident (A -> B -> C))
-            (F : interp var A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp var) C)
-          : interp var A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x
-             => (App (App (Ident idc) (expr.reify x))
-                 + (F x))%function.
-        Let defaulted_App_eep_e {A B C D} (idc : ident (A -> B -> C -> D))
-            (F : interp var A
-                 -> interp var B
-                 -> interp_prestep (interp var) C
-                 -> interp var D)
-          : interp var A
-            -> interp var B
-            -> @expr var C + interp_prestep (interp var) C
-            -> interp var D
-          := fun x y z
-             => match z with
-                | inl z => expr.reflect (App (App (App (Ident idc) (expr.reify x)) (expr.reify y)) z)
-                | inr z => F x y z
-                end.
-        Let defaulted_App_pe_p {A B C} (idc : ident (A -> B -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp var B
-                 -> interp_prestep (interp var) C)
-          : @expr var A + interp_prestep (interp var) A
-            -> interp var B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x y
-             => match x with
-                | inl x => inl (App (App (Ident idc) x) (expr.reify y))
-                | inr x => inr (F x y)
-                end.
-        Let defaulted_App_pep_p {A B C D} (idc : ident (A -> B -> C -> D))
-            (F : interp_prestep (interp var) A
-                 -> interp var B
-                 -> interp_prestep (interp var) C
-                 -> interp_prestep (interp var) D)
-          : @expr var A + interp_prestep (interp var) A
-            -> interp var B
-            -> @expr var C + interp_prestep (interp var) C
-            -> @expr var D + interp_prestep (interp var) D
-          := fun x y z
-             => let xz
-                    := match x, z with
-                       | inl x, inl z => inl (x, z)
-                       | inr x, inl z => inl (expr.reify (unprestep x), z)
-                       | inl x, inr z => inl (x, expr.reify (unprestep z))
-                       | inr x, inr z => inr (x, z)
-                       end in
-                match xz with
-                | inl (x, z) => inl (App (App (App (Ident idc) x) (expr.reify y)) z)
-                | inr (x, z) => inr (F x y z)
-                end.
-        Let defaulted_App_pp_p {A B C} (idc : ident (A -> B -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp var) C)
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x y
-             => let xy
-                    := match x, y with
-                       | inl x, inl y => inl (x, y)
-                       | inr x, inl y => inl (expr.reify (unprestep x), y)
-                       | inl x, inr y => inl (x, expr.reify (unprestep y))
-                       | inr x, inr y => inr (x, y)
-                       end in
-                match xy with
-                | inl (x, y) => inl (App (App (Ident idc) x) y)
-                | inr (x, y) => inr (F x y)
-                end.
-        Let defaulted_App_pp_p_or_pe_e_or_ep_e {A B C} (idc : ident (A -> B -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp var) C)
-            (F1 : interp_prestep (interp var) A
-                 -> @expr var B
-                 -> option (@expr var C + interp_prestep (interp var) C))
-            (F2 : @expr var A
-                 -> interp_prestep (interp var) B
-                 -> option (@expr var C + interp_prestep (interp var) C))
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x y
-             => let default := defaulted_App_pp_p idc F x y in
-                match x, y with
-                | inl x, inl y => inl (App (App (Ident idc) x) y)
-                | inl x, inr y => match F2 x y with
-                                  | Some Fxy => Fxy
-                                  | None => default
-                                  end
-                | inr x, inl y => match F1 x y with
-                                  | Some Fxy => Fxy
-                                  | None => default
-                                  end
-                | inr x, inr y => inr (F x y)
-                end.
-        Let defaulted_App_pp_p_or_pe_e_comm {A C} (idc : ident (A -> A -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) A
-                 -> interp_prestep (interp var) C)
-            (F1 : interp_prestep (interp var) A
-                 -> @expr var A
-                 -> option (@expr var C + interp_prestep (interp var) C))
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var A + interp_prestep (interp var) A
-            -> @expr var C + interp_prestep (interp var) C
-          := defaulted_App_pp_p_or_pe_e_or_ep_e
-               idc
-               F
-               F1
-               (fun x y => F1 y x).
-        Let defaulted_App_epp_e {A B C D} (idc : ident (A -> B -> C -> D))
-            (F : interp var A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp var) C
-                 -> interp var D)
-          : interp var A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + interp_prestep (interp var) C
-            -> interp var D
-          := fun x y z
-             => let yz
-                    := match y, z with
-                       | inl y, inl z => inl (y, z)
-                       | inr y, inl z => inl (expr.reify (unprestep y), z)
-                       | inl y, inr z => inl (y, expr.reify (unprestep z))
-                       | inr y, inr z => inr (y, z)
-                       end in
-                match yz with
-                | inl (y, z) => expr.reflect (App (App (App (Ident idc) (expr.reify x)) y) z)
-                | inr (y, z) => F x y z
-                end.
-        Let defaulted_App_pp_p2 {A B C} (idc : ident (A -> B -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp_prestep (interp var)) C)
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + match C with
-                             | type.arrow s d => interp_prestep (interp_prestep (interp var)) C
-                             | C => interp_prestep (interp var) C
-                             end
-          := fun x y
-             => let xy
-                    := match x, y with
-                       | inl x, inl y => inl (x, y)
-                       | inr x, inl y => inl (expr.reify (unprestep x), y)
-                       | inl x, inr y => inl (x, expr.reify (unprestep y))
-                       | inr x, inr y => inr (x, y)
-                       end in
-                match xy with
-                | inl (x, y) => inl (App (App (Ident idc) x) y)
-                | inr (x, y) => inr (unprestep2 (F x y))
-                end.
-        Let defaulted_App_ep_p2o {A B C} (idc : ident (A -> B -> C))
-            (F : interp var A
-                 -> interp_prestep (interp var) B
-                 -> option (interp_prestep (interp_prestep (interp var)) C))
-          : interp var A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + match C with
-                             | type.arrow s d => interp_prestep (interp_prestep (interp var)) C
-                             | C => interp_prestep (interp var) C
-                             end
-          := fun x y
-             => match y with
-                | inl y => inl (App (App (Ident idc) (expr.reify x)) y)
-                | inr y
-                  => match F x y with
-                     | Some Fxy => inr (unprestep2 Fxy)
-                     | None
-                       => inl (App (App (Ident idc) (expr.reify x)) (expr.reify (unprestep y)))
-                     end
-                end.
-
-
-
-        Let defaulted_App_ee_p {A B C} (idc : ident (A -> B -> C))
-            (F : interp var A
-                 -> interp var B
-                 -> interp_prestep (interp var) C)
-          : interp var A
-            -> interp var B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x y => inr (F x y).
-
         Definition interp {t} (idc : ident t) : interp var t
           := match idc in ident t return interp var t with
              | ident.Const t v as idc
@@ -1095,104 +1534,101 @@ Module Compilers.
              | ident.nil t
                => inr (@nil (interp var t))
              | ident.cons t as idc
-               => defaulted_App_ep_p idc (@cons (interp var t))
-             | ident.pair A B as idc
-               => defaulted_App_ee_p idc (@pair (interp var A) (interp var B))
-             | ident.fst A B as idc
-               => defaulted_App_p_e idc (@fst (interp var A) (interp var B))
-             | ident.snd A B as idc
-               => defaulted_App_p_e idc (@snd (interp var A) (interp var B))
-             | ident.bool_rect T as idc
-               => defaulted_App_eep_e idc (@bool_rect (fun _ => interp var T))
-             | ident.nat_rect P as idc
-               => defaulted_App_eep_e
-                    idc
-                    (fun O_case S_case n
-                     => @nat_rect
-                          (fun _ => interp var P)
-                          O_case
-                          (fun n' => S_case (inr n'))
-                          n)
-             | ident.List_seq as idc
-               => defaulted_App_pp_p2 idc List.seq
-             | ident.List_repeat A as idc
-               => defaulted_App_ep_p idc (@List.repeat (interp var A))
-             | ident.List_combine A B as idc
-               => defaulted_App_pp_p2 idc (@List.combine (interp var A) (interp var B))
-             | ident.List_map A B as idc
-               => defaulted_App_ep_p idc (@List.map (interp var A) (interp var B))
-             | ident.List_flat_map A B as idc
-               => fun (f : interp var A -> expr (type.list B) + list (interp var B))
-                      (ls : expr (type.list A) + list (interp var A))
-                  => match ls return expr (type.list B) + list (interp var B) with
-                     | inl lse
-                       => inl (App (App (Ident idc) (expr.reify (t:=A->type.list B) f)) lse)
-                     | inr ls
-                       => match option_flat_map
-                                  (fun x => match f x with
-                                            | inl _ => None
-                                            | inr v => Some v
-                                            end)
-                                  ls
-                          with
-                          | Some res => inr res
-                          | None
-                            => let ls'
-                                   := List.map
-                                        (fun x => match f x with
-                                                  | inl e => e
-                                                  | inr v => reify_list (List.map expr.reify v)
-                                                  end)
-                                        ls in
-                               inl (reify_list_by_app ls')
-                          end
+               => fun x (xs : expr (type.list t) + list (interp var t))
+                  => match xs return expr (type.list t) + list (interp var t) with
+                     | inr xs => inr (cons x xs)
+                     | _ => expr.reflect (Ident idc) x xs
                      end
-             | ident.List_partition A as idc
-               => defaulted_App_ep_p2o
-                    idc
-                    (fun f => option_partition (fun x => match f x with
-                                                         | inl _ => None
-                                                         | inr b => Some b
-                                                         end))
-             | ident.List_app A as idc
-               => defaulted_App_pp_p idc (@List.app (interp var A))
-             | ident.List_rev A as idc
-               => defaulted_App_p_p idc (@List.rev (interp var A))
-             | ident.List_fold_right A B as idc
-               => defaulted_App_eep_e idc (@List.fold_right (interp var A) (interp var B))
-             | ident.List_update_nth T as idc
-               => defaulted_App_pep_p idc (@update_nth (interp var T))
-             | ident.List_nth_default T as idc
-               => defaulted_App_epp_e idc (@List.nth_default (interp var T))
+             | ident.pair A B as idc
+               => fun x y => @inr _ (interp var A * interp var B) (x, y)
+             | ident.fst A B as idc
+               => fun x : expr (A * B) + interp var A * interp var B
+                  => match x with
+                     | inr x => fst x
+                     | _ => expr.reflect (Ident idc) x
+                     end
+             | ident.snd A B as idc
+               => fun x : expr (A * B) + interp var A * interp var B
+                  => match x with
+                     | inr x => snd x
+                     | _ => expr.reflect (Ident idc) x
+                     end
+             | ident.bool_rect T as idc
+               => fun true_case false_case (b : expr type.bool + bool)
+                  => match b with
+                     | inr b => @bool_rect (fun _ => interp var T) true_case false_case b
+                     | _ => expr.reflect (Ident idc) true_case false_case b
+                     end
+             | ident.nat_rect P as idc
+               => fun (O_case : interp var P)
+                      (S_case : expr type.nat + nat -> interp var P -> interp var P)
+                      (n : expr type.nat + nat)
+                  => match n with
+                     | inr n => @nat_rect (fun _ => interp var P)
+                                          O_case
+                                          (fun n' => S_case (inr n'))
+                                          n
+                     | _ => expr.reflect (Ident idc) O_case S_case n
+                     end
+             | ident.list_rect A P as idc
+               => fun (nil_case : interp var P)
+                      (cons_case : interp var A -> expr (type.list A) + list (interp var A) -> interp var P -> interp var P)
+                      (ls : expr (type.list A) + list (interp var A))
+                  => match ls with
+                     | inr ls => @list_rect
+                                   (interp var A)
+                                   (fun _ => interp var P)
+                                   nil_case
+                                   (fun x xs rec => cons_case x (inr xs) rec)
+                                   ls
+                     | _ => expr.reflect (Ident idc) nil_case cons_case ls
+                     end
              | ident.pred as idc
              | ident.S as idc
              | ident.Z_of_nat as idc
              | ident.Z_opp as idc
-               => defaulted_App_p_p idc (ident.interp idc)
-             | ident.Z_runtime_mul as idc
-               => defaulted_App_pp_p_or_pe_e_comm
-                    idc (ident.interp idc)
-                    (fun x e
-                     => if Z.eqb x 0
-                        then Some (inr 0%Z)
-                        else if Z.eqb x 1
-                             then Some (inl e)
-                             else None)
-             | ident.Z_runtime_add as idc
-               => defaulted_App_pp_p_or_pe_e_comm
-                    idc (ident.interp idc)
-                    (fun x e
-                     => if Z.eqb x 0
-                        then Some (inl e)
-                        else None)
+               => fun x : expr _ + type.interp _
+                  => match x return expr _ + type.interp _ with
+                     | inr x => inr (ident.interp idc x)
+                     | _ => expr.reflect (Ident idc) x
+                     end
              | ident.Z_add as idc
              | ident.Z_mul as idc
              | ident.Z_pow as idc
              | ident.Z_div as idc
              | ident.Z_modulo as idc
              | ident.Z_eqb as idc
-             | ident.Nat_sub as idc
-               => defaulted_App_pp_p idc (ident.interp idc)
+               => fun (x y : expr _ + type.interp _)
+                  => match x, y return expr _ + type.interp _ with
+                     | inr x, inr y => inr (ident.interp idc x y)
+                     | _, _ => expr.reflect (Ident idc) x y
+                     end
+             | ident.Z_runtime_mul as idc
+               => fun (x y : expr _ + type.interp _)
+                  => let default := expr.reflect (Ident idc) x y in
+                     match x, y return expr _ + type.interp _ with
+                     | inr x, inr y => inr (ident.interp idc x y)
+                     | inr x, inl e
+                     | inl e, inr x
+                       => if Z.eqb x 0
+                          then inr 0%Z
+                          else if Z.eqb x 1
+                               then inl e
+                               else default
+                     | inl _, inl _ => default
+                     end
+             | ident.Z_runtime_add as idc
+               => fun (x y : expr _ + type.interp _)
+                  => let default := expr.reflect (Ident idc) x y in
+                     match x, y return expr _ + type.interp _ with
+                     | inr x, inr y => inr (ident.interp idc x y)
+                     | inr x, inl e
+                     | inl e, inr x
+                       => if Z.eqb x 0
+                          then inl e
+                          else default
+                     | inl _, inl _ => default
+                     end
              end.
       End interp.
     End ident.
@@ -1203,7 +1639,7 @@ Module Compilers.
 
     Fixpoint partial_reduce' {t} (e : @expr (partial.interp var) t)
       : partial.interp var t
-      := match e in expr t return partial.interp var t with
+      := match e in expr.expr t return partial.interp var t with
          | Var t v => v
          | Ident t idc => partial.ident.interp idc
          | App s d f x => @partial_reduce' _ f (@partial_reduce' _ x)
@@ -1217,274 +1653,6 @@ Module Compilers.
   Definition PartialReduce {t} (e : Expr t) : Expr t
     := fun var => @partial_reduce var t (e _).
 
-  Ltac is_known_const_cps2 term on_success on_failure :=
-    let recurse term := is_known_const_cps2 term on_success on_failure in
-    lazymatch term with
-    | tt => on_success ()
-    | @nil _ => on_success ()
-    | S ?term => recurse term
-    | O => on_success ()
-    | Z0 => on_success ()
-    | Zpos ?p => recurse p
-    | Zneg ?p => recurse p
-    | xI ?p => recurse p
-    | xO ?p => recurse p
-    | xH => on_success ()
-    | ?term => on_failure term
-    end.
-  Ltac require_known_const term :=
-    is_known_const_cps2 term ltac:(fun _ => idtac) ltac:(fun term => fail 0 "Not a known const:" term).
-  Ltac is_known_const term :=
-    is_known_const_cps2 term ltac:(fun _ => true) ltac:(fun _ => false).
-
-  Print ident.ident.
-  Ltac reify_ident term :=
-    (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
-    lazymatch term with
-    | S => ident.S
-    | @nil ?T
-      => let rT := type.reify T in
-         constr:(@ident.nil rT)
-    | @cons ?T
-      => let rT := type.reify T in
-         constr:(@ident.cons rT)
-    | @pair ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         constr:(@ident.pair rA rB)
-    | @fst ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         constr:(@ident.fst rA rB)
-    | @snd ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         constr:(@ident.snd rA rB)
-    | @bool_rect (fun _ => ?T)
-      => let rT := type.reify T in
-         constr:(@ident.bool_rect rT)
-    | @nat_rect (fun _ => ?T)
-      => let rT := type.reify T in
-         constr:(@ident.nat_rect rT)
-    | pred => ident.pred
-    | seq => ident.List.seq
-    | @List.repeat ?A
-      => let rA := type.reify A in
-         constr:(@ident.List.repeat rA)
-    | @Let_In ?A (fun _ => ?B)
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         constr:(@ident.Let_In rA rB)
-    | @combine ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         constr:(@ident.List.combine rA rB)
-    | @List.map ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         constr:(@ident.List.map rA rB)
-    | @List.flat_map ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         constr:(@ident.List.flat_map rA rB)
-    | @List.partition ?A
-      => let rA := type.reify A in
-         constr:(@ident.List.partition rA)
-    | @List.app ?A
-      => let rA := type.reify A in
-         constr:(@ident.List.app rA)
-    | @List.rev ?A
-      => let rA := type.reify A in
-         constr:(@ident.List.rev rA)
-    | @List.fold_right ?A ?B
-      => let rA := type.reify A in
-         let rB := type.reify B in
-         constr:(@ident.List.fold_right rA rB)
-    | @update_nth ?T
-      => let rT := type.reify T in
-         constr:(@ident.List.update_nth rT)
-    | @List.nth_default ?T
-      => let rT := type.reify T in
-         constr:(@ident.List.nth_default rT)
-    | runtime_mul => ident.Z.runtime_mul
-    | runtime_add => ident.Z.runtime_add
-    | Z.add => ident.Z.add
-    | Z.mul => ident.Z.mul
-    | Z.pow => ident.Z.pow
-    | Z.opp => ident.Z.opp
-    | Z.div => ident.Z.div
-    | Z.modulo => ident.Z.modulo
-    | Z.eqb => ident.Z.eqb
-    | Z.of_nat => ident.Z.of_nat
-    | Nat.sub => ident.Nat.sub
-    | _
-      => let assert_const := match goal with
-                             | _ => require_known_const term
-                             end in
-         let T := type of term in
-         let rT := type.reify T in
-         constr:(@ident.Const rT term)
-    end.
-
-  Module var_context.
-    Inductive list {var : type -> Type} :=
-    | nil
-    | cons {t} (gallina_v : type.interp t) (v : var t) (ctx : list).
-  End var_context.
-
-  (* cf COQBUG(https://github.com/coq/coq/issues/5448) , COQBUG(https://github.com/coq/coq/issues/6315) *)
-  Ltac refresh n :=
-    let n' := fresh n in
-    let n' := fresh n in
-    n'.
-
-  Ltac type_of_first_argument_of f :=
-    let f_ty := type of f in
-    lazymatch eval hnf in f_ty with
-    | forall x : ?T, _ => T
-    end.
-
-  (** Forms of abstraction in Gallina that our reflective language
-      cannot handle get handled by specializing the code "template" to
-      each particular application of that abstraction. In particular,
-      type arguments (nat, Z, (λ _, nat), etc) get substituted into
-      lambdas and treated as a integral part of primitive operations
-      (such as [@List.app T], [@list_rect (λ _, nat)]).  During
-      reification, we accumulate them in a right-associated tuple,
-      using [tt] as the "nil" base case.  When we hit a λ or an
-      identifier, we plug in the template parameters as necessary. *)
-  Ltac require_template_parameter parameter_type :=
-    first [ unify parameter_type Prop
-          | unify parameter_type Set
-          | unify parameter_type Type
-          | lazymatch eval hnf in parameter_type with
-            | forall x : ?T, @?P x
-              => let check := constr:(fun x : T
-                                      => ltac:(require_template_parameter (P x);
-                                               exact I)) in
-                 idtac
-            end ].
-  Ltac is_template_parameter parameter_type :=
-    is_success_run_tactic ltac:(fun _ => require_template_parameter parameter_type).
-  Ltac plug_template_ctx f template_ctx :=
-    lazymatch template_ctx with
-    | tt => f
-    | (?arg, ?template_ctx')
-      =>
-      let T := type_of_first_argument_of f in
-      let x_is_template_parameter := is_template_parameter T in
-      lazymatch x_is_template_parameter with
-      | true
-        => plug_template_ctx (f arg) template_ctx'
-      | false
-        => constr:(fun x : T
-                   => ltac:(let v := plug_template_ctx (f x) template_ctx in
-                            exact v))
-      end
-    end.
-
-  Ltac reify_helper var term value_ctx template_ctx :=
-    let reify_rec term := reify_helper var term value_ctx template_ctx in
-    (*let dummy := match goal with _ => idtac "reify_helper: attempting to reify:" term end in*)
-    lazymatch value_ctx with
-    | context[@var_context.cons _ ?rT term ?v _]
-      => constr:(@Var var rT v)
-    | _
-      =>
-      let term_is_known_const := is_known_const term in
-      lazymatch term_is_known_const with
-      | true
-        => let rv := reify_ident term in
-           constr:(Ident (var:=var) rv)
-      | false
-        =>
-        lazymatch term with
-        | match ?b with true => ?t | false => ?f end
-          => let T := type of t in
-             reify_rec (@bool_rect (fun _ => T) t f b)
-        | let x := ?a in @?b x
-          => let A := type of a in
-             let B := lazymatch type of b with forall x, @?B x => B end in
-             reify_rec (@Let_In A B a b)
-        | ?f ?x
-          =>
-          let ty := type_of_first_argument_of f in
-          let x_is_template_parameter := is_template_parameter ty in
-          lazymatch x_is_template_parameter with
-          | true
-            => (* we can't reify things of type [Type], so we save it for later to plug in *)
-            reify_helper var f value_ctx (x, template_ctx)
-          | false
-            =>
-            let rx := reify_helper var x value_ctx tt in
-            let rf := reify_helper var f value_ctx template_ctx in
-            constr:(App (var:=var) rf rx)
-          end
-        | (fun x : ?T => ?f)
-          =>
-          let x_is_template_parameter := is_template_parameter T in
-          lazymatch x_is_template_parameter with
-          | true
-            =>
-            lazymatch template_ctx with
-            | (?arg, ?template_ctx)
-              => (* we pull a trick with [match] to plug in [arg] without running cbv β *)
-              reify_helper var (match arg with x => f end) value_ctx template_ctx
-            end
-          | false
-            =>
-            let rT := type.reify T in
-            let not_x := refresh x in
-            let not_x2 := refresh not_x in
-            let not_x3 := refresh not_x2 in
-            let rf0 :=
-                constr:(
-                  fun (x : T) (not_x : var rT)
-                  => match f, @var_context.cons var rT x not_x value_ctx return _ with (* c.f. COQBUG(https://github.com/coq/coq/issues/6252#issuecomment-347041995) for [return _] *)
-                     | not_x2, not_x3
-                       => ltac:(
-                            let f := (eval cbv delta [not_x2] in not_x2) in
-                            let var_ctx := (eval cbv delta [not_x3] in not_x3) in
-                            (*idtac "rec call" f "was" term;*)
-                            let rf := reify_helper var f var_ctx template_ctx in
-                            exact rf)
-                     end) in
-            lazymatch rf0 with
-            | (fun _ => ?rf)
-              => constr:(@Abs var rT _ rf)
-            | _
-              => (* This will happen if the reified term still
-              mentions the non-var variable.  By chance, [cbv delta]
-              strips type casts, which are only places that I can
-              think of where such dependency might remain.  However,
-              if this does come up, having a distinctive error message
-              is much more useful for debugging than the generic "no
-              matching clause" *)
-              let dummy := match goal with
-                           | _ => fail 1 "Failure to eliminate functional dependencies of" rf0
-                           end in
-              constr:(I : I)
-            end
-          end
-        | _
-          => let term := plug_template_ctx term template_ctx in
-             let idc := reify_ident term in
-             constr:(Ident (var:=var) idc)
-        end
-      end
-    end.
-  Ltac reify var term :=
-    reify_helper var term (@var_context.nil var) tt.
-  Ltac Reify term :=
-    constr:(fun var : type -> Type
-            => ltac:(let r := reify var term in
-                     exact r)).
-  Ltac Reify_rhs _ :=
-    let RHS := lazymatch goal with |- _ = ?RHS => RHS end in
-    let R := Reify RHS in
-    transitivity (Interp R);
-    [ | cbv beta iota delta [Interp interp ident.interp Let_In type.interp bool_rect];
-        reflexivity ].
 End Compilers.
 Import Associational Positional Compilers.
 Local Coercion Z.of_nat : nat >-> Z.
@@ -1524,18 +1692,34 @@ Proof.
 Qed.
 
 Delimit Scope RT_expr_scope with RT_expr.
+Import expr.
+Import for_reification.Notations.Reification.
 Notation "ls _{ n }"
-  := (App (App (App (Ident ident.List.nth_default) _) ls%expr) (Ident (ident.Const n%nat)))
+  := (App (App (App (Ident for_reification.ident.List.nth_default) _) ls%expr) (Ident (ident.Const n%nat)))
        (at level 20, format "ls _{ n }")
      : expr_scope.
+
+Notation "'hd' ls" := (App (App (App (Ident ident.list_rect) (Ident (ident.Const (-1)%Z)))
+                                (Abs (fun x1 => Abs (fun _ => Abs (fun _ => Var x1)))))
+                           ls%expr) (at level 10, ls at level 10) : expr_scope.
+Notation "( λₗ xs .. ys , f ) ( 'tl' ls )" := (App (App (App (Ident ident.list_rect) (Ident (ident.Const (-1)%Z)))
+                                      (Abs (fun _ => Abs (fun xs => .. (fun ys => Abs (fun _ => f)) .. ))))
+                                 ls%expr) (at level 10, xs binder, ys binder, ls at level 10) : expr_scope.
 Notation "x + y"
   := (App (App (Ident ident.Z.runtime_add) x%RT_expr) y%RT_expr)
      : RT_expr_scope.
 Notation "x * y"
   := (App (App (Ident ident.Z.runtime_mul) x%RT_expr) y%RT_expr)
      : RT_expr_scope.
+Notation "x + y"
+  := (App (App (Ident ident.Z.runtime_add) x%RT_expr) y%RT_expr)
+     : expr_scope.
+Notation "x * y"
+  := (App (App (Ident ident.Z.runtime_mul) x%RT_expr) y%RT_expr)
+     : expr_scope.
 Notation "x" := (Ident (ident.Const x)) (only printing, at level 10) : expr_scope.
 Notation "x" := (Var x) (only printing, at level 10) : expr_scope.
+Open Scope RT_expr_scope.
 
 Require Import AdmitAxiom.
 
@@ -1573,11 +1757,12 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
     end.
     cbv [n expand_list expand_list_helper].
     cbv delta [mulmod w to_associational mul to_associational reduce from_associational add_to_nth zeros place split].
+    Locate Ltac Reify.
     assert True.
     { let v := Reify ((fun x => 2^x) 255)%Z in
       pose v as E.
       vm_compute in E.
-      pose (PartialReduce E) as E'.
+      pose (PartialReduce (canonicalize_list_recursion E)) as E'.
       vm_compute in E'.
       lazymatch (eval cbv delta [E'] in E') with
       | (fun var => Ident (ident.Const ?v)) => idtac
@@ -1592,7 +1777,7 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
                            (fun v => v)) in
       pose v as E.
       vm_compute in E.
-      pose (PartialReduce E) as E'.
+      pose (PartialReduce (canonicalize_list_recursion E)) as E'.
       vm_compute in E'.
       lazymatch (eval cbv delta [E'] in E') with
       | (fun var : type -> Type =>
@@ -1606,9 +1791,9 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
     reflexivity.
   } Unfocus.
   cbv beta.
-  let e := match goal with |- _ = Interp ?e _ _ => e end in
+  let e := match goal with |- _ = expr.Interp _ ?e _ _ => e end in
   set (E := e).
-  let E' := constr:(PartialReduce E) in
+  let E' := constr:(PartialReduce (canonicalize_list_recursion E)) in
   let E' := (eval vm_compute in E') in
   pose E' as E''.
   transitivity (Interp E'' f g); [ clear E | admit ].
@@ -1628,99 +1813,1211 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
   f0*g0+ 38*f1*g9+ 19*f2*g8+ 38*f3*g7+ 19*f4*g6+ 38*f5*g5+ 19*f6*g4+ 38*f7*g3+ 19*f8*g2+ 38*f9*g1) *)
   (*trivial.*)
 Defined.
-
 Eval cbv [proj1_sig base_25_5_mul] in (fun f g Hf Hg => proj1_sig (base_25_5_mul f g Hf Hg)).
-(*      = fun (f g : list Z) (_ : length f = 10%nat) (_ : length g = 10%nat) =>
-       Interp
+
+(*     = fun (f g : list Z) (_ : length f = 10%nat) (_ : length g = 10%nat) =>
+       expr.Interp (@ident.interp)
          (fun var : type -> Type =>
           (λ x x0 : var (type.list type.Z),
-           (x_{0} * x0_{0} +
-            (2 * (19 * (x_{1} * x0_{9})) +
-             (19 * (x_{2} * x0_{8}) +
-              (2 * (19 * (x_{3} * x0_{7})) +
-               (19 * (x_{4} * x0_{6}) +
-                (2 * (19 * (x_{5} * x0_{5})) +
-                 (19 * (x_{6} * x0_{4}) +
-                  (2 * (19 * (x_{7} * x0_{3})) +
-                   (19 * (x_{8} * x0_{2}) + 2 * (19 * (x_{9} * x0_{1})))))))))))%RT_expr
-           :: (x_{0} * x0_{1} +
-               (x_{1} * x0_{0} +
-                (19 * (x_{2} * x0_{9}) +
-                 (19 * (x_{3} * x0_{8}) +
-                  (19 * (x_{4} * x0_{7}) +
-                   (19 * (x_{5} * x0_{6}) +
-                    (19 * (x_{6} * x0_{5}) +
-                     (19 * (x_{7} * x0_{4}) + (19 * (x_{8} * x0_{3}) + 19 * (x_{9} * x0_{2}))))))))))%RT_expr
-              :: (x_{0} * x0_{2} +
-                  (2 * (x_{1} * x0_{1}) +
-                   (x_{2} * x0_{0} +
-                    (2 * (19 * (x_{3} * x0_{9})) +
-                     (19 * (x_{4} * x0_{8}) +
-                      (2 * (19 * (x_{5} * x0_{7})) +
-                       (19 * (x_{6} * x0_{6}) +
-                        (2 * (19 * (x_{7} * x0_{5})) +
-                         (19 * (x_{8} * x0_{4}) + 2 * (19 * (x_{9} * x0_{3})))))))))))%RT_expr
-                 :: (x_{0} * x0_{3} +
-                     (x_{1} * x0_{2} +
-                      (x_{2} * x0_{1} +
-                       (x_{3} * x0_{0} +
-                        (19 * (x_{4} * x0_{9}) +
-                         (19 * (x_{5} * x0_{8}) +
-                          (19 * (x_{6} * x0_{7}) +
-                           (19 * (x_{7} * x0_{6}) +
-                            (19 * (x_{8} * x0_{5}) + 19 * (x_{9} * x0_{4}))))))))))%RT_expr
-                    :: (x_{0} * x0_{4} +
-                        (2 * (x_{1} * x0_{3}) +
-                         (x_{2} * x0_{2} +
-                          (2 * (x_{3} * x0_{1}) +
-                           (x_{4} * x0_{0} +
-                            (2 * (19 * (x_{5} * x0_{9})) +
-                             (19 * (x_{6} * x0_{8}) +
-                              (2 * (19 * (x_{7} * x0_{7})) +
-                               (19 * (x_{8} * x0_{6}) + 2 * (19 * (x_{9} * x0_{5})))))))))))%RT_expr
-                       :: (x_{0} * x0_{5} +
-                           (x_{1} * x0_{4} +
-                            (x_{2} * x0_{3} +
-                             (x_{3} * x0_{2} +
-                              (x_{4} * x0_{1} +
-                               (x_{5} * x0_{0} +
-                                (19 * (x_{6} * x0_{9}) +
-                                 (19 * (x_{7} * x0_{8}) +
-                                  (19 * (x_{8} * x0_{7}) + 19 * (x_{9} * x0_{6}))))))))))%RT_expr
-                          :: (x_{0} * x0_{6} +
-                              (2 * (x_{1} * x0_{5}) +
-                               (x_{2} * x0_{4} +
-                                (2 * (x_{3} * x0_{3}) +
-                                 (x_{4} * x0_{2} +
-                                  (2 * (x_{5} * x0_{1}) +
-                                   (x_{6} * x0_{0} +
-                                    (2 * (19 * (x_{7} * x0_{9})) +
-                                     (19 * (x_{8} * x0_{8}) + 2 * (19 * (x_{9} * x0_{7})))))))))))%RT_expr
-                             :: (x_{0} * x0_{7} +
-                                 (x_{1} * x0_{6} +
-                                  (x_{2} * x0_{5} +
-                                   (x_{3} * x0_{4} +
-                                    (x_{4} * x0_{3} +
-                                     (x_{5} * x0_{2} +
-                                      (x_{6} * x0_{1} +
-                                       (x_{7} * x0_{0} +
-                                        (19 * (x_{8} * x0_{9}) + 19 * (x_{9} * x0_{8}))))))))))%RT_expr
-                                :: (x_{0} * x0_{8} +
-                                    (2 * (x_{1} * x0_{7}) +
-                                     (x_{2} * x0_{6} +
-                                      (2 * (x_{3} * x0_{5}) +
-                                       (x_{4} * x0_{4} +
-                                        (2 * (x_{5} * x0_{3}) +
-                                         (x_{6} * x0_{2} +
-                                          (2 * (x_{7} * x0_{1}) +
-                                           (x_{8} * x0_{0} + 2 * (19 * (x_{9} * x0_{9})))))))))))%RT_expr
-                                   :: (x_{0} * x0_{9} +
-                                       (x_{1} * x0_{8} +
-                                        (x_{2} * x0_{7} +
-                                         (x_{3} * x0_{6} +
-                                          (x_{4} * x0_{5} +
-                                           (x_{5} * x0_{4} +
-                                            (x_{6} * x0_{3} +
-                                             (x_{7} * x0_{2} + (x_{8} * x0_{1} + x_{9} * x0_{0})))))))))%RT_expr
-                                      :: [])%expr) f g
-     : forall f g : list Z, length f = 10%nat -> length g = 10%nat -> list Z *)
+           hd x * hd x0 +
+           (2 *
+            (19 *
+             (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+              ( λₗ x2 : var (type.list type.Z),
+              ( λₗ x5 : var (type.list type.Z),
+              ( λₗ x8 : var (type.list type.Z),
+              ( λₗ x11 : var (type.list type.Z),
+              ( λₗ x14 : var (type.list type.Z),
+              ( λₗ x17 : var (type.list type.Z),
+              ( λₗ x20 : var (type.list type.Z),
+              ( λₗ x23 : var (type.list type.Z),
+              ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl x20))( tl
+              x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0))) +
+            (19 *
+             (( λₗ x2 : var (type.list type.Z), ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))
+              ( tl x) *
+              ( λₗ x2 : var (type.list type.Z),
+              ( λₗ x5 : var (type.list type.Z),
+              ( λₗ x8 : var (type.list type.Z),
+              ( λₗ x11 : var (type.list type.Z),
+              ( λₗ x14 : var (type.list type.Z),
+              ( λₗ x17 : var (type.list type.Z),
+              ( λₗ x20 : var (type.list type.Z),
+              ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl x17))( tl
+              x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
+             (2 *
+              (19 *
+               (( λₗ x2 : var (type.list type.Z),
+                ( λₗ x5 : var (type.list type.Z), ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))
+                ( tl x2))( tl x) *
+                ( λₗ x2 : var (type.list type.Z),
+                ( λₗ x5 : var (type.list type.Z),
+                ( λₗ x8 : var (type.list type.Z),
+                ( λₗ x11 : var (type.list type.Z),
+                ( λₗ x14 : var (type.list type.Z),
+                ( λₗ x17 : var (type.list type.Z),
+                ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0))) +
+              (19 *
+               (( λₗ x2 : var (type.list type.Z),
+                ( λₗ x5 : var (type.list type.Z),
+                ( λₗ x8 : var (type.list type.Z),
+                ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                x5))( tl x2))( tl x) *
+                ( λₗ x2 : var (type.list type.Z),
+                ( λₗ x5 : var (type.list type.Z),
+                ( λₗ x8 : var (type.list type.Z),
+                ( λₗ x11 : var (type.list type.Z),
+                ( λₗ x14 : var (type.list type.Z),
+                ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
+               (2 *
+                (19 *
+                 (( λₗ x2 : var (type.list type.Z),
+                  ( λₗ x5 : var (type.list type.Z),
+                  ( λₗ x8 : var (type.list type.Z),
+                  ( λₗ x11 : var (type.list type.Z),
+                  ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                  x8))( tl x5))( tl x2))( tl x) *
+                  ( λₗ x2 : var (type.list type.Z),
+                  ( λₗ x5 : var (type.list type.Z),
+                  ( λₗ x8 : var (type.list type.Z),
+                  ( λₗ x11 : var (type.list type.Z),
+                  ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                  x8))( tl x5))( tl x2))( tl x0))) +
+                (19 *
+                 (( λₗ x2 : var (type.list type.Z),
+                  ( λₗ x5 : var (type.list type.Z),
+                  ( λₗ x8 : var (type.list type.Z),
+                  ( λₗ x11 : var (type.list type.Z),
+                  ( λₗ x14 : var (type.list type.Z),
+                  ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                  x11))( tl x8))( tl x5))( tl x2))( tl x) *
+                  ( λₗ x2 : var (type.list type.Z),
+                  ( λₗ x5 : var (type.list type.Z),
+                  ( λₗ x8 : var (type.list type.Z),
+                  ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                  x5))( tl x2))( tl x0)) +
+                 (2 *
+                  (19 *
+                   (( λₗ x2 : var (type.list type.Z),
+                    ( λₗ x5 : var (type.list type.Z),
+                    ( λₗ x8 : var (type.list type.Z),
+                    ( λₗ x11 : var (type.list type.Z),
+                    ( λₗ x14 : var (type.list type.Z),
+                    ( λₗ x17 : var (type.list type.Z),
+                    ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                    x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x) *
+                    ( λₗ x2 : var (type.list type.Z),
+                    ( λₗ x5 : var (type.list type.Z),
+                    ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                    x2))( tl x0))) +
+                  (19 *
+                   (( λₗ x2 : var (type.list type.Z),
+                    ( λₗ x5 : var (type.list type.Z),
+                    ( λₗ x8 : var (type.list type.Z),
+                    ( λₗ x11 : var (type.list type.Z),
+                    ( λₗ x14 : var (type.list type.Z),
+                    ( λₗ x17 : var (type.list type.Z),
+                    ( λₗ x20 : var (type.list type.Z),
+                    ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                    x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                    x) *
+                    ( λₗ x2 : var (type.list type.Z),
+                    ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                    x0)) +
+                   2 *
+                   (19 *
+                    (( λₗ x2 : var (type.list type.Z),
+                     ( λₗ x5 : var (type.list type.Z),
+                     ( λₗ x8 : var (type.list type.Z),
+                     ( λₗ x11 : var (type.list type.Z),
+                     ( λₗ x14 : var (type.list type.Z),
+                     ( λₗ x17 : var (type.list type.Z),
+                     ( λₗ x20 : var (type.list type.Z),
+                     ( λₗ x23 : var (type.list type.Z),
+                     ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                     x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
+                     x2))( tl x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)))))))))))
+           :: hd x * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
+              (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) * hd x0 +
+               (19 *
+                (( λₗ x2 : var (type.list type.Z), ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))
+                 ( tl x) *
+                 ( λₗ x2 : var (type.list type.Z),
+                 ( λₗ x5 : var (type.list type.Z),
+                 ( λₗ x8 : var (type.list type.Z),
+                 ( λₗ x11 : var (type.list type.Z),
+                 ( λₗ x14 : var (type.list type.Z),
+                 ( λₗ x17 : var (type.list type.Z),
+                 ( λₗ x20 : var (type.list type.Z),
+                 ( λₗ x23 : var (type.list type.Z),
+                 ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                 x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
+                 x2))( tl x0)) +
+                (19 *
+                 (( λₗ x2 : var (type.list type.Z),
+                  ( λₗ x5 : var (type.list type.Z),
+                  ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                  x2))( tl x) *
+                  ( λₗ x2 : var (type.list type.Z),
+                  ( λₗ x5 : var (type.list type.Z),
+                  ( λₗ x8 : var (type.list type.Z),
+                  ( λₗ x11 : var (type.list type.Z),
+                  ( λₗ x14 : var (type.list type.Z),
+                  ( λₗ x17 : var (type.list type.Z),
+                  ( λₗ x20 : var (type.list type.Z),
+                  ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                  x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                  x0)) +
+                 (19 *
+                  (( λₗ x2 : var (type.list type.Z),
+                   ( λₗ x5 : var (type.list type.Z),
+                   ( λₗ x8 : var (type.list type.Z),
+                   ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                   x5))( tl x2))( tl x) *
+                   ( λₗ x2 : var (type.list type.Z),
+                   ( λₗ x5 : var (type.list type.Z),
+                   ( λₗ x8 : var (type.list type.Z),
+                   ( λₗ x11 : var (type.list type.Z),
+                   ( λₗ x14 : var (type.list type.Z),
+                   ( λₗ x17 : var (type.list type.Z),
+                   ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                   x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
+                  (19 *
+                   (( λₗ x2 : var (type.list type.Z),
+                    ( λₗ x5 : var (type.list type.Z),
+                    ( λₗ x8 : var (type.list type.Z),
+                    ( λₗ x11 : var (type.list type.Z),
+                    ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                    x8))( tl x5))( tl x2))( tl x) *
+                    ( λₗ x2 : var (type.list type.Z),
+                    ( λₗ x5 : var (type.list type.Z),
+                    ( λₗ x8 : var (type.list type.Z),
+                    ( λₗ x11 : var (type.list type.Z),
+                    ( λₗ x14 : var (type.list type.Z),
+                    ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                    x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
+                   (19 *
+                    (( λₗ x2 : var (type.list type.Z),
+                     ( λₗ x5 : var (type.list type.Z),
+                     ( λₗ x8 : var (type.list type.Z),
+                     ( λₗ x11 : var (type.list type.Z),
+                     ( λₗ x14 : var (type.list type.Z),
+                     ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                     x11))( tl x8))( tl x5))( tl x2))( tl x) *
+                     ( λₗ x2 : var (type.list type.Z),
+                     ( λₗ x5 : var (type.list type.Z),
+                     ( λₗ x8 : var (type.list type.Z),
+                     ( λₗ x11 : var (type.list type.Z),
+                     ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                     x8))( tl x5))( tl x2))( tl x0)) +
+                    (19 *
+                     (( λₗ x2 : var (type.list type.Z),
+                      ( λₗ x5 : var (type.list type.Z),
+                      ( λₗ x8 : var (type.list type.Z),
+                      ( λₗ x11 : var (type.list type.Z),
+                      ( λₗ x14 : var (type.list type.Z),
+                      ( λₗ x17 : var (type.list type.Z),
+                      ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                      x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x) *
+                      ( λₗ x2 : var (type.list type.Z),
+                      ( λₗ x5 : var (type.list type.Z),
+                      ( λₗ x8 : var (type.list type.Z),
+                      ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                      x5))( tl x2))( tl x0)) +
+                     (19 *
+                      (( λₗ x2 : var (type.list type.Z),
+                       ( λₗ x5 : var (type.list type.Z),
+                       ( λₗ x8 : var (type.list type.Z),
+                       ( λₗ x11 : var (type.list type.Z),
+                       ( λₗ x14 : var (type.list type.Z),
+                       ( λₗ x17 : var (type.list type.Z),
+                       ( λₗ x20 : var (type.list type.Z),
+                       ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                       x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                       x) *
+                       ( λₗ x2 : var (type.list type.Z),
+                       ( λₗ x5 : var (type.list type.Z),
+                       ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                       x2))( tl x0)) +
+                      19 *
+                      (( λₗ x2 : var (type.list type.Z),
+                       ( λₗ x5 : var (type.list type.Z),
+                       ( λₗ x8 : var (type.list type.Z),
+                       ( λₗ x11 : var (type.list type.Z),
+                       ( λₗ x14 : var (type.list type.Z),
+                       ( λₗ x17 : var (type.list type.Z),
+                       ( λₗ x20 : var (type.list type.Z),
+                       ( λₗ x23 : var (type.list type.Z),
+                       ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                       x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
+                       x5))( tl x2))( tl x) *
+                       ( λₗ x2 : var (type.list type.Z),
+                       ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                       x0))))))))))
+              :: hd x *
+                 ( λₗ x2 : var (type.list type.Z), ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))
+                 ( tl x0) +
+                 (2 *
+                  (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+                   ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)) +
+                  (( λₗ x2 : var (type.list type.Z),
+                   ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                   x) * hd x0 +
+                   (2 *
+                    (19 *
+                     (( λₗ x2 : var (type.list type.Z),
+                      ( λₗ x5 : var (type.list type.Z),
+                      ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                      x2))( tl x) *
+                      ( λₗ x2 : var (type.list type.Z),
+                      ( λₗ x5 : var (type.list type.Z),
+                      ( λₗ x8 : var (type.list type.Z),
+                      ( λₗ x11 : var (type.list type.Z),
+                      ( λₗ x14 : var (type.list type.Z),
+                      ( λₗ x17 : var (type.list type.Z),
+                      ( λₗ x20 : var (type.list type.Z),
+                      ( λₗ x23 : var (type.list type.Z),
+                      ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                      x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
+                      x2))( tl x0))) +
+                    (19 *
+                     (( λₗ x2 : var (type.list type.Z),
+                      ( λₗ x5 : var (type.list type.Z),
+                      ( λₗ x8 : var (type.list type.Z),
+                      ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                      x5))( tl x2))( tl x) *
+                      ( λₗ x2 : var (type.list type.Z),
+                      ( λₗ x5 : var (type.list type.Z),
+                      ( λₗ x8 : var (type.list type.Z),
+                      ( λₗ x11 : var (type.list type.Z),
+                      ( λₗ x14 : var (type.list type.Z),
+                      ( λₗ x17 : var (type.list type.Z),
+                      ( λₗ x20 : var (type.list type.Z),
+                      ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                      x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                      x0)) +
+                     (2 *
+                      (19 *
+                       (( λₗ x2 : var (type.list type.Z),
+                        ( λₗ x5 : var (type.list type.Z),
+                        ( λₗ x8 : var (type.list type.Z),
+                        ( λₗ x11 : var (type.list type.Z),
+                        ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                        x8))( tl x5))( tl x2))( tl x) *
+                        ( λₗ x2 : var (type.list type.Z),
+                        ( λₗ x5 : var (type.list type.Z),
+                        ( λₗ x8 : var (type.list type.Z),
+                        ( λₗ x11 : var (type.list type.Z),
+                        ( λₗ x14 : var (type.list type.Z),
+                        ( λₗ x17 : var (type.list type.Z),
+                        ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                        x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0))) +
+                      (19 *
+                       (( λₗ x2 : var (type.list type.Z),
+                        ( λₗ x5 : var (type.list type.Z),
+                        ( λₗ x8 : var (type.list type.Z),
+                        ( λₗ x11 : var (type.list type.Z),
+                        ( λₗ x14 : var (type.list type.Z),
+                        ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                        x11))( tl x8))( tl x5))( tl x2))( tl x) *
+                        ( λₗ x2 : var (type.list type.Z),
+                        ( λₗ x5 : var (type.list type.Z),
+                        ( λₗ x8 : var (type.list type.Z),
+                        ( λₗ x11 : var (type.list type.Z),
+                        ( λₗ x14 : var (type.list type.Z),
+                        ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                        x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
+                       (2 *
+                        (19 *
+                         (( λₗ x2 : var (type.list type.Z),
+                          ( λₗ x5 : var (type.list type.Z),
+                          ( λₗ x8 : var (type.list type.Z),
+                          ( λₗ x11 : var (type.list type.Z),
+                          ( λₗ x14 : var (type.list type.Z),
+                          ( λₗ x17 : var (type.list type.Z),
+                          ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                          x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                          x) *
+                          ( λₗ x2 : var (type.list type.Z),
+                          ( λₗ x5 : var (type.list type.Z),
+                          ( λₗ x8 : var (type.list type.Z),
+                          ( λₗ x11 : var (type.list type.Z),
+                          ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                          x8))( tl x5))( tl x2))( tl x0))) +
+                        (19 *
+                         (( λₗ x2 : var (type.list type.Z),
+                          ( λₗ x5 : var (type.list type.Z),
+                          ( λₗ x8 : var (type.list type.Z),
+                          ( λₗ x11 : var (type.list type.Z),
+                          ( λₗ x14 : var (type.list type.Z),
+                          ( λₗ x17 : var (type.list type.Z),
+                          ( λₗ x20 : var (type.list type.Z),
+                          ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                          x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
+                          x2))( tl x) *
+                          ( λₗ x2 : var (type.list type.Z),
+                          ( λₗ x5 : var (type.list type.Z),
+                          ( λₗ x8 : var (type.list type.Z),
+                          ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                          x5))( tl x2))( tl x0)) +
+                         2 *
+                         (19 *
+                          (( λₗ x2 : var (type.list type.Z),
+                           ( λₗ x5 : var (type.list type.Z),
+                           ( λₗ x8 : var (type.list type.Z),
+                           ( λₗ x11 : var (type.list type.Z),
+                           ( λₗ x14 : var (type.list type.Z),
+                           ( λₗ x17 : var (type.list type.Z),
+                           ( λₗ x20 : var (type.list type.Z),
+                           ( λₗ x23 : var (type.list type.Z),
+                           ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                           x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
+                           x5))( tl x2))( tl x) *
+                           ( λₗ x2 : var (type.list type.Z),
+                           ( λₗ x5 : var (type.list type.Z),
+                           ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                           x2))( tl x0)))))))))))
+                 :: hd x *
+                    ( λₗ x2 : var (type.list type.Z),
+                    ( λₗ x5 : var (type.list type.Z),
+                    ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                    x2))( tl x0) +
+                    (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+                     ( λₗ x2 : var (type.list type.Z),
+                     ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                     x0) +
+                     (( λₗ x2 : var (type.list type.Z),
+                      ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                      x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
+                      (( λₗ x2 : var (type.list type.Z),
+                       ( λₗ x5 : var (type.list type.Z),
+                       ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                       x2))( tl x) * hd x0 +
+                       (19 *
+                        (( λₗ x2 : var (type.list type.Z),
+                         ( λₗ x5 : var (type.list type.Z),
+                         ( λₗ x8 : var (type.list type.Z),
+                         ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                         x5))( tl x2))( tl x) *
+                         ( λₗ x2 : var (type.list type.Z),
+                         ( λₗ x5 : var (type.list type.Z),
+                         ( λₗ x8 : var (type.list type.Z),
+                         ( λₗ x11 : var (type.list type.Z),
+                         ( λₗ x14 : var (type.list type.Z),
+                         ( λₗ x17 : var (type.list type.Z),
+                         ( λₗ x20 : var (type.list type.Z),
+                         ( λₗ x23 : var (type.list type.Z),
+                         ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                         x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
+                         x5))( tl x2))( tl x0)) +
+                        (19 *
+                         (( λₗ x2 : var (type.list type.Z),
+                          ( λₗ x5 : var (type.list type.Z),
+                          ( λₗ x8 : var (type.list type.Z),
+                          ( λₗ x11 : var (type.list type.Z),
+                          ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                          x8))( tl x5))( tl x2))( tl x) *
+                          ( λₗ x2 : var (type.list type.Z),
+                          ( λₗ x5 : var (type.list type.Z),
+                          ( λₗ x8 : var (type.list type.Z),
+                          ( λₗ x11 : var (type.list type.Z),
+                          ( λₗ x14 : var (type.list type.Z),
+                          ( λₗ x17 : var (type.list type.Z),
+                          ( λₗ x20 : var (type.list type.Z),
+                          ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                          x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
+                          x2))( tl x0)) +
+                         (19 *
+                          (( λₗ x2 : var (type.list type.Z),
+                           ( λₗ x5 : var (type.list type.Z),
+                           ( λₗ x8 : var (type.list type.Z),
+                           ( λₗ x11 : var (type.list type.Z),
+                           ( λₗ x14 : var (type.list type.Z),
+                           ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                           x11))( tl x8))( tl x5))( tl x2))( tl x) *
+                           ( λₗ x2 : var (type.list type.Z),
+                           ( λₗ x5 : var (type.list type.Z),
+                           ( λₗ x8 : var (type.list type.Z),
+                           ( λₗ x11 : var (type.list type.Z),
+                           ( λₗ x14 : var (type.list type.Z),
+                           ( λₗ x17 : var (type.list type.Z),
+                           ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                           x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                           x0)) +
+                          (19 *
+                           (( λₗ x2 : var (type.list type.Z),
+                            ( λₗ x5 : var (type.list type.Z),
+                            ( λₗ x8 : var (type.list type.Z),
+                            ( λₗ x11 : var (type.list type.Z),
+                            ( λₗ x14 : var (type.list type.Z),
+                            ( λₗ x17 : var (type.list type.Z),
+                            ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                            x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                            x) *
+                            ( λₗ x2 : var (type.list type.Z),
+                            ( λₗ x5 : var (type.list type.Z),
+                            ( λₗ x8 : var (type.list type.Z),
+                            ( λₗ x11 : var (type.list type.Z),
+                            ( λₗ x14 : var (type.list type.Z),
+                            ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                            x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
+                           (19 *
+                            (( λₗ x2 : var (type.list type.Z),
+                             ( λₗ x5 : var (type.list type.Z),
+                             ( λₗ x8 : var (type.list type.Z),
+                             ( λₗ x11 : var (type.list type.Z),
+                             ( λₗ x14 : var (type.list type.Z),
+                             ( λₗ x17 : var (type.list type.Z),
+                             ( λₗ x20 : var (type.list type.Z),
+                             ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                             x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
+                             x2))( tl x) *
+                             ( λₗ x2 : var (type.list type.Z),
+                             ( λₗ x5 : var (type.list type.Z),
+                             ( λₗ x8 : var (type.list type.Z),
+                             ( λₗ x11 : var (type.list type.Z),
+                             ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                             x8))( tl x5))( tl x2))( tl x0)) +
+                            19 *
+                            (( λₗ x2 : var (type.list type.Z),
+                             ( λₗ x5 : var (type.list type.Z),
+                             ( λₗ x8 : var (type.list type.Z),
+                             ( λₗ x11 : var (type.list type.Z),
+                             ( λₗ x14 : var (type.list type.Z),
+                             ( λₗ x17 : var (type.list type.Z),
+                             ( λₗ x20 : var (type.list type.Z),
+                             ( λₗ x23 : var (type.list type.Z),
+                             ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                             x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
+                             x5))( tl x2))( tl x) *
+                             ( λₗ x2 : var (type.list type.Z),
+                             ( λₗ x5 : var (type.list type.Z),
+                             ( λₗ x8 : var (type.list type.Z),
+                             ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                             x5))( tl x2))( tl x0))))))))))
+                    :: hd x *
+                       ( λₗ x2 : var (type.list type.Z),
+                       ( λₗ x5 : var (type.list type.Z),
+                       ( λₗ x8 : var (type.list type.Z),
+                       ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                       x5))( tl x2))( tl x0) +
+                       (2 *
+                        (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+                         ( λₗ x2 : var (type.list type.Z),
+                         ( λₗ x5 : var (type.list type.Z),
+                         ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                         x2))( tl x0)) +
+                        (( λₗ x2 : var (type.list type.Z),
+                         ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                         x) *
+                         ( λₗ x2 : var (type.list type.Z),
+                         ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                         x0) +
+                         (2 *
+                          (( λₗ x2 : var (type.list type.Z),
+                           ( λₗ x5 : var (type.list type.Z),
+                           ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                           x2))( tl x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)) +
+                          (( λₗ x2 : var (type.list type.Z),
+                           ( λₗ x5 : var (type.list type.Z),
+                           ( λₗ x8 : var (type.list type.Z),
+                           ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                           x5))( tl x2))( tl x) * hd x0 +
+                           (2 *
+                            (19 *
+                             (( λₗ x2 : var (type.list type.Z),
+                              ( λₗ x5 : var (type.list type.Z),
+                              ( λₗ x8 : var (type.list type.Z),
+                              ( λₗ x11 : var (type.list type.Z),
+                              ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                              x8))( tl x5))( tl x2))( tl x) *
+                              ( λₗ x2 : var (type.list type.Z),
+                              ( λₗ x5 : var (type.list type.Z),
+                              ( λₗ x8 : var (type.list type.Z),
+                              ( λₗ x11 : var (type.list type.Z),
+                              ( λₗ x14 : var (type.list type.Z),
+                              ( λₗ x17 : var (type.list type.Z),
+                              ( λₗ x20 : var (type.list type.Z),
+                              ( λₗ x23 : var (type.list type.Z),
+                              ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                              x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
+                              x5))( tl x2))( tl x0))) +
+                            (19 *
+                             (( λₗ x2 : var (type.list type.Z),
+                              ( λₗ x5 : var (type.list type.Z),
+                              ( λₗ x8 : var (type.list type.Z),
+                              ( λₗ x11 : var (type.list type.Z),
+                              ( λₗ x14 : var (type.list type.Z),
+                              ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                              x11))( tl x8))( tl x5))( tl x2))( tl x) *
+                              ( λₗ x2 : var (type.list type.Z),
+                              ( λₗ x5 : var (type.list type.Z),
+                              ( λₗ x8 : var (type.list type.Z),
+                              ( λₗ x11 : var (type.list type.Z),
+                              ( λₗ x14 : var (type.list type.Z),
+                              ( λₗ x17 : var (type.list type.Z),
+                              ( λₗ x20 : var (type.list type.Z),
+                              ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                              x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
+                              x2))( tl x0)) +
+                             (2 *
+                              (19 *
+                               (( λₗ x2 : var (type.list type.Z),
+                                ( λₗ x5 : var (type.list type.Z),
+                                ( λₗ x8 : var (type.list type.Z),
+                                ( λₗ x11 : var (type.list type.Z),
+                                ( λₗ x14 : var (type.list type.Z),
+                                ( λₗ x17 : var (type.list type.Z),
+                                ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                                x) *
+                                ( λₗ x2 : var (type.list type.Z),
+                                ( λₗ x5 : var (type.list type.Z),
+                                ( λₗ x8 : var (type.list type.Z),
+                                ( λₗ x11 : var (type.list type.Z),
+                                ( λₗ x14 : var (type.list type.Z),
+                                ( λₗ x17 : var (type.list type.Z),
+                                ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                                x0))) +
+                              (19 *
+                               (( λₗ x2 : var (type.list type.Z),
+                                ( λₗ x5 : var (type.list type.Z),
+                                ( λₗ x8 : var (type.list type.Z),
+                                ( λₗ x11 : var (type.list type.Z),
+                                ( λₗ x14 : var (type.list type.Z),
+                                ( λₗ x17 : var (type.list type.Z),
+                                ( λₗ x20 : var (type.list type.Z),
+                                ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                                x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
+                                x2))( tl x) *
+                                ( λₗ x2 : var (type.list type.Z),
+                                ( λₗ x5 : var (type.list type.Z),
+                                ( λₗ x8 : var (type.list type.Z),
+                                ( λₗ x11 : var (type.list type.Z),
+                                ( λₗ x14 : var (type.list type.Z),
+                                ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                                x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
+                               2 *
+                               (19 *
+                                (( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z),
+                                 ( λₗ x8 : var (type.list type.Z),
+                                 ( λₗ x11 : var (type.list type.Z),
+                                 ( λₗ x14 : var (type.list type.Z),
+                                 ( λₗ x17 : var (type.list type.Z),
+                                 ( λₗ x20 : var (type.list type.Z),
+                                 ( λₗ x23 : var (type.list type.Z),
+                                 ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                                 x20))( tl x17))( tl x14))( tl x11))( tl
+                                 x8))( tl x5))( tl x2))( tl x) *
+                                 ( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z),
+                                 ( λₗ x8 : var (type.list type.Z),
+                                 ( λₗ x11 : var (type.list type.Z),
+                                 ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                                 x8))( tl x5))( tl x2))( tl x0)))))))))))
+                       :: hd x *
+                          ( λₗ x2 : var (type.list type.Z),
+                          ( λₗ x5 : var (type.list type.Z),
+                          ( λₗ x8 : var (type.list type.Z),
+                          ( λₗ x11 : var (type.list type.Z),
+                          ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                          x8))( tl x5))( tl x2))( tl x0) +
+                          (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+                           ( λₗ x2 : var (type.list type.Z),
+                           ( λₗ x5 : var (type.list type.Z),
+                           ( λₗ x8 : var (type.list type.Z),
+                           ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                           x5))( tl x2))( tl x0) +
+                           (( λₗ x2 : var (type.list type.Z),
+                            ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                            x) *
+                            ( λₗ x2 : var (type.list type.Z),
+                            ( λₗ x5 : var (type.list type.Z),
+                            ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                            x2))( tl x0) +
+                            (( λₗ x2 : var (type.list type.Z),
+                             ( λₗ x5 : var (type.list type.Z),
+                             ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                             x2))( tl x) *
+                             ( λₗ x2 : var (type.list type.Z),
+                             ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                             x0) +
+                             (( λₗ x2 : var (type.list type.Z),
+                              ( λₗ x5 : var (type.list type.Z),
+                              ( λₗ x8 : var (type.list type.Z),
+                              ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                              x5))( tl x2))( tl x) *
+                              ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
+                              (( λₗ x2 : var (type.list type.Z),
+                               ( λₗ x5 : var (type.list type.Z),
+                               ( λₗ x8 : var (type.list type.Z),
+                               ( λₗ x11 : var (type.list type.Z),
+                               ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                               x8))( tl x5))( tl x2))( tl x) * hd x0 +
+                               (19 *
+                                (( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z),
+                                 ( λₗ x8 : var (type.list type.Z),
+                                 ( λₗ x11 : var (type.list type.Z),
+                                 ( λₗ x14 : var (type.list type.Z),
+                                 ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                                 x11))( tl x8))( tl x5))( tl x2))( tl x) *
+                                 ( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z),
+                                 ( λₗ x8 : var (type.list type.Z),
+                                 ( λₗ x11 : var (type.list type.Z),
+                                 ( λₗ x14 : var (type.list type.Z),
+                                 ( λₗ x17 : var (type.list type.Z),
+                                 ( λₗ x20 : var (type.list type.Z),
+                                 ( λₗ x23 : var (type.list type.Z),
+                                 ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                                 x20))( tl x17))( tl x14))( tl x11))( tl
+                                 x8))( tl x5))( tl x2))( tl x0)) +
+                                (19 *
+                                 (( λₗ x2 : var (type.list type.Z),
+                                  ( λₗ x5 : var (type.list type.Z),
+                                  ( λₗ x8 : var (type.list type.Z),
+                                  ( λₗ x11 : var (type.list type.Z),
+                                  ( λₗ x14 : var (type.list type.Z),
+                                  ( λₗ x17 : var (type.list type.Z),
+                                  ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                  x14))( tl x11))( tl x8))( tl x5))( tl
+                                  x2))( tl x) *
+                                  ( λₗ x2 : var (type.list type.Z),
+                                  ( λₗ x5 : var (type.list type.Z),
+                                  ( λₗ x8 : var (type.list type.Z),
+                                  ( λₗ x11 : var (type.list type.Z),
+                                  ( λₗ x14 : var (type.list type.Z),
+                                  ( λₗ x17 : var (type.list type.Z),
+                                  ( λₗ x20 : var (type.list type.Z),
+                                  ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                                  x17))( tl x14))( tl x11))( tl x8))( tl
+                                  x5))( tl x2))( tl x0)) +
+                                 (19 *
+                                  (( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z),
+                                   ( λₗ x11 : var (type.list type.Z),
+                                   ( λₗ x14 : var (type.list type.Z),
+                                   ( λₗ x17 : var (type.list type.Z),
+                                   ( λₗ x20 : var (type.list type.Z),
+                                   ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                                   x17))( tl x14))( tl x11))( tl x8))( tl
+                                   x5))( tl x2))( tl x) *
+                                   ( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z),
+                                   ( λₗ x11 : var (type.list type.Z),
+                                   ( λₗ x14 : var (type.list type.Z),
+                                   ( λₗ x17 : var (type.list type.Z),
+                                   ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                   x14))( tl x11))( tl x8))( tl x5))( tl
+                                   x2))( tl x0)) +
+                                  19 *
+                                  (( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z),
+                                   ( λₗ x11 : var (type.list type.Z),
+                                   ( λₗ x14 : var (type.list type.Z),
+                                   ( λₗ x17 : var (type.list type.Z),
+                                   ( λₗ x20 : var (type.list type.Z),
+                                   ( λₗ x23 : var (type.list type.Z),
+                                   ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                                   x20))( tl x17))( tl x14))( tl x11))( tl
+                                   x8))( tl x5))( tl x2))( tl x) *
+                                   ( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z),
+                                   ( λₗ x11 : var (type.list type.Z),
+                                   ( λₗ x14 : var (type.list type.Z),
+                                   ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                                   x11))( tl x8))( tl x5))( tl x2))( tl
+                                   x0))))))))))
+                          :: hd x *
+                             ( λₗ x2 : var (type.list type.Z),
+                             ( λₗ x5 : var (type.list type.Z),
+                             ( λₗ x8 : var (type.list type.Z),
+                             ( λₗ x11 : var (type.list type.Z),
+                             ( λₗ x14 : var (type.list type.Z),
+                             ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                             x11))( tl x8))( tl x5))( tl x2))( tl x0) +
+                             (2 *
+                              (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+                               ( λₗ x2 : var (type.list type.Z),
+                               ( λₗ x5 : var (type.list type.Z),
+                               ( λₗ x8 : var (type.list type.Z),
+                               ( λₗ x11 : var (type.list type.Z),
+                               ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                               x8))( tl x5))( tl x2))( tl x0)) +
+                              (( λₗ x2 : var (type.list type.Z),
+                               ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                               x) *
+                               ( λₗ x2 : var (type.list type.Z),
+                               ( λₗ x5 : var (type.list type.Z),
+                               ( λₗ x8 : var (type.list type.Z),
+                               ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                               x5))( tl x2))( tl x0) +
+                               (2 *
+                                (( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z),
+                                 ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                                 x2))( tl x) *
+                                 ( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z),
+                                 ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                                 x2))( tl x0)) +
+                                (( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z),
+                                 ( λₗ x8 : var (type.list type.Z),
+                                 ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                                 x5))( tl x2))( tl x) *
+                                 ( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                                 x0) +
+                                 (2 *
+                                  (( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z),
+                                   ( λₗ x11 : var (type.list type.Z),
+                                   ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                                   x8))( tl x5))( tl x2))( tl x) *
+                                   ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)) +
+                                  (( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z),
+                                   ( λₗ x11 : var (type.list type.Z),
+                                   ( λₗ x14 : var (type.list type.Z),
+                                   ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                                   x11))( tl x8))( tl x5))( tl x2))( tl
+                                   x) * hd x0 +
+                                   (2 *
+                                    (19 *
+                                     (( λₗ x2 : var (type.list type.Z),
+                                      ( λₗ x5 : var (type.list type.Z),
+                                      ( λₗ x8 : var (type.list type.Z),
+                                      ( λₗ x11 : var (type.list type.Z),
+                                      ( λₗ x14 : var (type.list type.Z),
+                                      ( λₗ x17 : var (type.list type.Z),
+                                      ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                      x14))( tl x11))( tl x8))( tl x5))( tl
+                                      x2))( tl x) *
+                                      ( λₗ x2 : var (type.list type.Z),
+                                      ( λₗ x5 : var (type.list type.Z),
+                                      ( λₗ x8 : var (type.list type.Z),
+                                      ( λₗ x11 : var (type.list type.Z),
+                                      ( λₗ x14 : var (type.list type.Z),
+                                      ( λₗ x17 : var (type.list type.Z),
+                                      ( λₗ x20 : var (type.list type.Z),
+                                      ( λₗ x23 : var (type.list type.Z),
+                                      ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                                      x20))( tl x17))( tl x14))( tl x11))( tl
+                                      x8))( tl x5))( tl x2))( tl x0))) +
+                                    (19 *
+                                     (( λₗ x2 : var (type.list type.Z),
+                                      ( λₗ x5 : var (type.list type.Z),
+                                      ( λₗ x8 : var (type.list type.Z),
+                                      ( λₗ x11 : var (type.list type.Z),
+                                      ( λₗ x14 : var (type.list type.Z),
+                                      ( λₗ x17 : var (type.list type.Z),
+                                      ( λₗ x20 : var (type.list type.Z),
+                                      ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                                      x17))( tl x14))( tl x11))( tl x8))( tl
+                                      x5))( tl x2))( tl x) *
+                                      ( λₗ x2 : var (type.list type.Z),
+                                      ( λₗ x5 : var (type.list type.Z),
+                                      ( λₗ x8 : var (type.list type.Z),
+                                      ( λₗ x11 : var (type.list type.Z),
+                                      ( λₗ x14 : var (type.list type.Z),
+                                      ( λₗ x17 : var (type.list type.Z),
+                                      ( λₗ x20 : var (type.list type.Z),
+                                      ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                                      x17))( tl x14))( tl x11))( tl x8))( tl
+                                      x5))( tl x2))( tl x0)) +
+                                     2 *
+                                     (19 *
+                                      (( λₗ x2 : var (type.list type.Z),
+                                       ( λₗ x5 : var (type.list type.Z),
+                                       ( λₗ x8 : var (type.list type.Z),
+                                       ( λₗ x11 : var (type.list type.Z),
+                                       ( λₗ x14 : var (type.list type.Z),
+                                       ( λₗ x17 : var (type.list type.Z),
+                                       ( λₗ x20 : var (type.list type.Z),
+                                       ( λₗ x23 : var (type.list type.Z),
+                                       ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                                       x20))( tl x17))( tl x14))( tl x11))( tl
+                                       x8))( tl x5))( tl x2))( tl x) *
+                                       ( λₗ x2 : var (type.list type.Z),
+                                       ( λₗ x5 : var (type.list type.Z),
+                                       ( λₗ x8 : var (type.list type.Z),
+                                       ( λₗ x11 : var (type.list type.Z),
+                                       ( λₗ x14 : var (type.list type.Z),
+                                       ( λₗ x17 : var (type.list type.Z),
+                                       ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                       x14))( tl x11))( tl x8))( tl x5))( tl
+                                       x2))( tl x0)))))))))))
+                             :: hd x *
+                                ( λₗ x2 : var (type.list type.Z),
+                                ( λₗ x5 : var (type.list type.Z),
+                                ( λₗ x8 : var (type.list type.Z),
+                                ( λₗ x11 : var (type.list type.Z),
+                                ( λₗ x14 : var (type.list type.Z),
+                                ( λₗ x17 : var (type.list type.Z),
+                                ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
+                                x0) +
+                                (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+                                 ( λₗ x2 : var (type.list type.Z),
+                                 ( λₗ x5 : var (type.list type.Z),
+                                 ( λₗ x8 : var (type.list type.Z),
+                                 ( λₗ x11 : var (type.list type.Z),
+                                 ( λₗ x14 : var (type.list type.Z),
+                                 ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                                 x11))( tl x8))( tl x5))( tl x2))( tl x0) +
+                                 (( λₗ x2 : var (type.list type.Z),
+                                  ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                                  x) *
+                                  ( λₗ x2 : var (type.list type.Z),
+                                  ( λₗ x5 : var (type.list type.Z),
+                                  ( λₗ x8 : var (type.list type.Z),
+                                  ( λₗ x11 : var (type.list type.Z),
+                                  ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                                  x8))( tl x5))( tl x2))( tl x0) +
+                                  (( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                                   x2))( tl x) *
+                                   ( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z),
+                                   ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                                   x5))( tl x2))( tl x0) +
+                                   (( λₗ x2 : var (type.list type.Z),
+                                    ( λₗ x5 : var (type.list type.Z),
+                                    ( λₗ x8 : var (type.list type.Z),
+                                    ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                                    x5))( tl x2))( tl x) *
+                                    ( λₗ x2 : var (type.list type.Z),
+                                    ( λₗ x5 : var (type.list type.Z),
+                                    ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                                    x2))( tl x0) +
+                                    (( λₗ x2 : var (type.list type.Z),
+                                     ( λₗ x5 : var (type.list type.Z),
+                                     ( λₗ x8 : var (type.list type.Z),
+                                     ( λₗ x11 : var (type.list type.Z),
+                                     ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                                     x8))( tl x5))( tl x2))( tl x) *
+                                     ( λₗ x2 : var (type.list type.Z),
+                                     ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                                     x0) +
+                                     (( λₗ x2 : var (type.list type.Z),
+                                      ( λₗ x5 : var (type.list type.Z),
+                                      ( λₗ x8 : var (type.list type.Z),
+                                      ( λₗ x11 : var (type.list type.Z),
+                                      ( λₗ x14 : var (type.list type.Z),
+                                      ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                                      x11))( tl x8))( tl x5))( tl x2))( tl
+                                      x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
+                                      (( λₗ x2 : var (type.list type.Z),
+                                       ( λₗ x5 : var (type.list type.Z),
+                                       ( λₗ x8 : var (type.list type.Z),
+                                       ( λₗ x11 : var (type.list type.Z),
+                                       ( λₗ x14 : var (type.list type.Z),
+                                       ( λₗ x17 : var (type.list type.Z),
+                                       ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                       x14))( tl x11))( tl x8))( tl x5))( tl
+                                       x2))( tl x) * hd x0 +
+                                       (19 *
+                                        (( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z),
+                                         ( λₗ x11 : var (type.list type.Z),
+                                         ( λₗ x14 : var (type.list type.Z),
+                                         ( λₗ x17 : var (type.list type.Z),
+                                         ( λₗ x20 : var (type.list type.Z),
+                                         ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))
+                                         ( tl x17))( tl x14))( tl x11))( tl
+                                         x8))( tl x5))( tl x2))( tl x) *
+                                         ( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z),
+                                         ( λₗ x11 : var (type.list type.Z),
+                                         ( λₗ x14 : var (type.list type.Z),
+                                         ( λₗ x17 : var (type.list type.Z),
+                                         ( λₗ x20 : var (type.list type.Z),
+                                         ( λₗ x23 : var (type.list type.Z),
+                                         ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))
+                                         ( tl x20))( tl x17))( tl x14))( tl
+                                         x11))( tl x8))( tl x5))( tl x2))( tl
+                                         x0)) +
+                                        19 *
+                                        (( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z),
+                                         ( λₗ x11 : var (type.list type.Z),
+                                         ( λₗ x14 : var (type.list type.Z),
+                                         ( λₗ x17 : var (type.list type.Z),
+                                         ( λₗ x20 : var (type.list type.Z),
+                                         ( λₗ x23 : var (type.list type.Z),
+                                         ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))
+                                         ( tl x20))( tl x17))( tl x14))( tl
+                                         x11))( tl x8))( tl x5))( tl x2))( tl
+                                         x) *
+                                         ( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z),
+                                         ( λₗ x11 : var (type.list type.Z),
+                                         ( λₗ x14 : var (type.list type.Z),
+                                         ( λₗ x17 : var (type.list type.Z),
+                                         ( λₗ x20 : var (type.list type.Z),
+                                         ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))
+                                         ( tl x17))( tl x14))( tl x11))( tl
+                                         x8))( tl x5))( tl x2))( tl x0))))))))))
+                                :: hd x *
+                                   ( λₗ x2 : var (type.list type.Z),
+                                   ( λₗ x5 : var (type.list type.Z),
+                                   ( λₗ x8 : var (type.list type.Z),
+                                   ( λₗ x11 : var (type.list type.Z),
+                                   ( λₗ x14 : var (type.list type.Z),
+                                   ( λₗ x17 : var (type.list type.Z),
+                                   ( λₗ x20 : var (type.list type.Z),
+                                   ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                                   x17))( tl x14))( tl x11))( tl x8))( tl
+                                   x5))( tl x2))( tl x0) +
+                                   (2 *
+                                    (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+                                     ( λₗ x2 : var (type.list type.Z),
+                                     ( λₗ x5 : var (type.list type.Z),
+                                     ( λₗ x8 : var (type.list type.Z),
+                                     ( λₗ x11 : var (type.list type.Z),
+                                     ( λₗ x14 : var (type.list type.Z),
+                                     ( λₗ x17 : var (type.list type.Z),
+                                     ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
+                                     x14))( tl x11))( tl x8))( tl x5))( tl
+                                     x2))( tl x0)) +
+                                    (( λₗ x2 : var (type.list type.Z),
+                                     ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                                     x) *
+                                     ( λₗ x2 : var (type.list type.Z),
+                                     ( λₗ x5 : var (type.list type.Z),
+                                     ( λₗ x8 : var (type.list type.Z),
+                                     ( λₗ x11 : var (type.list type.Z),
+                                     ( λₗ x14 : var (type.list type.Z),
+                                     ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
+                                     x11))( tl x8))( tl x5))( tl x2))( tl
+                                     x0) +
+                                     (2 *
+                                      (( λₗ x2 : var (type.list type.Z),
+                                       ( λₗ x5 : var (type.list type.Z),
+                                       ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                                       x2))( tl x) *
+                                       ( λₗ x2 : var (type.list type.Z),
+                                       ( λₗ x5 : var (type.list type.Z),
+                                       ( λₗ x8 : var (type.list type.Z),
+                                       ( λₗ x11 : var (type.list type.Z),
+                                       ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
+                                       x8))( tl x5))( tl x2))( tl x0)) +
+                                      (( λₗ x2 : var (type.list type.Z),
+                                       ( λₗ x5 : var (type.list type.Z),
+                                       ( λₗ x8 : var (type.list type.Z),
+                                       ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                                       x5))( tl x2))( tl x) *
+                                       ( λₗ x2 : var (type.list type.Z),
+                                       ( λₗ x5 : var (type.list type.Z),
+                                       ( λₗ x8 : var (type.list type.Z),
+                                       ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
+                                       x5))( tl x2))( tl x0) +
+                                       (2 *
+                                        (( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z),
+                                         ( λₗ x11 : var (type.list type.Z),
+                                         ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))
+                                         ( tl x8))( tl x5))( tl x2))( tl
+                                         x) *
+                                         ( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                                         x2))( tl x0)) +
+                                        (( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z),
+                                         ( λₗ x11 : var (type.list type.Z),
+                                         ( λₗ x14 : var (type.list type.Z),
+                                         ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))
+                                         ( tl x11))( tl x8))( tl x5))( tl
+                                         x2))( tl x) *
+                                         ( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                                         x0) +
+                                         (2 *
+                                          (( λₗ x2 : var (type.list type.Z),
+                                           ( λₗ x5 : var (type.list type.Z),
+                                           ( λₗ x8 : var (type.list type.Z),
+                                           ( λₗ x11 : var (type.list type.Z),
+                                           ( λₗ x14 : var (type.list type.Z),
+                                           ( λₗ x17 : var (type.list type.Z),
+                                           ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))
+                                           ( tl x14))( tl x11))( tl x8))( tl
+                                           x5))( tl x2))( tl x) *
+                                           ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)) +
+                                          (( λₗ x2 : var (type.list type.Z),
+                                           ( λₗ x5 : var (type.list type.Z),
+                                           ( λₗ x8 : var (type.list type.Z),
+                                           ( λₗ x11 : var (type.list type.Z),
+                                           ( λₗ x14 : var (type.list type.Z),
+                                           ( λₗ x17 : var (type.list type.Z),
+                                           ( λₗ x20 : var (type.list type.Z),
+                                           ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))
+                                           ( tl x17))( tl x14))( tl x11))( tl
+                                           x8))( tl x5))( tl x2))( tl x) *
+                                           hd x0 +
+                                           2 *
+                                           (19 *
+                                            (( λₗ x2 : var (type.list type.Z),
+                                             ( λₗ x5 : var (type.list type.Z),
+                                             ( λₗ x8 : var (type.list type.Z),
+                                             ( λₗ x11 : var (type.list type.Z),
+                                             ( λₗ x14 : var (type.list type.Z),
+                                             ( λₗ x17 : var (type.list type.Z),
+                                             ( λₗ x20 : var (type.list type.Z),
+                                             ( λₗ x23 : var (...),
+                                             ( λₗ x26 : var ..., hd x26)( tl x23))( tl
+                                             x20))( tl x17))( tl x14))( tl
+                                             x11))( tl x8))( tl x5))( tl
+                                             x2))( tl x) *
+                                             ( λₗ x2 : var (type.list type.Z),
+                                             ( λₗ x5 : var (type.list type.Z),
+                                             ( λₗ x8 : var (type.list type.Z),
+                                             ( λₗ x11 : var (type.list type.Z),
+                                             ( λₗ x14 : var (type.list type.Z),
+                                             ( λₗ x17 : var (type.list type.Z),
+                                             ( λₗ x20 : var (type.list type.Z),
+                                             ( λₗ x23 : var (...),
+                                             ( λₗ x26 : var ..., hd x26)( tl x23))( tl
+                                             x20))( tl x17))( tl x14))( tl
+                                             x11))( tl x8))( tl x5))( tl
+                                             x2))( tl x0)))))))))))
+                                   :: hd x *
+                                      ( λₗ x2 : var (type.list type.Z),
+                                      ( λₗ x5 : var (type.list type.Z),
+                                      ( λₗ x8 : var (type.list type.Z),
+                                      ( λₗ x11 : var (type.list type.Z),
+                                      ( λₗ x14 : var (type.list type.Z),
+                                      ( λₗ x17 : var (type.list type.Z),
+                                      ( λₗ x20 : var (type.list type.Z),
+                                      ( λₗ x23 : var (type.list type.Z),
+                                      ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
+                                      x20))( tl x17))( tl x14))( tl x11))( tl
+                                      x8))( tl x5))( tl x2))( tl x0) +
+                                      (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
+                                       ( λₗ x2 : var (type.list type.Z),
+                                       ( λₗ x5 : var (type.list type.Z),
+                                       ( λₗ x8 : var (type.list type.Z),
+                                       ( λₗ x11 : var (type.list type.Z),
+                                       ( λₗ x14 : var (type.list type.Z),
+                                       ( λₗ x17 : var (type.list type.Z),
+                                       ( λₗ x20 : var (type.list type.Z),
+                                       ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
+                                       x17))( tl x14))( tl x11))( tl x8))( tl
+                                       x5))( tl x2))( tl x0) +
+                                       (( λₗ x2 : var (type.list type.Z),
+                                        ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
+                                        x) *
+                                        ( λₗ x2 : var (type.list type.Z),
+                                        ( λₗ x5 : var (type.list type.Z),
+                                        ( λₗ x8 : var (type.list type.Z),
+                                        ( λₗ x11 : var (type.list type.Z),
+                                        ( λₗ x14 : var (type.list type.Z),
+                                        ( λₗ x17 : var (type.list type.Z),
+                                        ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))
+                                        ( tl x14))( tl x11))( tl x8))( tl
+                                        x5))( tl x2))( tl x0) +
+                                        (( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
+                                         x2))( tl x) *
+                                         ( λₗ x2 : var (type.list type.Z),
+                                         ( λₗ x5 : var (type.list type.Z),
+                                         ( λₗ x8 : var (type.list type.Z),
+                                         ( λₗ x11 : var (type.list type.Z),
+                                         ( λₗ x14 : var (type.list type.Z),
+                                         ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))
+                                         ( tl x11))( tl x8))( tl x5))( tl
+                                         x2))( tl x0) +
+                                         (( λₗ x2 : var (type.list type.Z),
+                                          ( λₗ x5 : var (type.list type.Z),
+                                          ( λₗ x8 : var (type.list type.Z),
+                                          ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))
+                                          ( tl x5))( tl x2))( tl x) *
+                                          ( λₗ x2 : var (type.list type.Z),
+                                          ( λₗ x5 : var (type.list type.Z),
+                                          ( λₗ x8 : var (type.list type.Z),
+                                          ( λₗ x11 : var (type.list type.Z),
+                                          ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))
+                                          ( tl x8))( tl x5))( tl x2))( tl
+                                          x0) +
+                                          (( λₗ x2 : var (type.list type.Z),
+                                           ( λₗ x5 : var (type.list type.Z),
+                                           ( λₗ x8 : var (type.list type.Z),
+                                           ( λₗ x11 : var (type.list type.Z),
+                                           ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))
+                                           ( tl x8))( tl x5))( tl x2))( tl
+                                           x) *
+                                           ( λₗ x2 : var (type.list type.Z),
+                                           ( λₗ x5 : var (type.list type.Z),
+                                           ( λₗ x8 : var (type.list type.Z),
+                                           ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))
+                                           ( tl x5))( tl x2))( tl x0) +
+                                           (( λₗ x2 : var (type.list type.Z),
+                                            ( λₗ x5 : var (type.list type.Z),
+                                            ( λₗ x8 : var (type.list type.Z),
+                                            ( λₗ x11 : var (type.list type.Z),
+                                            ( λₗ x14 : var (type.list type.Z),
+                                            ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))
+                                            ( tl x11))( tl x8))( tl x5))( tl
+                                            x2))( tl x) *
+                                            ( λₗ x2 : var (type.list type.Z),
+                                            ( λₗ x5 : var (type.list type.Z),
+                                            ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))
+                                            ( tl x2))( tl x0) +
+                                            (( λₗ x2 : var (type.list type.Z),
+                                             ( λₗ x5 : var (type.list type.Z),
+                                             ( λₗ x8 : var (type.list type.Z),
+                                             ( λₗ x11 : var (type.list type.Z),
+                                             ( λₗ x14 : var (type.list type.Z),
+                                             ( λₗ x17 : var (type.list type.Z),
+                                             ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))
+                                             ( tl x14))( tl x11))( tl x8))( tl
+                                             x5))( tl x2))( tl x) *
+                                             ( λₗ x2 : var (type.list type.Z),
+                                             ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))
+                                             ( tl x0) +
+                                             (( λₗ x2 : var (type.list type.Z),
+                                              ( λₗ x5 : var (type.list type.Z),
+                                              ( λₗ x8 : var (type.list type.Z),
+                                              ( λₗ x11 : var (type.list type.Z),
+                                              ( λₗ x14 : var (type.list type.Z),
+                                              ( λₗ x17 : var (type.list type.Z),
+                                              ( λₗ x20 : var (type.list type.Z),
+                                              ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))
+                                              ( tl x17))( tl x14))( tl x11))( tl
+                                              x8))( tl x5))( tl x2))( tl
+                                              x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
+                                              ( λₗ x2 : var (type.list type.Z),
+                                              ( λₗ x5 : var (type.list type.Z),
+                                              ( λₗ x8 : var (type.list type.Z),
+                                              ( λₗ x11 : var (type.list type.Z),
+                                              ( λₗ x14 : var (type.list type.Z),
+                                              ( λₗ x17 : var (type.list type.Z),
+                                              ( λₗ x20 : var (type.list type.Z),
+                                              ( λₗ x23 : var (type.list type.Z),
+                                              ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))
+                                              ( tl x20))( tl x17))( tl x14))( tl
+                                              x11))( tl x8))( tl x5))( tl
+                                              x2))( tl x) * hd x0)))))))) :: [])%expr) f g
+     : forall f g : list Z, length f = 10%nat -> length g = 10%nat -> list Z
+*)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -1333,75 +1333,34 @@ Module Compilers.
 
   Module partial.
     (** TODO: pick a better name for this (partial_expr?) *)
-    Section interp.
+    Section value.
       Context (var : type -> Type).
-      Definition interp_prestep (interp : type -> Type) (t : type)
+      Definition value_prestep (value : type -> Type) (t : type)
         := match t return Type with
-           | type.prod A B as t => interp A * interp B
-           | type.arrow s d => interp s -> interp d
-           | type.list A => list (interp A)
+           | type.prod A B as t => value A * value B
+           | type.arrow s d => value s -> value d
+           | type.list A => list (value A)
            | type.unit as t
            | type.Z as t
            | type.nat as t
            | type.bool as t
              => type.interp t
            end%type.
-      Definition interp_step (interp : type -> Type) (t : type)
+      Definition value_step (value : type -> Type) (t : type)
         := match t return Type with
            | type.unit as t
            | type.arrow _ _ as t
-             => interp_prestep interp t
+             => value_prestep value t
            | type.prod _ _ as t
            | type.list _ as t
            | type.Z as t
            | type.nat as t
            | type.bool as t
-             => @expr var t + interp_prestep interp t
+             => @expr var t + value_prestep value t
            end%type.
-      Fixpoint interp (t : type)
-        := interp_step interp t.
-
-      Definition unprestep {t : type} : interp_prestep interp t -> interp t
-        := match t return interp_prestep interp t -> interp t with
-           | type.unit as t
-           | type.arrow _ _ as t
-             => id
-           | type.prod _ _ as t
-           | type.list _ as t
-           | type.Z as t
-           | type.nat as t
-           | type.bool as t
-             => @inr _ (interp_prestep interp t)
-           end%type.
-
-      Definition unprestep2 {t : type}
-        : interp_prestep (interp_prestep interp) t
-          -> match t with
-             | type.arrow _ _ => interp_prestep (interp_prestep interp) t
-             | t => interp_prestep interp t
-             end
-        := match t
-                 return (interp_prestep (interp_prestep interp) t
-                         -> match t with
-                            | type.arrow _ _ => interp_prestep (interp_prestep interp) t
-                            | t => interp_prestep interp t
-                            end)
-           with
-           | type.prod A B
-             => fun '((a, b) : interp_prestep interp A * interp_prestep interp B)
-                => (@unprestep A a, @unprestep B b)
-           | type.list A as t
-             => List.map (@unprestep A)
-           | type.arrow _ _ as t
-           | type.unit as t
-           | type.Z as t
-           | type.nat as t
-           | type.bool as t
-             => id
-           end%type.
-    End interp.
-    Arguments unprestep {var t} _.
-    Arguments unprestep2 {var t} _.
+      Fixpoint value (t : type)
+        := value_step value t.
+    End value.
 
     Notation expr_const := const.
 
@@ -1409,21 +1368,21 @@ Module Compilers.
       Section reify.
         Context {var : type -> Type}.
         Fixpoint reify {t : type} {struct t}
-          : interp var t -> @expr var t
-          := match t return interp var t -> expr t with
+          : value var t -> @expr var t
+          := match t return value var t -> expr t with
              | type.unit as t => expr_const (t:=t)
              | type.prod A B as t
-               => fun x : expr t + interp var A * interp var B
+               => fun x : expr t + value var A * value var B
                   => match x with
                      | inl v => v
                      | inr (a, b) => (@reify A a, @reify B b)%expr
                      end
              | type.arrow s d
-               => fun (f : interp var s -> interp var d)
+               => fun (f : value var s -> value var d)
                   => Abs (fun x
                           => @reify d (f (@reflect s (Var x))))
              | type.list A as t
-               => fun x : expr t + list (interp var A)
+               => fun x : expr t + list (value var A)
                   => match x with
                      | inl v => v
                      | inr v => reify_list (List.map (@reify A) v)
@@ -1438,16 +1397,16 @@ Module Compilers.
                      end
              end
         with reflect {t : type}
-             : @expr var t -> interp var t
-             := match t return expr t -> interp var t with
+             : @expr var t -> value var t
+             := match t return expr t -> value var t with
                 | type.arrow s d
-                  => fun (f : expr (s -> d)) (x : interp var s)
+                  => fun (f : expr (s -> d)) (x : value var s)
                      => @reflect d (App f (@reify s x))
                 | type.unit => fun _ => tt
                 | type.prod A B as t
                   => fun v : expr t
-                     => let inr := @inr (expr t) (interp_prestep (interp var) t) in
-                        let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                     => let inr := @inr (expr t) (value_prestep (value var) t) in
+                        let inl := @inl (expr t) (value_prestep (value var) t) in
                         match Smart_invert_Pair v with
                         | Some (a, b)
                           => inr (@reflect A a, @reflect B b)
@@ -1456,8 +1415,8 @@ Module Compilers.
                         end
                 | type.list A as t
                   => fun v : expr t
-                     => let inr := @inr (expr t) (interp_prestep (interp var) t) in
-                        let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                     => let inr := @inr (expr t) (value_prestep (value var) t) in
+                        let inl := @inl (expr t) (value_prestep (value var) t) in
                         match Smart_invert_list_full v with
                         | Some ls
                           => inr (List.map (@reflect A) ls)
@@ -1466,8 +1425,8 @@ Module Compilers.
                         end
                 | type.nat as t
                   => fun v : expr t
-                     => let inr := @inr (expr t) (interp_prestep (interp var) t) in
-                        let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                     => let inr := @inr (expr t) (value_prestep (value var) t) in
+                        let inl := @inl (expr t) (value_prestep (value var) t) in
                         match invert_nat_full v with
                         | Some v => inr v
                         | None => inl v
@@ -1475,8 +1434,8 @@ Module Compilers.
                 | type.Z as t
                 | type.bool as t
                   => fun v : expr t
-                     => let inr := @inr (expr t) (interp_prestep (interp var) t) in
-                        let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                     => let inr := @inr (expr t) (value_prestep (value var) t) in
+                        let inl := @inl (expr t) (value_prestep (value var) t) in
                         match invert_Const v with
                         | Some v => inr v
                         | None => inl v
@@ -1489,8 +1448,8 @@ Module Compilers.
         (** TODO: Find a better name for this *)
         (** N.B. This always inlines functions; not sure if this is the right thing to do *)
         (** TODO: should we handle let-bound pairs, let-bound lists?  What should we do with them?  Here, I make the decision to always inline them; not sure if this is right *)
-        Fixpoint SmartLetIn {tx : type} : interp var tx -> (interp var tx -> interp var tC) -> interp var tC
-          := match tx return interp var tx -> (interp var tx -> interp var tC) -> interp var tC with
+        Fixpoint SmartLetIn {tx : type} : value var tx -> (value var tx -> value var tC) -> value var tC
+          := match tx return value var tx -> (value var tx -> value var tC) -> value var tC with
              | type.unit => fun _ f => f tt
              | type.arrow _ _
              | type.prod _ _
@@ -1499,7 +1458,7 @@ Module Compilers.
              | type.nat as t
              | type.Z as t
              | type.bool as t
-               => fun (x : expr t + type.interp t) (f : expr t + type.interp t -> interp var tC)
+               => fun (x : expr t + type.interp t) (f : expr t + type.interp t -> value var tC)
                   => match x with
                      | inl e
                        => match invert_Var e, invert_Const e with
@@ -1525,30 +1484,30 @@ Module Compilers.
     Module ident.
       Section interp.
         Context {var : type -> Type}.
-        Definition interp {t} (idc : ident t) : interp var t
-          := match idc in ident t return interp var t with
+        Definition interp {t} (idc : ident t) : value var t
+          := match idc in ident t return value var t with
              | ident.Const t v as idc
                => expr.reflect (Ident idc)
              | ident.Let_In tx tC
                => expr.SmartLetIn
              | ident.nil t
-               => inr (@nil (interp var t))
+               => inr (@nil (value var t))
              | ident.cons t as idc
-               => fun x (xs : expr (type.list t) + list (interp var t))
-                  => match xs return expr (type.list t) + list (interp var t) with
+               => fun x (xs : expr (type.list t) + list (value var t))
+                  => match xs return expr (type.list t) + list (value var t) with
                      | inr xs => inr (cons x xs)
                      | _ => expr.reflect (Ident idc) x xs
                      end
              | ident.pair A B as idc
-               => fun x y => @inr _ (interp var A * interp var B) (x, y)
+               => fun x y => @inr _ (value var A * value var B) (x, y)
              | ident.fst A B as idc
-               => fun x : expr (A * B) + interp var A * interp var B
+               => fun x : expr (A * B) + value var A * value var B
                   => match x with
                      | inr x => fst x
                      | _ => expr.reflect (Ident idc) x
                      end
              | ident.snd A B as idc
-               => fun x : expr (A * B) + interp var A * interp var B
+               => fun x : expr (A * B) + value var A * value var B
                   => match x with
                      | inr x => snd x
                      | _ => expr.reflect (Ident idc) x
@@ -1556,28 +1515,28 @@ Module Compilers.
              | ident.bool_rect T as idc
                => fun true_case false_case (b : expr type.bool + bool)
                   => match b with
-                     | inr b => @bool_rect (fun _ => interp var T) true_case false_case b
+                     | inr b => @bool_rect (fun _ => value var T) true_case false_case b
                      | _ => expr.reflect (Ident idc) true_case false_case b
                      end
              | ident.nat_rect P as idc
-               => fun (O_case : interp var P)
-                      (S_case : expr type.nat + nat -> interp var P -> interp var P)
+               => fun (O_case : value var P)
+                      (S_case : expr type.nat + nat -> value var P -> value var P)
                       (n : expr type.nat + nat)
                   => match n with
-                     | inr n => @nat_rect (fun _ => interp var P)
+                     | inr n => @nat_rect (fun _ => value var P)
                                           O_case
                                           (fun n' => S_case (inr n'))
                                           n
                      | _ => expr.reflect (Ident idc) O_case S_case n
                      end
              | ident.list_rect A P as idc
-               => fun (nil_case : interp var P)
-                      (cons_case : interp var A -> expr (type.list A) + list (interp var A) -> interp var P -> interp var P)
-                      (ls : expr (type.list A) + list (interp var A))
+               => fun (nil_case : value var P)
+                      (cons_case : value var A -> expr (type.list A) + list (value var A) -> value var P -> value var P)
+                      (ls : expr (type.list A) + list (value var A))
                   => match ls with
                      | inr ls => @list_rect
-                                   (interp var A)
-                                   (fun _ => interp var P)
+                                   (value var A)
+                                   (fun _ => value var P)
                                    nil_case
                                    (fun x xs rec => cons_case x (inr xs) rec)
                                    ls
@@ -1637,16 +1596,16 @@ Module Compilers.
   Section partial_reduce.
     Context {var : type -> Type}.
 
-    Fixpoint partial_reduce' {t} (e : @expr (partial.interp var) t)
-      : partial.interp var t
-      := match e in expr.expr t return partial.interp var t with
+    Fixpoint partial_reduce' {t} (e : @expr (partial.value var) t)
+      : partial.value var t
+      := match e in expr.expr t return partial.value var t with
          | Var t v => v
          | Ident t idc => partial.ident.interp idc
          | App s d f x => @partial_reduce' _ f (@partial_reduce' _ x)
          | Abs s d f => fun x => @partial_reduce' d (f x)
          end.
 
-    Definition partial_reduce {t} (e : @expr (partial.interp var) t) : @expr var t
+    Definition partial_reduce {t} (e : @expr (partial.value var) t) : @expr var t
       := partial.expr.reify (@partial_reduce' t e).
   End partial_reduce.
 

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -685,77 +685,6 @@ Module Compilers.
          | _, Some ls => Some ls
          | None, None => None
          end.
-
-
-    (*Section with_map.
-      (* oh, the horrors of not being able to use non-linear deep
-         pattern matches.  Luckily Coq's guard checker unfolds things,
-         so as long as the thing we need to evaluate at the bottom is
-         generic in what type it's looking at, we're good.  We can
-         even give it data of the right type, which we need, but it
-         costs us a lot *)
-      Context (extra_dataT : type -> Type) {U} (f : forall t (d : extra_dataT t), @expr var t -> U t d).
-      Local Notation list_to_extra_dataT t
-        := (match t%ctype return Type with
-            | type.list t' => extra_dataT t'
-            | _ => True
-            end).
-      Local Notation list_to_forall_data_option_list t
-        := (forall (d : list_to_extra_dataT t),
-               option (match t%ctype as t'
-                             return list_to_extra_dataT t' -> Type
-                       with
-                       | type.list t' => fun d => list (U t' d)
-                       | _ => fun _ => True
-                       end d)).
-      Local Notation prod_list_to_extra_dataT t
-        := (match t%ctype return Type with
-            | type.prod _ (type.list t') => extra_dataT t'
-            | _ => True
-            end).
-      Local Notation prod_list_to_forall_data_option_list t
-        := (forall (d : prod_list_to_extra_dataT t),
-               option (match t%ctype as t'
-                             return prod_list_to_extra_dataT t' -> Type
-                       with
-                       | type.prod A (type.list t') => fun d => (expr A * list (U t' d))%type
-                       | _ => fun _ => True
-                       end d)).
-
-
-
-      Fixpoint invert_map_list_full {t} (e : @expr var (type.list t))
-        : forall d : extra_dataT t, option (list (U t d))
-      := match e in expr t return list_to_forall_data_option_list t
-           with
-           | Op s d idc args
-             => match idc in op s d
-                      return (prod_list_to_forall_data_option_list s
-                              -> list_to_forall_data_option_list d)
-                with
-                | ident.Const (type.list _) v
-                  => fun _ data => Some (List.map (f _ data) (List.map const v))
-                | ident.cons _
-                  => fun xs data
-                     => option_map (fun '(x, xs) => cons (f _ data x) xs) (xs data)
-                | ident.nil _
-                  => fun _ _ => Some nil
-                | _ => fun _ _ => None
-                end
-                  (match args in expr t
-                         return prod_list_to_forall_data_option_list t
-                   with
-                   | Pair _ (type.list _) x xs
-                     => fun data
-                        => match @invert_map_list_full _ xs data with
-                           | Some xs => Some (x, xs)
-                           | None => None
-                           end
-                   | _ => fun _ => None
-                   end)
-           | _ => fun _ => None
-           end.
-    End with_map.*)
   End invert.
 
   Section gallina_reify.
@@ -777,7 +706,6 @@ Module Compilers.
 
   (** TODO: should this even be named [arguments]? *)
   Module arguments.
-    (*Module rec.*)
     (** TODO: pick a better name for this (partial_expr?) *)
     Section interp.
       Context (var : type -> Type).
@@ -849,445 +777,116 @@ Module Compilers.
     Arguments unprestep {var t} _.
     Arguments unprestep2 {var t} _.
 
+    Notation expr_const := const.
 
-      (*Definition invert1 {var} {t : type}
-        : interp var t -> (var t + interp_step (interp var) t)
-        := match t with
-           | type.unit
-           | _
-             => id
-           end.
-
-      Definition generic {var : type -> Type} {t : type} : var t -> interp var t
-        := match t with
-           | type.unit
-           | _
-             => @inl _ _
-           end.*)
-
-      Notation expr_const := const.
-
-      Module expr.
-        Section reify.
-          Context {var : type -> Type}.
-          (** TODO: figure out if these names are good; [eta_expand] is maybe better called [reflect]?  or [expand]? *)
-          Fixpoint reify {t : type} {struct t}
-            : interp var t -> @expr var t
-            := match t return interp var t -> expr t with
-               | type.unit as t => expr_const (t:=t)
-               | type.prod A B as t
-                 => fun x : expr t + interp var A * interp var B
-                    => match x with
-                       | inl v => v
-                       | inr (a, b) => (@reify A a, @reify B b)%expr
-                       end
-               | type.arrow s d
-                 => fun (f : interp var s -> interp var d)
-                    => Abs (fun x
-                            => @reify d (f (@eta_expand s (Var x))))
-               | type.list A as t
-                 => fun x : expr t + list (interp var A)
-                    => match x with
-                       | inl v => v
-                       | inr v => reify_list (List.map (@reify A) v)
-                       end
-               | type.nat as t
-               | type.Z as t
-               | type.bool as t
-                 => fun x : expr t + type.interp t
-                    => match x with
-                       | inl v => v
-                       | inr v => expr_const (t:=t) v
-                       end
-               end
-          with eta_expand {t : type}
-               : @expr var t -> interp var t
-               := match t return expr t -> interp var t with
-                  | type.arrow s d
-                    => fun (f : expr (s -> d)) (x : interp var s)
-                       => @eta_expand d (App f (@reify s x))
-                  | type.unit => fun _ => tt
-                  | type.prod A B as t
-                    => fun v : expr t
-                       => let inr := @inr (expr t) (interp_prestep (interp var) t) in
-                          let inl := @inl (expr t) (interp_prestep (interp var) t) in
-                          match Smart_invert_Pair v with
-                          | Some (a, b)
-                            => inr (@eta_expand A a, @eta_expand B b)
-                          | None
-                            => inl v
-                          end
-                  | type.list A as t
-                    => fun v : expr t
-                       => let inr := @inr (expr t) (interp_prestep (interp var) t) in
-                          let inl := @inl (expr t) (interp_prestep (interp var) t) in
-                          match Smart_invert_list_full v with
-                          | Some ls
-                            => inr (List.map (@eta_expand A) ls)
-                          | None
-                            => inl v
-                          end
-                  | type.nat as t
-                    => fun v : expr t
-                       => let inr := @inr (expr t) (interp_prestep (interp var) t) in
-                          let inl := @inl (expr t) (interp_prestep (interp var) t) in
-                          match invert_nat_full v with
-                          | Some v => inr v
-                          | None => inl v
-                          end
-                  | type.Z as t
-                  | type.bool as t
-                    => fun v : expr t
-                       => let inr := @inr (expr t) (interp_prestep (interp var) t) in
-                          let inl := @inl (expr t) (interp_prestep (interp var) t) in
-                          match invert_Const v with
-                          | Some v => inr v
-                          | None => inl v
-                          end
-                  end.
-        End reify.
-
-        Section SmartLetIn.
-          Context {var : type -> Type} {tC : type}.
-          (** TODO: Find a better name for this *)
-          (** N.B. This always inlines functions; not sure if this is the right thing to do *)
-          (** TODO: should we handle let-bound pairs, let-bound lists?  What should we do with them?  Here, I make the decision to always inline them; not sure if this is right *)
-          Fixpoint SmartLetIn {tx : type} : interp var tx -> (interp var tx -> interp var tC) -> interp var tC
-            := match tx return interp var tx -> (interp var tx -> interp var tC) -> interp var tC with
-               | type.unit => fun _ f => f tt
-               | type.arrow _ _
-               | type.prod _ _
-               | type.list _
-                 => fun x f => f x
-               | type.nat as t
-               | type.Z as t
-               | type.bool as t
-                 => fun (x : expr t + type.interp t) (f : expr t + type.interp t -> interp var tC)
-                    => match x with
-                       | inl e
-                         => match invert_Var e, invert_Const e with
-                            | Some v, _ => f (inl (Var v))
-                            | _, Some v => f (inr v)
-                            | None, None => eta_expand (expr_let y := e in reify (f (inl (Var y))))%expr
-                            end
-                       | inr v => f (inr v)
-                       end
-               end.
-        End SmartLetIn.
-      End expr.
-      (*
-      Section const.
-        Context {var : type -> Type} (const_var_arrow : forall s d,
-                                         type.interp (s -> d) -> var (s -> d)%ctype).
-        Fixpoint const {t : type} : type.interp t -> interp var t.
-          refine match t return type.interp t -> interp var t with
+    Module expr.
+      Section reify.
+        Context {var : type -> Type}.
+        (** TODO: figure out if these names are good; [eta_expand] is maybe better called [reflect]?  or [expand]? *)
+        Fixpoint reify {t : type} {struct t}
+          : interp var t -> @expr var t
+          := match t return interp var t -> expr t with
+             | type.unit as t => expr_const (t:=t)
              | type.prod A B as t
-               => fun '((a, b) : type.interp A * type.interp B)
-                  => @inr
-                       (expr t) (interp var A * interp var B)
-                       (@const A a, @const B b)
+               => fun x : expr t + interp var A * interp var B
+                  => match x with
+                     | inl v => v
+                     | inr (a, b) => (@reify A a, @reify B b)%expr
+                     end
              | type.arrow s d
-               => fun (f : type.interp s -> type.interp d) (x : interp var s)
-                  => _ : interp var d
+               => fun (f : interp var s -> interp var d)
+                  => Abs (fun x
+                          => @reify d (f (@eta_expand s (Var x))))
              | type.list A as t
-               => fun ls : list (type.interp A)
-                  => @inr (expr t) (list (interp var A))
-                          (List.map (@const A) ls)
-             | type.unit as t
-               => id
+               => fun x : expr t + list (interp var A)
+                  => match x with
+                     | inl v => v
+                     | inr v => reify_list (List.map (@reify A) v)
+                     end
              | type.nat as t
              | type.Z as t
              | type.bool as t
-               => @inr (expr t) (type.interp t)
-                 end.
-          cbn.
-      End const.
-*)
-  (*End rec.*)
-
-      (*Module ind.
-      Module arguments.
-        Inductive arguments : type -> Set :=
-        | generic {T} : arguments T
-        (*| cps {T} (aT : arguments T) : arguments T*)
-        | arrow {A B} (aB : arguments B) : arguments (A -> B)
-        | unit : arguments type.unit
-        | prod {A B} (aA : arguments A) (aB : arguments B) : arguments (A * B)
-        | list {T} (aT : arguments T) : arguments (type.list T)
-        | nat : arguments type.nat
-        | Z : arguments type.Z
-        | bool : arguments type.bool.
-
-    Definition preinvertT (t : type) :=
-      match t with
-      | type.unit => Datatypes.unit
-      | type.prod A B => arguments A * arguments B
-      | type.arrow s d => arguments d
-      | type.list A => arguments A
-      | type.nat => Datatypes.unit
-      | type.Z => Datatypes.unit
-      | type.bool => Datatypes.unit
-      end%type.
-    Definition invertT (t : type) :=
-      option (* [None] means "generic" *) (preinvertT t).
-
-    Definition invert {t : type} (P : arguments t -> Type)
-               (generic_case : P generic)
-               (non_generic_cases
-                : forall v : preinvertT t,
-                   match t return forall v : preinvertT t, (arguments t -> Type) -> Type with
-                   | type.unit
-                     => fun v P => P unit
-                   | type.prod A B
-                     => fun '((a, b) : arguments A * arguments B) P
-                        => P (prod a b)
-                   | type.arrow s d => fun v P => P (arrow v)
-                   | type.list A => fun v P => P (list v)
-                   | type.nat => fun v P => P nat
-                   | type.Z => fun v P => P Z
-                   | type.bool => fun v P => P bool
-                   end v P)
-               (a : arguments t)
-      : P a.
-    Proof.
-      destruct a;
-        try specialize (fun a b => non_generic_cases (a, b));
-        cbn in *;
-        [ exact generic_case | apply non_generic_cases; apply tt .. ].
-    Defined.
-
-    Definition invert_arrow {s d} (a : arguments (type.arrow s d)) : arguments d
-      := @invert (type.arrow s d) (fun _ => arguments d) generic (fun ad => ad) a.
-
-    Definition invert_prod {A B} (a : arguments (type.prod A B)) : arguments A * arguments B
-      := @invert (type.prod A B) (fun _ => arguments A * arguments B)%type (generic, generic) (fun '(a, b) => (a, b)) a.
-
-
-    Fixpoint ground {t : type} : arguments t
-      := match t with
-         | type.unit => unit
-         | type.prod A B => prod (@ground A) (@ground B)
-         | type.arrow s d => arrow (@ground d)
-         | type.list A => list (@ground A)
-         | type.nat => nat
-         | type.Z => Z
-         | type.bool => bool
-         end.
-
-    Module type.
-      Local Notation interp_type := type.interp.
-      Section interp.
-        Context (var_dom var_cod : type -> Type).
-        Fixpoint interp {t} (a : arguments t) : Type
-          := match a with
-             | generic T => var_cod T
-             (*| cps T aT => forall U, (@interp T aT -> var U) -> var U*)
-             | arrow A B aB => var_dom A -> @interp B aB
-             | unit => Datatypes.unit
-             | prod A B aA aB => @interp A aA * @interp B aB
-             | list T aT => Datatypes.list (@interp T aT)
-             | nat => Datatypes.nat
-             | Z => BinInt.Z
-             | bool => Datatypes.bool
-             end%type.
-      End interp.
-
-      Section ground.
-        Context {var_dom var_cod : type -> Type}.
-        Fixpoint const_of_ground {t}
-          : interp_type t -> option (interp var_dom (@expr var_cod) (@ground t))
-          := match t return interp_type t -> option (interp var_dom expr (@ground t)) with
-             | type.prod A B
-               => fun '((a, b) : interp_type A * interp_type B)
-                  => match @const_of_ground A a, @const_of_ground B b with
-                     | Some a', Some b' => Some (a', b')
-                     | _, _ => None
+               => fun x : expr t + type.interp t
+                  => match x with
+                     | inl v => v
+                     | inr v => expr_const (t:=t) v
                      end
-             | type.arrow s d => fun _ => None
-             | type.list A
-               => fun ls : Datatypes.list (interp_type A)
-                  => lift_option_list
-                       (List.map (@const_of_ground A) ls)
-             | type.unit
-             | type.nat
-             | type.Z
-             | type.bool
-               => fun v => Some v
+             end
+        with eta_expand {t : type}
+             : @expr var t -> interp var t
+             := match t return expr t -> interp var t with
+                | type.arrow s d
+                  => fun (f : expr (s -> d)) (x : interp var s)
+                     => @eta_expand d (App f (@reify s x))
+                | type.unit => fun _ => tt
+                | type.prod A B as t
+                  => fun v : expr t
+                     => let inr := @inr (expr t) (interp_prestep (interp var) t) in
+                        let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                        match Smart_invert_Pair v with
+                        | Some (a, b)
+                          => inr (@eta_expand A a, @eta_expand B b)
+                        | None
+                          => inl v
+                        end
+                | type.list A as t
+                  => fun v : expr t
+                     => let inr := @inr (expr t) (interp_prestep (interp var) t) in
+                        let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                        match Smart_invert_list_full v with
+                        | Some ls
+                          => inr (List.map (@eta_expand A) ls)
+                        | None
+                          => inl v
+                        end
+                | type.nat as t
+                  => fun v : expr t
+                     => let inr := @inr (expr t) (interp_prestep (interp var) t) in
+                        let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                        match invert_nat_full v with
+                        | Some v => inr v
+                        | None => inl v
+                        end
+                | type.Z as t
+                | type.bool as t
+                  => fun v : expr t
+                     => let inr := @inr (expr t) (interp_prestep (interp var) t) in
+                        let inl := @inl (expr t) (interp_prestep (interp var) t) in
+                        match invert_Const v with
+                        | Some v => inr v
+                        | None => inl v
+                        end
+                end.
+      End reify.
+
+      Section SmartLetIn.
+        Context {var : type -> Type} {tC : type}.
+        (** TODO: Find a better name for this *)
+        (** N.B. This always inlines functions; not sure if this is the right thing to do *)
+        (** TODO: should we handle let-bound pairs, let-bound lists?  What should we do with them?  Here, I make the decision to always inline them; not sure if this is right *)
+        Fixpoint SmartLetIn {tx : type} : interp var tx -> (interp var tx -> interp var tC) -> interp var tC
+          := match tx return interp var tx -> (interp var tx -> interp var tC) -> interp var tC with
+             | type.unit => fun _ f => f tt
+             | type.arrow _ _
+             | type.prod _ _
+             | type.list _
+               => fun x f => f x
+             | type.nat as t
+             | type.Z as t
+             | type.bool as t
+               => fun (x : expr t + type.interp t) (f : expr t + type.interp t -> interp var tC)
+                  => match x with
+                     | inl e
+                       => match invert_Var e, invert_Const e with
+                          | Some v, _ => f (inl (Var v))
+                          | _, Some v => f (inr v)
+                          | None, None => eta_expand (expr_let y := e in reify (f (inl (Var y))))%expr
+                          end
+                     | inr v => f (inr v)
+                     end
              end.
-      End ground.
-
-      Module option.
-        Section interp.
-          Context (var_dom var_cod : type -> Type).
-          Fixpoint interp {t} (a : arguments t) : Type
-            := match a with
-               | generic T => var_cod T
-               (*| cps T aT => forall U, (@interp T aT -> var U) -> var U*)
-               | arrow A B aB => var_dom A -> @interp B aB
-               | unit => Datatypes.unit
-               | prod A B aA aB => option (@interp A aA * @interp B aB)
-               | list T aT => option (Datatypes.list (@interp T aT))
-               | nat => option Datatypes.nat
-               | Z => option BinInt.Z
-               | bool => option Datatypes.bool
-               end%type.
-        End interp.
-
-        Section flat_interp.
-          Context (var_generic var_dom : type -> Type) (var_cod : forall t, arguments t -> Type).
-          Fixpoint flat_interp {t} (a : arguments t) : Type
-            := match a with
-               | generic T => var_generic T
-               (*| cps T aT => forall U, (@interp T aT -> var U) -> var U*)
-               | arrow A B aB => var_dom A -> var_cod B aB
-               | unit => Datatypes.unit
-               | prod A B aA aB => @flat_interp A aA * @flat_interp B aB
-               | list T aT => Datatypes.list (@flat_interp T aT)
-               | nat => Datatypes.nat
-               | Z => BinInt.Z
-               | bool => Datatypes.bool
-               end%type.
-        End flat_interp.
-
-        Definition interp_to_arrow_or_generic var_dom var_cod {t} a
-          := @flat_interp var_cod var_dom (@interp var_dom var_cod) t a.
-
-        Section lift_option.
-          Context {var_dom var_cod : type -> Type}.
-          Fixpoint lift_interp {t} {a : arguments t}
-            : interp var_dom var_cod a -> option (interp_to_arrow_or_generic var_dom var_cod a)
-            := match a in arguments t
-                     return interp var_dom var_cod a -> option (interp_to_arrow_or_generic var_dom var_cod a)
-               with
-               | prod A B aA aB
-                 => fun ab : option (interp _ _ aA * interp _ _ aB)
-                    => match ab with
-                       | Some (a, b)
-                         => match @lift_interp A aA a, @lift_interp B aB b with
-                            | Some a, Some b => Some (a, b)
-                            | _, _ => None
-                            end
-                       | None => None
-                       end
-               | list T aT
-                 => fun ls : option (Datatypes.list (interp _ _ aT))
-                    => match ls with
-                       | Some ls
-                         => lift_option_list
-                              (List.map (@lift_interp T aT) ls)
-                       | None => None
-                       end
-               | arrow _ _ _
-               | generic _
-               | unit
-                 => fun v => Some v
-               | nat
-               | Z
-               | bool
-                 => fun x => x
-               end.
-        End lift_option.
-      End option.
-    End type.
-
-     Module expr.
-+      Section reify.
-+        Context {var : type -> Type}.
-+        Fixpoint reify {t : type} (v : interp (@expr var) t) {struct t}
-+          : @expr var t
-+          := match invert1 v with
-+             | inl e => e
-+             | inr e
-+               => match t return interp_step (interp expr) t -> expr t with
-+                  | type.prod A B
-+                    => fun '((a, b) : interp expr A * interp expr B)
-+                       => Pair (@reify A a) (@reify B b)
-+                  | type.arrow s d
-+                    => fun f
-+                       => Abs (fun x => @reify d (f (generic (Var x))))
-+                  | type.list A
-+                    => fun e
-+                       => list_rect
-+                            (fun _ => expr (type.list A))
-+                            (Ident ident.nil)
-+                            (fun x _ xs
-+                             => App (App (Ident ident.cons) x) xs)
-+                            (List.map (@reify A) e)
-+                  | type.unit as t
-+                  | type.nat as t
-+                  | type.Z as t
-+                  | type.bool as t
-+                    => expr_const (t:=t)
-+                  end e
-+             end.
-+      End reify.
-+
-    End ind.*)
-      (*
-      Section interp.
-        Context (var : type -> Type).
-        Fixpoint interp {t} (a : arguments t)
-          : @expr var t -> type.option.interp (@expr var) (@expr var) a
-          := match a in arguments t return expr t -> type.option.interp expr expr a with
-             | generic T => fun e => e
-             (*| cps T aT => fun e*)
-             | arrow A B aB
-               => fun e arg
-                  => @interp
-                       B aB
-                       match invert_Abs e, invert_Var arg with
-                       | Some f, Some arg => f arg
-                       | _, _ => Op ident.App (e, arg)
-                       end
-             | unit => fun _ => tt
-             | prod A B aA aB
-               => fun e
-                  => option_map (fun '(a, b)
-                                 => (@interp A aA a, @interp B aB b))
-                                (invert_Pair e)
-             | list T aT
-               => fun e
-                  => option_map
-                       (List.map (@interp T aT))
-                       (invert_list_full e)
-             | nat => invert_nat_full
-             | Z => invert_Z
-             | bool => invert_bool
-             end.
-      End interp.
-
-      Section reify.
-        Context (var : type -> Type).
-        Fixpoint reify {t} (a : arguments t)
-          : type.interp var (@expr var) a -> @expr var t
-          := match a in arguments t return type.interp var expr a -> expr t with
-             | generic T => fun e => e
-             | arrow A B aB => fun f => Abs (fun x => @reify B aB (f x))
-             | unit => fun _ => TT
-             | prod A B aA aB
-               => fun '((a, b) : type.interp _ _ aA * type.interp _ _ aB)
-                  => (@reify A aA a, @reify B aB b)%expr
-             | list T aT
-               => fun ls
-                  => reify_list (List.map (@reify T aT) ls)
-             | nat => @const var type.nat
-             | Z => @const var type.Z
-             | bool => @const var type.bool
-             end.
-      End reify.*)
-    (*End expr.*)
-    (*
-    Module Export Notations.
-      Delimit Scope arguments_scope with arguments.
-      Bind Scope arguments_scope with interp.
-      Notation "()" := (inr tt) : arguments_scope.
-      Notation "A * B" := (prod A B) : arguments_scope.
-      Notation "A -> B" := (@arrow A _ B) (only printing) : arguments_scope.
-      Notation "A -> B" := (arrow B) (only parsing) : arguments_scope.
-      Global Coercion generic : type.type >-> arguments.
-      Notation arguments := arguments.
-    End Notations.
-     *)
+      End SmartLetIn.
+    End expr.
 
     Definition sum_arrow {A A' B B'} (f : A -> A') (g : B -> B')
                (v : A + B)
@@ -1299,31 +898,8 @@ Module Compilers.
     Infix "+" := sum_arrow : function_scope.
 
     Module ident.
-      (*Local Open Scope arguments_scope.*)
       Section interp.
         Context {var : type -> Type}.
-        (*Notation default_App0 idc
-          := (inr (ident.interp idc))
-               (only parsing).
-        Notation default_App1 idc
-          := (inr (App (Ident idc) + ident.interp idc)%function)
-               (only parsing).
-        Notation default_App2 idc
-          := (inr (App (Ident idc)
-                   + (fun x
-                      => App (App (Ident idc) (expr_const x))
-                         + ident.interp idc x))%function)
-               (only parsing).
-
-        Let default_App1e {A B}
-            (f : interp (@expr var) A -> interp (@expr var) B)
-          : interp (@expr var) (A -> B)
-          := inr f.
-        Let default_App2e {A B C}
-            (f : interp (@expr var) A -> interp (@expr var) B -> interp (@expr var) C)
-          : interp (@expr var) (A -> B -> C)
-          := inr (fun x => inr (f x)).
-         *)
         Let defaulted_App_p_e {A B} (idc : ident (A -> B))
             (F : interp_prestep (interp var) A
                  -> interp var B)
@@ -1641,120 +1217,9 @@ Module Compilers.
              | ident.Nat_sub as idc
                => defaulted_App_pp_p idc (ident.interp idc)
              end.
-      End interp. (*
-
-      Definition lookup {s d} (idc : op s d) : arguments s * arguments d
-        := match idc in op s d return arguments s * arguments d with
-           | ident.Const t v => (generic, ground)
-           | ident.Let_In tx tC => (tx * (tx -> tC), generic)
-           | ident.App s d => ((s -> d) * s, generic)
-           | ident.S => (ground, ground)
-           | ident.nil t => (generic, ground)
-           | ident.cons t => (t * list t, list t)
-           | ident.fst A B => (A * B, generic)
-           | ident.snd A B => (A * B, generic)
-           | ident.bool_rect T => (T * T * bool, generic)
-           | ident.nat_rect P => (P * (nat -> P -> P) * nat, generic)
-           | ident.pred => (nat, ground)
-           | ident.List_seq => (nat * nat, ground)
-           | ident.List_repeat A => (A * nat, list A)
-           | ident.List_combine A B => (list A * list B, list (A * B))
-           | ident.List_map A B => ((A -> B) * list A, list B)
-           | ident.List_flat_map A B => ((A -> list B) * list A, list B)
-           | ident.List_partition A => ((A -> bool) * list A, list A * list A)
-           | ident.List_app A => (list A * list A, list A)
-           | ident.List_fold_right A B => ((B -> A -> A) * A * list B, generic)
-           | ident.List_update_nth T => (nat * (T -> T) * list T, list T)
-           | ident.Z_runtime_mul => (Z * Z, Z)
-           | ident.Z_runtime_add => (Z * Z, Z)
-           | ident.Z_add => (Z * Z, Z)
-           | ident.Z_mul => (Z * Z, Z)
-           | ident.Z_pow => (Z * Z, Z)
-           | ident.Z_opp => (Z, Z)
-           | ident.Z_div => (Z * Z, Z)
-           | ident.Z_modulo => (Z * Z, Z)
-           | ident.Z_eqb => (Z * Z, bool)
-           | ident.Z_of_nat => (nat, Z)
-           end.
-
-      Definition lookup_src {s d} idc := fst (@lookup s d idc).
-      Definition lookup_dst {s d} idc := snd (@lookup s d idc).
-
-      Definition option_map_prod {A B C} (f : A -> B -> C) (v : option (option A * option B))
-        : option C
-        := match v with
-           | Some (Some a, Some b) => Some (f a b)
-           | _ => None
-           end.
-
-
-
-      Definition rewrite
-                 {var : type -> Type}
-                 {s d} (idc : op s d)
-                 (exploded_arguments : type.option.interp (@expr var) (@expr var) (lookup_src idc))
-        : option (type.interp var (@expr var) (lookup_dst idc))
-        := match idc in op s d
-                 return
-                 (forall (exploded_arguments' : option (type.option.interp_to_arrow_or_generic expr expr (lookup_src idc))),
-                     option (type.interp var expr (lookup_dst idc)))
-           with
-           | ident.Const t v => fun _ => arguments.type.const_of_ground v
-           | ident.Let_In tx tC
-             => option_map
-                  (fun '(ex, eC)
-                   => match invert_Var ex, invert_Idconst ex with
-                      | Some v, _ => eC ex
-                      | None, Some v => eC ex
-                      | None, None => Op ident.Let_In (ex, Abs (fun v => eC (Var v)))
-                      end)
-           | ident.App s d => option_map (fun '(f, x) => f x)
-           | ident.S as idc
-           | ident.pred as idc
-           | ident.Z_runtime_mul as idc
-           | ident.Z_runtime_add as idc
-           | ident.Z_add as idc
-           | ident.Z_mul as idc
-           | ident.Z_pow as idc
-           | ident.Z_opp as idc
-           | ident.Z_div as idc
-           | ident.Z_modulo as idc
-           | ident.Z_eqb as idc
-           | ident.Z_of_nat as idc
-             => option_map (ident.interp idc)
-           | ident.nil t => fun _ => Some (@nil (type.interp _ _ ground))
-           | ident.cons t => option_map (ident.curry2 cons)
-           | ident.fst A B => option_map (@fst (expr A) (expr B))
-           | ident.snd A B => option_map (@snd (expr A) (expr B))
-           | ident.bool_rect T => option_map (ident.curry3 (bool_rect (fun _ => _)))
-           | ident.nat_rect P
-             => option_map
-                  (fun '(O_case, S_case, v)
-                   => nat_rect (fun _ => expr P) O_case (fun n (v : expr P) => S_case (@const _ type.nat n) v) v)
-           | ident.List_seq => option_map (ident.curry2 List.seq)
-           | ident.List_repeat A => option_map (ident.curry2 (@List.repeat (expr A)))
-           | ident.List_combine A B => option_map (ident.curry2 (@List.combine (expr A) (expr B)))
-           | ident.List_map A B => option_map (ident.curry2 (@List.map (expr A) (expr B)))
-           | ident.List_flat_map A B
-             => fun args : option ((expr A -> option (Datatypes.list (expr B))) * Datatypes.list (expr A))
-                => match args with
-                   | Some (f, ls) => option_flat_map f ls
-                   | None => None
-                   end
-           | ident.List_partition A
-             => fun args : option ((expr A -> option Datatypes.bool) * Datatypes.list (expr A))
-                => match args with
-                   | Some (f, ls) => option_partition f ls
-                   | None => None
-                   end
-           | ident.List_app A => option_map (ident.curry2 (@List.app (expr A)))
-           | ident.List_fold_right A B => option_map (ident.curry3 (@List.fold_right (expr A) (expr B)))
-           | ident.List_update_nth T => option_map (ident.curry3 (@update_nth (expr T)))
-           end
-             (type.option.lift_interp exploded_arguments).*)
+      End interp.
     End ident.
   End arguments.
-  (*Export arguments.Notations.*)
 
   Section partial_reduce.
     Context {var : type -> Type}.
@@ -1764,11 +1229,8 @@ Module Compilers.
       := match e in expr t return arguments.interp var t with
          | Var t v => v
          | Ident t idc => arguments.ident.interp idc
-         | App s d f x
-           => @partial_reduce' _ f (@partial_reduce' _ x)
-         | Abs s d f
-           => fun x
-              => @partial_reduce' d (f x)
+         | App s d f x => @partial_reduce' _ f (@partial_reduce' _ x)
+         | Abs s d f => fun x => @partial_reduce' d (f x)
          end.
 
     Definition partial_reduce {t} (e : @expr (arguments.interp var) t) : @expr var t

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -687,19 +687,17 @@ Module Compilers.
     (** TODO: pick a better name for this (partial_expr?) *)
     Section interp.
       Context (var : type -> Type).
-      Definition interp_prestep_gen (interp_dom interp_cod : type -> Type) (t : type)
+      Definition interp_prestep (interp : type -> Type) (t : type)
         := match t return Type with
-           | type.prod A B as t => interp_cod A * interp_cod B
-           | type.arrow s d => interp_dom s -> interp_cod d
-           | type.list A => list (interp_cod A)
+           | type.prod A B as t => interp A * interp B
+           | type.arrow s d => interp s -> interp d
+           | type.list A => list (interp A)
            | type.unit as t
            | type.Z as t
            | type.nat as t
            | type.bool as t
              => type.interp t
            end%type.
-      Definition interp_prestep (interp : type -> Type) (t : type)
-        := interp_prestep_gen interp interp t.
       Definition interp_step (interp : type -> Type) (t : type)
         := match t return Type with
            | type.unit as t
@@ -715,75 +713,47 @@ Module Compilers.
       Fixpoint interp (t : type)
         := interp_step interp t.
 
-      Fixpoint interp_prestepn (n : nat) : type -> Type
-        := match n with
-           | O => interp
-           | S n' => interp_prestep_gen
-                       interp
-                       (interp_prestepn n')
-           end.
-
-      Definition lift_interp_prestep_gen
-                 {interp_dom1 interp_dom2 interp_cod1 interp_cod2 : type -> Type}
-                 (f_dom : forall A, interp_dom2 A -> interp_dom1 A)
-                 (f_cod : forall A, interp_cod1 A -> interp_cod2 A)
-                 {t : type}
-        : interp_prestep_gen interp_dom1 interp_cod1 t
-          -> interp_prestep_gen interp_dom2 interp_cod2 t
-        := match t return interp_prestep_gen interp_dom1 interp_cod1 t
-                          -> interp_prestep_gen interp_dom2 interp_cod2 t with
-           | type.prod A B
-             => fun '((a, b) : interp_cod1 A * interp_cod1 B)
-                => (f_cod A a, f_cod B b)
-           | type.arrow s d => fun f x => f_cod d (f (f_dom s x))
-           | type.list A
-             => List.map (f_cod A)
-           | type.unit
-           | type.nat
-           | type.Z
-           | type.bool
-             => id
-           end.
-
-      Definition uninterp_prestep_gen
-                 {interp_dom1 interp_cod1 : type -> Type}
-                 (f_dom : forall A, interp A -> interp_dom1 A)
-                 (f_cod : forall A, interp_cod1 A -> interp A)
-                 {t : type}
-        : interp_prestep_gen interp_dom1 interp_cod1 t
-          -> interp t
-        := match t return interp_prestep_gen interp_dom1 interp_cod1 t
-                          -> interp t with
-           | type.arrow s d
-             => fun f (x : interp s)
-                => f_cod d (f (f_dom s x))
-           | type.unit
+      Definition unprestep {t : type} : interp_prestep interp t -> interp t
+        := match t return interp_prestep interp t -> interp t with
+           | type.unit as t
+           | type.arrow _ _ as t
              => id
            | type.prod _ _ as t
            | type.list _ as t
-           | type.nat as t
            | type.Z as t
+           | type.nat as t
            | type.bool as t
-             => fun x => @inr (expr t) (interp_prestep interp t)
-                              (lift_interp_prestep_gen f_dom f_cod x)
-           end.
+             => @inr _ (interp_prestep interp t)
+           end%type.
 
-        Fixpoint unprestepn {n : nat} : forall {t : type}, interp_prestepn n t -> interp t
-          := match n return forall t, interp_prestepn n t -> interp t with
-             | O => fun t v => v
-             | S n'
-               => @uninterp_prestep_gen
-                    interp (@interp_prestepn n')
-                    (fun _ => id)
-                    (@unprestepn n')
-             end.
-
-        Definition unprestep {t : type} : interp_prestep interp t -> interp t
-          := @unprestepn 1 t.
+      Definition unprestep2 {t : type}
+        : interp_prestep (interp_prestep interp) t
+          -> match t with
+             | type.arrow _ _ => interp_prestep (interp_prestep interp) t
+             | t => interp_prestep interp t
+             end
+        := match t
+                 return (interp_prestep (interp_prestep interp) t
+                         -> match t with
+                            | type.arrow _ _ => interp_prestep (interp_prestep interp) t
+                            | t => interp_prestep interp t
+                            end)
+           with
+           | type.prod A B
+             => fun '((a, b) : interp_prestep interp A * interp_prestep interp B)
+                => (@unprestep A a, @unprestep B b)
+           | type.list A as t
+             => List.map (@unprestep A)
+           | type.arrow _ _ as t
+           | type.unit as t
+           | type.Z as t
+           | type.nat as t
+           | type.bool as t
+             => id
+           end%type.
     End interp.
     Arguments unprestep {var t} _.
-    Arguments uninterp_prestep_gen {var _ _} _ _ {t} _.
-    Arguments unprestepn {var n t} _.
+    Arguments unprestep2 {var t} _.
 
     Notation expr_const := const.
 
@@ -895,100 +865,6 @@ Module Compilers.
       End SmartLetIn.
     End expr.
 
-    Module Controlled.
-      Inductive arguments : type -> Set :=
-      | evaluated {T} (n : nat) : arguments T
-      | optionally {T} (a : arguments T) : arguments T
-      | arrow {s d} (sn : nat) (da : arguments d) : arguments (type.arrow s d).
-
-      Module Export Notations.
-        Bind Scope arguments_scope with arguments.
-        Delimit Scope arguments_scope with arguments.
-        Notation "!" := (@evaluated _) : arguments_scope.
-        Notation "a -> b" := (@arrow _ _ a%nat b%arguments) : arguments_scope.
-      End Notations.
-
-      Section with_var.
-        Context (var : type -> Type).
-
-        Fixpoint preinterp_in {t : type} (a : arguments t) : Type
-          := match a return Type with
-             | evaluated T n
-               => interp_prestepn var n T
-             | optionally T a
-               => option (@preinterp_in T a)
-             | arrow s d n da
-               => interp_prestepn var n s -> @preinterp_in d da
-             end.
-
-        Fixpoint preinterp_out {t : type} (a : arguments t) : Type
-          := match a return Type with
-             | evaluated T O
-               => interp var T
-             | evaluated T n
-               => @expr var T + interp_prestep (interp var) T
-             | optionally T a
-               => @preinterp_out T a
-             | arrow s d O da
-               => interp var s
-                  -> @preinterp_out d da
-             | arrow s d n da
-               => (@expr var s + interp_prestepn var n s)
-                  -> @preinterp_out d da
-             end.
-
-        Fixpoint out_expr {t} {a : arguments t} : @expr var t -> preinterp_out a
-          := match a in arguments t return expr t -> preinterp_out a with
-             | evaluated T O
-               => expr.reflect
-             | evaluated T n
-               => inl
-             | optionally T a
-               => @out_expr T a
-             | arrow s d O da
-               => fun e x
-                  => @out_expr d da (App e (expr.reify x))
-             | arrow s d sa da
-               => fun e x
-                  => @out_expr
-                       d da (App e match x with
-                                   | inl xe => xe
-                                   | inr xi => expr.reify (unprestepn xi)
-                                   end)
-             end.
-
-        Fixpoint defaulted_App {t} (default : @expr var t) (a : arguments t)
-          : preinterp_in a -> preinterp_out a
-          := match a in arguments t return expr t -> preinterp_in a -> preinterp_out a with
-             | evaluated T O => fun _ => id
-             | evaluated T n
-               => fun _ x => inr (@lift_interp_prestep_gen
-                                    (interp var) (interp var) (interp_prestepn var _) (interp var)
-                                    (fun _ => id)
-                                    (@unprestepn _ _)
-                                    _
-                                    x)
-             | optionally T a
-               => fun default (v : option (preinterp_in a))
-                  => match v with
-                     | Some v => @defaulted_App T default a v
-                     | None => out_expr default
-                     end
-             | arrow s d O da
-               => fun e F x
-                  => @defaulted_App d (App e (expr.reify x)) da (F x)
-             | arrow s d sa da
-               => fun e F x
-                  => match x return preinterp_out da with
-                     | inl xe => out_expr (App e xe)
-                     | inr xi => @defaulted_App d (App e (expr.reify (unprestepn xi))) da (F xi)
-                     end
-             end default.
-      End with_var.
-      Arguments defaulted_App {var t} _ _ _.
-    End Controlled.
-    Export Controlled.Notations.
-
     Definition sum_arrow {A A' B B'} (f : A -> A') (g : B -> B')
                (v : A + B)
       : A' + B'
@@ -1001,9 +877,214 @@ Module Compilers.
     Module ident.
       Section interp.
         Context {var : type -> Type}.
+        Let defaulted_App_p_e {A B} (idc : ident (A -> B))
+            (F : interp_prestep (interp var) A
+                 -> interp var B)
+          : @expr var A + interp_prestep (interp var) A
+            -> interp var B
+          := fun x
+             => match x with
+                | inl e => expr.reflect (App (Ident idc) e)
+                | inr x => F x
+                end.
+        Let defaulted_App_p_p {A B} (idc : ident (A -> B))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) B)
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var B + interp_prestep (interp var) B
+          := (App (Ident idc) + F)%function.
+        Let defaulted_App_ep_p {A B C} (idc : ident (A -> B -> C))
+            (F : interp var A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp var) C)
+          : interp var A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x
+             => (App (App (Ident idc) (expr.reify x))
+                 + (F x))%function.
+        Let defaulted_App_eep_e {A B C D} (idc : ident (A -> B -> C -> D))
+            (F : interp var A
+                 -> interp var B
+                 -> interp_prestep (interp var) C
+                 -> interp var D)
+          : interp var A
+            -> interp var B
+            -> @expr var C + interp_prestep (interp var) C
+            -> interp var D
+          := fun x y z
+             => match z with
+                | inl z => expr.reflect (App (App (App (Ident idc) (expr.reify x)) (expr.reify y)) z)
+                | inr z => F x y z
+                end.
+        Let defaulted_App_pe_p {A B C} (idc : ident (A -> B -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp var B
+                 -> interp_prestep (interp var) C)
+          : @expr var A + interp_prestep (interp var) A
+            -> interp var B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x y
+             => match x with
+                | inl x => inl (App (App (Ident idc) x) (expr.reify y))
+                | inr x => inr (F x y)
+                end.
+        Let defaulted_App_pep_p {A B C D} (idc : ident (A -> B -> C -> D))
+            (F : interp_prestep (interp var) A
+                 -> interp var B
+                 -> interp_prestep (interp var) C
+                 -> interp_prestep (interp var) D)
+          : @expr var A + interp_prestep (interp var) A
+            -> interp var B
+            -> @expr var C + interp_prestep (interp var) C
+            -> @expr var D + interp_prestep (interp var) D
+          := fun x y z
+             => let xz
+                    := match x, z with
+                       | inl x, inl z => inl (x, z)
+                       | inr x, inl z => inl (expr.reify (unprestep x), z)
+                       | inl x, inr z => inl (x, expr.reify (unprestep z))
+                       | inr x, inr z => inr (x, z)
+                       end in
+                match xz with
+                | inl (x, z) => inl (App (App (App (Ident idc) x) (expr.reify y)) z)
+                | inr (x, z) => inr (F x y z)
+                end.
+        Let defaulted_App_pp_p {A B C} (idc : ident (A -> B -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp var) C)
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x y
+             => let xy
+                    := match x, y with
+                       | inl x, inl y => inl (x, y)
+                       | inr x, inl y => inl (expr.reify (unprestep x), y)
+                       | inl x, inr y => inl (x, expr.reify (unprestep y))
+                       | inr x, inr y => inr (x, y)
+                       end in
+                match xy with
+                | inl (x, y) => inl (App (App (Ident idc) x) y)
+                | inr (x, y) => inr (F x y)
+                end.
+        Let defaulted_App_pp_p_or_pe_e_or_ep_e {A B C} (idc : ident (A -> B -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp var) C)
+            (F1 : interp_prestep (interp var) A
+                 -> @expr var B
+                 -> option (@expr var C + interp_prestep (interp var) C))
+            (F2 : @expr var A
+                 -> interp_prestep (interp var) B
+                 -> option (@expr var C + interp_prestep (interp var) C))
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x y
+             => let default := defaulted_App_pp_p idc F x y in
+                match x, y with
+                | inl x, inl y => inl (App (App (Ident idc) x) y)
+                | inl x, inr y => match F2 x y with
+                                  | Some Fxy => Fxy
+                                  | None => default
+                                  end
+                | inr x, inl y => match F1 x y with
+                                  | Some Fxy => Fxy
+                                  | None => default
+                                  end
+                | inr x, inr y => inr (F x y)
+                end.
+        Let defaulted_App_pp_p_or_pe_e_comm {A C} (idc : ident (A -> A -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) A
+                 -> interp_prestep (interp var) C)
+            (F1 : interp_prestep (interp var) A
+                 -> @expr var A
+                 -> option (@expr var C + interp_prestep (interp var) C))
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var A + interp_prestep (interp var) A
+            -> @expr var C + interp_prestep (interp var) C
+          := defaulted_App_pp_p_or_pe_e_or_ep_e
+               idc
+               F
+               F1
+               (fun x y => F1 y x).
+        Let defaulted_App_epp_e {A B C D} (idc : ident (A -> B -> C -> D))
+            (F : interp var A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp var) C
+                 -> interp var D)
+          : interp var A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + interp_prestep (interp var) C
+            -> interp var D
+          := fun x y z
+             => let yz
+                    := match y, z with
+                       | inl y, inl z => inl (y, z)
+                       | inr y, inl z => inl (expr.reify (unprestep y), z)
+                       | inl y, inr z => inl (y, expr.reify (unprestep z))
+                       | inr y, inr z => inr (y, z)
+                       end in
+                match yz with
+                | inl (y, z) => expr.reflect (App (App (App (Ident idc) (expr.reify x)) y) z)
+                | inr (y, z) => F x y z
+                end.
+        Let defaulted_App_pp_p2 {A B C} (idc : ident (A -> B -> C))
+            (F : interp_prestep (interp var) A
+                 -> interp_prestep (interp var) B
+                 -> interp_prestep (interp_prestep (interp var)) C)
+          : @expr var A + interp_prestep (interp var) A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + match C with
+                             | type.arrow s d => interp_prestep (interp_prestep (interp var)) C
+                             | C => interp_prestep (interp var) C
+                             end
+          := fun x y
+             => let xy
+                    := match x, y with
+                       | inl x, inl y => inl (x, y)
+                       | inr x, inl y => inl (expr.reify (unprestep x), y)
+                       | inl x, inr y => inl (x, expr.reify (unprestep y))
+                       | inr x, inr y => inr (x, y)
+                       end in
+                match xy with
+                | inl (x, y) => inl (App (App (Ident idc) x) y)
+                | inr (x, y) => inr (unprestep2 (F x y))
+                end.
+        Let defaulted_App_ep_p2o {A B C} (idc : ident (A -> B -> C))
+            (F : interp var A
+                 -> interp_prestep (interp var) B
+                 -> option (interp_prestep (interp_prestep (interp var)) C))
+          : interp var A
+            -> @expr var B + interp_prestep (interp var) B
+            -> @expr var C + match C with
+                             | type.arrow s d => interp_prestep (interp_prestep (interp var)) C
+                             | C => interp_prestep (interp var) C
+                             end
+          := fun x y
+             => match y with
+                | inl y => inl (App (App (Ident idc) (expr.reify x)) y)
+                | inr y
+                  => match F x y with
+                     | Some Fxy => inr (unprestep2 Fxy)
+                     | None
+                       => inl (App (App (Ident idc) (expr.reify x)) (expr.reify (unprestep y)))
+                     end
+                end.
 
-        Local Notation defaulted_App idc args F
-          := (Controlled.defaulted_App (Ident idc) args F).
+
+
+        Let defaulted_App_ee_p {A B C} (idc : ident (A -> B -> C))
+            (F : interp var A
+                 -> interp var B
+                 -> interp_prestep (interp var) C)
+          : interp var A
+            -> interp var B
+            -> @expr var C + interp_prestep (interp var) C
+          := fun x y => inr (F x y).
 
         Definition interp {t} (idc : ident t) : interp var t
           := match idc in ident t return interp var t with
@@ -1014,19 +1095,18 @@ Module Compilers.
              | ident.nil t
                => inr (@nil (interp var t))
              | ident.cons t as idc
-               => defaulted_App idc (0->1->!1) (@cons (interp var t))
+               => defaulted_App_ep_p idc (@cons (interp var t))
              | ident.pair A B as idc
-               => defaulted_App idc (0->0->!1) (@pair (interp var A) (interp var B))
+               => defaulted_App_ee_p idc (@pair (interp var A) (interp var B))
              | ident.fst A B as idc
-               => defaulted_App idc (1->!0) (@fst (interp var A) (interp var B))
+               => defaulted_App_p_e idc (@fst (interp var A) (interp var B))
              | ident.snd A B as idc
-               => defaulted_App idc (1->!0) (@snd (interp var A) (interp var B))
+               => defaulted_App_p_e idc (@snd (interp var A) (interp var B))
              | ident.bool_rect T as idc
-               => defaulted_App idc (0->0->1->!0) (@bool_rect (fun _ => interp var T))
+               => defaulted_App_eep_e idc (@bool_rect (fun _ => interp var T))
              | ident.nat_rect P as idc
-               => defaulted_App
+               => defaulted_App_eep_e
                     idc
-                    (0->0->1->!0)
                     (fun O_case S_case n
                      => @nat_rect
                           (fun _ => interp var P)
@@ -1034,91 +1114,77 @@ Module Compilers.
                           (fun n' => S_case (inr n'))
                           n)
              | ident.List_seq as idc
-               => defaulted_App idc (1->1->!2) List.seq
+               => defaulted_App_pp_p2 idc List.seq
              | ident.List_repeat A as idc
-               => defaulted_App idc (0->1->!1) (@List.repeat (interp var A))
+               => defaulted_App_ep_p idc (@List.repeat (interp var A))
              | ident.List_combine A B as idc
-               => defaulted_App idc (1->1->!2) (@List.combine (interp var A) (interp var B))
+               => defaulted_App_pp_p2 idc (@List.combine (interp var A) (interp var B))
              | ident.List_map A B as idc
-               => defaulted_App idc (0->1->!1) (@List.map (interp var A) (interp var B))
+               => defaulted_App_ep_p idc (@List.map (interp var A) (interp var B))
              | ident.List_flat_map A B as idc
-               => defaulted_App
-                    idc (0->1->!0)
-                    (fun (f : interp var A -> expr (type.list B) + list (interp var B))
-                         (ls : list (interp var A))
-                     => match option_flat_map
-                                (fun x => match f x with
-                                          | inl _ => None
-                                          | inr v => Some v
-                                          end)
-                                ls
-                              return expr (type.list B) + list (interp var B)
-                        with
-                        | Some res => inr res
-                        | None
-                          => let ls'
-                                 := List.map
-                                      (fun x => match f x with
-                                                | inl e => e
-                                                | inr v => reify_list (List.map expr.reify v)
-                                                end)
-                                      ls in
-                             inl (reify_list_by_app ls')
-                        end)
+               => fun (f : interp var A -> expr (type.list B) + list (interp var B))
+                      (ls : expr (type.list A) + list (interp var A))
+                  => match ls return expr (type.list B) + list (interp var B) with
+                     | inl lse
+                       => inl (App (App (Ident idc) (expr.reify (t:=A->type.list B) f)) lse)
+                     | inr ls
+                       => match option_flat_map
+                                  (fun x => match f x with
+                                            | inl _ => None
+                                            | inr v => Some v
+                                            end)
+                                  ls
+                          with
+                          | Some res => inr res
+                          | None
+                            => let ls'
+                                   := List.map
+                                        (fun x => match f x with
+                                                  | inl e => e
+                                                  | inr v => reify_list (List.map expr.reify v)
+                                                  end)
+                                        ls in
+                               inl (reify_list_by_app ls')
+                          end
+                     end
              | ident.List_partition A as idc
-               => defaulted_App
-                    idc (0->1->Controlled.optionally (!2))
+               => defaulted_App_ep_p2o
+                    idc
                     (fun f => option_partition (fun x => match f x with
                                                          | inl _ => None
                                                          | inr b => Some b
                                                          end))
              | ident.List_app A as idc
-               => defaulted_App idc (1->1->!1) (@List.app (interp var A))
+               => defaulted_App_pp_p idc (@List.app (interp var A))
              | ident.List_rev A as idc
-               => defaulted_App idc (1->!1) (@List.rev (interp var A))
+               => defaulted_App_p_p idc (@List.rev (interp var A))
              | ident.List_fold_right A B as idc
-               => defaulted_App idc (0->0->1->!0) (@List.fold_right (interp var A) (interp var B))
+               => defaulted_App_eep_e idc (@List.fold_right (interp var A) (interp var B))
              | ident.List_update_nth T as idc
-               => defaulted_App idc (1->0->1->!1) (@update_nth (interp var T))
+               => defaulted_App_pep_p idc (@update_nth (interp var T))
              | ident.List_nth_default T as idc
-               => defaulted_App idc (0->1->1->!0) (@List.nth_default (interp var T))
+               => defaulted_App_epp_e idc (@List.nth_default (interp var T))
              | ident.pred as idc
              | ident.S as idc
              | ident.Z_of_nat as idc
              | ident.Z_opp as idc
-               => defaulted_App idc (1->!1) (ident.interp idc)
+               => defaulted_App_p_p idc (ident.interp idc)
              | ident.Z_runtime_mul as idc
-               => defaulted_App
-                    idc
-                    (0 -> 0 -> Controlled.optionally (!0))
-                    (fun x y
-                     => match x, y with
-                        | inr x, inr y
-                          => Some (inr (ident.interp idc x y))
-                        | inr x, inl y
-                        | inl y, inr x
-                          => if Z.eqb x 0
-                             then Some (inr 0%Z)
-                             else if Z.eqb x 1
-                                  then Some (inl y)
-                                  else None
-                        | inl x, inl y => None
-                        end)
+               => defaulted_App_pp_p_or_pe_e_comm
+                    idc (ident.interp idc)
+                    (fun x e
+                     => if Z.eqb x 0
+                        then Some (inr 0%Z)
+                        else if Z.eqb x 1
+                             then Some (inl e)
+                             else None)
              | ident.Z_runtime_add as idc
-               => defaulted_App
-                    idc
-                    (0 -> 0 -> Controlled.optionally (!0))
-                    (fun x y
-                     => match x, y with
-                        | inr x, inr y
-                          => Some (inr (ident.interp idc x y))
-                        | inr x, inl y
-                        | inl y, inr x
-                          => if Z.eqb x 0
-                             then Some (inl y)
-                             else None
-                        | inl x, inl y => None
-                        end)
+               => defaulted_App_pp_p_or_pe_e_comm
+                    idc (ident.interp idc)
+                    (fun x e
+                     => if Z.eqb x 0
+                        then Some (inl e)
+                        else None)
              | ident.Z_add as idc
              | ident.Z_mul as idc
              | ident.Z_pow as idc
@@ -1126,7 +1192,7 @@ Module Compilers.
              | ident.Z_modulo as idc
              | ident.Z_eqb as idc
              | ident.Nat_sub as idc
-               => defaulted_App idc (1->1->!1) (ident.interp idc)
+               => defaulted_App_pp_p idc (ident.interp idc)
              end.
       End interp.
     End ident.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -708,17 +708,19 @@ Module Compilers.
     (** TODO: pick a better name for this (partial_expr?) *)
     Section interp.
       Context (var : type -> Type).
-      Definition interp_prestep (interp : type -> Type) (t : type)
+      Definition interp_prestep_gen (interp_dom interp_cod : type -> Type) (t : type)
         := match t return Type with
-           | type.prod A B as t => interp A * interp B
-           | type.arrow s d => interp s -> interp d
-           | type.list A => list (interp A)
+           | type.prod A B as t => interp_cod A * interp_cod B
+           | type.arrow s d => interp_dom s -> interp_cod d
+           | type.list A => list (interp_cod A)
            | type.unit as t
            | type.Z as t
            | type.nat as t
            | type.bool as t
              => type.interp t
            end%type.
+      Definition interp_prestep (interp : type -> Type) (t : type)
+        := interp_prestep_gen interp interp t.
       Definition interp_step (interp : type -> Type) (t : type)
         := match t return Type with
            | type.unit as t
@@ -734,47 +736,75 @@ Module Compilers.
       Fixpoint interp (t : type)
         := interp_step interp t.
 
-      Definition unprestep {t : type} : interp_prestep interp t -> interp t
-        := match t return interp_prestep interp t -> interp t with
-           | type.unit as t
-           | type.arrow _ _ as t
+      Fixpoint interp_prestepn (n : nat) : type -> Type
+        := match n with
+           | O => interp
+           | S n' => interp_prestep_gen
+                       interp
+                       (interp_prestepn n')
+           end.
+
+      Definition lift_interp_prestep_gen
+                 {interp_dom1 interp_dom2 interp_cod1 interp_cod2 : type -> Type}
+                 (f_dom : forall A, interp_dom2 A -> interp_dom1 A)
+                 (f_cod : forall A, interp_cod1 A -> interp_cod2 A)
+                 {t : type}
+        : interp_prestep_gen interp_dom1 interp_cod1 t
+          -> interp_prestep_gen interp_dom2 interp_cod2 t
+        := match t return interp_prestep_gen interp_dom1 interp_cod1 t
+                          -> interp_prestep_gen interp_dom2 interp_cod2 t with
+           | type.prod A B
+             => fun '((a, b) : interp_cod1 A * interp_cod1 B)
+                => (f_cod A a, f_cod B b)
+           | type.arrow s d => fun f x => f_cod d (f (f_dom s x))
+           | type.list A
+             => List.map (f_cod A)
+           | type.unit
+           | type.nat
+           | type.Z
+           | type.bool
+             => id
+           end.
+
+      Definition uninterp_prestep_gen
+                 {interp_dom1 interp_cod1 : type -> Type}
+                 (f_dom : forall A, interp A -> interp_dom1 A)
+                 (f_cod : forall A, interp_cod1 A -> interp A)
+                 {t : type}
+        : interp_prestep_gen interp_dom1 interp_cod1 t
+          -> interp t
+        := match t return interp_prestep_gen interp_dom1 interp_cod1 t
+                          -> interp t with
+           | type.arrow s d
+             => fun f (x : interp s)
+                => f_cod d (f (f_dom s x))
+           | type.unit
              => id
            | type.prod _ _ as t
            | type.list _ as t
-           | type.Z as t
            | type.nat as t
+           | type.Z as t
            | type.bool as t
-             => @inr _ (interp_prestep interp t)
-           end%type.
+             => fun x => @inr (expr t) (interp_prestep interp t)
+                              (lift_interp_prestep_gen f_dom f_cod x)
+           end.
 
-      Definition unprestep2 {t : type}
-        : interp_prestep (interp_prestep interp) t
-          -> match t with
-             | type.arrow _ _ => interp_prestep (interp_prestep interp) t
-             | t => interp_prestep interp t
-             end
-        := match t
-                 return (interp_prestep (interp_prestep interp) t
-                         -> match t with
-                            | type.arrow _ _ => interp_prestep (interp_prestep interp) t
-                            | t => interp_prestep interp t
-                            end)
-           with
-           | type.prod A B
-             => fun '((a, b) : interp_prestep interp A * interp_prestep interp B)
-                => (@unprestep A a, @unprestep B b)
-           | type.list A as t
-             => List.map (@unprestep A)
-           | type.arrow _ _ as t
-           | type.unit as t
-           | type.Z as t
-           | type.nat as t
-           | type.bool as t
-             => id
-           end%type.
+        Fixpoint unprestepn {n : nat} : forall {t : type}, interp_prestepn n t -> interp t
+          := match n return forall t, interp_prestepn n t -> interp t with
+             | O => fun t v => v
+             | S n'
+               => @uninterp_prestep_gen
+                    interp (@interp_prestepn n')
+                    (fun _ => id)
+                    (@unprestepn n')
+             end.
+
+        Definition unprestep {t : type} : interp_prestep interp t -> interp t
+          := @unprestepn 1 t.
     End interp.
     Arguments unprestep {var t} _.
-    Arguments unprestep2 {var t} _.
+    Arguments uninterp_prestep_gen {var _ _} _ _ {t} _.
+    Arguments unprestepn {var n t} _.
 
     Notation expr_const := const.
 
@@ -886,6 +916,100 @@ Module Compilers.
       End SmartLetIn.
     End expr.
 
+    Module Controlled.
+      Inductive arguments : type -> Set :=
+      | evaluated {T} (n : nat) : arguments T
+      | optionally {T} (a : arguments T) : arguments T
+      | arrow {s d} (sn : nat) (da : arguments d) : arguments (type.arrow s d).
+
+      Module Export Notations.
+        Bind Scope arguments_scope with arguments.
+        Delimit Scope arguments_scope with arguments.
+        Notation "!" := (@evaluated _) : arguments_scope.
+        Notation "a -> b" := (@arrow _ _ a%nat b%arguments) : arguments_scope.
+      End Notations.
+
+      Section with_var.
+        Context (var : type -> Type).
+
+        Fixpoint preinterp_in {t : type} (a : arguments t) : Type
+          := match a return Type with
+             | evaluated T n
+               => interp_prestepn var n T
+             | optionally T a
+               => option (@preinterp_in T a)
+             | arrow s d n da
+               => interp_prestepn var n s -> @preinterp_in d da
+             end.
+
+        Fixpoint preinterp_out {t : type} (a : arguments t) : Type
+          := match a return Type with
+             | evaluated T O
+               => interp var T
+             | evaluated T n
+               => @expr var T + interp_prestep (interp var) T
+             | optionally T a
+               => @preinterp_out T a
+             | arrow s d O da
+               => interp var s
+                  -> @preinterp_out d da
+             | arrow s d n da
+               => (@expr var s + interp_prestepn var n s)
+                  -> @preinterp_out d da
+             end.
+
+        Fixpoint out_expr {t} {a : arguments t} : @expr var t -> preinterp_out a
+          := match a in arguments t return expr t -> preinterp_out a with
+             | evaluated T O
+               => expr.reflect
+             | evaluated T n
+               => inl
+             | optionally T a
+               => @out_expr T a
+             | arrow s d O da
+               => fun e x
+                  => @out_expr d da (App e (expr.reify x))
+             | arrow s d sa da
+               => fun e x
+                  => @out_expr
+                       d da (App e match x with
+                                   | inl xe => xe
+                                   | inr xi => expr.reify (unprestepn xi)
+                                   end)
+             end.
+
+        Fixpoint defaulted_App {t} (default : @expr var t) (a : arguments t)
+          : preinterp_in a -> preinterp_out a
+          := match a in arguments t return expr t -> preinterp_in a -> preinterp_out a with
+             | evaluated T O => fun _ => id
+             | evaluated T n
+               => fun _ x => inr (@lift_interp_prestep_gen
+                                    (interp var) (interp var) (interp_prestepn var _) (interp var)
+                                    (fun _ => id)
+                                    (@unprestepn _ _)
+                                    _
+                                    x)
+             | optionally T a
+               => fun default (v : option (preinterp_in a))
+                  => match v with
+                     | Some v => @defaulted_App T default a v
+                     | None => out_expr default
+                     end
+             | arrow s d O da
+               => fun e F x
+                  => @defaulted_App d (App e (expr.reify x)) da (F x)
+             | arrow s d sa da
+               => fun e F x
+                  => match x return preinterp_out da with
+                     | inl xe => out_expr (App e xe)
+                     | inr xi => @defaulted_App d (App e (expr.reify (unprestepn xi))) da (F xi)
+                     end
+             end default.
+      End with_var.
+      Arguments defaulted_App {var t} _ _ _.
+    End Controlled.
+    Export Controlled.Notations.
+
     Definition sum_arrow {A A' B B'} (f : A -> A') (g : B -> B')
                (v : A + B)
       : A' + B'
@@ -898,214 +1022,9 @@ Module Compilers.
     Module ident.
       Section interp.
         Context {var : type -> Type}.
-        Let defaulted_App_p_e {A B} (idc : ident (A -> B))
-            (F : interp_prestep (interp var) A
-                 -> interp var B)
-          : @expr var A + interp_prestep (interp var) A
-            -> interp var B
-          := fun x
-             => match x with
-                | inl e => expr.reflect (App (Ident idc) e)
-                | inr x => F x
-                end.
-        Let defaulted_App_p_p {A B} (idc : ident (A -> B))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) B)
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var B + interp_prestep (interp var) B
-          := (App (Ident idc) + F)%function.
-        Let defaulted_App_ep_p {A B C} (idc : ident (A -> B -> C))
-            (F : interp var A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp var) C)
-          : interp var A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x
-             => (App (App (Ident idc) (expr.reify x))
-                 + (F x))%function.
-        Let defaulted_App_eep_e {A B C D} (idc : ident (A -> B -> C -> D))
-            (F : interp var A
-                 -> interp var B
-                 -> interp_prestep (interp var) C
-                 -> interp var D)
-          : interp var A
-            -> interp var B
-            -> @expr var C + interp_prestep (interp var) C
-            -> interp var D
-          := fun x y z
-             => match z with
-                | inl z => expr.reflect (App (App (App (Ident idc) (expr.reify x)) (expr.reify y)) z)
-                | inr z => F x y z
-                end.
-        Let defaulted_App_pe_p {A B C} (idc : ident (A -> B -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp var B
-                 -> interp_prestep (interp var) C)
-          : @expr var A + interp_prestep (interp var) A
-            -> interp var B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x y
-             => match x with
-                | inl x => inl (App (App (Ident idc) x) (expr.reify y))
-                | inr x => inr (F x y)
-                end.
-        Let defaulted_App_pep_p {A B C D} (idc : ident (A -> B -> C -> D))
-            (F : interp_prestep (interp var) A
-                 -> interp var B
-                 -> interp_prestep (interp var) C
-                 -> interp_prestep (interp var) D)
-          : @expr var A + interp_prestep (interp var) A
-            -> interp var B
-            -> @expr var C + interp_prestep (interp var) C
-            -> @expr var D + interp_prestep (interp var) D
-          := fun x y z
-             => let xz
-                    := match x, z with
-                       | inl x, inl z => inl (x, z)
-                       | inr x, inl z => inl (expr.reify (unprestep x), z)
-                       | inl x, inr z => inl (x, expr.reify (unprestep z))
-                       | inr x, inr z => inr (x, z)
-                       end in
-                match xz with
-                | inl (x, z) => inl (App (App (App (Ident idc) x) (expr.reify y)) z)
-                | inr (x, z) => inr (F x y z)
-                end.
-        Let defaulted_App_pp_p {A B C} (idc : ident (A -> B -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp var) C)
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x y
-             => let xy
-                    := match x, y with
-                       | inl x, inl y => inl (x, y)
-                       | inr x, inl y => inl (expr.reify (unprestep x), y)
-                       | inl x, inr y => inl (x, expr.reify (unprestep y))
-                       | inr x, inr y => inr (x, y)
-                       end in
-                match xy with
-                | inl (x, y) => inl (App (App (Ident idc) x) y)
-                | inr (x, y) => inr (F x y)
-                end.
-        Let defaulted_App_pp_p_or_pe_e_or_ep_e {A B C} (idc : ident (A -> B -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp var) C)
-            (F1 : interp_prestep (interp var) A
-                 -> @expr var B
-                 -> option (@expr var C + interp_prestep (interp var) C))
-            (F2 : @expr var A
-                 -> interp_prestep (interp var) B
-                 -> option (@expr var C + interp_prestep (interp var) C))
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x y
-             => let default := defaulted_App_pp_p idc F x y in
-                match x, y with
-                | inl x, inl y => inl (App (App (Ident idc) x) y)
-                | inl x, inr y => match F2 x y with
-                                  | Some Fxy => Fxy
-                                  | None => default
-                                  end
-                | inr x, inl y => match F1 x y with
-                                  | Some Fxy => Fxy
-                                  | None => default
-                                  end
-                | inr x, inr y => inr (F x y)
-                end.
-        Let defaulted_App_pp_p_or_pe_e_comm {A C} (idc : ident (A -> A -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) A
-                 -> interp_prestep (interp var) C)
-            (F1 : interp_prestep (interp var) A
-                 -> @expr var A
-                 -> option (@expr var C + interp_prestep (interp var) C))
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var A + interp_prestep (interp var) A
-            -> @expr var C + interp_prestep (interp var) C
-          := defaulted_App_pp_p_or_pe_e_or_ep_e
-               idc
-               F
-               F1
-               (fun x y => F1 y x).
-        Let defaulted_App_epp_e {A B C D} (idc : ident (A -> B -> C -> D))
-            (F : interp var A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp var) C
-                 -> interp var D)
-          : interp var A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + interp_prestep (interp var) C
-            -> interp var D
-          := fun x y z
-             => let yz
-                    := match y, z with
-                       | inl y, inl z => inl (y, z)
-                       | inr y, inl z => inl (expr.reify (unprestep y), z)
-                       | inl y, inr z => inl (y, expr.reify (unprestep z))
-                       | inr y, inr z => inr (y, z)
-                       end in
-                match yz with
-                | inl (y, z) => expr.reflect (App (App (App (Ident idc) (expr.reify x)) y) z)
-                | inr (y, z) => F x y z
-                end.
-        Let defaulted_App_pp_p2 {A B C} (idc : ident (A -> B -> C))
-            (F : interp_prestep (interp var) A
-                 -> interp_prestep (interp var) B
-                 -> interp_prestep (interp_prestep (interp var)) C)
-          : @expr var A + interp_prestep (interp var) A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + match C with
-                             | type.arrow s d => interp_prestep (interp_prestep (interp var)) C
-                             | C => interp_prestep (interp var) C
-                             end
-          := fun x y
-             => let xy
-                    := match x, y with
-                       | inl x, inl y => inl (x, y)
-                       | inr x, inl y => inl (expr.reify (unprestep x), y)
-                       | inl x, inr y => inl (x, expr.reify (unprestep y))
-                       | inr x, inr y => inr (x, y)
-                       end in
-                match xy with
-                | inl (x, y) => inl (App (App (Ident idc) x) y)
-                | inr (x, y) => inr (unprestep2 (F x y))
-                end.
-        Let defaulted_App_ep_p2o {A B C} (idc : ident (A -> B -> C))
-            (F : interp var A
-                 -> interp_prestep (interp var) B
-                 -> option (interp_prestep (interp_prestep (interp var)) C))
-          : interp var A
-            -> @expr var B + interp_prestep (interp var) B
-            -> @expr var C + match C with
-                             | type.arrow s d => interp_prestep (interp_prestep (interp var)) C
-                             | C => interp_prestep (interp var) C
-                             end
-          := fun x y
-             => match y with
-                | inl y => inl (App (App (Ident idc) (expr.reify x)) y)
-                | inr y
-                  => match F x y with
-                     | Some Fxy => inr (unprestep2 Fxy)
-                     | None
-                       => inl (App (App (Ident idc) (expr.reify x)) (expr.reify (unprestep y)))
-                     end
-                end.
 
-
-
-        Let defaulted_App_ee_p {A B C} (idc : ident (A -> B -> C))
-            (F : interp var A
-                 -> interp var B
-                 -> interp_prestep (interp var) C)
-          : interp var A
-            -> interp var B
-            -> @expr var C + interp_prestep (interp var) C
-          := fun x y => inr (F x y).
+        Local Notation defaulted_App idc args F
+          := (Controlled.defaulted_App (Ident idc) args F).
 
         Definition interp {t} (idc : ident t) : interp var t
           := match idc in ident t return interp var t with
@@ -1116,18 +1035,19 @@ Module Compilers.
              | ident.nil t
                => inr (@nil (interp var t))
              | ident.cons t as idc
-               => defaulted_App_ep_p idc (@cons (interp var t))
+               => defaulted_App idc (0->1->!1) (@cons (interp var t))
              | ident.pair A B as idc
-               => defaulted_App_ee_p idc (@pair (interp var A) (interp var B))
+               => defaulted_App idc (0->0->!1) (@pair (interp var A) (interp var B))
              | ident.fst A B as idc
-               => defaulted_App_p_e idc (@fst (interp var A) (interp var B))
+               => defaulted_App idc (1->!0) (@fst (interp var A) (interp var B))
              | ident.snd A B as idc
-               => defaulted_App_p_e idc (@snd (interp var A) (interp var B))
+               => defaulted_App idc (1->!0) (@snd (interp var A) (interp var B))
              | ident.bool_rect T as idc
-               => defaulted_App_eep_e idc (@bool_rect (fun _ => interp var T))
+               => defaulted_App idc (0->0->1->!0) (@bool_rect (fun _ => interp var T))
              | ident.nat_rect P as idc
-               => defaulted_App_eep_e
+               => defaulted_App
                     idc
+                    (0->0->1->!0)
                     (fun O_case S_case n
                      => @nat_rect
                           (fun _ => interp var P)
@@ -1135,77 +1055,91 @@ Module Compilers.
                           (fun n' => S_case (inr n'))
                           n)
              | ident.List_seq as idc
-               => defaulted_App_pp_p2 idc List.seq
+               => defaulted_App idc (1->1->!2) List.seq
              | ident.List_repeat A as idc
-               => defaulted_App_ep_p idc (@List.repeat (interp var A))
+               => defaulted_App idc (0->1->!1) (@List.repeat (interp var A))
              | ident.List_combine A B as idc
-               => defaulted_App_pp_p2 idc (@List.combine (interp var A) (interp var B))
+               => defaulted_App idc (1->1->!2) (@List.combine (interp var A) (interp var B))
              | ident.List_map A B as idc
-               => defaulted_App_ep_p idc (@List.map (interp var A) (interp var B))
+               => defaulted_App idc (0->1->!1) (@List.map (interp var A) (interp var B))
              | ident.List_flat_map A B as idc
-               => fun (f : interp var A -> expr (type.list B) + list (interp var B))
-                      (ls : expr (type.list A) + list (interp var A))
-                  => match ls return expr (type.list B) + list (interp var B) with
-                     | inl lse
-                       => inl (App (App (Ident idc) (expr.reify (t:=A->type.list B) f)) lse)
-                     | inr ls
-                       => match option_flat_map
-                                  (fun x => match f x with
-                                            | inl _ => None
-                                            | inr v => Some v
-                                            end)
-                                  ls
-                          with
-                          | Some res => inr res
-                          | None
-                            => let ls'
-                                   := List.map
-                                        (fun x => match f x with
-                                                  | inl e => e
-                                                  | inr v => reify_list (List.map expr.reify v)
-                                                  end)
-                                        ls in
-                               inl (reify_list_by_app ls')
-                          end
-                     end
+               => defaulted_App
+                    idc (0->1->!0)
+                    (fun (f : interp var A -> expr (type.list B) + list (interp var B))
+                         (ls : list (interp var A))
+                     => match option_flat_map
+                                (fun x => match f x with
+                                          | inl _ => None
+                                          | inr v => Some v
+                                          end)
+                                ls
+                              return expr (type.list B) + list (interp var B)
+                        with
+                        | Some res => inr res
+                        | None
+                          => let ls'
+                                 := List.map
+                                      (fun x => match f x with
+                                                | inl e => e
+                                                | inr v => reify_list (List.map expr.reify v)
+                                                end)
+                                      ls in
+                             inl (reify_list_by_app ls')
+                        end)
              | ident.List_partition A as idc
-               => defaulted_App_ep_p2o
-                    idc
+               => defaulted_App
+                    idc (0->1->Controlled.optionally (!2))
                     (fun f => option_partition (fun x => match f x with
                                                          | inl _ => None
                                                          | inr b => Some b
                                                          end))
              | ident.List_app A as idc
-               => defaulted_App_pp_p idc (@List.app (interp var A))
+               => defaulted_App idc (1->1->!1) (@List.app (interp var A))
              | ident.List_rev A as idc
-               => defaulted_App_p_p idc (@List.rev (interp var A))
+               => defaulted_App idc (1->!1) (@List.rev (interp var A))
              | ident.List_fold_right A B as idc
-               => defaulted_App_eep_e idc (@List.fold_right (interp var A) (interp var B))
+               => defaulted_App idc (0->0->1->!0) (@List.fold_right (interp var A) (interp var B))
              | ident.List_update_nth T as idc
-               => defaulted_App_pep_p idc (@update_nth (interp var T))
+               => defaulted_App idc (1->0->1->!1) (@update_nth (interp var T))
              | ident.List_nth_default T as idc
-               => defaulted_App_epp_e idc (@List.nth_default (interp var T))
+               => defaulted_App idc (0->1->1->!0) (@List.nth_default (interp var T))
              | ident.pred as idc
              | ident.S as idc
              | ident.Z_of_nat as idc
              | ident.Z_opp as idc
-               => defaulted_App_p_p idc (ident.interp idc)
+               => defaulted_App idc (1->!1) (ident.interp idc)
              | ident.Z_runtime_mul as idc
-               => defaulted_App_pp_p_or_pe_e_comm
-                    idc (ident.interp idc)
-                    (fun x e
-                     => if Z.eqb x 0
-                        then Some (inr 0%Z)
-                        else if Z.eqb x 1
-                             then Some (inl e)
-                             else None)
+               => defaulted_App
+                    idc
+                    (0 -> 0 -> Controlled.optionally (!0))
+                    (fun x y
+                     => match x, y with
+                        | inr x, inr y
+                          => Some (inr (ident.interp idc x y))
+                        | inr x, inl y
+                        | inl y, inr x
+                          => if Z.eqb x 0
+                             then Some (inr 0%Z)
+                             else if Z.eqb x 1
+                                  then Some (inl y)
+                                  else None
+                        | inl x, inl y => None
+                        end)
              | ident.Z_runtime_add as idc
-               => defaulted_App_pp_p_or_pe_e_comm
-                    idc (ident.interp idc)
-                    (fun x e
-                     => if Z.eqb x 0
-                        then Some (inl e)
-                        else None)
+               => defaulted_App
+                    idc
+                    (0 -> 0 -> Controlled.optionally (!0))
+                    (fun x y
+                     => match x, y with
+                        | inr x, inr y
+                          => Some (inr (ident.interp idc x y))
+                        | inr x, inl y
+                        | inl y, inr x
+                          => if Z.eqb x 0
+                             then Some (inl y)
+                             else None
+                        | inl x, inl y => None
+                        end)
              | ident.Z_add as idc
              | ident.Z_mul as idc
              | ident.Z_pow as idc
@@ -1213,7 +1147,7 @@ Module Compilers.
              | ident.Z_modulo as idc
              | ident.Z_eqb as idc
              | ident.Nat_sub as idc
-               => defaulted_App_pp_p idc (ident.interp idc)
+               => defaulted_App idc (1->1->!1) (ident.interp idc)
              end.
       End interp.
     End ident.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -451,6 +451,590 @@ Module Compilers.
 
   Definition Interp {t} (e : Expr t) := interp (e _).
 
+  Definition const {var t} (v : type.interp t) : @expr var t
+    := Op (op.Const v) TT.
+
+  Section option_partition.
+    Context {A : Type} (f : A -> option Datatypes.bool).
+    Fixpoint option_partition (l : list A) : option (list A * list A)
+      := match l with
+         | nil => Some (nil, nil)
+         | cons x tl
+           => match option_partition tl, f x with
+              | Some (g, d), Some fx
+                => Some (if fx then (x :: g, d) else (g, x :: d))
+              | _, _ => None
+              end
+         end.
+  End option_partition.
+  Section option_flat_map.
+    Context {A B : Type} (f : A -> option (list B)).
+    Fixpoint option_flat_map (l : list A) : option (list B)
+      := match l with
+         | nil => Some nil
+         | cons x t => match f x, option_flat_map t with
+                       | Some fx, Some ft
+                         => Some (fx ++ ft)
+                       | _, _ => None
+                       end
+         end.
+  End option_flat_map.
+
+  Definition lift_option_list {A} (ls : list (option A)) : option (list A)
+    := list_rect
+         (fun _ => _)
+         (Some nil)
+         (fun x _ xs
+          => match x, xs with
+             | Some x, Some xs => Some (cons x xs)
+             | _, _ => None
+             end)
+         ls.
+
+  Section invert.
+    Context {var : type -> Type}.
+
+    Definition invert_Var {t} (e : @expr var t) : option (var t)
+      := match e with
+         | Var t v => Some v
+         | _ => None
+         end.
+
+    Definition invert_Abs {s d} (e : @expr var (type.arrow s d)) : option (var s -> @expr var d)
+      := match e in expr t return option match t with
+                                         | type.arrow _ _ => _
+                                         | _ => True
+                                         end with
+         | Abs s d f => Some f
+         | _ => None
+         end.
+
+    Definition invert_Pair {A B} (e : @expr var (type.prod A B)) : option (@expr var A * @expr var B)
+      := match e in expr t return option match t with
+                                         | type.prod _ _ => _
+                                         | _ => True
+                                         end with
+         | Pair _ _ a b => Some (a, b)
+         | _ => None
+         end.
+
+    Definition invert_Op {t} (e : @expr var t) : option { s : _ & op s t * @expr var s }%type
+      := match e with
+         | Op s d opc args => Some (existT _ s (opc, args))
+         | _ => None
+         end.
+
+    Definition invert_OpConst {t} (e : @expr var t) : option (type.interp t)
+      := match invert_Op e with
+         | Some (existT s (opc, args))
+           => match opc with
+              | op.Const t v => Some v
+              | _ => None
+              end
+         | None => None
+         end.
+
+    Definition invert_op_S (e : @expr var type.nat) : option (@expr var type.nat)
+      := match invert_Op e with
+         | Some (existT s (opc, args))
+           => match opc in op s d return expr s -> option (expr type.nat) with
+              | op.S => fun args => Some args
+              | _ => fun _ => None
+              end args
+         | None => None
+         end.
+
+    Definition invert_Z (e : @expr var type.Z) : option Z := invert_OpConst e.
+    Definition invert_bool (e : @expr var type.bool) : option bool := invert_OpConst e.
+    Fixpoint invert_nat_full (e : @expr var type.nat) : option nat
+      := match e with
+         | Op _ _ op.S args
+           => option_map S (invert_nat_full args)
+         | Op _ _ (op.Const type.nat v) _
+           => Some v
+         | _ => None
+         end.
+    (* oh, the horrors of not being able to use non-linear deep pattern matches *)
+    Fixpoint invert_list_full {t} (e : @expr var (type.list t))
+      : option (list (@expr var t))
+      := match e in expr t return option match t with
+                                         | type.list t => list (expr t)
+                                         | _ => True
+                                         end
+         with
+         | Op s d opc args
+           => match opc in op s d
+                    return option match s with
+                                  | type.prod A (type.list B) => expr A * list (expr B)
+                                  | _ => True
+                                  end
+                           -> option match d with
+                                     | type.list t => list (expr t)
+                                     | _ => True
+                                     end
+              with
+              | op.Const (type.list _) v => fun _ => Some (List.map const v)
+              | op.cons _ => option_map (fun '(x, xs) => cons x xs)
+              | op.nil _ => fun _ => Some nil
+              | _ => fun _ => None
+              end
+                (match args in expr t
+                       return option match t with
+                                     | type.prod A (type.list B) => expr A * list (expr B)
+                                     | _ => True
+                                     end
+                 with
+                 | Pair _ (type.list _) x xs
+                   => match @invert_list_full _ xs with
+                      | Some xs => Some (x, xs)
+                      | None => None
+                      end
+                 | _ => None
+                 end)
+         | _ => None
+         end.
+    (*Section with_map.
+      (* oh, the horrors of not being able to use non-linear deep
+         pattern matches.  Luckily Coq's guard checker unfolds things,
+         so as long as the thing we need to evaluate at the bottom is
+         generic in what type it's looking at, we're good.  We can
+         even give it data of the right type, which we need, but it
+         costs us a lot *)
+      Context (extra_dataT : type -> Type) {U} (f : forall t (d : extra_dataT t), @expr var t -> U t d).
+      Local Notation list_to_extra_dataT t
+        := (match t%ctype return Type with
+            | type.list t' => extra_dataT t'
+            | _ => True
+            end).
+      Local Notation list_to_forall_data_option_list t
+        := (forall (d : list_to_extra_dataT t),
+               option (match t%ctype as t'
+                             return list_to_extra_dataT t' -> Type
+                       with
+                       | type.list t' => fun d => list (U t' d)
+                       | _ => fun _ => True
+                       end d)).
+      Local Notation prod_list_to_extra_dataT t
+        := (match t%ctype return Type with
+            | type.prod _ (type.list t') => extra_dataT t'
+            | _ => True
+            end).
+      Local Notation prod_list_to_forall_data_option_list t
+        := (forall (d : prod_list_to_extra_dataT t),
+               option (match t%ctype as t'
+                             return prod_list_to_extra_dataT t' -> Type
+                       with
+                       | type.prod A (type.list t') => fun d => (expr A * list (U t' d))%type
+                       | _ => fun _ => True
+                       end d)).
+
+
+
+      Fixpoint invert_map_list_full {t} (e : @expr var (type.list t))
+        : forall d : extra_dataT t, option (list (U t d))
+      := match e in expr t return list_to_forall_data_option_list t
+           with
+           | Op s d opc args
+             => match opc in op s d
+                      return (prod_list_to_forall_data_option_list s
+                              -> list_to_forall_data_option_list d)
+                with
+                | op.Const (type.list _) v
+                  => fun _ data => Some (List.map (f _ data) (List.map const v))
+                | op.cons _
+                  => fun xs data
+                     => option_map (fun '(x, xs) => cons (f _ data x) xs) (xs data)
+                | op.nil _
+                  => fun _ _ => Some nil
+                | _ => fun _ _ => None
+                end
+                  (match args in expr t
+                         return prod_list_to_forall_data_option_list t
+                   with
+                   | Pair _ (type.list _) x xs
+                     => fun data
+                        => match @invert_map_list_full _ xs data with
+                           | Some xs => Some (x, xs)
+                           | None => None
+                           end
+                   | _ => fun _ => None
+                   end)
+           | _ => fun _ => None
+           end.
+    End with_map.*)
+  End invert.
+
+  Section gallina_reify.
+    Context {var : type -> Type}.
+    Definition reify_list {t} (ls : list (@expr var t)) : @expr var (type.list t)
+      := list_rect
+           (fun _ => _)
+           (Op op.nil TT)
+           (fun x _ xs => Op op.cons (x, xs))
+           ls.
+  End gallina_reify.
+
+
+  Module arguments.
+    Inductive arguments : type -> Set :=
+    | generic {T} : arguments T
+    (*| cps {T} (aT : arguments T) : arguments T*)
+    | arrow {A B} (aB : arguments B) : arguments (A -> B)
+    | unit : arguments type.unit
+    | prod {A B} (aA : arguments A) (aB : arguments B) : arguments (A * B)
+    | list {T} (aT : arguments T) : arguments (type.list T)
+    | nat : arguments type.nat
+    | Z : arguments type.Z
+    | bool : arguments type.bool.
+
+    Fixpoint ground {t : type} : arguments t
+      := match t with
+         | type.unit => unit
+         | type.prod A B => prod (@ground A) (@ground B)
+         | type.arrow s d => arrow (@ground d)
+         | type.list A => list (@ground A)
+         | type.nat => nat
+         | type.Z => Z
+         | type.bool => bool
+         end.
+
+    Module type.
+      Local Notation interp_type := type.interp.
+      Section interp.
+        Context (var_dom var_cod : type -> Type).
+        Fixpoint interp {t} (a : arguments t) : Type
+          := match a with
+             | generic T => var_cod T
+             (*| cps T aT => forall U, (@interp T aT -> var U) -> var U*)
+             | arrow A B aB => var_dom A -> @interp B aB
+             | unit => Datatypes.unit
+             | prod A B aA aB => @interp A aA * @interp B aB
+             | list T aT => Datatypes.list (@interp T aT)
+             | nat => Datatypes.nat
+             | Z => BinInt.Z
+             | bool => Datatypes.bool
+             end%type.
+      End interp.
+
+      Section ground.
+        Context {var_dom var_cod : type -> Type}.
+        Fixpoint const_of_ground {t}
+          : interp_type t -> option (interp var_dom (@expr var_cod) (@ground t))
+          := match t return interp_type t -> option (interp var_dom expr (@ground t)) with
+             | type.prod A B
+               => fun '((a, b) : interp_type A * interp_type B)
+                  => match @const_of_ground A a, @const_of_ground B b with
+                     | Some a', Some b' => Some (a', b')
+                     | _, _ => None
+                     end
+             | type.arrow s d => fun _ => None
+             | type.list A
+               => fun ls : Datatypes.list (interp_type A)
+                  => lift_option_list
+                       (List.map (@const_of_ground A) ls)
+             | type.unit
+             | type.nat
+             | type.Z
+             | type.bool
+               => fun v => Some v
+             end.
+      End ground.
+
+      Module option.
+        Section interp.
+          Context (var_dom var_cod : type -> Type).
+          Fixpoint interp {t} (a : arguments t) : Type
+            := match a with
+               | generic T => var_cod T
+               (*| cps T aT => forall U, (@interp T aT -> var U) -> var U*)
+               | arrow A B aB => var_dom A -> @interp B aB
+               | unit => Datatypes.unit
+               | prod A B aA aB => option (@interp A aA * @interp B aB)
+               | list T aT => option (Datatypes.list (@interp T aT))
+               | nat => option Datatypes.nat
+               | Z => option BinInt.Z
+               | bool => option Datatypes.bool
+               end%type.
+        End interp.
+
+        Section flat_interp.
+          Context (var_generic var_dom : type -> Type) (var_cod : forall t, arguments t -> Type).
+          Fixpoint flat_interp {t} (a : arguments t) : Type
+            := match a with
+               | generic T => var_generic T
+               (*| cps T aT => forall U, (@interp T aT -> var U) -> var U*)
+               | arrow A B aB => var_dom A -> var_cod B aB
+               | unit => Datatypes.unit
+               | prod A B aA aB => @flat_interp A aA * @flat_interp B aB
+               | list T aT => Datatypes.list (@flat_interp T aT)
+               | nat => Datatypes.nat
+               | Z => BinInt.Z
+               | bool => Datatypes.bool
+               end%type.
+        End flat_interp.
+
+        Definition interp_to_arrow_or_generic var_dom var_cod {t} a
+          := @flat_interp var_cod var_dom (@interp var_dom var_cod) t a.
+
+        Section lift_option.
+          Context {var_dom var_cod : type -> Type}.
+          Fixpoint lift_interp {t} {a : arguments t}
+            : interp var_dom var_cod a -> option (interp_to_arrow_or_generic var_dom var_cod a)
+            := match a in arguments t
+                     return interp var_dom var_cod a -> option (interp_to_arrow_or_generic var_dom var_cod a)
+               with
+               | prod A B aA aB
+                 => fun ab : option (interp _ _ aA * interp _ _ aB)
+                    => match ab with
+                       | Some (a, b)
+                         => match @lift_interp A aA a, @lift_interp B aB b with
+                            | Some a, Some b => Some (a, b)
+                            | _, _ => None
+                            end
+                       | None => None
+                       end
+               | list T aT
+                 => fun ls : option (Datatypes.list (interp _ _ aT))
+                    => match ls with
+                       | Some ls
+                         => lift_option_list
+                              (List.map (@lift_interp T aT) ls)
+                       | None => None
+                       end
+               | arrow _ _ _
+               | generic _
+               | unit
+                 => fun v => Some v
+               | nat
+               | Z
+               | bool
+                 => fun x => x
+               end.
+        End lift_option.
+      End option.
+    End type.
+
+    Module expr.
+      Section interp.
+        Context (var : type -> Type).
+        Fixpoint interp {t} (a : arguments t)
+          : @expr var t -> type.option.interp (@expr var) (@expr var) a
+          := match a in arguments t return expr t -> type.option.interp expr expr a with
+             | generic T => fun e => e
+             (*| cps T aT => fun e*)
+             | arrow A B aB
+               => fun e arg
+                  => @interp
+                       B aB
+                       match invert_Abs e, invert_Var arg with
+                       | Some f, Some arg => f arg
+                       | _, _ => Op op.App (e, arg)
+                       end
+             | unit => fun _ => tt
+             | prod A B aA aB
+               => fun e
+                  => option_map (fun '(a, b)
+                                 => (@interp A aA a, @interp B aB b))
+                                (invert_Pair e)
+             | list T aT
+               => fun e
+                  => option_map
+                       (List.map (@interp T aT))
+                       (invert_list_full e)
+             | nat => invert_nat_full
+             | Z => invert_Z
+             | bool => invert_bool
+             end.
+      End interp.
+
+      Section reify.
+        Context (var : type -> Type).
+        Fixpoint reify {t} (a : arguments t)
+          : type.interp var (@expr var) a -> @expr var t
+          := match a in arguments t return type.interp var expr a -> expr t with
+             | generic T => fun e => e
+             | arrow A B aB => fun f => Abs (fun x => @reify B aB (f x))
+             | unit => fun _ => TT
+             | prod A B aA aB
+               => fun '((a, b) : type.interp _ _ aA * type.interp _ _ aB)
+                  => (@reify A aA a, @reify B aB b)%expr
+             | list T aT
+               => fun ls
+                  => reify_list (List.map (@reify T aT) ls)
+             | nat => @const var type.nat
+             | Z => @const var type.Z
+             | bool => @const var type.bool
+             end.
+      End reify.
+    End expr.
+
+    Module Export Notations.
+      Delimit Scope arguments_scope with arguments.
+      Bind Scope arguments_scope with arguments.
+      Notation "()" := unit : arguments_scope.
+      Notation "A * B" := (prod A B) : arguments_scope.
+      Notation "A -> B" := (@arrow A _ B) (only printing) : arguments_scope.
+      Notation "A -> B" := (arrow B) (only parsing) : arguments_scope.
+      Global Coercion generic : type.type >-> arguments.
+      Notation arguments := arguments.
+    End Notations.
+
+    Module op.
+      Local Open Scope arguments_scope.
+      Definition lookup {s d} (opc : op s d) : arguments s * arguments d
+        := match opc in op s d return arguments s * arguments d with
+           | op.Const t v => (generic, ground)
+           | op.Let_In tx tC => (tx * (tx -> tC), generic)
+           | op.App s d => ((s -> d) * s, generic)
+           | op.S => (ground, ground)
+           | op.nil t => (generic, ground)
+           | op.cons t => (t * list t, list t)
+           | op.fst A B => (A * B, generic)
+           | op.snd A B => (A * B, generic)
+           | op.bool_rect T => (T * T * bool, generic)
+           | op.nat_rect P => (P * (nat -> P -> P) * nat, generic)
+           | op.pred => (nat, ground)
+           | op.List_seq => (nat * nat, ground)
+           | op.List_repeat A => (A * nat, list A)
+           | op.List_combine A B => (list A * list B, list (A * B))
+           | op.List_map A B => ((A -> B) * list A, list B)
+           | op.List_flat_map A B => ((A -> list B) * list A, list B)
+           | op.List_partition A => ((A -> bool) * list A, list A * list A)
+           | op.List_app A => (list A * list A, list A)
+           | op.List_fold_right A B => ((B -> A -> A) * A * list B, generic)
+           | op.List_update_nth T => (nat * (T -> T) * list T, list T)
+           | op.Z_runtime_mul => (Z * Z, Z)
+           | op.Z_runtime_add => (Z * Z, Z)
+           | op.Z_add => (Z * Z, Z)
+           | op.Z_mul => (Z * Z, Z)
+           | op.Z_pow => (Z * Z, Z)
+           | op.Z_opp => (Z, Z)
+           | op.Z_div => (Z * Z, Z)
+           | op.Z_modulo => (Z * Z, Z)
+           | op.Z_eqb => (Z * Z, bool)
+           | op.Z_of_nat => (nat, Z)
+           end.
+
+      Definition lookup_src {s d} opc := fst (@lookup s d opc).
+      Definition lookup_dst {s d} opc := snd (@lookup s d opc).
+
+      Definition option_map_prod {A B C} (f : A -> B -> C) (v : option (option A * option B))
+        : option C
+        := match v with
+           | Some (Some a, Some b) => Some (f a b)
+           | _ => None
+           end.
+
+
+
+      Definition rewrite
+                 {var : type -> Type}
+                 {s d} (opc : op s d)
+                 (exploded_arguments : type.option.interp (@expr var) (@expr var) (lookup_src opc))
+        : option (type.interp var (@expr var) (lookup_dst opc))
+        := match opc in op s d
+                 return
+                 (forall (exploded_arguments' : option (type.option.interp_to_arrow_or_generic expr expr (lookup_src opc))),
+                     option (type.interp var expr (lookup_dst opc)))
+           with
+           | op.Const t v => fun _ => arguments.type.const_of_ground v
+           | op.Let_In tx tC
+             => option_map
+                  (fun '(ex, eC)
+                   => match invert_Var ex, invert_OpConst ex with
+                      | Some v, _ => eC ex
+                      | None, Some v => eC ex
+                      | None, None => Op op.Let_In (ex, Abs (fun v => eC (Var v)))
+                      end)
+           | op.App s d => option_map (fun '(f, x) => f x)
+           | op.S as opc
+           | op.pred as opc
+           | op.Z_runtime_mul as opc
+           | op.Z_runtime_add as opc
+           | op.Z_add as opc
+           | op.Z_mul as opc
+           | op.Z_pow as opc
+           | op.Z_opp as opc
+           | op.Z_div as opc
+           | op.Z_modulo as opc
+           | op.Z_eqb as opc
+           | op.Z_of_nat as opc
+             => option_map (op.interp opc)
+           | op.nil t => fun _ => Some (@nil (type.interp _ _ ground))
+           | op.cons t => option_map (op.curry2 cons)
+           | op.fst A B => option_map (@fst (expr A) (expr B))
+           | op.snd A B => option_map (@snd (expr A) (expr B))
+           | op.bool_rect T => option_map (op.curry3 (bool_rect (fun _ => _)))
+           | op.nat_rect P
+             => option_map
+                  (fun '(O_case, S_case, v)
+                   => nat_rect (fun _ => expr P) O_case (fun n (v : expr P) => S_case (@const _ type.nat n) v) v)
+           | op.List_seq => option_map (op.curry2 List.seq)
+           | op.List_repeat A => option_map (op.curry2 (@List.repeat (expr A)))
+           | op.List_combine A B => option_map (op.curry2 (@List.combine (expr A) (expr B)))
+           | op.List_map A B => option_map (op.curry2 (@List.map (expr A) (expr B)))
+           | op.List_flat_map A B
+             => fun args : option ((expr A -> option (Datatypes.list (expr B))) * Datatypes.list (expr A))
+                => match args with
+                   | Some (f, ls) => option_flat_map f ls
+                   | None => None
+                   end
+           | op.List_partition A
+             => fun args : option ((expr A -> option Datatypes.bool) * Datatypes.list (expr A))
+                => match args with
+                   | Some (f, ls) => option_partition f ls
+                   | None => None
+                   end
+           | op.List_app A => option_map (op.curry2 (@List.app (expr A)))
+           | op.List_fold_right A B => option_map (op.curry3 (@List.fold_right (expr A) (expr B)))
+           | op.List_update_nth T => option_map (op.curry3 (@update_nth (expr T)))
+           end
+             (type.option.lift_interp exploded_arguments).
+    End op.
+  End arguments.
+  Export arguments.Notations.
+
+  Section partial_reduce.
+    Context {var : type -> Type}.
+
+    Fixpoint partial_reduce_cps {T} {t} (e : @expr (@expr var) t)
+      : (@expr var t -> @expr var T) -> @expr var T
+      := match e in expr t return (expr t -> expr T) -> expr T with
+         | TT => fun k => k TT
+         | Pair A B a b
+           => fun k
+              => @partial_reduce_cps
+                   T A a
+                   (fun a'
+                    => @partial_reduce_cps
+                         T B b
+                         (fun b' => k (Pair a' b')))
+         | Var t v => fun k => k v
+         | Abs s d f
+           => fun k
+              => k (Abs (fun x => @partial_reduce_cps _ d (f (Var x)) id))
+         | Op s d opc args
+           => fun k
+              => @partial_reduce_cps
+                   T s args
+                   (fun args'
+                    => k
+                         match arguments.op.rewrite
+                                 opc
+                                 (arguments.expr.interp _ _ args')
+                         with
+                         | Some e => arguments.expr.reify _ _ e
+                         | None => Op opc args'
+                         end)
+         end.
+
+    Definition partial_reduce {t} (e : @expr (@expr var) t) : @expr var t
+      := @partial_reduce_cps t t e id.
+  End partial_reduce.
+
+  Definition PartialReduce {t} (e : Expr t) : Expr t
+    := fun var => @partial_reduce var t (e _).
+
   Ltac is_known_const_cps2 term on_success on_failure :=
     let recurse term := is_known_const_cps2 term on_success on_failure in
     lazymatch term with
@@ -749,6 +1333,13 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
   cbv [n].
   cbv delta [mulmod w to_associational mul to_associational reduce from_associational add_to_nth zeros place split].
   Reify_rhs ().
+  let e := match goal with |- _ = Interp ?e => e end in
+  pose e as E.
+  exfalso.
+  Timeout 2 vm_compute in E.
+  pose (PartialReduce E) as E'.
+  Timeout 2 vm_compute in E'.
+
   (*cbv -[runtime_mul runtime_add]; cbv [runtime_mul runtime_add].
   ring_simplify_subterms.*)
 (* ?fg =

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -59,7 +59,7 @@ Module Associational.
     trivial.                                              Defined.
 
   Definition split (s:Z) (p:list (Z*Z)) : list (Z*Z) * list (Z*Z)
-    := dlet_nd hi_lo := partition (fun t => fst t mod s =? 0) p in
+    := let hi_lo := partition (fun t => fst t mod s =? 0) p in
        (snd hi_lo, map (fun t => (fst t / s, snd t)) (fst hi_lo)).
   Lemma eval_split s p (s_nz:s<>0) :
     eval (fst (split s p)) + s * eval (snd (split s p)) = eval p.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -273,7 +273,9 @@ End Positional. End Positional.
 
 Module Compilers.
   Module type.
-    Inductive type := unit | prod (A B : type) | arrow (s d : type) | list (A : type) | nat | Z | bool.
+    Variant opaque := Z.
+    Inductive type := type_opaque (_:opaque) | unit | prod (A B : type) | arrow (s d : type) | list (A : type) | nat | bool.
+    Global Coercion type_opaque : opaque >-> type.
 
     Fixpoint interp (t : type)
       := match t with
@@ -282,9 +284,14 @@ Module Compilers.
          | arrow A B => interp A -> interp B
          | list A => Datatypes.list (interp A)
          | nat => Datatypes.nat
-         | Z => BinInt.Z
+         | type_opaque Z => BinInt.Z
          | bool => Datatypes.bool
          end%type.
+
+    Ltac reify_opaque ty :=
+      lazymatch eval cbv beta in ty with
+      | BinInt.Z => constr:(Z)
+      end.
 
     Ltac reify ty :=
       lazymatch eval cbv beta in ty with
@@ -302,8 +309,9 @@ Module Compilers.
            constr:(list rT)
       | Datatypes.nat => nat
       | Datatypes.bool => bool
-      | BinInt.Z => Z
       | type.interp ?T => T
+      | _ => let rt := reify_opaque ty in
+             constr:(type_opaque rt)
       end.
 
     Module Export Notations.
@@ -349,13 +357,9 @@ Module Compilers.
       Definition Interp {t} (e : Expr t) := interp (e _).
     End with_ident.
 
-    Ltac is_known_const_cps2 term on_success on_failure :=
-      let recurse term := is_known_const_cps2 term on_success on_failure in
+    Ltac is_opaque_const_cps2 term on_success on_failure :=
+      let recurse term := is_opaque_const_cps2 term on_success on_failure in
       lazymatch term with
-      | tt => on_success ()
-      | @nil _ => on_success ()
-      | S ?term => recurse term
-      | O => on_success ()
       | Z0 => on_success ()
       | Zpos ?p => recurse p
       | Zneg ?p => recurse p
@@ -364,10 +368,10 @@ Module Compilers.
       | xH => on_success ()
       | ?term => on_failure term
       end.
-    Ltac require_known_const term :=
-      is_known_const_cps2 term ltac:(fun _ => idtac) ltac:(fun term => fail 0 "Not a known const:" term).
-    Ltac is_known_const term :=
-      is_known_const_cps2 term ltac:(fun _ => true) ltac:(fun _ => false).
+    Ltac require_opaque_const term :=
+      is_opaque_const_cps2 term ltac:(fun _ => idtac) ltac:(fun term => fail 0 "Not a known const:" term).
+    Ltac is_opaque_const term :=
+      is_opaque_const_cps2 term ltac:(fun _ => true) ltac:(fun _ => false).
 
     Module var_context.
       Inductive list {var : type -> Type} :=
@@ -435,8 +439,8 @@ Module Compilers.
         => constr:(@Var ident var rT v)
       | _
         =>
-        let term_is_known_const := is_known_const term in
-        lazymatch term_is_known_const with
+        let term_is_opaque_const := is_opaque_const term in
+        lazymatch term_is_opaque_const with
         | true
           => let rv := reify_ident term in
              constr:(Ident (var:=var) rv)
@@ -534,14 +538,18 @@ Module Compilers.
       Module ident.
         Import type.
         Inductive ident : type -> Set :=
-        | Const {t} (v : interp t) : ident t
+        | opaque {t:type.opaque} (v : interp t) : ident t
         | Let_In {tx tC} : ident (tx -> (tx -> tC) -> tC)
+        | tt : ident unit
+        | O : ident nat
         | S : ident (nat -> nat)
         | nil {t} : ident (list t)
         | cons {t} : ident (t -> list t -> list t)
         | pair {A B} : ident (A -> B -> A * B)
         | fst {A B} : ident (A * B -> A)
         | snd {A B} : ident (A * B -> B)
+        | true : ident bool
+        | false : ident bool
         | bool_rect {T} : ident (T -> T -> bool -> T)
         | nat_rect {P} : ident (P -> (nat -> P -> P) -> nat -> P)
         | pred : ident (nat -> nat)
@@ -569,14 +577,18 @@ Module Compilers.
 
         Definition interp {t} (idc : ident t) : type.interp t
           := match idc in ident t return type.interp t with
-             | Const t v => v
+             | opaque _ v => v
              | Let_In tx tC => @LetIn.Let_In (type.interp tx) (fun _ => type.interp tC)
+             | tt => Datatypes.tt
+             | O => Datatypes.O
              | S => Datatypes.S
              | nil t => @Datatypes.nil (type.interp t)
              | cons t => @Datatypes.cons (type.interp t)
              | pair A B => @Datatypes.pair (type.interp A) (type.interp B)
              | fst A B => @Datatypes.fst (type.interp A) (type.interp B)
              | snd A B => @Datatypes.snd (type.interp A) (type.interp B)
+             | true => @Datatypes.true
+             | false => @Datatypes.false
              | bool_rect T => @Datatypes.bool_rect (fun _ => type.interp T)
              | nat_rect P => @Datatypes.nat_rect (fun _ => type.interp P)
              | pred => Nat.pred
@@ -606,7 +618,11 @@ Module Compilers.
         Ltac reify term :=
           (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
           lazymatch term with
+          | Datatypes.tt => ident.tt
+          | Datatypes.O => ident.O
           | Datatypes.S => ident.S
+          | Datatypes.true => ident.true
+          | Datatypes.false => ident.false
           | @Datatypes.nil ?T
             => let rT := type.reify T in
                constr:(@ident.nil rT)
@@ -683,11 +699,11 @@ Module Compilers.
           | Z.of_nat => ident.Z_of_nat
           | _
             => let assert_const := match goal with
-                                   | _ => require_known_const term
+                                   | _ => require_opaque_const term
                                    end in
                let T := type of term in
-               let rT := type.reify T in
-               constr:(@ident.Const rT term)
+               let rT := type.reify_opaque T in
+               constr:(@ident.opaque rT term)
           end.
 
         Module List.
@@ -729,18 +745,13 @@ Module Compilers.
         Notation interp := (@interp ident (@ident.interp)).
         Notation Interp := (@Interp ident (@ident.interp)).
 
-        Notation TT := (Ident (@ident.Const type.unit tt)).
         Notation Pair x y := (App (App (Ident ident.pair) x) y).
 
         Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
-        Notation "( )" := TT : expr_scope.
-        Notation "()" := TT : expr_scope.
         Notation "'expr_let' x := A 'in' b" := (App (App (Ident ident.Let_In) A%expr) (Abs (fun x => b%expr))) : expr_scope.
         Notation "[ ]" := (Ident ident.nil) : expr_scope.
         Notation "x :: xs" := (App (App (Ident ident.cons) x%expr) xs%expr) : expr_scope.
 
-        Definition const {var t} (v : type.interp t) : @expr var t
-          := Ident (ident.Const v).
         Module Reification.
           Ltac reify var term := expr.reify ident ident.reify var term.
           Ltac Reify term := expr.Reify ident ident.reify term.
@@ -756,14 +767,18 @@ Module Compilers.
       Module ident.
         Import type.
         Inductive ident : type -> Set :=
-        | Const {t} (v : interp t) : ident t
+        | opaque {t : type.opaque} (v : interp t) : ident t
         | Let_In {tx tC} : ident (tx -> (tx -> tC) -> tC)
+        | tt : ident unit
+        | O : ident nat
         | S : ident (nat -> nat)
         | nil {t} : ident (list t)
         | cons {t} : ident (t -> list t -> list t)
         | pair {A B} : ident (A -> B -> A * B)
         | fst {A B} : ident (A * B -> A)
         | snd {A B} : ident (A * B -> B)
+        | true : ident bool
+        | false : ident bool
         | bool_rect {T} : ident (T -> T -> bool -> T)
         | nat_rect {P} : ident (P -> (nat -> P -> P) -> nat -> P)
         | pred : ident (nat -> nat)
@@ -781,9 +796,13 @@ Module Compilers.
 
         Definition interp {t} (idc : ident t) : type.interp t
           := match idc in ident t return type.interp t with
-             | Const t v => v
+             | opaque _ v => v
              | Let_In tx tC => @LetIn.Let_In (type.interp tx) (fun _ => type.interp tC)
+             | tt => Datatypes.tt
+             | O => Datatypes.O
              | S => Datatypes.S
+             | true => Datatypes.true
+             | false => Datatypes.false
              | nil t => @Datatypes.nil (type.interp t)
              | cons t => @Datatypes.cons (type.interp t)
              | pair A B => @Datatypes.pair (type.interp A) (type.interp B)
@@ -808,7 +827,11 @@ Module Compilers.
         Ltac reify term :=
           (*let dummy := match goal with _ => idtac "attempting to reify_op" term end in*)
           lazymatch term with
+          | Datatypes.tt => ident.tt
+          | Datatypes.O => ident.O
           | Datatypes.S => ident.S
+          | Datatypes.true => ident.true
+          | Datatypes.false => ident.false
           | @Datatypes.nil ?T
             => let rT := type.reify T in
                constr:(@ident.nil rT)
@@ -854,11 +877,11 @@ Module Compilers.
           | Z.of_nat => ident.Z_of_nat
           | _
             => let assert_const := match goal with
-                                   | _ => require_known_const term
+                                   | _ => require_opaque_const term
                                    end in
                let T := type of term in
-               let rT := type.reify T in
-               constr:(@ident.Const rT term)
+               let rT := type.reify_opaque T in
+               constr:(@ident.opaque rT term)
           end.
 
         Module Z.
@@ -886,18 +909,12 @@ Module Compilers.
         Notation interp := (@interp ident (@ident.interp)).
         Notation Interp := (@Interp ident (@ident.interp)).
 
-        Notation TT := (Ident (@ident.Const type.unit tt)).
         Notation Pair x y := (App (App (Ident ident.pair) x) y).
 
         Notation "( x , y , .. , z )" := (Pair .. (Pair x%expr y%expr) .. z%expr) : expr_scope.
-        Notation "( )" := TT : expr_scope.
-        Notation "()" := TT : expr_scope.
         Notation "'expr_let' x := A 'in' b" := (App (App (Ident ident.Let_In) A%expr) (Abs (fun x => b%expr))) : expr_scope.
         Notation "[ ]" := (Ident ident.nil) : expr_scope.
         Notation "x :: xs" := (App (App (Ident ident.cons) x%expr) xs%expr) : expr_scope.
-
-        Definition const {var t} (v : type.interp t) : @expr var t
-          := Ident (ident.Const v).
 
         Ltac reify var term := expr.reify ident ident.reify var term.
         Ltac Reify term := expr.Reify ident ident.reify term.
@@ -919,12 +936,18 @@ Module Compilers.
                  (fun m => m)
                  (fun a l1 app_l1 m => a :: app_l1 m) in
            match idc with
-           | for_reification.ident.Const t v
-             => Ident (ident.Const v)
            | for_reification.ident.Let_In tx tC
              => Ident ident.Let_In
+           | for_reification.ident.tt
+             => Ident ident.tt
+           | for_reification.ident.O
+             => Ident ident.O
            | for_reification.ident.S
              => Ident ident.S
+           | for_reification.ident.true
+             => Ident ident.true
+           | for_reification.ident.false
+             => Ident ident.false
            | for_reification.ident.nil t
              => Ident ident.nil
            | for_reification.ident.cons t
@@ -941,6 +964,8 @@ Module Compilers.
              => Ident ident.nat_rect
            | for_reification.ident.pred
              => Ident ident.pred
+           | for_reification.ident.opaque t v
+             => Ident (ident.opaque v)
            | for_reification.ident.Z_runtime_mul
              => Ident ident.Z.runtime_mul
            | for_reification.ident.Z_runtime_add
@@ -1189,16 +1214,6 @@ Module Compilers.
          | _ => None
          end.
 
-    Definition invert_Const {t} (e : @expr var t) : option (type.interp t)
-      := match invert_Ident e with
-         | Some idc
-           => match idc with
-              | ident.Const t v => Some v
-              | _ => None
-              end
-         | None => None
-         end.
-
     Definition invert_AppIdent {d} (e : @expr var d) : option { s : _ & @ident (s -> d) * @expr var s }%type
       := match invert_App e with
          | Some (existT s (f, x))
@@ -1244,26 +1259,39 @@ Module Compilers.
          | None => None
          end.
 
-    Definition invert_S (e : @expr var type.nat) : option (@expr var type.nat)
-      := match invert_AppIdent e with
-         | Some (existT s (idc, x))
-           => match idc in ident t
-                    return if_arrow_s expr t -> option (expr type.nat)
-              with
-              | ident.S => fun args => Some args
-              | _ => fun _ => None
-              end x
+    (* if we want more code for the below, I would suggest [reify_base_type] and [reflect_base_type] *)
+    Definition reflect_opaque {t} (e : @expr var (type.type_opaque t)) : option (type.interp (type.type_opaque t))
+      := match invert_Ident e with
+         | Some idc
+           => match idc in ident t return option (type.interp t) with
+              | ident.opaque _ v => Some v
+              | _ => None
+              end
          | None => None
          end.
 
-    Definition invert_Z (e : @expr var type.Z) : option Z := invert_Const e.
-    Definition invert_bool (e : @expr var type.bool) : option bool := invert_Const e.
-    Fixpoint invert_nat_full (e : @expr var type.nat) : option nat
+    Fixpoint reify_nat (n:nat) : @expr var type.nat
+      := match n with
+         | S n' => App (Ident ident.S) (reify_nat n')
+         | O => Ident ident.O
+         end.
+    Fixpoint reflect_nat (e : @expr var type.nat) : option nat
       := match e return option nat with
          | App type.nat _ (Ident _ ident.S) args
-           => option_map S (invert_nat_full args)
-         | Ident _ (ident.Const type.nat v)
-           => Some v
+           => option_map S (reflect_nat args)
+         | Ident type.nat ident.O
+           => Some O
+         | _ => None
+         end.
+
+    Fixpoint reify_bool (b:bool) : @expr var type.bool
+      := if b then Ident ident.true else Ident ident.false.
+    Fixpoint reflect_bool (e : @expr var type.bool) : option bool
+      := match e return option bool with
+         | Ident type.nat ident.true
+           => Some true
+         | Ident type.nat ident.false
+           => Some false
          | _ => None
          end.
 
@@ -1274,17 +1302,17 @@ Module Compilers.
                    end) (only parsing).
 
     (* oh, the horrors of not being able to use non-linear deep pattern matches.  c.f. COQBUG(https://github.com/coq/coq/issues/6320) *)
-    Fixpoint invert_list_full {t} (e : @expr var (type.list t))
+    Fixpoint reflect_list {t} (e : @expr var (type.list t))
       : option (list (@expr var t))
       := match e in expr.expr t return option (list_expr t) with
          | Ident t idc
            => match idc in ident t return option (list_expr t) with
-              | ident.Const (type.list _) v => Some (List.map const v)
               | ident.nil _ => Some nil
               | _ => None
               end
          | App (type.list s) d f xs
-           => match @invert_list_full s xs return _ with
+               (* WHY reflect xs before x? *)
+           => match @reflect_list s xs return _ with
               | Some xs
                 => match invert_AppIdent f return option (list_expr d) with
                    | Some (existT s' (idc, x))
@@ -1301,23 +1329,6 @@ Module Compilers.
               | None => None
               end
          | _ => None
-         end.
-
-    (** TODO: figure out a better name for this *)
-    Definition Smart_invert_Pair {A B} (e : @expr var (type.prod A B)) : option (@expr var A * @expr var B)
-      := match invert_Pair e, invert_Var e, invert_Const e with
-         | Some ab, _, _ => Some ab
-         | _, Some v, _ => Some (App (Ident ident.fst) (Var v), App (Ident ident.snd) (Var v))
-         | _, _, Some v => Some (@const var A (fst v), @const var B (snd v))
-         | None, None, None => None
-         end.
-
-    (** TODO: figure out a better name for this *)
-    Definition Smart_invert_list_full {A} (e : @expr var (type.list A)) : option (list (@expr var A))
-      := match invert_Const e, invert_list_full e with
-         | Some ls, _ => Some (List.map (@const var A) ls)
-         | _, Some ls => Some ls
-         | None, None => None
          end.
   End invert.
 
@@ -1341,7 +1352,7 @@ Module Compilers.
            | type.arrow s d => value s -> value d
            | type.list A => list (value A)
            | type.unit as t
-           | type.Z as t
+           | type.type_opaque _ as t
            | type.nat as t
            | type.bool as t
              => type.interp t
@@ -1353,7 +1364,7 @@ Module Compilers.
              => value_prestep value t
            | type.prod _ _ as t
            | type.list _ as t
-           | type.Z as t
+           | type.type_opaque _ as t
            | type.nat as t
            | type.bool as t
              => @expr var t + value_prestep value t
@@ -1362,15 +1373,14 @@ Module Compilers.
         := value_step value t.
     End value.
 
-    Notation expr_const := const.
-
     Module expr.
       Section reify.
         Context {var : type -> Type}.
+        Check ident.tt.
         Fixpoint reify {t : type} {struct t}
           : value var t -> @expr var t
           := match t return value var t -> expr t with
-             | type.unit as t => expr_const (t:=t)
+             | type.unit as t => fun _ => expr.Ident ident.tt
              | type.prod A B as t
                => fun x : expr t + value var A * value var B
                   => match x with
@@ -1388,12 +1398,22 @@ Module Compilers.
                      | inr v => reify_list (List.map (@reify A) v)
                      end
              | type.nat as t
-             | type.Z as t
+               => fun x : expr t + type.interp t
+                  => match x with
+                     | inl v => v
+                     | inr v => reify_nat v
+                     end
              | type.bool as t
                => fun x : expr t + type.interp t
                   => match x with
                      | inl v => v
-                     | inr v => expr_const (t:=t) v
+                     | inr v => reify_bool v
+                     end
+             | type.type_opaque _ as t
+               => fun x : expr t + type.interp t
+                  => match x with
+                     | inl v => v
+                     | inr v => Ident (ident.opaque v)
                      end
              end
         with reflect {t : type}
@@ -1407,7 +1427,7 @@ Module Compilers.
                   => fun v : expr t
                      => let inr := @inr (expr t) (value_prestep (value var) t) in
                         let inl := @inl (expr t) (value_prestep (value var) t) in
-                        match Smart_invert_Pair v with
+                        match invert_Pair v with
                         | Some (a, b)
                           => inr (@reflect A a, @reflect B b)
                         | None
@@ -1417,7 +1437,7 @@ Module Compilers.
                   => fun v : expr t
                      => let inr := @inr (expr t) (value_prestep (value var) t) in
                         let inl := @inl (expr t) (value_prestep (value var) t) in
-                        match Smart_invert_list_full v with
+                        match reflect_list v with
                         | Some ls
                           => inr (List.map (@reflect A) ls)
                         | None
@@ -1427,49 +1447,28 @@ Module Compilers.
                   => fun v : expr t
                      => let inr := @inr (expr t) (value_prestep (value var) t) in
                         let inl := @inl (expr t) (value_prestep (value var) t) in
-                        match invert_nat_full v with
+                        match reflect_nat v with
                         | Some v => inr v
                         | None => inl v
                         end
-                | type.Z as t
                 | type.bool as t
                   => fun v : expr t
                      => let inr := @inr (expr t) (value_prestep (value var) t) in
                         let inl := @inl (expr t) (value_prestep (value var) t) in
-                        match invert_Const v with
+                        match reflect_bool v with
+                        | Some v => inr v
+                        | None => inl v
+                        end
+                | type.type_opaque _ as t
+                  => fun v : expr t
+                     => let inr := @inr (expr t) (value_prestep (value var) t) in
+                        let inl := @inl (expr t) (value_prestep (value var) t) in
+                        match reflect_opaque v with
                         | Some v => inr v
                         | None => inl v
                         end
                 end.
       End reify.
-
-      Section SmartLetIn.
-        Context {var : type -> Type} {tC : type}.
-        (** TODO: Find a better name for this *)
-        (** N.B. This always inlines functions; not sure if this is the right thing to do *)
-        (** TODO: should we handle let-bound pairs, let-bound lists?  What should we do with them?  Here, I make the decision to always inline them; not sure if this is right *)
-        Fixpoint SmartLetIn {tx : type} : value var tx -> (value var tx -> value var tC) -> value var tC
-          := match tx return value var tx -> (value var tx -> value var tC) -> value var tC with
-             | type.unit => fun _ f => f tt
-             | type.arrow _ _
-             | type.prod _ _
-             | type.list _
-               => fun x f => f x
-             | type.nat as t
-             | type.Z as t
-             | type.bool as t
-               => fun (x : expr t + type.interp t) (f : expr t + type.interp t -> value var tC)
-                  => match x with
-                     | inl e
-                       => match invert_Var e, invert_Const e with
-                          | Some v, _ => f (inl (Var v))
-                          | _, Some v => f (inr v)
-                          | None, None => reflect (expr_let y := e in reify (f (inl (Var y))))%expr
-                          end
-                     | inr v => f (inr v)
-                     end
-             end.
-      End SmartLetIn.
     End expr.
 
     Definition sum_arrow {A A' B B'} (f : A -> A') (g : B -> B')
@@ -1484,14 +1483,42 @@ Module Compilers.
     Module ident.
       Section interp.
         Context {var : type -> Type}.
+        Definition interp_let_in {tC tx : type} : value var tx -> (value var tx -> value var tC) -> value var tC
+          := match tx return value var tx -> (value var tx -> value var tC) -> value var tC with
+             | type.unit => fun _ f => f tt
+             | type.arrow _ _
+             | type.prod _ _
+             | type.list _
+               => fun x f => f x
+             | type.nat as t
+             | type.type_opaque _ as t
+             | type.bool as t
+               => fun (x : expr t + type.interp t) (f : expr t + type.interp t -> value var tC)
+                  => match x with
+                     | inl e
+                       => match invert_Var e with
+                          | Some v => f (inl (Var v))
+                          | None => partial.expr.reflect (expr_let y := e in partial.expr.reify (f (inl (Var y))))%expr
+                          end
+                     | inr v => f (inr v) (* FIXME: do not substitute [S (big stuck term)] *)
+                     end
+             end.
         Definition interp {t} (idc : ident t) : value var t
           := match idc in ident t return value var t with
-             | ident.Const t v as idc
-               => expr.reflect (Ident idc)
              | ident.Let_In tx tC
-               => expr.SmartLetIn
+               => interp_let_in
+             | ident.tt
+               => tt
+             | ident.O
+               => inr O
+             | ident.true
+               => inr true
+             | ident.false
+               => inr false
              | ident.nil t
                => inr (@nil (value var t))
+             | ident.opaque type.Z z
+               => inr z
              | ident.cons t as idc
                => fun x (xs : expr (type.list t) + list (value var t))
                   => match xs return expr (type.list t) + list (value var t) with
@@ -1653,17 +1680,7 @@ Qed.
 Delimit Scope RT_expr_scope with RT_expr.
 Import expr.
 Import for_reification.Notations.Reification.
-Notation "ls _{ n }"
-  := (App (App (App (Ident for_reification.ident.List.nth_default) _) ls%expr) (Ident (ident.Const n%nat)))
-       (at level 20, format "ls _{ n }")
-     : expr_scope.
 
-Notation "'hd' ls" := (App (App (App (Ident ident.list_rect) (Ident (ident.Const (-1)%Z)))
-                                (Abs (fun x1 => Abs (fun _ => Abs (fun _ => Var x1)))))
-                           ls%expr) (at level 10, ls at level 10) : expr_scope.
-Notation "( λₗ xs .. ys , f ) ( 'tl' ls )" := (App (App (App (Ident ident.list_rect) (Ident (ident.Const (-1)%Z)))
-                                      (Abs (fun _ => Abs (fun xs => .. (fun ys => Abs (fun _ => f)) .. ))))
-                                 ls%expr) (at level 10, xs binder, ys binder, ls at level 10) : expr_scope.
 Notation "x + y"
   := (App (App (Ident ident.Z.runtime_add) x%RT_expr) y%RT_expr)
      : RT_expr_scope.
@@ -1676,7 +1693,6 @@ Notation "x + y"
 Notation "x * y"
   := (App (App (Ident ident.Z.runtime_mul) x%RT_expr) y%RT_expr)
      : expr_scope.
-Notation "x" := (Ident (ident.Const x)) (only printing, at level 10) : expr_scope.
 Notation "x" := (Var x) (only printing, at level 10) : expr_scope.
 Open Scope RT_expr_scope.
 
@@ -1724,7 +1740,7 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
       pose (PartialReduce (canonicalize_list_recursion E)) as E'.
       vm_compute in E'.
       lazymatch (eval cbv delta [E'] in E') with
-      | (fun var => Ident (ident.Const ?v)) => idtac
+      | (fun var => Ident (ident.opaque ?v)) => idtac
       end.
       constructor. }
     assert True.
@@ -1740,7 +1756,7 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
       vm_compute in E'.
       lazymatch (eval cbv delta [E'] in E') with
       | (fun var : type -> Type =>
-           (λ x : var type.Z,
+           (λ x : var (type.type_opaque type.Z),
                   expr_let x0 := (Var x * Var x)%RT_expr in
                 expr_let x1 := (Var x0 * Var x0)%RT_expr in
                 (Var x1, Var x1))%expr) => idtac
@@ -1773,1210 +1789,58 @@ Example base_25_5_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g
   (*trivial.*)
 Defined.
 Eval cbv [proj1_sig base_25_5_mul] in (fun f g Hf Hg => proj1_sig (base_25_5_mul f g Hf Hg)).
-
-(*     = fun (f g : list Z) (_ : length f = 10%nat) (_ : length g = 10%nat) =>
-       expr.Interp (@ident.interp)
-         (fun var : type -> Type =>
-          (λ x x0 : var (type.list type.Z),
-           hd x * hd x0 +
-           (2 *
-            (19 *
-             (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-              ( λₗ x2 : var (type.list type.Z),
-              ( λₗ x5 : var (type.list type.Z),
-              ( λₗ x8 : var (type.list type.Z),
-              ( λₗ x11 : var (type.list type.Z),
-              ( λₗ x14 : var (type.list type.Z),
-              ( λₗ x17 : var (type.list type.Z),
-              ( λₗ x20 : var (type.list type.Z),
-              ( λₗ x23 : var (type.list type.Z),
-              ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl x20))( tl
-              x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0))) +
-            (19 *
-             (( λₗ x2 : var (type.list type.Z), ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))
-              ( tl x) *
-              ( λₗ x2 : var (type.list type.Z),
-              ( λₗ x5 : var (type.list type.Z),
-              ( λₗ x8 : var (type.list type.Z),
-              ( λₗ x11 : var (type.list type.Z),
-              ( λₗ x14 : var (type.list type.Z),
-              ( λₗ x17 : var (type.list type.Z),
-              ( λₗ x20 : var (type.list type.Z),
-              ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl x17))( tl
-              x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
-             (2 *
-              (19 *
-               (( λₗ x2 : var (type.list type.Z),
-                ( λₗ x5 : var (type.list type.Z), ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))
-                ( tl x2))( tl x) *
-                ( λₗ x2 : var (type.list type.Z),
-                ( λₗ x5 : var (type.list type.Z),
-                ( λₗ x8 : var (type.list type.Z),
-                ( λₗ x11 : var (type.list type.Z),
-                ( λₗ x14 : var (type.list type.Z),
-                ( λₗ x17 : var (type.list type.Z),
-                ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0))) +
-              (19 *
-               (( λₗ x2 : var (type.list type.Z),
-                ( λₗ x5 : var (type.list type.Z),
-                ( λₗ x8 : var (type.list type.Z),
-                ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                x5))( tl x2))( tl x) *
-                ( λₗ x2 : var (type.list type.Z),
-                ( λₗ x5 : var (type.list type.Z),
-                ( λₗ x8 : var (type.list type.Z),
-                ( λₗ x11 : var (type.list type.Z),
-                ( λₗ x14 : var (type.list type.Z),
-                ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
-               (2 *
-                (19 *
-                 (( λₗ x2 : var (type.list type.Z),
-                  ( λₗ x5 : var (type.list type.Z),
-                  ( λₗ x8 : var (type.list type.Z),
-                  ( λₗ x11 : var (type.list type.Z),
-                  ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                  x8))( tl x5))( tl x2))( tl x) *
-                  ( λₗ x2 : var (type.list type.Z),
-                  ( λₗ x5 : var (type.list type.Z),
-                  ( λₗ x8 : var (type.list type.Z),
-                  ( λₗ x11 : var (type.list type.Z),
-                  ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                  x8))( tl x5))( tl x2))( tl x0))) +
-                (19 *
-                 (( λₗ x2 : var (type.list type.Z),
-                  ( λₗ x5 : var (type.list type.Z),
-                  ( λₗ x8 : var (type.list type.Z),
-                  ( λₗ x11 : var (type.list type.Z),
-                  ( λₗ x14 : var (type.list type.Z),
-                  ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                  x11))( tl x8))( tl x5))( tl x2))( tl x) *
-                  ( λₗ x2 : var (type.list type.Z),
-                  ( λₗ x5 : var (type.list type.Z),
-                  ( λₗ x8 : var (type.list type.Z),
-                  ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                  x5))( tl x2))( tl x0)) +
-                 (2 *
-                  (19 *
-                   (( λₗ x2 : var (type.list type.Z),
-                    ( λₗ x5 : var (type.list type.Z),
-                    ( λₗ x8 : var (type.list type.Z),
-                    ( λₗ x11 : var (type.list type.Z),
-                    ( λₗ x14 : var (type.list type.Z),
-                    ( λₗ x17 : var (type.list type.Z),
-                    ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                    x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x) *
-                    ( λₗ x2 : var (type.list type.Z),
-                    ( λₗ x5 : var (type.list type.Z),
-                    ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                    x2))( tl x0))) +
-                  (19 *
-                   (( λₗ x2 : var (type.list type.Z),
-                    ( λₗ x5 : var (type.list type.Z),
-                    ( λₗ x8 : var (type.list type.Z),
-                    ( λₗ x11 : var (type.list type.Z),
-                    ( λₗ x14 : var (type.list type.Z),
-                    ( λₗ x17 : var (type.list type.Z),
-                    ( λₗ x20 : var (type.list type.Z),
-                    ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                    x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                    x) *
-                    ( λₗ x2 : var (type.list type.Z),
-                    ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                    x0)) +
-                   2 *
-                   (19 *
-                    (( λₗ x2 : var (type.list type.Z),
-                     ( λₗ x5 : var (type.list type.Z),
-                     ( λₗ x8 : var (type.list type.Z),
-                     ( λₗ x11 : var (type.list type.Z),
-                     ( λₗ x14 : var (type.list type.Z),
-                     ( λₗ x17 : var (type.list type.Z),
-                     ( λₗ x20 : var (type.list type.Z),
-                     ( λₗ x23 : var (type.list type.Z),
-                     ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                     x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
-                     x2))( tl x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)))))))))))
-           :: hd x * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
-              (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) * hd x0 +
-               (19 *
-                (( λₗ x2 : var (type.list type.Z), ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))
-                 ( tl x) *
-                 ( λₗ x2 : var (type.list type.Z),
-                 ( λₗ x5 : var (type.list type.Z),
-                 ( λₗ x8 : var (type.list type.Z),
-                 ( λₗ x11 : var (type.list type.Z),
-                 ( λₗ x14 : var (type.list type.Z),
-                 ( λₗ x17 : var (type.list type.Z),
-                 ( λₗ x20 : var (type.list type.Z),
-                 ( λₗ x23 : var (type.list type.Z),
-                 ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                 x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
-                 x2))( tl x0)) +
-                (19 *
-                 (( λₗ x2 : var (type.list type.Z),
-                  ( λₗ x5 : var (type.list type.Z),
-                  ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                  x2))( tl x) *
-                  ( λₗ x2 : var (type.list type.Z),
-                  ( λₗ x5 : var (type.list type.Z),
-                  ( λₗ x8 : var (type.list type.Z),
-                  ( λₗ x11 : var (type.list type.Z),
-                  ( λₗ x14 : var (type.list type.Z),
-                  ( λₗ x17 : var (type.list type.Z),
-                  ( λₗ x20 : var (type.list type.Z),
-                  ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                  x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                  x0)) +
-                 (19 *
-                  (( λₗ x2 : var (type.list type.Z),
-                   ( λₗ x5 : var (type.list type.Z),
-                   ( λₗ x8 : var (type.list type.Z),
-                   ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                   x5))( tl x2))( tl x) *
-                   ( λₗ x2 : var (type.list type.Z),
-                   ( λₗ x5 : var (type.list type.Z),
-                   ( λₗ x8 : var (type.list type.Z),
-                   ( λₗ x11 : var (type.list type.Z),
-                   ( λₗ x14 : var (type.list type.Z),
-                   ( λₗ x17 : var (type.list type.Z),
-                   ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                   x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
-                  (19 *
-                   (( λₗ x2 : var (type.list type.Z),
-                    ( λₗ x5 : var (type.list type.Z),
-                    ( λₗ x8 : var (type.list type.Z),
-                    ( λₗ x11 : var (type.list type.Z),
-                    ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                    x8))( tl x5))( tl x2))( tl x) *
-                    ( λₗ x2 : var (type.list type.Z),
-                    ( λₗ x5 : var (type.list type.Z),
-                    ( λₗ x8 : var (type.list type.Z),
-                    ( λₗ x11 : var (type.list type.Z),
-                    ( λₗ x14 : var (type.list type.Z),
-                    ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                    x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
-                   (19 *
-                    (( λₗ x2 : var (type.list type.Z),
-                     ( λₗ x5 : var (type.list type.Z),
-                     ( λₗ x8 : var (type.list type.Z),
-                     ( λₗ x11 : var (type.list type.Z),
-                     ( λₗ x14 : var (type.list type.Z),
-                     ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                     x11))( tl x8))( tl x5))( tl x2))( tl x) *
-                     ( λₗ x2 : var (type.list type.Z),
-                     ( λₗ x5 : var (type.list type.Z),
-                     ( λₗ x8 : var (type.list type.Z),
-                     ( λₗ x11 : var (type.list type.Z),
-                     ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                     x8))( tl x5))( tl x2))( tl x0)) +
-                    (19 *
-                     (( λₗ x2 : var (type.list type.Z),
-                      ( λₗ x5 : var (type.list type.Z),
-                      ( λₗ x8 : var (type.list type.Z),
-                      ( λₗ x11 : var (type.list type.Z),
-                      ( λₗ x14 : var (type.list type.Z),
-                      ( λₗ x17 : var (type.list type.Z),
-                      ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                      x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x) *
-                      ( λₗ x2 : var (type.list type.Z),
-                      ( λₗ x5 : var (type.list type.Z),
-                      ( λₗ x8 : var (type.list type.Z),
-                      ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                      x5))( tl x2))( tl x0)) +
-                     (19 *
-                      (( λₗ x2 : var (type.list type.Z),
-                       ( λₗ x5 : var (type.list type.Z),
-                       ( λₗ x8 : var (type.list type.Z),
-                       ( λₗ x11 : var (type.list type.Z),
-                       ( λₗ x14 : var (type.list type.Z),
-                       ( λₗ x17 : var (type.list type.Z),
-                       ( λₗ x20 : var (type.list type.Z),
-                       ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                       x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                       x) *
-                       ( λₗ x2 : var (type.list type.Z),
-                       ( λₗ x5 : var (type.list type.Z),
-                       ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                       x2))( tl x0)) +
-                      19 *
-                      (( λₗ x2 : var (type.list type.Z),
-                       ( λₗ x5 : var (type.list type.Z),
-                       ( λₗ x8 : var (type.list type.Z),
-                       ( λₗ x11 : var (type.list type.Z),
-                       ( λₗ x14 : var (type.list type.Z),
-                       ( λₗ x17 : var (type.list type.Z),
-                       ( λₗ x20 : var (type.list type.Z),
-                       ( λₗ x23 : var (type.list type.Z),
-                       ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                       x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
-                       x5))( tl x2))( tl x) *
-                       ( λₗ x2 : var (type.list type.Z),
-                       ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                       x0))))))))))
-              :: hd x *
-                 ( λₗ x2 : var (type.list type.Z), ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))
-                 ( tl x0) +
-                 (2 *
-                  (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-                   ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)) +
-                  (( λₗ x2 : var (type.list type.Z),
-                   ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                   x) * hd x0 +
-                   (2 *
-                    (19 *
-                     (( λₗ x2 : var (type.list type.Z),
-                      ( λₗ x5 : var (type.list type.Z),
-                      ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                      x2))( tl x) *
-                      ( λₗ x2 : var (type.list type.Z),
-                      ( λₗ x5 : var (type.list type.Z),
-                      ( λₗ x8 : var (type.list type.Z),
-                      ( λₗ x11 : var (type.list type.Z),
-                      ( λₗ x14 : var (type.list type.Z),
-                      ( λₗ x17 : var (type.list type.Z),
-                      ( λₗ x20 : var (type.list type.Z),
-                      ( λₗ x23 : var (type.list type.Z),
-                      ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                      x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
-                      x2))( tl x0))) +
-                    (19 *
-                     (( λₗ x2 : var (type.list type.Z),
-                      ( λₗ x5 : var (type.list type.Z),
-                      ( λₗ x8 : var (type.list type.Z),
-                      ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                      x5))( tl x2))( tl x) *
-                      ( λₗ x2 : var (type.list type.Z),
-                      ( λₗ x5 : var (type.list type.Z),
-                      ( λₗ x8 : var (type.list type.Z),
-                      ( λₗ x11 : var (type.list type.Z),
-                      ( λₗ x14 : var (type.list type.Z),
-                      ( λₗ x17 : var (type.list type.Z),
-                      ( λₗ x20 : var (type.list type.Z),
-                      ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                      x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                      x0)) +
-                     (2 *
-                      (19 *
-                       (( λₗ x2 : var (type.list type.Z),
-                        ( λₗ x5 : var (type.list type.Z),
-                        ( λₗ x8 : var (type.list type.Z),
-                        ( λₗ x11 : var (type.list type.Z),
-                        ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                        x8))( tl x5))( tl x2))( tl x) *
-                        ( λₗ x2 : var (type.list type.Z),
-                        ( λₗ x5 : var (type.list type.Z),
-                        ( λₗ x8 : var (type.list type.Z),
-                        ( λₗ x11 : var (type.list type.Z),
-                        ( λₗ x14 : var (type.list type.Z),
-                        ( λₗ x17 : var (type.list type.Z),
-                        ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                        x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl x0))) +
-                      (19 *
-                       (( λₗ x2 : var (type.list type.Z),
-                        ( λₗ x5 : var (type.list type.Z),
-                        ( λₗ x8 : var (type.list type.Z),
-                        ( λₗ x11 : var (type.list type.Z),
-                        ( λₗ x14 : var (type.list type.Z),
-                        ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                        x11))( tl x8))( tl x5))( tl x2))( tl x) *
-                        ( λₗ x2 : var (type.list type.Z),
-                        ( λₗ x5 : var (type.list type.Z),
-                        ( λₗ x8 : var (type.list type.Z),
-                        ( λₗ x11 : var (type.list type.Z),
-                        ( λₗ x14 : var (type.list type.Z),
-                        ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                        x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
-                       (2 *
-                        (19 *
-                         (( λₗ x2 : var (type.list type.Z),
-                          ( λₗ x5 : var (type.list type.Z),
-                          ( λₗ x8 : var (type.list type.Z),
-                          ( λₗ x11 : var (type.list type.Z),
-                          ( λₗ x14 : var (type.list type.Z),
-                          ( λₗ x17 : var (type.list type.Z),
-                          ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                          x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                          x) *
-                          ( λₗ x2 : var (type.list type.Z),
-                          ( λₗ x5 : var (type.list type.Z),
-                          ( λₗ x8 : var (type.list type.Z),
-                          ( λₗ x11 : var (type.list type.Z),
-                          ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                          x8))( tl x5))( tl x2))( tl x0))) +
-                        (19 *
-                         (( λₗ x2 : var (type.list type.Z),
-                          ( λₗ x5 : var (type.list type.Z),
-                          ( λₗ x8 : var (type.list type.Z),
-                          ( λₗ x11 : var (type.list type.Z),
-                          ( λₗ x14 : var (type.list type.Z),
-                          ( λₗ x17 : var (type.list type.Z),
-                          ( λₗ x20 : var (type.list type.Z),
-                          ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                          x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
-                          x2))( tl x) *
-                          ( λₗ x2 : var (type.list type.Z),
-                          ( λₗ x5 : var (type.list type.Z),
-                          ( λₗ x8 : var (type.list type.Z),
-                          ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                          x5))( tl x2))( tl x0)) +
-                         2 *
-                         (19 *
-                          (( λₗ x2 : var (type.list type.Z),
-                           ( λₗ x5 : var (type.list type.Z),
-                           ( λₗ x8 : var (type.list type.Z),
-                           ( λₗ x11 : var (type.list type.Z),
-                           ( λₗ x14 : var (type.list type.Z),
-                           ( λₗ x17 : var (type.list type.Z),
-                           ( λₗ x20 : var (type.list type.Z),
-                           ( λₗ x23 : var (type.list type.Z),
-                           ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                           x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
-                           x5))( tl x2))( tl x) *
-                           ( λₗ x2 : var (type.list type.Z),
-                           ( λₗ x5 : var (type.list type.Z),
-                           ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                           x2))( tl x0)))))))))))
-                 :: hd x *
-                    ( λₗ x2 : var (type.list type.Z),
-                    ( λₗ x5 : var (type.list type.Z),
-                    ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                    x2))( tl x0) +
-                    (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-                     ( λₗ x2 : var (type.list type.Z),
-                     ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                     x0) +
-                     (( λₗ x2 : var (type.list type.Z),
-                      ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                      x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
-                      (( λₗ x2 : var (type.list type.Z),
-                       ( λₗ x5 : var (type.list type.Z),
-                       ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                       x2))( tl x) * hd x0 +
-                       (19 *
-                        (( λₗ x2 : var (type.list type.Z),
-                         ( λₗ x5 : var (type.list type.Z),
-                         ( λₗ x8 : var (type.list type.Z),
-                         ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                         x5))( tl x2))( tl x) *
-                         ( λₗ x2 : var (type.list type.Z),
-                         ( λₗ x5 : var (type.list type.Z),
-                         ( λₗ x8 : var (type.list type.Z),
-                         ( λₗ x11 : var (type.list type.Z),
-                         ( λₗ x14 : var (type.list type.Z),
-                         ( λₗ x17 : var (type.list type.Z),
-                         ( λₗ x20 : var (type.list type.Z),
-                         ( λₗ x23 : var (type.list type.Z),
-                         ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                         x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
-                         x5))( tl x2))( tl x0)) +
-                        (19 *
-                         (( λₗ x2 : var (type.list type.Z),
-                          ( λₗ x5 : var (type.list type.Z),
-                          ( λₗ x8 : var (type.list type.Z),
-                          ( λₗ x11 : var (type.list type.Z),
-                          ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                          x8))( tl x5))( tl x2))( tl x) *
-                          ( λₗ x2 : var (type.list type.Z),
-                          ( λₗ x5 : var (type.list type.Z),
-                          ( λₗ x8 : var (type.list type.Z),
-                          ( λₗ x11 : var (type.list type.Z),
-                          ( λₗ x14 : var (type.list type.Z),
-                          ( λₗ x17 : var (type.list type.Z),
-                          ( λₗ x20 : var (type.list type.Z),
-                          ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                          x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
-                          x2))( tl x0)) +
-                         (19 *
-                          (( λₗ x2 : var (type.list type.Z),
-                           ( λₗ x5 : var (type.list type.Z),
-                           ( λₗ x8 : var (type.list type.Z),
-                           ( λₗ x11 : var (type.list type.Z),
-                           ( λₗ x14 : var (type.list type.Z),
-                           ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                           x11))( tl x8))( tl x5))( tl x2))( tl x) *
-                           ( λₗ x2 : var (type.list type.Z),
-                           ( λₗ x5 : var (type.list type.Z),
-                           ( λₗ x8 : var (type.list type.Z),
-                           ( λₗ x11 : var (type.list type.Z),
-                           ( λₗ x14 : var (type.list type.Z),
-                           ( λₗ x17 : var (type.list type.Z),
-                           ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                           x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                           x0)) +
-                          (19 *
-                           (( λₗ x2 : var (type.list type.Z),
-                            ( λₗ x5 : var (type.list type.Z),
-                            ( λₗ x8 : var (type.list type.Z),
-                            ( λₗ x11 : var (type.list type.Z),
-                            ( λₗ x14 : var (type.list type.Z),
-                            ( λₗ x17 : var (type.list type.Z),
-                            ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                            x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                            x) *
-                            ( λₗ x2 : var (type.list type.Z),
-                            ( λₗ x5 : var (type.list type.Z),
-                            ( λₗ x8 : var (type.list type.Z),
-                            ( λₗ x11 : var (type.list type.Z),
-                            ( λₗ x14 : var (type.list type.Z),
-                            ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                            x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
-                           (19 *
-                            (( λₗ x2 : var (type.list type.Z),
-                             ( λₗ x5 : var (type.list type.Z),
-                             ( λₗ x8 : var (type.list type.Z),
-                             ( λₗ x11 : var (type.list type.Z),
-                             ( λₗ x14 : var (type.list type.Z),
-                             ( λₗ x17 : var (type.list type.Z),
-                             ( λₗ x20 : var (type.list type.Z),
-                             ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                             x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
-                             x2))( tl x) *
-                             ( λₗ x2 : var (type.list type.Z),
-                             ( λₗ x5 : var (type.list type.Z),
-                             ( λₗ x8 : var (type.list type.Z),
-                             ( λₗ x11 : var (type.list type.Z),
-                             ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                             x8))( tl x5))( tl x2))( tl x0)) +
-                            19 *
-                            (( λₗ x2 : var (type.list type.Z),
-                             ( λₗ x5 : var (type.list type.Z),
-                             ( λₗ x8 : var (type.list type.Z),
-                             ( λₗ x11 : var (type.list type.Z),
-                             ( λₗ x14 : var (type.list type.Z),
-                             ( λₗ x17 : var (type.list type.Z),
-                             ( λₗ x20 : var (type.list type.Z),
-                             ( λₗ x23 : var (type.list type.Z),
-                             ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                             x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
-                             x5))( tl x2))( tl x) *
-                             ( λₗ x2 : var (type.list type.Z),
-                             ( λₗ x5 : var (type.list type.Z),
-                             ( λₗ x8 : var (type.list type.Z),
-                             ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                             x5))( tl x2))( tl x0))))))))))
-                    :: hd x *
-                       ( λₗ x2 : var (type.list type.Z),
-                       ( λₗ x5 : var (type.list type.Z),
-                       ( λₗ x8 : var (type.list type.Z),
-                       ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                       x5))( tl x2))( tl x0) +
-                       (2 *
-                        (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-                         ( λₗ x2 : var (type.list type.Z),
-                         ( λₗ x5 : var (type.list type.Z),
-                         ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                         x2))( tl x0)) +
-                        (( λₗ x2 : var (type.list type.Z),
-                         ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                         x) *
-                         ( λₗ x2 : var (type.list type.Z),
-                         ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                         x0) +
-                         (2 *
-                          (( λₗ x2 : var (type.list type.Z),
-                           ( λₗ x5 : var (type.list type.Z),
-                           ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                           x2))( tl x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)) +
-                          (( λₗ x2 : var (type.list type.Z),
-                           ( λₗ x5 : var (type.list type.Z),
-                           ( λₗ x8 : var (type.list type.Z),
-                           ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                           x5))( tl x2))( tl x) * hd x0 +
-                           (2 *
-                            (19 *
-                             (( λₗ x2 : var (type.list type.Z),
-                              ( λₗ x5 : var (type.list type.Z),
-                              ( λₗ x8 : var (type.list type.Z),
-                              ( λₗ x11 : var (type.list type.Z),
-                              ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                              x8))( tl x5))( tl x2))( tl x) *
-                              ( λₗ x2 : var (type.list type.Z),
-                              ( λₗ x5 : var (type.list type.Z),
-                              ( λₗ x8 : var (type.list type.Z),
-                              ( λₗ x11 : var (type.list type.Z),
-                              ( λₗ x14 : var (type.list type.Z),
-                              ( λₗ x17 : var (type.list type.Z),
-                              ( λₗ x20 : var (type.list type.Z),
-                              ( λₗ x23 : var (type.list type.Z),
-                              ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                              x20))( tl x17))( tl x14))( tl x11))( tl x8))( tl
-                              x5))( tl x2))( tl x0))) +
-                            (19 *
-                             (( λₗ x2 : var (type.list type.Z),
-                              ( λₗ x5 : var (type.list type.Z),
-                              ( λₗ x8 : var (type.list type.Z),
-                              ( λₗ x11 : var (type.list type.Z),
-                              ( λₗ x14 : var (type.list type.Z),
-                              ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                              x11))( tl x8))( tl x5))( tl x2))( tl x) *
-                              ( λₗ x2 : var (type.list type.Z),
-                              ( λₗ x5 : var (type.list type.Z),
-                              ( λₗ x8 : var (type.list type.Z),
-                              ( λₗ x11 : var (type.list type.Z),
-                              ( λₗ x14 : var (type.list type.Z),
-                              ( λₗ x17 : var (type.list type.Z),
-                              ( λₗ x20 : var (type.list type.Z),
-                              ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                              x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
-                              x2))( tl x0)) +
-                             (2 *
-                              (19 *
-                               (( λₗ x2 : var (type.list type.Z),
-                                ( λₗ x5 : var (type.list type.Z),
-                                ( λₗ x8 : var (type.list type.Z),
-                                ( λₗ x11 : var (type.list type.Z),
-                                ( λₗ x14 : var (type.list type.Z),
-                                ( λₗ x17 : var (type.list type.Z),
-                                ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                                x) *
-                                ( λₗ x2 : var (type.list type.Z),
-                                ( λₗ x5 : var (type.list type.Z),
-                                ( λₗ x8 : var (type.list type.Z),
-                                ( λₗ x11 : var (type.list type.Z),
-                                ( λₗ x14 : var (type.list type.Z),
-                                ( λₗ x17 : var (type.list type.Z),
-                                ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                                x0))) +
-                              (19 *
-                               (( λₗ x2 : var (type.list type.Z),
-                                ( λₗ x5 : var (type.list type.Z),
-                                ( λₗ x8 : var (type.list type.Z),
-                                ( λₗ x11 : var (type.list type.Z),
-                                ( λₗ x14 : var (type.list type.Z),
-                                ( λₗ x17 : var (type.list type.Z),
-                                ( λₗ x20 : var (type.list type.Z),
-                                ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                                x17))( tl x14))( tl x11))( tl x8))( tl x5))( tl
-                                x2))( tl x) *
-                                ( λₗ x2 : var (type.list type.Z),
-                                ( λₗ x5 : var (type.list type.Z),
-                                ( λₗ x8 : var (type.list type.Z),
-                                ( λₗ x11 : var (type.list type.Z),
-                                ( λₗ x14 : var (type.list type.Z),
-                                ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                                x11))( tl x8))( tl x5))( tl x2))( tl x0)) +
-                               2 *
-                               (19 *
-                                (( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z),
-                                 ( λₗ x8 : var (type.list type.Z),
-                                 ( λₗ x11 : var (type.list type.Z),
-                                 ( λₗ x14 : var (type.list type.Z),
-                                 ( λₗ x17 : var (type.list type.Z),
-                                 ( λₗ x20 : var (type.list type.Z),
-                                 ( λₗ x23 : var (type.list type.Z),
-                                 ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                                 x20))( tl x17))( tl x14))( tl x11))( tl
-                                 x8))( tl x5))( tl x2))( tl x) *
-                                 ( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z),
-                                 ( λₗ x8 : var (type.list type.Z),
-                                 ( λₗ x11 : var (type.list type.Z),
-                                 ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                                 x8))( tl x5))( tl x2))( tl x0)))))))))))
-                       :: hd x *
-                          ( λₗ x2 : var (type.list type.Z),
-                          ( λₗ x5 : var (type.list type.Z),
-                          ( λₗ x8 : var (type.list type.Z),
-                          ( λₗ x11 : var (type.list type.Z),
-                          ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                          x8))( tl x5))( tl x2))( tl x0) +
-                          (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-                           ( λₗ x2 : var (type.list type.Z),
-                           ( λₗ x5 : var (type.list type.Z),
-                           ( λₗ x8 : var (type.list type.Z),
-                           ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                           x5))( tl x2))( tl x0) +
-                           (( λₗ x2 : var (type.list type.Z),
-                            ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                            x) *
-                            ( λₗ x2 : var (type.list type.Z),
-                            ( λₗ x5 : var (type.list type.Z),
-                            ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                            x2))( tl x0) +
-                            (( λₗ x2 : var (type.list type.Z),
-                             ( λₗ x5 : var (type.list type.Z),
-                             ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                             x2))( tl x) *
-                             ( λₗ x2 : var (type.list type.Z),
-                             ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                             x0) +
-                             (( λₗ x2 : var (type.list type.Z),
-                              ( λₗ x5 : var (type.list type.Z),
-                              ( λₗ x8 : var (type.list type.Z),
-                              ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                              x5))( tl x2))( tl x) *
-                              ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
-                              (( λₗ x2 : var (type.list type.Z),
-                               ( λₗ x5 : var (type.list type.Z),
-                               ( λₗ x8 : var (type.list type.Z),
-                               ( λₗ x11 : var (type.list type.Z),
-                               ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                               x8))( tl x5))( tl x2))( tl x) * hd x0 +
-                               (19 *
-                                (( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z),
-                                 ( λₗ x8 : var (type.list type.Z),
-                                 ( λₗ x11 : var (type.list type.Z),
-                                 ( λₗ x14 : var (type.list type.Z),
-                                 ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                                 x11))( tl x8))( tl x5))( tl x2))( tl x) *
-                                 ( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z),
-                                 ( λₗ x8 : var (type.list type.Z),
-                                 ( λₗ x11 : var (type.list type.Z),
-                                 ( λₗ x14 : var (type.list type.Z),
-                                 ( λₗ x17 : var (type.list type.Z),
-                                 ( λₗ x20 : var (type.list type.Z),
-                                 ( λₗ x23 : var (type.list type.Z),
-                                 ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                                 x20))( tl x17))( tl x14))( tl x11))( tl
-                                 x8))( tl x5))( tl x2))( tl x0)) +
-                                (19 *
-                                 (( λₗ x2 : var (type.list type.Z),
-                                  ( λₗ x5 : var (type.list type.Z),
-                                  ( λₗ x8 : var (type.list type.Z),
-                                  ( λₗ x11 : var (type.list type.Z),
-                                  ( λₗ x14 : var (type.list type.Z),
-                                  ( λₗ x17 : var (type.list type.Z),
-                                  ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                  x14))( tl x11))( tl x8))( tl x5))( tl
-                                  x2))( tl x) *
-                                  ( λₗ x2 : var (type.list type.Z),
-                                  ( λₗ x5 : var (type.list type.Z),
-                                  ( λₗ x8 : var (type.list type.Z),
-                                  ( λₗ x11 : var (type.list type.Z),
-                                  ( λₗ x14 : var (type.list type.Z),
-                                  ( λₗ x17 : var (type.list type.Z),
-                                  ( λₗ x20 : var (type.list type.Z),
-                                  ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                                  x17))( tl x14))( tl x11))( tl x8))( tl
-                                  x5))( tl x2))( tl x0)) +
-                                 (19 *
-                                  (( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z),
-                                   ( λₗ x11 : var (type.list type.Z),
-                                   ( λₗ x14 : var (type.list type.Z),
-                                   ( λₗ x17 : var (type.list type.Z),
-                                   ( λₗ x20 : var (type.list type.Z),
-                                   ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                                   x17))( tl x14))( tl x11))( tl x8))( tl
-                                   x5))( tl x2))( tl x) *
-                                   ( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z),
-                                   ( λₗ x11 : var (type.list type.Z),
-                                   ( λₗ x14 : var (type.list type.Z),
-                                   ( λₗ x17 : var (type.list type.Z),
-                                   ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                   x14))( tl x11))( tl x8))( tl x5))( tl
-                                   x2))( tl x0)) +
-                                  19 *
-                                  (( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z),
-                                   ( λₗ x11 : var (type.list type.Z),
-                                   ( λₗ x14 : var (type.list type.Z),
-                                   ( λₗ x17 : var (type.list type.Z),
-                                   ( λₗ x20 : var (type.list type.Z),
-                                   ( λₗ x23 : var (type.list type.Z),
-                                   ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                                   x20))( tl x17))( tl x14))( tl x11))( tl
-                                   x8))( tl x5))( tl x2))( tl x) *
-                                   ( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z),
-                                   ( λₗ x11 : var (type.list type.Z),
-                                   ( λₗ x14 : var (type.list type.Z),
-                                   ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                                   x11))( tl x8))( tl x5))( tl x2))( tl
-                                   x0))))))))))
-                          :: hd x *
-                             ( λₗ x2 : var (type.list type.Z),
-                             ( λₗ x5 : var (type.list type.Z),
-                             ( λₗ x8 : var (type.list type.Z),
-                             ( λₗ x11 : var (type.list type.Z),
-                             ( λₗ x14 : var (type.list type.Z),
-                             ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                             x11))( tl x8))( tl x5))( tl x2))( tl x0) +
-                             (2 *
-                              (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-                               ( λₗ x2 : var (type.list type.Z),
-                               ( λₗ x5 : var (type.list type.Z),
-                               ( λₗ x8 : var (type.list type.Z),
-                               ( λₗ x11 : var (type.list type.Z),
-                               ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                               x8))( tl x5))( tl x2))( tl x0)) +
-                              (( λₗ x2 : var (type.list type.Z),
-                               ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                               x) *
-                               ( λₗ x2 : var (type.list type.Z),
-                               ( λₗ x5 : var (type.list type.Z),
-                               ( λₗ x8 : var (type.list type.Z),
-                               ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                               x5))( tl x2))( tl x0) +
-                               (2 *
-                                (( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z),
-                                 ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                                 x2))( tl x) *
-                                 ( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z),
-                                 ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                                 x2))( tl x0)) +
-                                (( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z),
-                                 ( λₗ x8 : var (type.list type.Z),
-                                 ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                                 x5))( tl x2))( tl x) *
-                                 ( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                                 x0) +
-                                 (2 *
-                                  (( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z),
-                                   ( λₗ x11 : var (type.list type.Z),
-                                   ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                                   x8))( tl x5))( tl x2))( tl x) *
-                                   ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)) +
-                                  (( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z),
-                                   ( λₗ x11 : var (type.list type.Z),
-                                   ( λₗ x14 : var (type.list type.Z),
-                                   ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                                   x11))( tl x8))( tl x5))( tl x2))( tl
-                                   x) * hd x0 +
-                                   (2 *
-                                    (19 *
-                                     (( λₗ x2 : var (type.list type.Z),
-                                      ( λₗ x5 : var (type.list type.Z),
-                                      ( λₗ x8 : var (type.list type.Z),
-                                      ( λₗ x11 : var (type.list type.Z),
-                                      ( λₗ x14 : var (type.list type.Z),
-                                      ( λₗ x17 : var (type.list type.Z),
-                                      ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                      x14))( tl x11))( tl x8))( tl x5))( tl
-                                      x2))( tl x) *
-                                      ( λₗ x2 : var (type.list type.Z),
-                                      ( λₗ x5 : var (type.list type.Z),
-                                      ( λₗ x8 : var (type.list type.Z),
-                                      ( λₗ x11 : var (type.list type.Z),
-                                      ( λₗ x14 : var (type.list type.Z),
-                                      ( λₗ x17 : var (type.list type.Z),
-                                      ( λₗ x20 : var (type.list type.Z),
-                                      ( λₗ x23 : var (type.list type.Z),
-                                      ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                                      x20))( tl x17))( tl x14))( tl x11))( tl
-                                      x8))( tl x5))( tl x2))( tl x0))) +
-                                    (19 *
-                                     (( λₗ x2 : var (type.list type.Z),
-                                      ( λₗ x5 : var (type.list type.Z),
-                                      ( λₗ x8 : var (type.list type.Z),
-                                      ( λₗ x11 : var (type.list type.Z),
-                                      ( λₗ x14 : var (type.list type.Z),
-                                      ( λₗ x17 : var (type.list type.Z),
-                                      ( λₗ x20 : var (type.list type.Z),
-                                      ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                                      x17))( tl x14))( tl x11))( tl x8))( tl
-                                      x5))( tl x2))( tl x) *
-                                      ( λₗ x2 : var (type.list type.Z),
-                                      ( λₗ x5 : var (type.list type.Z),
-                                      ( λₗ x8 : var (type.list type.Z),
-                                      ( λₗ x11 : var (type.list type.Z),
-                                      ( λₗ x14 : var (type.list type.Z),
-                                      ( λₗ x17 : var (type.list type.Z),
-                                      ( λₗ x20 : var (type.list type.Z),
-                                      ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                                      x17))( tl x14))( tl x11))( tl x8))( tl
-                                      x5))( tl x2))( tl x0)) +
-                                     2 *
-                                     (19 *
-                                      (( λₗ x2 : var (type.list type.Z),
-                                       ( λₗ x5 : var (type.list type.Z),
-                                       ( λₗ x8 : var (type.list type.Z),
-                                       ( λₗ x11 : var (type.list type.Z),
-                                       ( λₗ x14 : var (type.list type.Z),
-                                       ( λₗ x17 : var (type.list type.Z),
-                                       ( λₗ x20 : var (type.list type.Z),
-                                       ( λₗ x23 : var (type.list type.Z),
-                                       ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                                       x20))( tl x17))( tl x14))( tl x11))( tl
-                                       x8))( tl x5))( tl x2))( tl x) *
-                                       ( λₗ x2 : var (type.list type.Z),
-                                       ( λₗ x5 : var (type.list type.Z),
-                                       ( λₗ x8 : var (type.list type.Z),
-                                       ( λₗ x11 : var (type.list type.Z),
-                                       ( λₗ x14 : var (type.list type.Z),
-                                       ( λₗ x17 : var (type.list type.Z),
-                                       ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                       x14))( tl x11))( tl x8))( tl x5))( tl
-                                       x2))( tl x0)))))))))))
-                             :: hd x *
-                                ( λₗ x2 : var (type.list type.Z),
-                                ( λₗ x5 : var (type.list type.Z),
-                                ( λₗ x8 : var (type.list type.Z),
-                                ( λₗ x11 : var (type.list type.Z),
-                                ( λₗ x14 : var (type.list type.Z),
-                                ( λₗ x17 : var (type.list type.Z),
-                                ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                x14))( tl x11))( tl x8))( tl x5))( tl x2))( tl
-                                x0) +
-                                (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-                                 ( λₗ x2 : var (type.list type.Z),
-                                 ( λₗ x5 : var (type.list type.Z),
-                                 ( λₗ x8 : var (type.list type.Z),
-                                 ( λₗ x11 : var (type.list type.Z),
-                                 ( λₗ x14 : var (type.list type.Z),
-                                 ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                                 x11))( tl x8))( tl x5))( tl x2))( tl x0) +
-                                 (( λₗ x2 : var (type.list type.Z),
-                                  ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                                  x) *
-                                  ( λₗ x2 : var (type.list type.Z),
-                                  ( λₗ x5 : var (type.list type.Z),
-                                  ( λₗ x8 : var (type.list type.Z),
-                                  ( λₗ x11 : var (type.list type.Z),
-                                  ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                                  x8))( tl x5))( tl x2))( tl x0) +
-                                  (( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                                   x2))( tl x) *
-                                   ( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z),
-                                   ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                                   x5))( tl x2))( tl x0) +
-                                   (( λₗ x2 : var (type.list type.Z),
-                                    ( λₗ x5 : var (type.list type.Z),
-                                    ( λₗ x8 : var (type.list type.Z),
-                                    ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                                    x5))( tl x2))( tl x) *
-                                    ( λₗ x2 : var (type.list type.Z),
-                                    ( λₗ x5 : var (type.list type.Z),
-                                    ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                                    x2))( tl x0) +
-                                    (( λₗ x2 : var (type.list type.Z),
-                                     ( λₗ x5 : var (type.list type.Z),
-                                     ( λₗ x8 : var (type.list type.Z),
-                                     ( λₗ x11 : var (type.list type.Z),
-                                     ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                                     x8))( tl x5))( tl x2))( tl x) *
-                                     ( λₗ x2 : var (type.list type.Z),
-                                     ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                                     x0) +
-                                     (( λₗ x2 : var (type.list type.Z),
-                                      ( λₗ x5 : var (type.list type.Z),
-                                      ( λₗ x8 : var (type.list type.Z),
-                                      ( λₗ x11 : var (type.list type.Z),
-                                      ( λₗ x14 : var (type.list type.Z),
-                                      ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                                      x11))( tl x8))( tl x5))( tl x2))( tl
-                                      x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
-                                      (( λₗ x2 : var (type.list type.Z),
-                                       ( λₗ x5 : var (type.list type.Z),
-                                       ( λₗ x8 : var (type.list type.Z),
-                                       ( λₗ x11 : var (type.list type.Z),
-                                       ( λₗ x14 : var (type.list type.Z),
-                                       ( λₗ x17 : var (type.list type.Z),
-                                       ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                       x14))( tl x11))( tl x8))( tl x5))( tl
-                                       x2))( tl x) * hd x0 +
-                                       (19 *
-                                        (( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z),
-                                         ( λₗ x11 : var (type.list type.Z),
-                                         ( λₗ x14 : var (type.list type.Z),
-                                         ( λₗ x17 : var (type.list type.Z),
-                                         ( λₗ x20 : var (type.list type.Z),
-                                         ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))
-                                         ( tl x17))( tl x14))( tl x11))( tl
-                                         x8))( tl x5))( tl x2))( tl x) *
-                                         ( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z),
-                                         ( λₗ x11 : var (type.list type.Z),
-                                         ( λₗ x14 : var (type.list type.Z),
-                                         ( λₗ x17 : var (type.list type.Z),
-                                         ( λₗ x20 : var (type.list type.Z),
-                                         ( λₗ x23 : var (type.list type.Z),
-                                         ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))
-                                         ( tl x20))( tl x17))( tl x14))( tl
-                                         x11))( tl x8))( tl x5))( tl x2))( tl
-                                         x0)) +
-                                        19 *
-                                        (( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z),
-                                         ( λₗ x11 : var (type.list type.Z),
-                                         ( λₗ x14 : var (type.list type.Z),
-                                         ( λₗ x17 : var (type.list type.Z),
-                                         ( λₗ x20 : var (type.list type.Z),
-                                         ( λₗ x23 : var (type.list type.Z),
-                                         ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))
-                                         ( tl x20))( tl x17))( tl x14))( tl
-                                         x11))( tl x8))( tl x5))( tl x2))( tl
-                                         x) *
-                                         ( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z),
-                                         ( λₗ x11 : var (type.list type.Z),
-                                         ( λₗ x14 : var (type.list type.Z),
-                                         ( λₗ x17 : var (type.list type.Z),
-                                         ( λₗ x20 : var (type.list type.Z),
-                                         ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))
-                                         ( tl x17))( tl x14))( tl x11))( tl
-                                         x8))( tl x5))( tl x2))( tl x0))))))))))
-                                :: hd x *
-                                   ( λₗ x2 : var (type.list type.Z),
-                                   ( λₗ x5 : var (type.list type.Z),
-                                   ( λₗ x8 : var (type.list type.Z),
-                                   ( λₗ x11 : var (type.list type.Z),
-                                   ( λₗ x14 : var (type.list type.Z),
-                                   ( λₗ x17 : var (type.list type.Z),
-                                   ( λₗ x20 : var (type.list type.Z),
-                                   ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                                   x17))( tl x14))( tl x11))( tl x8))( tl
-                                   x5))( tl x2))( tl x0) +
-                                   (2 *
-                                    (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-                                     ( λₗ x2 : var (type.list type.Z),
-                                     ( λₗ x5 : var (type.list type.Z),
-                                     ( λₗ x8 : var (type.list type.Z),
-                                     ( λₗ x11 : var (type.list type.Z),
-                                     ( λₗ x14 : var (type.list type.Z),
-                                     ( λₗ x17 : var (type.list type.Z),
-                                     ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))( tl
-                                     x14))( tl x11))( tl x8))( tl x5))( tl
-                                     x2))( tl x0)) +
-                                    (( λₗ x2 : var (type.list type.Z),
-                                     ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                                     x) *
-                                     ( λₗ x2 : var (type.list type.Z),
-                                     ( λₗ x5 : var (type.list type.Z),
-                                     ( λₗ x8 : var (type.list type.Z),
-                                     ( λₗ x11 : var (type.list type.Z),
-                                     ( λₗ x14 : var (type.list type.Z),
-                                     ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))( tl
-                                     x11))( tl x8))( tl x5))( tl x2))( tl
-                                     x0) +
-                                     (2 *
-                                      (( λₗ x2 : var (type.list type.Z),
-                                       ( λₗ x5 : var (type.list type.Z),
-                                       ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                                       x2))( tl x) *
-                                       ( λₗ x2 : var (type.list type.Z),
-                                       ( λₗ x5 : var (type.list type.Z),
-                                       ( λₗ x8 : var (type.list type.Z),
-                                       ( λₗ x11 : var (type.list type.Z),
-                                       ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))( tl
-                                       x8))( tl x5))( tl x2))( tl x0)) +
-                                      (( λₗ x2 : var (type.list type.Z),
-                                       ( λₗ x5 : var (type.list type.Z),
-                                       ( λₗ x8 : var (type.list type.Z),
-                                       ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                                       x5))( tl x2))( tl x) *
-                                       ( λₗ x2 : var (type.list type.Z),
-                                       ( λₗ x5 : var (type.list type.Z),
-                                       ( λₗ x8 : var (type.list type.Z),
-                                       ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))( tl
-                                       x5))( tl x2))( tl x0) +
-                                       (2 *
-                                        (( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z),
-                                         ( λₗ x11 : var (type.list type.Z),
-                                         ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))
-                                         ( tl x8))( tl x5))( tl x2))( tl
-                                         x) *
-                                         ( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                                         x2))( tl x0)) +
-                                        (( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z),
-                                         ( λₗ x11 : var (type.list type.Z),
-                                         ( λₗ x14 : var (type.list type.Z),
-                                         ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))
-                                         ( tl x11))( tl x8))( tl x5))( tl
-                                         x2))( tl x) *
-                                         ( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                                         x0) +
-                                         (2 *
-                                          (( λₗ x2 : var (type.list type.Z),
-                                           ( λₗ x5 : var (type.list type.Z),
-                                           ( λₗ x8 : var (type.list type.Z),
-                                           ( λₗ x11 : var (type.list type.Z),
-                                           ( λₗ x14 : var (type.list type.Z),
-                                           ( λₗ x17 : var (type.list type.Z),
-                                           ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))
-                                           ( tl x14))( tl x11))( tl x8))( tl
-                                           x5))( tl x2))( tl x) *
-                                           ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0)) +
-                                          (( λₗ x2 : var (type.list type.Z),
-                                           ( λₗ x5 : var (type.list type.Z),
-                                           ( λₗ x8 : var (type.list type.Z),
-                                           ( λₗ x11 : var (type.list type.Z),
-                                           ( λₗ x14 : var (type.list type.Z),
-                                           ( λₗ x17 : var (type.list type.Z),
-                                           ( λₗ x20 : var (type.list type.Z),
-                                           ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))
-                                           ( tl x17))( tl x14))( tl x11))( tl
-                                           x8))( tl x5))( tl x2))( tl x) *
-                                           hd x0 +
-                                           2 *
-                                           (19 *
-                                            (( λₗ x2 : var (type.list type.Z),
-                                             ( λₗ x5 : var (type.list type.Z),
-                                             ( λₗ x8 : var (type.list type.Z),
-                                             ( λₗ x11 : var (type.list type.Z),
-                                             ( λₗ x14 : var (type.list type.Z),
-                                             ( λₗ x17 : var (type.list type.Z),
-                                             ( λₗ x20 : var (type.list type.Z),
-                                             ( λₗ x23 : var (...),
-                                             ( λₗ x26 : var ..., hd x26)( tl x23))( tl
-                                             x20))( tl x17))( tl x14))( tl
-                                             x11))( tl x8))( tl x5))( tl
-                                             x2))( tl x) *
-                                             ( λₗ x2 : var (type.list type.Z),
-                                             ( λₗ x5 : var (type.list type.Z),
-                                             ( λₗ x8 : var (type.list type.Z),
-                                             ( λₗ x11 : var (type.list type.Z),
-                                             ( λₗ x14 : var (type.list type.Z),
-                                             ( λₗ x17 : var (type.list type.Z),
-                                             ( λₗ x20 : var (type.list type.Z),
-                                             ( λₗ x23 : var (...),
-                                             ( λₗ x26 : var ..., hd x26)( tl x23))( tl
-                                             x20))( tl x17))( tl x14))( tl
-                                             x11))( tl x8))( tl x5))( tl
-                                             x2))( tl x0)))))))))))
-                                   :: hd x *
-                                      ( λₗ x2 : var (type.list type.Z),
-                                      ( λₗ x5 : var (type.list type.Z),
-                                      ( λₗ x8 : var (type.list type.Z),
-                                      ( λₗ x11 : var (type.list type.Z),
-                                      ( λₗ x14 : var (type.list type.Z),
-                                      ( λₗ x17 : var (type.list type.Z),
-                                      ( λₗ x20 : var (type.list type.Z),
-                                      ( λₗ x23 : var (type.list type.Z),
-                                      ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))( tl
-                                      x20))( tl x17))( tl x14))( tl x11))( tl
-                                      x8))( tl x5))( tl x2))( tl x0) +
-                                      (( λₗ x2 : var (type.list type.Z), hd x2)( tl x) *
-                                       ( λₗ x2 : var (type.list type.Z),
-                                       ( λₗ x5 : var (type.list type.Z),
-                                       ( λₗ x8 : var (type.list type.Z),
-                                       ( λₗ x11 : var (type.list type.Z),
-                                       ( λₗ x14 : var (type.list type.Z),
-                                       ( λₗ x17 : var (type.list type.Z),
-                                       ( λₗ x20 : var (type.list type.Z),
-                                       ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))( tl
-                                       x17))( tl x14))( tl x11))( tl x8))( tl
-                                       x5))( tl x2))( tl x0) +
-                                       (( λₗ x2 : var (type.list type.Z),
-                                        ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))( tl
-                                        x) *
-                                        ( λₗ x2 : var (type.list type.Z),
-                                        ( λₗ x5 : var (type.list type.Z),
-                                        ( λₗ x8 : var (type.list type.Z),
-                                        ( λₗ x11 : var (type.list type.Z),
-                                        ( λₗ x14 : var (type.list type.Z),
-                                        ( λₗ x17 : var (type.list type.Z),
-                                        ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))
-                                        ( tl x14))( tl x11))( tl x8))( tl
-                                        x5))( tl x2))( tl x0) +
-                                        (( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))( tl
-                                         x2))( tl x) *
-                                         ( λₗ x2 : var (type.list type.Z),
-                                         ( λₗ x5 : var (type.list type.Z),
-                                         ( λₗ x8 : var (type.list type.Z),
-                                         ( λₗ x11 : var (type.list type.Z),
-                                         ( λₗ x14 : var (type.list type.Z),
-                                         ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))
-                                         ( tl x11))( tl x8))( tl x5))( tl
-                                         x2))( tl x0) +
-                                         (( λₗ x2 : var (type.list type.Z),
-                                          ( λₗ x5 : var (type.list type.Z),
-                                          ( λₗ x8 : var (type.list type.Z),
-                                          ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))
-                                          ( tl x5))( tl x2))( tl x) *
-                                          ( λₗ x2 : var (type.list type.Z),
-                                          ( λₗ x5 : var (type.list type.Z),
-                                          ( λₗ x8 : var (type.list type.Z),
-                                          ( λₗ x11 : var (type.list type.Z),
-                                          ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))
-                                          ( tl x8))( tl x5))( tl x2))( tl
-                                          x0) +
-                                          (( λₗ x2 : var (type.list type.Z),
-                                           ( λₗ x5 : var (type.list type.Z),
-                                           ( λₗ x8 : var (type.list type.Z),
-                                           ( λₗ x11 : var (type.list type.Z),
-                                           ( λₗ x14 : var (type.list type.Z), hd x14)( tl x11))
-                                           ( tl x8))( tl x5))( tl x2))( tl
-                                           x) *
-                                           ( λₗ x2 : var (type.list type.Z),
-                                           ( λₗ x5 : var (type.list type.Z),
-                                           ( λₗ x8 : var (type.list type.Z),
-                                           ( λₗ x11 : var (type.list type.Z), hd x11)( tl x8))
-                                           ( tl x5))( tl x2))( tl x0) +
-                                           (( λₗ x2 : var (type.list type.Z),
-                                            ( λₗ x5 : var (type.list type.Z),
-                                            ( λₗ x8 : var (type.list type.Z),
-                                            ( λₗ x11 : var (type.list type.Z),
-                                            ( λₗ x14 : var (type.list type.Z),
-                                            ( λₗ x17 : var (type.list type.Z), hd x17)( tl x14))
-                                            ( tl x11))( tl x8))( tl x5))( tl
-                                            x2))( tl x) *
-                                            ( λₗ x2 : var (type.list type.Z),
-                                            ( λₗ x5 : var (type.list type.Z),
-                                            ( λₗ x8 : var (type.list type.Z), hd x8)( tl x5))
-                                            ( tl x2))( tl x0) +
-                                            (( λₗ x2 : var (type.list type.Z),
-                                             ( λₗ x5 : var (type.list type.Z),
-                                             ( λₗ x8 : var (type.list type.Z),
-                                             ( λₗ x11 : var (type.list type.Z),
-                                             ( λₗ x14 : var (type.list type.Z),
-                                             ( λₗ x17 : var (type.list type.Z),
-                                             ( λₗ x20 : var (type.list type.Z), hd x20)( tl x17))
-                                             ( tl x14))( tl x11))( tl x8))( tl
-                                             x5))( tl x2))( tl x) *
-                                             ( λₗ x2 : var (type.list type.Z),
-                                             ( λₗ x5 : var (type.list type.Z), hd x5)( tl x2))
-                                             ( tl x0) +
-                                             (( λₗ x2 : var (type.list type.Z),
-                                              ( λₗ x5 : var (type.list type.Z),
-                                              ( λₗ x8 : var (type.list type.Z),
-                                              ( λₗ x11 : var (type.list type.Z),
-                                              ( λₗ x14 : var (type.list type.Z),
-                                              ( λₗ x17 : var (type.list type.Z),
-                                              ( λₗ x20 : var (type.list type.Z),
-                                              ( λₗ x23 : var (type.list type.Z), hd x23)( tl x20))
-                                              ( tl x17))( tl x14))( tl x11))( tl
-                                              x8))( tl x5))( tl x2))( tl
-                                              x) * ( λₗ x2 : var (type.list type.Z), hd x2)( tl x0) +
-                                              ( λₗ x2 : var (type.list type.Z),
-                                              ( λₗ x5 : var (type.list type.Z),
-                                              ( λₗ x8 : var (type.list type.Z),
-                                              ( λₗ x11 : var (type.list type.Z),
-                                              ( λₗ x14 : var (type.list type.Z),
-                                              ( λₗ x17 : var (type.list type.Z),
-                                              ( λₗ x20 : var (type.list type.Z),
-                                              ( λₗ x23 : var (type.list type.Z),
-                                              ( λₗ x26 : var (type.list type.Z), hd x26)( tl x23))
-                                              ( tl x20))( tl x17))( tl x14))( tl
-                                              x11))( tl x8))( tl x5))( tl
-                                              x2))( tl x) * hd x0)))))))) :: [])%expr) f g
-     : forall f g : list Z, length f = 10%nat -> length g = 10%nat -> list Z
-*)
+     (* = fun (f g : list Z) (_ : length f = 10%nat) (_ : length g = 10%nat) => *)
+     (*   expr.Interp (@ident.interp) *)
+     (*     (fun var : type -> Type => *)
+     (*      (λ x x0 : var (type.list (type.type_opaque type.Z)), *)
+     (*       Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*       (λ (x1 : var (type.type_opaque type.Z))(_ : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*        x1) (x) * *)
+     (*       Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*       (λ (x1 : var (type.type_opaque type.Z))(_ : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*        x1) (x0) + *)
+     (*       (Ident (ident.opaque 2) * *)
+     (*        (Ident (ident.opaque 19) * *)
+     (*         (Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*          (λ (_ : var (type.type_opaque type.Z))(x2 : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*           Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*           (λ (x4 : var (type.type_opaque type.Z))(_ : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*            x4) (x2)) (x) * *)
+     (*          Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*          (λ (_ : var (type.type_opaque type.Z))(x2 : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*           Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*           (λ (_ : var (type.type_opaque type.Z))(x5 : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*            Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*            (λ (_ : var (type.type_opaque type.Z))(x8 : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*             Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*             (λ (_ : var (type.type_opaque type.Z))(x11 : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*              Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*              (λ (_ : var (type.type_opaque type.Z))(x14 : var (type.list (type.type_opaque type.Z)))(_ :  *)
+     (*                                                                                                      var  *)
+     (*                                                                                                        (type.type_opaque type.Z)), *)
+     (*               Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*               (λ (_ : var (type.type_opaque type.Z))(x17 : var (type.list (type.type_opaque type.Z)))(_ :  *)
+     (*                                                                                                       var  *)
+     (*                                                                                                         (type.type_opaque type.Z)), *)
+     (*                Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*                (λ (_ : var (type.type_opaque type.Z))(x20 : var (type.list (type.type_opaque type.Z)))(_ :  *)
+     (*                                                                                                        var  *)
+     (*                                                                                                         (type.type_opaque type.Z)), *)
+     (*                 Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*                 (λ (_ : var (type.type_opaque type.Z))(x23 : var (type.list (type.type_opaque type.Z)))(_ :  *)
+     (*                                                                                                         var  *)
+     (*                                                                                                         (type.type_opaque type.Z)), *)
+     (*                  Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*                  (λ (_ : var (type.type_opaque type.Z))(x26 : var (type.list (type.type_opaque type.Z)))(_ :  *)
+     (*                                                                                                         var  *)
+     (*                                                                                                         (type.type_opaque type.Z)), *)
+     (*                   Ident ident.list_rect (Ident (...)) (λ (x28 : var (...))(_ : var (...))(_ : var (...)), *)
+     (*                                                        x28) (x26)) (x23)) (x20)) (x17)) (x14)) (x11)) (x8))  *)
+     (*            (x5)) (x2)) (x0))) + *)
+     (*        (Ident (ident.opaque 19) * *)
+     (*         (Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*          (λ (_ : var (type.type_opaque type.Z))(x2 : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*           Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (*           (λ (_ : var (type.type_opaque type.Z))(x5 : var (type.list (type.type_opaque type.Z)))(_ : var (type.type_opaque type.Z)), *)
+     (*            Ident ident.list_rect (Ident (ident.opaque (-1))) *)
+     (* ... *)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -525,7 +525,7 @@ Module Compilers.
           | let x := ?a in @?b x
             => let A := type of a in
                let B := lazymatch type of b with forall x, @?B x => B end in
-               reify_rec (@Let_In A B a b)
+               reify_rec (b a) (*(@Let_In A B a b)*)
           | Datatypes.pair ?x ?y
             => let rx := reify_rec x in
                let ry := reify_rec y in
@@ -2356,8 +2356,8 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
     assert True.
     { let v := Reify (fun y : Z
                       => (fun k : Z * Z -> Z * Z
-                          => let x := (y * y)%RT in
-                             let z := (x * x)%RT in
+                          => dlet_nd x := (y * y)%RT in
+                             dlet_nd z := (x * x)%RT in
                              k (z, z))
                            (fun v => v)) in
       pose v as E.
@@ -2374,10 +2374,10 @@ Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 
       constructor. }
     assert True.
     { let v := Reify (fun y : Z
-                      => let x := let x := (y * y)%RT in
-                                  (x * x)%RT in
-                         let z := let z := (x * x)%RT in
-                                  (z * z)%RT in
+                      => dlet_nd x := dlet_nd x := (y * y)%RT in
+                                      (x * x)%RT in
+                         dlet_nd z := dlet_nd z := (x * x)%RT in
+                                      (z * z)%RT in
                          (z * z)%RT) in
       pose v as E.
       vm_compute in E.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -1776,7 +1776,6 @@ End Compilers.
 Import Associational Positional Compilers.
 Local Coercion Z.of_nat : nat >-> Z.
 Local Coercion QArith_base.inject_Z : Z >-> Q.
-Definition w (i:nat) : Z := 2^Qceiling((25+1/2)*i).
 
 (* TODO: is this the right way to do things? *)
 Definition expand_list_helper {A} (default : A) (ls : list A) (n : nat) (idx : nat) : list A
@@ -1831,6 +1830,8 @@ Open Scope RT_expr_scope.
 
 Require Import AdmitAxiom.
 
+(*Definition w (i:nat) : Z := 2^Qceiling((25+1/2)*i).*)
+Definition w (i:nat) : Z := 2^Qceiling(51*i).
 Example base_51_carry_mul (*(f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 g0 g1 g2 g3 g4 g5 g6 g7 g8 g9 : Z)
         (f:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)
         (g:=(f0 :: f1 :: f2 :: f3 :: f4 :: f5 :: f6 :: f7 :: f8 :: f9 :: nil)%list)*) (f g : list Z)
@@ -1954,194 +1955,148 @@ Eval cbv [proj1_sig base_51_carry_mul] in (fun f g Hf Hg => proj1_sig (base_51_c
          (fun var : type -> Type =>
           (λ x x0 : var (type.list type.Z),
            expr_let y := x [[0]] * x0 [[4]] +
-                         (2 * (x [[1]] * x0 [[3]]) +
-                          (67108864 * (x [[1]] * x0 [[4]]) +
-                           (x [[2]] * x0 [[2]] +
-                            (67108864 * (x [[2]] * x0 [[3]]) +
-                             (2251799813685248 * (x [[2]] * x0 [[4]]) +
-                              (2 * (x [[3]] * x0 [[1]]) +
-                               (67108864 * (x [[3]] * x0 [[2]]) +
-                                (4503599627370496 * (x [[3]] * x0 [[3]]) +
-                                 (151115727451828646838272 * (x [[3]] * x0 [[4]]) +
-                                  (x [[4]] * x0 [[0]] +
-                                   (67108864 * (x [[4]] * x0 [[1]]) +
-                                    (2251799813685248 * (x [[4]] * x0 [[2]]) +
-                                     (151115727451828646838272 * (x [[4]] * x0 [[3]]) +
-                                      5070602400912917605986812821504 * (x [[4]] * x0 [[4]])))))))))))))) in
-           expr_let _ := Ident ident.Z.div @ y @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y @ 67108864 in
+                         (x [[1]] * x0 [[3]] +
+                          (x [[2]] * x0 [[2]] +
+                           (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]]))) in
+           expr_let _ := Ident ident.Z.div @ y @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y @ 2251799813685248 in
            expr_let y2 := x [[0]] * x0 [[3]] +
-                          (x [[1]] * x0 [[2]] + (x [[2]] * x0 [[1]] + x [[3]] * x0 [[0]])) in
-           expr_let _ := Ident ident.Z.div @ y2 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y2 @ 67108864 in
-           expr_let y5 := x [[0]] * x0 [[2]] + (2 * (x [[1]] * x0 [[1]]) + x [[2]] * x0 [[0]]) in
-           expr_let _ := Ident ident.Z.div @ y5 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y5 @ 67108864 in
-           expr_let y8 := x [[0]] * x0 [[1]] + x [[1]] * x0 [[0]] in
-           expr_let _ := Ident ident.Z.div @ y8 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y8 @ 67108864 in
-           expr_let y11 := x [[0]] * x0 [[0]] in
-           expr_let y12 := Ident ident.Z.div @ y11 @ 67108864 in
-           expr_let y13 := Ident ident.Z.modulo @ y11 @ 67108864 in
+                          (x [[1]] * x0 [[2]] +
+                           (x [[2]] * x0 [[1]] +
+                            (x [[3]] * x0 [[0]] + 19 * (x [[4]] * x0 [[4]])))) in
+           expr_let _ := Ident ident.Z.div @ y2 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y2 @ 2251799813685248 in
+           expr_let y5 := x [[0]] * x0 [[2]] +
+                          (x [[1]] * x0 [[1]] +
+                           (x [[2]] * x0 [[0]] +
+                            (19 * (x [[3]] * x0 [[4]]) + 19 * (x [[4]] * x0 [[3]])))) in
+           expr_let _ := Ident ident.Z.div @ y5 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y5 @ 2251799813685248 in
+           expr_let y8 := x [[0]] * x0 [[1]] +
+                          (x [[1]] * x0 [[0]] +
+                           (19 * (x [[2]] * x0 [[4]]) +
+                            (19 * (x [[3]] * x0 [[3]]) + 19 * (x [[4]] * x0 [[2]])))) in
+           expr_let _ := Ident ident.Z.div @ y8 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y8 @ 2251799813685248 in
+           expr_let y11 := x [[0]] * x0 [[0]] +
+                           (19 * (x [[1]] * x0 [[4]]) +
+                            (19 * (x [[2]] * x0 [[3]]) +
+                             (19 * (x [[3]] * x0 [[2]]) +
+                              19 * (x [[4]] * x0 [[1]])))) in
+           expr_let y12 := Ident ident.Z.div @ y11 @ 2251799813685248 in
+           expr_let y13 := Ident ident.Z.modulo @ y11 @ 2251799813685248 in
            expr_let y14 := x [[0]] * x0 [[4]] +
-                           (2 * (x [[1]] * x0 [[3]]) +
-                            (67108864 * (x [[1]] * x0 [[4]]) +
-                             (x [[2]] * x0 [[2]] +
-                              (67108864 * (x [[2]] * x0 [[3]]) +
-                               (2251799813685248 * (x [[2]] * x0 [[4]]) +
-                                (2 * (x [[3]] * x0 [[1]]) +
-                                 (67108864 * (x [[3]] * x0 [[2]]) +
-                                  (4503599627370496 * (x [[3]] * x0 [[3]]) +
-                                   (151115727451828646838272 * (x [[3]] * x0 [[4]]) +
-                                    (x [[4]] * x0 [[0]] +
-                                     (67108864 * (x [[4]] * x0 [[1]]) +
-                                      (2251799813685248 * (x [[4]] * x0 [[2]]) +
-                                       (151115727451828646838272 * (x [[4]] * x0 [[3]]) +
-                                        5070602400912917605986812821504 * (x [[4]] * x0 [[4]])))))))))))))) in
-           expr_let _ := Ident ident.Z.div @ y14 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y14 @ 33554432 in
+                           (x [[1]] * x0 [[3]] +
+                            (x [[2]] * x0 [[2]] +
+                             (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]]))) in
+           expr_let _ := Ident ident.Z.div @ y14 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y14 @ 2251799813685248 in
            expr_let y17 := x [[0]] * x0 [[3]] +
-                           (x [[1]] * x0 [[2]] + (x [[2]] * x0 [[1]] + x [[3]] * x0 [[0]])) in
-           expr_let _ := Ident ident.Z.div @ y17 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y17 @ 33554432 in
-           expr_let y20 := x [[0]] * x0 [[2]] + (2 * (x [[1]] * x0 [[1]]) + x [[2]] * x0 [[0]]) in
-           expr_let _ := Ident ident.Z.div @ y20 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y20 @ 33554432 in
-           expr_let y23 := y12 + (x [[0]] * x0 [[1]] + x [[1]] * x0 [[0]]) in
-           expr_let y24 := Ident ident.Z.div @ y23 @ 33554432 in
-           expr_let y25 := Ident ident.Z.modulo @ y23 @ 33554432 in
-           expr_let _ := Ident ident.Z.div @ y13 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y13 @ 33554432 in
+                           (x [[1]] * x0 [[2]] +
+                            (x [[2]] * x0 [[1]] +
+                             (x [[3]] * x0 [[0]] + 19 * (x [[4]] * x0 [[4]])))) in
+           expr_let _ := Ident ident.Z.div @ y17 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y17 @ 2251799813685248 in
+           expr_let y20 := x [[0]] * x0 [[2]] +
+                           (x [[1]] * x0 [[1]] +
+                            (x [[2]] * x0 [[0]] +
+                             (19 * (x [[3]] * x0 [[4]]) +
+                              19 * (x [[4]] * x0 [[3]])))) in
+           expr_let _ := Ident ident.Z.div @ y20 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y20 @ 2251799813685248 in
+           expr_let y23 := y12 +
+                           (x [[0]] * x0 [[1]] +
+                            (x [[1]] * x0 [[0]] +
+                             (19 * (x [[2]] * x0 [[4]]) +
+                              (19 * (x [[3]] * x0 [[3]]) +
+                               19 * (x [[4]] * x0 [[2]]))))) in
+           expr_let y24 := Ident ident.Z.div @ y23 @ 2251799813685248 in
+           expr_let y25 := Ident ident.Z.modulo @ y23 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y13 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y13 @ 2251799813685248 in
            expr_let y28 := x [[0]] * x0 [[4]] +
-                           (2 * (x [[1]] * x0 [[3]]) +
-                            (67108864 * (x [[1]] * x0 [[4]]) +
-                             (x [[2]] * x0 [[2]] +
-                              (67108864 * (x [[2]] * x0 [[3]]) +
-                               (2251799813685248 * (x [[2]] * x0 [[4]]) +
-                                (2 * (x [[3]] * x0 [[1]]) +
-                                 (67108864 * (x [[3]] * x0 [[2]]) +
-                                  (4503599627370496 * (x [[3]] * x0 [[3]]) +
-                                   (151115727451828646838272 * (x [[3]] * x0 [[4]]) +
-                                    (x [[4]] * x0 [[0]] +
-                                     (67108864 * (x [[4]] * x0 [[1]]) +
-                                      (2251799813685248 * (x [[4]] * x0 [[2]]) +
-                                       (151115727451828646838272 * (x [[4]] * x0 [[3]]) +
-                                        5070602400912917605986812821504 * (x [[4]] * x0 [[4]])))))))))))))) in
-           expr_let _ := Ident ident.Z.div @ y28 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y28 @ 67108864 in
+                           (x [[1]] * x0 [[3]] +
+                            (x [[2]] * x0 [[2]] +
+                             (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]]))) in
+           expr_let _ := Ident ident.Z.div @ y28 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y28 @ 2251799813685248 in
            expr_let y31 := x [[0]] * x0 [[3]] +
-                           (x [[1]] * x0 [[2]] + (x [[2]] * x0 [[1]] + x [[3]] * x0 [[0]])) in
-           expr_let _ := Ident ident.Z.div @ y31 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y31 @ 67108864 in
+                           (x [[1]] * x0 [[2]] +
+                            (x [[2]] * x0 [[1]] +
+                             (x [[3]] * x0 [[0]] + 19 * (x [[4]] * x0 [[4]])))) in
+           expr_let _ := Ident ident.Z.div @ y31 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y31 @ 2251799813685248 in
            expr_let y34 := y24 +
-                           (x [[0]] * x0 [[2]] + (2 * (x [[1]] * x0 [[1]]) + x [[2]] * x0 [[0]])) in
-           expr_let y35 := Ident ident.Z.div @ y34 @ 67108864 in
-           expr_let y36 := Ident ident.Z.modulo @ y34 @ 67108864 in
-           expr_let _ := Ident ident.Z.div @ y25 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y25 @ 67108864 in
-           expr_let _ := Ident ident.Z.div @ y13 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y13 @ 67108864 in
+                           (x [[0]] * x0 [[2]] +
+                            (x [[1]] * x0 [[1]] +
+                             (x [[2]] * x0 [[0]] +
+                              (19 * (x [[3]] * x0 [[4]]) +
+                               19 * (x [[4]] * x0 [[3]]))))) in
+           expr_let y35 := Ident ident.Z.div @ y34 @ 2251799813685248 in
+           expr_let y36 := Ident ident.Z.modulo @ y34 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y25 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y25 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y13 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y13 @ 2251799813685248 in
            expr_let y41 := x [[0]] * x0 [[4]] +
-                           (2 * (x [[1]] * x0 [[3]]) +
-                            (67108864 * (x [[1]] * x0 [[4]]) +
-                             (x [[2]] * x0 [[2]] +
-                              (67108864 * (x [[2]] * x0 [[3]]) +
-                               (2251799813685248 * (x [[2]] * x0 [[4]]) +
-                                (2 * (x [[3]] * x0 [[1]]) +
-                                 (67108864 * (x [[3]] * x0 [[2]]) +
-                                  (4503599627370496 * (x [[3]] * x0 [[3]]) +
-                                   (151115727451828646838272 * (x [[3]] * x0 [[4]]) +
-                                    (x [[4]] * x0 [[0]] +
-                                     (67108864 * (x [[4]] * x0 [[1]]) +
-                                      (2251799813685248 * (x [[4]] * x0 [[2]]) +
-                                       (151115727451828646838272 * (x [[4]] * x0 [[3]]) +
-                                        5070602400912917605986812821504 * (x [[4]] * x0 [[4]])))))))))))))) in
-           expr_let _ := Ident ident.Z.div @ y41 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y41 @ 33554432 in
+                           (x [[1]] * x0 [[3]] +
+                            (x [[2]] * x0 [[2]] +
+                             (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]]))) in
+           expr_let _ := Ident ident.Z.div @ y41 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y41 @ 2251799813685248 in
            expr_let y44 := y35 +
                            (x [[0]] * x0 [[3]] +
-                            (x [[1]] * x0 [[2]] + (x [[2]] * x0 [[1]] + x [[3]] * x0 [[0]]))) in
-           expr_let y45 := Ident ident.Z.div @ y44 @ 33554432 in
-           expr_let y46 := Ident ident.Z.modulo @ y44 @ 33554432 in
-           expr_let _ := Ident ident.Z.div @ y36 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y36 @ 33554432 in
-           expr_let _ := Ident ident.Z.div @ y25 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y25 @ 33554432 in
-           expr_let _ := Ident ident.Z.div @ y13 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y13 @ 33554432 in
+                            (x [[1]] * x0 [[2]] +
+                             (x [[2]] * x0 [[1]] +
+                              (x [[3]] * x0 [[0]] + 19 * (x [[4]] * x0 [[4]]))))) in
+           expr_let y45 := Ident ident.Z.div @ y44 @ 2251799813685248 in
+           expr_let y46 := Ident ident.Z.modulo @ y44 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y36 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y36 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y25 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y25 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y13 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y13 @ 2251799813685248 in
            expr_let y53 := y45 +
                            (x [[0]] * x0 [[4]] +
-                            (2 * (x [[1]] * x0 [[3]]) +
-                             (67108864 * (x [[1]] * x0 [[4]]) +
-                              (x [[2]] * x0 [[2]] +
-                               (67108864 * (x [[2]] * x0 [[3]]) +
-                                (2251799813685248 * (x [[2]] * x0 [[4]]) +
-                                 (2 * (x [[3]] * x0 [[1]]) +
-                                  (67108864 * (x [[3]] * x0 [[2]]) +
-                                   (4503599627370496 * (x [[3]] * x0 [[3]]) +
-                                    (151115727451828646838272 * (x [[3]] * x0 [[4]]) +
-                                     (x [[4]] * x0 [[0]] +
-                                      (67108864 * (x [[4]] * x0 [[1]]) +
-                                       (2251799813685248 * (x [[4]] * x0 [[2]]) +
-                                        (151115727451828646838272 * (x [[4]] * x0 [[3]]) +
-                                         5070602400912917605986812821504 * (x [[4]] * x0 [[4]]))))))))))))))) in
-           expr_let _ := Ident ident.Z.div @ y53 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y53 @ 67108864 in
-           expr_let _ := Ident ident.Z.div @ y46 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y46 @ 67108864 in
-           expr_let _ := Ident ident.Z.div @ y36 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y36 @ 67108864 in
-           expr_let _ := Ident ident.Z.div @ y25 @ 67108864 in
-           expr_let _ := Ident ident.Z.modulo @ y25 @ 67108864 in
-           expr_let y62 := Ident ident.Z.div @ y13 @ 67108864 in
-           expr_let y63 := Ident ident.Z.modulo @ y13 @ 67108864 in
+                            (x [[1]] * x0 [[3]] +
+                             (x [[2]] * x0 [[2]] +
+                              (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]])))) in
+           expr_let _ := Ident ident.Z.div @ y53 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y53 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y46 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y46 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y36 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y36 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y25 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y25 @ 2251799813685248 in
+           expr_let y62 := Ident ident.Z.div @ y13 @ 2251799813685248 in
+           expr_let y63 := Ident ident.Z.modulo @ y13 @ 2251799813685248 in
            expr_let y64 := y45 +
                            (x [[0]] * x0 [[4]] +
-                            (2 * (x [[1]] * x0 [[3]]) +
-                             (67108864 * (x [[1]] * x0 [[4]]) +
-                              (x [[2]] * x0 [[2]] +
-                               (67108864 * (x [[2]] * x0 [[3]]) +
-                                (2251799813685248 * (x [[2]] * x0 [[4]]) +
-                                 (2 * (x [[3]] * x0 [[1]]) +
-                                  (67108864 * (x [[3]] * x0 [[2]]) +
-                                   (4503599627370496 * (x [[3]] * x0 [[3]]) +
-                                    (151115727451828646838272 * (x [[3]] * x0 [[4]]) +
-                                     (x [[4]] * x0 [[0]] +
-                                      (67108864 * (x [[4]] * x0 [[1]]) +
-                                       (2251799813685248 * (x [[4]] * x0 [[2]]) +
-                                        (151115727451828646838272 * (x [[4]] * x0 [[3]]) +
-                                         5070602400912917605986812821504 * (x [[4]] * x0 [[4]]))))))))))))))) in
-           expr_let _ := Ident ident.Z.div @ y64 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y64 @ 33554432 in
-           expr_let _ := Ident ident.Z.div @ y46 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y46 @ 33554432 in
-           expr_let _ := Ident ident.Z.div @ y36 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y36 @ 33554432 in
+                            (x [[1]] * x0 [[3]] +
+                             (x [[2]] * x0 [[2]] +
+                              (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]])))) in
+           expr_let _ := Ident ident.Z.div @ y64 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y64 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y46 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y46 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y36 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y36 @ 2251799813685248 in
            expr_let y71 := y62 + y25 in
-           expr_let y72 := Ident ident.Z.div @ y71 @ 33554432 in
-           expr_let y73 := Ident ident.Z.modulo @ y71 @ 33554432 in
-           expr_let _ := Ident ident.Z.div @ y63 @ 33554432 in
-           expr_let _ := Ident ident.Z.modulo @ y63 @ 33554432 in
+           expr_let y72 := Ident ident.Z.div @ y71 @ 2251799813685248 in
+           expr_let y73 := Ident ident.Z.modulo @ y71 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.div @ y63 @ 2251799813685248 in
+           expr_let _ := Ident ident.Z.modulo @ y63 @ 2251799813685248 in
            y63
            :: y73
               :: y72 + y36
                  :: y46
                     :: y45 +
                        (x [[0]] * x0 [[4]] +
-                        (2 * (x [[1]] * x0 [[3]]) +
-                         (67108864 * (x [[1]] * x0 [[4]]) +
-                          (x [[2]] * x0 [[2]] +
-                           (67108864 * (x [[2]] * x0 [[3]]) +
-                            (2251799813685248 * (x [[2]] * x0 [[4]]) +
-                             (2 * (x [[3]] * x0 [[1]]) +
-                              (67108864 * (x [[3]] * x0 [[2]]) +
-                               (4503599627370496 * (x [[3]] * x0 [[3]]) +
-                                (151115727451828646838272 * (x [[3]] * x0 [[4]]) +
-                                 (x [[4]] * x0 [[0]] +
-                                  (67108864 * (x [[4]] * x0 [[1]]) +
-                                   (2251799813685248 * (x [[4]] * x0 [[2]]) +
-                                    (151115727451828646838272 * (x [[4]] * x0 [[3]]) +
-                                     5070602400912917605986812821504 * (x [[4]] * x0 [[4]])))))))))))))))
-                       :: [])%expr) f g
+                        (x [[1]] * x0 [[3]] +
+                         (x [[2]] * x0 [[2]] +
+                          (x [[3]] * x0 [[1]] + x [[4]] * x0 [[0]])))) :: [])%expr)
+         f g
      : forall f g : list Z, length f = 5%nat -> length g = 5%nat -> list Z
 *)


### PR DESCRIPTION
Here is the code that implements what we discussed today.  It doesn't do the right thing.  In particular, the recursive call to `partial_reduce_cps` in the `Abs` node is wrong; it should not always be passing `Var`, but instead be computing something of shape `expr -> expr` that gets handled correctly elsewhere.  I'm too deep into the code to make sense of the exact issue right now; the encoding in my head is "the var types for different pieces of machinery don't line up the right way; has something to do with cps, probably; has something to do with arrows, probably", which is unhelpful.