### PR TITLE
[experiments] Implement much of the bounds pipeline (no proofs)

### DIFF
--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -4162,12 +4162,12 @@ Qed.
 
 (** XXX TODO: Translate Jade's python script *)
 Section rcarry_mul.
-  Context (limbwidth : Q)
+  Context (n : nat)
           (s : Z)
           (c : list (Z * Z))
           (machine_wordsize : Z).
 
-  Let n := Z.to_nat (Qceiling (Z.log2_up (s - Associational.eval c) / limbwidth)).
+  Let limbwidth := (Z.log2_up (s - Associational.eval c) / Z.of_nat n)%Q.
   Let idxs := (seq 0 n ++ [0; 1])%list%nat.
   Let f_bounds := List.repeat r[0~>(2^Qceiling limbwidth + 2^(Qceiling limbwidth - 3))%Z]%zrange n.
 
@@ -4255,7 +4255,7 @@ Section rcarry_mul.
       [ | clear -Hrv; cbv [check_args] in Hrv; break_innermost_match_hyps; discriminate ].
     erewrite <- carry_mul_gen_correct.
     eapply Pipeline.BoundsPipeline_correct in Hrv'.
-    apply check_args_success_id in Hrv; inversion Hrv; subst.
+    apply check_args_success_id in Hrv; inversion Hrv; subst rv.
     rewrite Hrv'.
     cbv [expr.Interp].
     cbn [expr.interp].
@@ -4350,13 +4350,13 @@ End PrintingNotations.
 
 
 Module X25519_64.
-  Definition limbwidth := 51%Q.
+  Definition n := 5%nat.
   Definition s := 2^255.
   Definition c := [(1, 19)].
   Definition machine_wordsize := 64.
 
   Derive base_51_carry_mul
-         SuchThat (rcarry_mul_correctT limbwidth s c machine_wordsize base_51_carry_mul)
+         SuchThat (rcarry_mul_correctT n s c machine_wordsize base_51_carry_mul)
          As base_51_carry_mul_correct.
   Proof. Time solve_rcarry_mul (). Time Qed.
 
@@ -4428,13 +4428,13 @@ End X25519_64.
 
 (*
 Module X25519_32.
-  Definition limbwidth := (25 + 1/2)%Q.
+  Definition n := 10%nat.
   Definition s := 2^255.
   Definition c := [(1, 19)].
   Definition machine_wordsize := 32.
 
   Derive base_25p5_carry_mul
-         SuchThat (rcarry_mul_correctT limbwidth s c machine_wordsize base_25p5_carry_mul)
+         SuchThat (rcarry_mul_correctT n s c machine_wordsize base_25p5_carry_mul)
          As base_25p5_carry_mul_correct.
   Proof. Time solve_rcarry_mul (). Time Qed.
 

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -1591,12 +1591,12 @@ Module Compilers.
            end.
     End reify.
 
-    Definition Reify {t : type} (v : forall var, value var t) : Expr t
+    Definition Reify_as (t : type) (v : forall var, value var t) : Expr t
       := fun var => reify (v _).
 
-    (** [AutoReify] does Ltac type inference to get the type *)
-    Notation AutoReify v
-      := (Reify (t:=type.reify_type_of v) (fun _ => v)) (only parsing).
+    (** [Reify] does Ltac type inference to get the type *)
+    Notation Reify v
+      := (Reify_as (type.reify_type_of v) (fun _ => v)) (only parsing).
   End GallinaReify.
 
   Module CPS.
@@ -4138,8 +4138,8 @@ Proof.
   let E := constr:(app_and_maybe_cancel
                      (app_and_maybe_cancel
                         (canonicalize_list_recursion E)
-                        (GallinaReify.AutoReify n))
-                     (GallinaReify.AutoReify dz)) in
+                        (GallinaReify.Reify n))
+                     (GallinaReify.Reify dz)) in
   let E := (eval vm_compute in E) in
   transitivity (Interp E i);
     [
@@ -4166,12 +4166,12 @@ Section rcarry_mul.
   Local Arguments relax_zrange_of_machine_wordsize / .
 
   Let rw := rweight limbwidth.
-  Let rs := GallinaReify.AutoReify s.
-  Let rc := GallinaReify.AutoReify c.
-  Let rn := GallinaReify.AutoReify n.
-  Let ridxs := GallinaReify.AutoReify idxs.
-  Let rlen_c := GallinaReify.AutoReify (List.length c).
-  Let rlen_idxs := GallinaReify.AutoReify (List.length idxs).
+  Let rs := GallinaReify.Reify s.
+  Let rc := GallinaReify.Reify c.
+  Let rn := GallinaReify.Reify n.
+  Let ridxs := GallinaReify.Reify idxs.
+  Let rlen_c := GallinaReify.Reify (List.length c).
+  Let rlen_idxs := GallinaReify.Reify (List.length idxs).
   Let relax_zrange := relax_zrange_of_machine_wordsize.
   Let arg_bounds : BoundsAnalysis.Indexed.Range.range (BoundsAnalysis.Indexed.OfPHOAS.type.compile (type.list type.Z * type.list type.Z))
     := (f_bounds, f_bounds).

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -299,7 +299,7 @@ Module Positional. Section Positional.
                             (Hw_div_nz : forall i : nat, weight (S i) / weight i <> 0),
                         (eval n carry_mulmod) mod (s - Associational.eval c)
                         = (eval n f * eval n g) mod (s - Associational.eval c))
-           As carry_mulmod_correct.
+           As eval_carry_mulmod.
     Proof.
       intros.
       erewrite <-eval_mulmod with (s:=s) (c:=c)
@@ -4275,7 +4275,7 @@ Section rcarry_mul.
 
   (** This code may eventually be useful; it proves that [check_args]
       is sufficient to satisfy the preconditions of
-      [carry_mulmod_correct] *)
+      [eval_carry_mulmod] *)
   (*
 <<
     break_innermost_match_hyps; try solve [ exfalso; clear -Hrv; discriminate ]; [].

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -308,12 +308,8 @@ Module Positional. Section Positional.
         [ | rewrite <- @eval_chained_carries with (s:=s) (c:=c) (idxs:=idxs) (modulo:=fun x y => Z.modulo x y) (div:=fun x y => Z.div x y)
             by (subst; try assumption; auto using Z.div_mod); reflexivity ].
       eapply f_equal2; [|trivial]. eapply f_equal.
-      erewrite <- (expand_list_correct _ (-1)%Z f),
-      <- (expand_list_correct _ (-1)%Z g),
-      <- (expand_list_correct _ 0%nat idxs),
-      <- (expand_list_correct _ (-1,-1)%Z c)
-        by eassumption.
-      subst carry_mulmod; reflexivity.
+      expand_lists ().
+      refine eq_refl.
     Qed.
   End carry_mulmod.
 End Positional. End Positional.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -1596,6 +1596,10 @@ Module Compilers.
 
     Definition Reify {t : type} (v : forall var, value var t) : Expr t
       := fun var => reify (v _).
+
+    (** [AutoReify] does Ltac type inference to get the type *)
+    Notation AutoReify v
+      := (Reify (t:=type.reify_type_of v) (fun _ => v)) (only parsing).
   End GallinaReify.
 
   Module CPS.
@@ -4149,8 +4153,8 @@ Proof.
   let E := constr:(app_and_maybe_cancel
                      (app_and_maybe_cancel
                         (canonicalize_list_recursion E)
-                        (GallinaReify.Reify (t:=type.Z) (fun _ => n)))
-                     (GallinaReify.Reify (t:=type.Z) (fun _ => dz))) in
+                        (GallinaReify.AutoReify n))
+                     (GallinaReify.AutoReify dz)) in
   let E := (eval vm_compute in E) in
   transitivity (Interp E i);
     [
@@ -4175,12 +4179,12 @@ Section rcarry_mul.
   Definition make_carry_mul_rargs
     : mul_rargs
     := {| rw := rweight limbwidth;
-          rs var := GallinaReify.reify (t:=type.Z) s;
-          rc var := GallinaReify.reify (t:=type.list (type.Z * type.Z)) c;
-          rn var := GallinaReify.reify (t:=type.nat) n;
-          ridxs var := GallinaReify.reify (t:=type.list type.nat) idxs;
-          rlen_c var := GallinaReify.reify (t:=type.nat) (List.length c);
-          rlen_idxs var := GallinaReify.reify (t:=type.nat) (List.length idxs);
+          rs := GallinaReify.AutoReify s;
+          rc := GallinaReify.AutoReify c;
+          rn := GallinaReify.AutoReify n;
+          ridxs := GallinaReify.AutoReify idxs;
+          rlen_c := GallinaReify.AutoReify (List.length c);
+          rlen_idxs := GallinaReify.AutoReify (List.length idxs);
           relax_zrange := relax_zrange_gen [machine_wordsize; 2 * machine_wordsize]%Z;
           arg_bounds := (f_bounds, f_bounds);
           out_bounds := f_bounds;
@@ -4262,7 +4266,7 @@ Section rcarry_mul.
     cbv [expr.Interp].
     cbn [expr.interp].
     apply f_equal; f_equal;
-      cbn;
+      cbn -[reify_list];
       rewrite interp_reify_list, map_map; cbn;
         erewrite map_ext with (g:=id), map_id; try reflexivity.
     intros []; reflexivity.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -309,7 +309,8 @@ Module Positional. Section Positional.
             by (subst; try assumption; auto using Z.div_mod); reflexivity ].
       eapply f_equal2; [|trivial]. eapply f_equal.
       expand_lists ().
-      refine eq_refl.
+      subst carry_mulmod.
+      reflexivity.
     Qed.
   End carry_mulmod.
 End Positional. End Positional.


### PR DESCRIPTION
Most of what we talked about today is in here.  I haven't translated @jadephilipoom 's python script to Gallina.  I also haven't assembled things together into a ring.  I'm (almost) quite happy with the tactic that executes the pipeline for a specific choice of parameters / prime:
```coq
Ltac solve_rcarry_mul _ :=
  eapply rcarry_mul_correct;
  lazy; reflexivity.
```
My biggest issue is that the `lazy` runs twice: once during the proof, and again during `Qed`.

Once Jade's script is translated to Gallina, the curve-specific code for a single operation will look like:
```coq
Derive fecarry_mul SuchThat (rcarry_mul_correctT "2^255 - 19" 64) As fecarry_mul_correct.
Proof. Time solve_rcarry_mul (). Time Qed.
```

A large chunk of the code here is to about allowing a more general sort of transformation out of CPS-land.  Previously we were restricted to things of the form `s -> d` where `d` could not have any arrows, and we had to manually correct for arrows in `s`.  Now we can handle anything of the form `x -> y -> ... -> z` where `z` has no arrows and `x`, `y`, etc. are of the form `a -> b -> ... -> d` where `a`, `b`, ..., `d` must not contain arrows.  (Is this any first-order function? second-order?)  We make use of this expressivity; we need to handle the weight function (of type `nat -> Z`) as an argument.  It is not very pretty, and I possibly filled in too much of it by making tyes line up, but everything that it does with continuations actually makes sense to me.  (I don't know how to handle continuations in higher-order things, which is why this isn't more general.)
I did this so we could remove the manual tuple-munging that we were previously doing.