### PR TITLE
Curves.Montgomery.XZ: add+check boringssl ladderstep

### DIFF
--- a/src/Curves/Montgomery/XZ.v
+++ b/src/Curves/Montgomery/XZ.v
@@ -85,6 +85,31 @@ Module M.
         ((x2, z2), (x3, z3))%core
       end.
 
+    Context {ap2d4:F} {ap2d4_correct:(1+1+1+1)*a24 = a+1+1}.
+    Definition boringladderstep (x1:F) (Q Q':F*F) : (F*F)*(F*F) :=
+      match Q, Q' with
+        pair x2 z2, pair x3 z3 =>
+        dlet tmp0l := x3 - z3 in
+        dlet tmp1l := x2 - z2 in
+        dlet x2l := x2 + z2 in
+        dlet z2l := x3 + z3 in
+        dlet z3 := tmp0l * x2l in
+        dlet z2 := z2l * tmp1l in
+        dlet tmp0 := tmp1l^2 in
+        dlet tmp1 := x2l^2 in
+        dlet x3l := z3 + z2 in
+        dlet z2l := z3 - z2 in
+        dlet x2 := tmp1 * tmp0 in
+        dlet tmp1l := tmp1 - tmp0 in
+        dlet z2 := z2l^2 in
+        dlet z3 := ap2d4 * tmp1l in
+        dlet x3 := x3l^2 in
+        dlet tmp0l := tmp0 + z3 in
+        dlet z3 := x1 * z2 in
+        dlet z2 := tmp1l * tmp0l in
+        ((x2, z2), (x3, z3))%core
+      end.
+ 
     Context {cswap:bool->F*F->F*F->(F*F)*(F*F)}.
 
     Local Notation xor := Coq.Init.Datatypes.xorb.

--- a/src/Curves/Montgomery/XZProofs.v
+++ b/src/Curves/Montgomery/XZProofs.v
@@ -29,16 +29,23 @@ Module M.
 
     Context {a b: F} {b_nonzero:b <> 0}.
     Context {a24:F} {a24_correct:(1+1+1+1)*a24 = a-(1+1)}.
+    Context {ap2d4:F} {ap2d4_correct:(1+1+1+1)*a24 = a+1+1}.
     Local Notation Madd := (M.add(a:=a)(b_nonzero:=b_nonzero)(char_ge_3:=char_ge_3)).
     Local Notation Mopp := (M.opp(a:=a)(b_nonzero:=b_nonzero)).
     Local Notation Mpoint := (@M.point F Feq Fadd Fmul a b).
     Local Notation xzladderstep := (M.xzladderstep(a24:=a24)(Fadd:=Fadd)(Fsub:=Fsub)(Fmul:=Fmul)).
     Local Notation donnaladderstep := (M.donnaladderstep(a24:=a24)(Fadd:=Fadd)(Fsub:=Fsub)(Fmul:=Fmul)).
+    Local Notation boringladderstep := (M.boringladderstep(ap2d4:=ap2d4)(Fadd:=Fadd)(Fsub:=Fsub)(Fmul:=Fmul)).
     Local Notation to_xz := (M.to_xz(Fzero:=Fzero)(Fone:=Fone)(Feq:=Feq)(Fadd:=Fadd)(Fmul:=Fmul)(a:=a)(b:=b)).
 
     Lemma donnaladderstep_ok x1 Q Q' :
       let eq := fieldwise (n:=2) (fieldwise (n:=2) Feq) in
       eq (xzladderstep x1 Q Q') (donnaladderstep x1 Q Q').
+    Proof. cbv; break_match; repeat split; fsatz. Qed.
+
+    Lemma boringladderstep_ok x1 Q Q' :
+      let eq := fieldwise (n:=2) (fieldwise (n:=2) Feq) in
+      eq (xzladderstep x1 Q Q') (boringladderstep x1 Q Q').
     Proof. cbv; break_match; repeat split; fsatz. Qed.
 
     Definition projective (P:F*F) :=


### PR DESCRIPTION
This PR is to check that the elliptic curve arithmetic at https://boringssl.googlesource.com/boringssl/+/7ce2378750f9f56459ddba67947c3c4ba001a526/third_party/fiat/curve25519.c#4945 does what we want it to do. In particular, we prove it equivalent to the version in https://cr.yp.to/ecdh/curve25519-20060209.pdf appendix B, which has already been proven to correspond to addition in affine coordinates at https://github.com/mit-plv/fiat-crypto/compare/boringladderstep?diff=split&expand=1&name=boringladderstep#diff-d9c50f42ae6bdbec2520e416b2848608R150

Apparently the previous decision to name the small hardcoded constant `a24` was a poor one: the two ladderstep functions use two different hardcoded constants (`(a+2)/4` and `(a-2)/4`) compensating for it with slight changes in the formula.

@davidben please take a look :)