### PR TITLE
Change Implicit Arguments to Arguments in coqprime

### DIFF
--- a/coqprime/Coqprime/Iterator.v
+++ b/coqprime/Coqprime/Iterator.v
@@ -82,9 +82,9 @@ intros z n; generalize z; elim n; simpl; auto.
 Qed.
 
 End Iterator.
-Implicit Arguments iter [A B].
-Implicit Arguments progression [A].
-Implicit Arguments next_n [A].
+Arguments iter [A B].
+Arguments progression [A].
+Arguments next_n [A].
 Hint Unfold iter .
 Hint Unfold progression .
 Hint Unfold next_n .

--- a/coqprime/Coqprime/Permutation.v
+++ b/coqprime/Coqprime/Permutation.v
@@ -434,10 +434,10 @@ Hint Resolve permutation_app_swap.
    Implicits
    **************************************)
 
-Implicit Arguments permutation [A].
-Implicit Arguments split_one [A].
-Implicit Arguments all_permutations [A].
-Implicit Arguments permutation_dec [A].
+Arguments permutation [A] _ _.
+Arguments split_one [A] _.
+Arguments all_permutations [A] _.
+Arguments permutation_dec [A].
 
 (**************************************
    Permutation is compatible with map

--- a/coqprime/Coqprime/UList.v
+++ b/coqprime/Coqprime/UList.v
@@ -255,7 +255,7 @@ apply ulist_incl_length; auto.
 Qed.
 
 End UniqueList.
-Implicit Arguments ulist [A].
+Arguments ulist [A].
 Hint Constructors ulist .
 
 Theorem ulist_map:


### PR DESCRIPTION
The Implicit Arguments command is deprecated, and these changes already happened in https://github.com/thery/coqprime: see [Iterator.v](https://github.com/thery/coqprime/blob/bed89c336f6d0615afe86f9a7e153f9479e84199/List/Iterator.v#L85-L87) [Permutation.v](https://github.com/thery/coqprime/blob/bed89c336f6d0615afe86f9a7e153f9479e84199/List/Permutation.v#L437-L440) [UList.v](https://github.com/thery/coqprime/blob/bed89c336f6d0615afe86f9a7e153f9479e84199/List/UList.v#L258)

See also coq/coq#6802