### PR TITLE
row-wise flatten

### DIFF
--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -18,6 +18,10 @@ Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
 Require Import Crypto.Util.Notations.
 Require Import Crypto.Util.ZUtil.Definitions.
+Require Import Crypto.Util.ZUtil.AddGetCarry Crypto.Util.ZUtil.MulSplit.
+Require Import Crypto.Util.ZUtil Crypto.Util.ZUtil.Hints.Core.
+Require Import Crypto.Util.ZUtil.Modulo Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Hints.PullPush.
 Import ListNotations. Local Open Scope Z_scope.
 
 Module Associational.
@@ -445,8 +449,6 @@ Module Positional. Section Positional.
   End carry_mulmod.
 End Positional. End Positional.
 
-Require Import Crypto.Util.ZUtil.AddGetCarry Crypto.Util.ZUtil.MulSplit.
-
 Module BaseConversion.
   Import Positional.
   Section BaseConversion.
@@ -470,10 +472,6 @@ Module BaseConversion.
 
   End BaseConversion.
 End BaseConversion.
-
-Require Import Crypto.Util.ZUtil.
-Require Import Crypto.Util.ZUtil.Modulo Crypto.Util.ZUtil.Div Crypto.Util.ZUtil.Hints.Core.
-Require Import Crypto.Util.ZUtil.Hints.PullPush.
 
 Module Saturated.
   Section Weight.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -6584,22 +6584,22 @@ Module Montgomery256PrintingNotations.
                    (primitive {| BoundsAnalysis.type.value := 0; BoundsAnalysis.type.value_bounded := _ |})
                    BoundsAnalysis.Indexed.expr.TT) (only printing, at level 9) : nexpr_scope.
   Notation "'$R'" := 115792089237316195423570985008687907853269984665640564039457584007913129639936 : nexpr_scope.
-  Notation "'Lower128{RegMod}'" :=
+  Notation "c.LowerHalf(RegMod)" :=
     (BoundsAnalysis.Indexed.expr.AppIdent
                    (primitive {| BoundsAnalysis.type.value := 79228162514264337593543950335; BoundsAnalysis.type.value_bounded := _ |})
                    BoundsAnalysis.Indexed.expr.TT) (only printing, at level 9) : nexpr_scope.
-  Notation "'RegMod' '<<' '128'" :=
+  Notation "c.UpperHalf(RegMod)" :=
     (BoundsAnalysis.Indexed.expr.AppIdent
                    (primitive {| BoundsAnalysis.type.value := 340282366841710300967557013911933812736; BoundsAnalysis.type.value_bounded := _ |})
-                   BoundsAnalysis.Indexed.expr.TT) (only printing, at level 9, format "'RegMod'  '<<'  '128'") : nexpr_scope.
-  Notation "'Lower128{RegPinv}'" :=
+                   BoundsAnalysis.Indexed.expr.TT) (only printing, at level 9) : nexpr_scope.
+  Notation "c.LowerHalf(RegPinv)" :=
     (BoundsAnalysis.Indexed.expr.AppIdent
                    (primitive {| BoundsAnalysis.type.value := 79228162514264337593543950337; BoundsAnalysis.type.value_bounded := _ |})
                    BoundsAnalysis.Indexed.expr.TT) (only printing, at level 9) : nexpr_scope.
-  Notation "'RegPinv' '>>' '128'" :=
+  Notation "c.UpperHalf(RegPinv)" :=
     (BoundsAnalysis.Indexed.expr.AppIdent
                    (primitive {| BoundsAnalysis.type.value := 340282366841710300986003757985643364352; BoundsAnalysis.type.value_bounded := _ |})
-                   BoundsAnalysis.Indexed.expr.TT) (only printing, at level 9, format "'RegPinv'  '>>'  '128'") : nexpr_scope.
+                   BoundsAnalysis.Indexed.expr.TT) (only printing, at level 9) : nexpr_scope.
   Notation "'uint256'"
     := (BoundsAnalysis.type.ZBounded 0 115792089237316195423570985008687907853269984665640564039457584007913129639935) : btype_scope.
   Notation "'uint128'"
@@ -6639,39 +6639,44 @@ Module Montgomery256PrintingNotations.
     (expr_let n := (shiftl _ _ y @@ x) in f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.ShiftL(' '$r' n ','  x ','  y ');' ']' '//' f") : nexpr_scope.
   Notation "'c.Lower128(' '$r' n ',' x ');' f" :=
     (expr_let n := (land _ _ 340282366920938463463374607431768211455 @@ x) in f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.Lower128(' '$r' n ','  x ');' ']' '//' f") : nexpr_scope.
-  Notation "'Lower128{' x '}'"
+  Notation "'c.LowerHalf(' x ')'"
     := ((land uint256 uint128 340282366920938463463374607431768211455 @@ x)%nexpr)
-         (at level 10, only printing, format "Lower128{ x }")
+         (at level 10, only printing, format "c.LowerHalf( x )")
+  : nexpr_scope.
+  Notation "'c.UpperHalf(' x ')'"
+    := ((shiftr uint256 uint128 128 @@ x)%nexpr)
+         (at level 10, only printing, format "c.UpperHalf( x )")
   : nexpr_scope.
   Notation "( v << count )"
     := ((shiftl _ _ count @@ v)%nexpr)
          (format "( v  <<  count )")
        : nexpr_scope.
+  (*
   Notation "( x >> count )"
     := ((shiftr _ _ count @@ x)%nexpr)
          (format "( x  >>  count )")
        : nexpr_scope.
+  *)
 End Montgomery256PrintingNotations.
 
 Import Montgomery256PrintingNotations.
 Local Open Scope nexpr_scope.
 
-
 Print Montgomery256.montred256.
 (*
-c.Mul128x128($r5, ($r1_lo >> 128), Lower128{RegPinv});
-c.Mul128x128($r8, Lower128{$r1_lo}, RegPinv >> 128);
-c.Mul128x128($r12, Lower128{$r1_lo}, Lower128{RegPinv});
-c.Add256($r13, (Lower128{$r5} << 128), $r12);
-c.Add256($r18, (Lower128{$r8} << 128), $r13_lo);
-c.Mul128x128($r24, ($r18_lo >> 128), Lower128{RegMod});
-c.Mul128x128($r27, Lower128{$r18_lo}, RegMod << 128);
-c.Mul128x128($r31, Lower128{$r18_lo}, Lower128{RegMod});
-c.Add256($r32, (Lower128{$r24} << 128), $r31);
-c.Mul128x128($r33, ($r18_lo >> 128), RegMod << 128);
-c.Addc($r34, $r33, ($r27 >> 128));
-c.Add256($r37, (Lower128{$r27} << 128), $r32_lo);
-c.Addc($r39, ($r24 >> 128), $r34_lo);
+c.Mul128x128($r5, c.UpperHalf($r1_lo), c.LowerHalf(RegPinv));
+c.Mul128x128($r8, c.LowerHalf($r1_lo), c.UpperHalf(RegPinv));
+c.Mul128x128($r12, c.LowerHalf($r1_lo), c.LowerHalf(RegPinv));
+c.Add256($r13, (c.LowerHalf($r5) << 128), $r12);
+c.Add256($r18, (c.LowerHalf($r8) << 128), $r13_lo);
+c.Mul128x128($r24, c.UpperHalf($r18_lo), c.LowerHalf(RegMod));
+c.Mul128x128($r27, c.LowerHalf($r18_lo), c.UpperHalf(RegMod));
+c.Mul128x128($r31, c.LowerHalf($r18_lo), c.LowerHalf(RegMod));
+c.Add256($r32, (c.LowerHalf($r24) << 128), $r31);
+c.Mul128x128($r33, c.UpperHalf($r18_lo), c.UpperHalf(RegMod));
+c.Addc($r34, $r33, c.UpperHalf($r27));
+c.Add256($r37, (c.LowerHalf($r27) << 128), $r32_lo);
+c.Addc($r39, c.UpperHalf($r24), $r34_lo);
 c.Add256($r40, $r1_lo, $r37_lo);
 c.Addc($r41, $r1_hi, $r39_lo);
 c.Selc($r42, RegZero, RegMod);

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -810,6 +810,39 @@ Module Columns.
           reflexivity. } }
     Qed.
 
+    Section Rows.
+
+      Print flatten_column.
+      Print Z.add_with_get_carry_full.
+      Definition rowwise_step (fw: Z) (carry:Z) (inp: list (list Z)) : list (list Z) :=
+        match inp with
+        | nil => nil
+        | col :: inp' =>
+          match col with
+          | nil => col :: rowwise_step fw 0 inp'
+          | x :: nil =>
+            let sum_carry := Z.add_with_get_carry_full fw carry x 0 in
+            (fst sum_carry) :: rowwise_step fw (snd sum_carry) inp'
+          | x :: y :: nil =>
+            let sum_carry := Z.add_with_get_carry_full fw carry x y in
+            
+      Check from_associational.
+
+      Local Notation row := (nat * list (Z * Z))%type.
+      Local Notation col := (list Z).
+      
+      Definition to_rows (start: nat) (inp : list col) : list row :=
+        match inp with
+        | nil => nil
+        | c :: inp' =>
+          match c with
+          | x :: y :: _ => (start, (x, y) :: get_single_row inp') :: to_rows (S start) inp'
+          | _ => to_rows (S start) inp'
+          end.
+        end.
+
+    End Rows.
+
     Section mul.
       Definition mul s n m (p q : list Z) : list Z :=
         let p_a := Positional.to_associational weight n p in

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -820,14 +820,6 @@ Module Rows.
     Hint Rewrite Positional.eval_nil Positional.eval0 @Positional.eval_snoc
          Columns.eval_nil Columns.eval_snoc using (auto; solve [distr_length]) : push_eval.
 
-    (* TODO: move to ListUtil *)
-    Lemma sum_app x y : sum (x ++ y) = sum x + sum y.
-    Proof. induction x; rewrite ?app_nil_l, <-?app_comm_cons, ?sum_nil, ?sum_cons; omega. Qed.
-    (* TODO: move to listUtil or wherever push_map is defined *)
-    Hint Rewrite @map_app : push_map.
-    Hint Rewrite sum_nil sum_cons sum_app : push_sum.
-    Hint Rewrite @combine_nil_r @combine_cons : push_combine.
-
     Hint Resolve in_eq in_cons.
 
     Definition eval n (inp : rows) :=
@@ -951,11 +943,6 @@ Module Rows.
     Proof. apply eval_from_columns'_with_length. Qed.
     Hint Rewrite eval_from_columns' using (auto; solve [distr_length]) : push_eval.
 
-    (* TODO: move to ListUtil *)
-    Lemma length_tl {A} ls : length (@tl A ls) = (length ls - 1)%nat.
-    Proof. destruct ls; cbn [tl length]; lia. Qed.
-    Hint Rewrite @length_tl : distr_length.
-    
     Lemma max_column_size_extract_row inp :
       max_column_size (fst (extract_row inp)) = (max_column_size inp - 1)%nat.
     Proof.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -6546,17 +6546,17 @@ Module Montgomery256.
     expr_let 5 := MUL_256 @@ ((uint128)(fst @@ x_1 >> 128), (79228162514264337593543950337)) in
     expr_let 8 := MUL_256 @@ (((uint128)fst @@ x_1 & 340282366920938463463374607431768211455), (340282366841710300986003757985643364352)) in
     expr_let 12 := MUL_256 @@ (((uint128)fst @@ x_1 & 340282366920938463463374607431768211455), (79228162514264337593543950337)) in
-    expr_let 13 := ADD_256 @@ ((uint128)(((uint128)x_5 & 340282366920938463463374607431768211455) << 128), x_12) in
-    expr_let 18 := ADD_256 @@ ((uint128)(((uint128)x_8 & 340282366920938463463374607431768211455) << 128), fst @@ x_13) in
-    expr_let 24 := MUL_256 @@ ((uint128)(fst @@ x_18 >> 128), (79228162514264337593543950335)) in
-    expr_let 27 := MUL_256 @@ (((uint128)fst @@ x_18 & 340282366920938463463374607431768211455), (340282366841710300967557013911933812736)) in
-    expr_let 31 := MUL_256 @@ (((uint128)fst @@ x_18 & 340282366920938463463374607431768211455), (79228162514264337593543950335)) in
-    expr_let 32 := ADD_256 @@ ((uint128)(((uint128)x_24 & 340282366920938463463374607431768211455) << 128), x_31) in
-    expr_let 33 := MUL_256 @@ ((uint128)(fst @@ x_18 >> 128), (340282366841710300967557013911933812736)) in
-    expr_let 34 := ADDC_256 @@ (snd @@ x_32, x_33, (uint128)(x_27 >> 128)) in
-    expr_let 37 := ADD_256 @@ ((uint128)(((uint128)x_27 & 340282366920938463463374607431768211455) << 128), fst @@ x_32) in
-    expr_let 39 := ADDC_256 @@ (snd @@ x_37, (uint128)(x_24 >> 128), fst @@ x_34) in
-    expr_let 40 := ADD_256 @@ (fst @@ x_1, fst @@ x_37) in
+    expr_let 13 := ADD_256 @@ ((uint256)(((uint128)x_8 & 340282366920938463463374607431768211455) << 128), x_12) in
+    expr_let 17 := ADD_256 @@ ((uint256)(((uint128)x_5 & 340282366920938463463374607431768211455) << 128), fst @@ x_13) in
+    expr_let 24 := MUL_256 @@ ((uint128)(fst @@ x_17 >> 128), (79228162514264337593543950335)) in
+    expr_let 27 := MUL_256 @@ (((uint128)fst @@ x_17 & 340282366920938463463374607431768211455), (340282366841710300967557013911933812736)) in
+    expr_let 31 := MUL_256 @@ (((uint128)fst @@ x_17 & 340282366920938463463374607431768211455), (79228162514264337593543950335)) in
+    expr_let 32 := ADD_256 @@ ((uint256)(((uint128)x_27 & 340282366920938463463374607431768211455) << 128), x_31) in
+    expr_let 33 := ADDC_256 @@ (snd @@ x_32, (uint128)(x_24 >> 128), (uint128)(x_27 >> 128)) in
+    expr_let 36 := ADD_256 @@ ((uint256)(((uint128)x_24 & 340282366920938463463374607431768211455) << 128), fst @@ x_32) in
+    expr_let 37 := MUL_256 @@ ((uint128)(fst @@ x_17 >> 128), (340282366841710300967557013911933812736)) in
+    expr_let 39 := ADDC_256 @@ (snd @@ x_36, x_37, fst @@ x_33) in
+    expr_let 40 := ADD_256 @@ (fst @@ x_1, fst @@ x_36) in
     expr_let 41 := ADDC_256 @@ (snd @@ x_40, snd @@ x_1, fst @@ x_39) in
     expr_let 42 := SELC @@ (snd @@ x_41, (0), (115792089210356248762697446949407573530086143415290314195533631308867097853951)) in
     expr_let 43 := fst @@ (SUB_256 @@ (fst @@ x_41, x_42)) in
@@ -6672,17 +6672,17 @@ Print Montgomery256.montred256.
 c.Mul128x128($r5, c.UpperHalf($r1_lo), c.LowerHalf(RegPinv));
 c.Mul128x128($r8, c.LowerHalf($r1_lo), c.UpperHalf(RegPinv));
 c.Mul128x128($r12, c.LowerHalf($r1_lo), c.LowerHalf(RegPinv));
-c.Add256($r13, (c.LowerHalf($r5) << 128), $r12);
-c.Add256($r18, (c.LowerHalf($r8) << 128), $r13_lo);
-c.Mul128x128($r24, c.UpperHalf($r18_lo), c.LowerHalf(RegMod));
-c.Mul128x128($r27, c.LowerHalf($r18_lo), c.UpperHalf(RegMod));
-c.Mul128x128($r31, c.LowerHalf($r18_lo), c.LowerHalf(RegMod));
-c.Add256($r32, (c.LowerHalf($r24) << 128), $r31);
-c.Mul128x128($r33, c.UpperHalf($r18_lo), c.UpperHalf(RegMod));
-c.Addc($r34, $r33, c.UpperHalf($r27));
-c.Add256($r37, (c.LowerHalf($r27) << 128), $r32_lo);
-c.Addc($r39, c.UpperHalf($r24), $r34_lo);
-c.Add256($r40, $r1_lo, $r37_lo);
+c.Add256($r13, (c.LowerHalf($r8) << 128), $r12);
+c.Add256($r17, (c.LowerHalf($r5) << 128), $r13_lo);
+c.Mul128x128($r24, c.UpperHalf($r17_lo), c.LowerHalf(RegMod));
+c.Mul128x128($r27, c.LowerHalf($r17_lo), c.UpperHalf(RegMod));
+c.Mul128x128($r31, c.LowerHalf($r17_lo), c.LowerHalf(RegMod));
+c.Add256($r32, (c.LowerHalf($r27) << 128), $r31);
+c.Addc($r33, c.UpperHalf($r24), c.UpperHalf($r27));
+c.Add256($r36, (c.LowerHalf($r24) << 128), $r32_lo);
+c.Mul128x128($r37, c.UpperHalf($r17_lo), c.UpperHalf(RegMod));
+c.Addc($r39, $r37, $r33_lo);
+c.Add256($r40, $r1_lo, $r36_lo);
 c.Addc($r41, $r1_hi, $r39_lo);
 c.Selc($r42, RegZero, RegMod);
 c.Sub($r43, $r41_lo, $r42);

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -6290,19 +6290,19 @@ Module MontgomeryReduction.
     Context (HN_range : 0 <= N < R) (HN'_range : 0 <= N' < R) (HN_nz : N <> 0) (R_gt_1 : R > 1)
             (N'_good : Z.equiv_modulo R (N*N') (-1)) (R'_good: Z.equiv_modulo N (R*R') 1).
 
-    Context (w w_half : nat -> Z).
-    Context (w_half_sq : forall i, (w_half i) * (w_half i) = w i).
-    Context (w_half_0 : w_half 0%nat = 1)
-            (w_half_nonzero : forall i, w_half i <> 0)
-            (w_half_positive : forall i, w_half i > 0)
-            (w_half_multiples : forall i, w_half (S i) mod w_half i = 0)
-            (w_half_divides : forall i : nat, w_half (S i) / w_half i > 0).
+    Context (w w_mul : nat -> Z).
+    Context (w_mul_sq : forall i, (w_mul i) * (w_mul i) = w i).
+    Context (w_mul_0 : w_mul 0%nat = 1)
+            (w_mul_nonzero : forall i, w_mul i <> 0)
+            (w_mul_positive : forall i, w_mul i > 0)
+            (w_mul_multiples : forall i, w_mul (S i) mod w_mul i = 0)
+            (w_mul_divides : forall i : nat, w_mul (S i) / w_mul i > 0).
     Context (w_0 : w 0%nat = 1)
             (w_nonzero : forall i, w i <> 0)
             (w_positive : forall i, w i > 0)
             (w_multiples : forall i, w (S i) mod w i = 0)
             (w_divides : forall i : nat, w (S i) / w i > 0).
-    Context (w_1_gt1 : w 1 > 1) (w_half_1_gt1 : w_half 1 > 1).
+    Context (w_1_gt1 : w 1 > 1) (w_mul_1_gt1 : w_mul 1 > 1).
     Context (n:nat) (Hn: n = 2%nat).
 
     (* simpler version of mul_converted with a carry chain that aligns
@@ -6311,8 +6311,8 @@ Module MontgomeryReduction.
       MulConverted.mul_converted w w' n n m m m (map (fun i => ((m * (i + 1)) - 1))%nat (seq 0 m)).
 
     Definition montred' (lo_hi : (Z * Z)) :=
-      dlet_nd y := nth_default 0 (mul_converted_aligned w w_half 1%nat n [fst lo_hi] [N']) 0  in
-      dlet_nd t1_t2 := mul_converted_aligned w w_half 1%nat n [y] [N] in
+      dlet_nd y := nth_default 0 (mul_converted_aligned w w_mul 1%nat n [fst lo_hi] [N']) 0  in
+      dlet_nd t1_t2 := mul_converted_aligned w w_mul 1%nat n [y] [N] in
       dlet_nd lo'_carry := Z.add_get_carry_full R (fst lo_hi) (nth_default 0 t1_t2 0) in
       dlet_nd hi'_carry := Z.add_with_get_carry_full R (snd lo'_carry) (snd lo_hi) (nth_default 0 t1_t2 1) in
       dlet_nd y' := Z.zselect (snd hi'_carry) 0 N in
@@ -6387,12 +6387,12 @@ Module MontgomeryReduction.
 
   Derive montred_gen
          SuchThat (forall (N R N' : Z)
-                          (w w_half : nat -> Z)
+                          (w w_mul : nat -> Z)
                           (n: nat)
                           (lo_hi : Z * Z),
                       Interp (t:=type.reify_type_of montred')
-                             montred_gen N R N' w w_half n lo_hi
-                      = montred' N R N' w w_half n lo_hi)
+                             montred_gen N R N' w w_mul n lo_hi
+                      = montred' N R N' w w_mul n lo_hi)
          As montred_gen_correct.
   Proof.
     intros.
@@ -6431,7 +6431,7 @@ Module MontgomeryReduction.
     Local Arguments relax_zrange_of_machine_wordsize / .
 
     Let rw := rweight machine_wordsize.
-    Let rw_half := rweight (machine_wordsize / 2).
+    Let rw_mul := rweight (machine_wordsize / 2).
     Let rN := GallinaReify.Reify N.
     Let rR := GallinaReify.Reify R.
     Let rN' := GallinaReify.Reify N'.
@@ -6470,7 +6470,7 @@ Module MontgomeryReduction.
                             @ (rR _)
                             @ (rN' _)
                             @ (rw _)
-                            @ (rw_half _)
+                            @ (rw_mul _)
                             @ (rn _)
                       )%expr in
          check_args res.
@@ -6489,7 +6489,7 @@ Module MontgomeryReduction.
           (bs:=out_bounds)
           arg
           rv
-        = Some (montred' (Interp rN) (Interp rR) (Interp rN') (Interp rw) (Interp rw_half) (Interp rn) arg').
+        = Some (montred' (Interp rN) (Interp rR) (Interp rN') (Interp rw) (Interp rw_mul) (Interp rn) arg').
 
     Lemma rmontred_correct
           rv

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -6233,6 +6233,24 @@ Module RemoveDeadLets.
         end
       end.
 
+    (* inlines lets that bind only shifts *)
+    Fixpoint inline_shifts t (e : @expr ident t) : @expr ident t :=
+      match e in (expr t') return expr t' with
+      | Var T n => Var T n
+      | TT => TT
+      | AppIdent s T idc x =>
+        AppIdent idc (inline_shifts _ x)
+      | Pair A B a b => Pair (inline_shifts _ a) (inline_shifts _ b)
+      | Let_In s T n x f =>
+        match x with
+        | AppIdent _ _ (@BoundsAnalysis.ident.shiftr T1 Tout b) (Var _ m) =>
+          inline_let n _ (@AppIdent _ _ _ (@BoundsAnalysis.ident.shiftr T1 Tout b) (Var _ m)) _ (inline_shifts _ f)
+        | AppIdent _ _ (@BoundsAnalysis.ident.shiftl T1 Tout b) (Var _ m) =>
+          inline_let n _ (@AppIdent _ _ _ (@BoundsAnalysis.ident.shiftl T1 Tout b) (Var _ m)) _ (inline_shifts _ f)
+        | _ => Let_In n (inline_shifts _ x) (inline_shifts _ f)
+        end
+      end.
+
     (* TODO: proofs--note these may block on getting canonical maps for contexts *)
     (* TODO(jgross, from jadep): Should I put this into the pipeline? *)
   End RemoveDeadLets.
@@ -6495,7 +6513,8 @@ Module Montgomery256.
         (RemoveDeadLets.remove_dead_lets _
         (RemoveDeadLets.remove_dead_lets _
         (RemoveDeadLets.remove_dead_lets _
-        (RemoveDeadLets.inline_silly_lets _ montred256_with_dead_code))))))).
+        (RemoveDeadLets.inline_shifts _
+        (RemoveDeadLets.inline_silly_lets _ montred256_with_dead_code)))))))).
 
   Import PrintingNotations.
   Open Scope nexpr_scope.
@@ -6507,27 +6526,21 @@ Module Montgomery256.
     expr_let 7 := ((uint128)x_5 & 340282366920938463463374607431768211455) in
     expr_let 8 := MUL_256 @@ (x_4, (340282366841710300986003757985643364352)) in
     expr_let 10 := ((uint128)x_8 & 340282366920938463463374607431768211455) in
-    expr_let 11 := (uint128)(x_7 << 128) in
     expr_let 12 := MUL_256 @@ (x_4, (79228162514264337593543950337)) in
-    expr_let 13 := ADDC_256 @@ ((0), x_11, x_12) in
-    expr_let 16 := (uint128)(x_10 << 128) in
-    expr_let 18 := ADDC_256 @@ ((0), x_16, fst @@ x_13) in
+    expr_let 13 := ADDC_256 @@ ((0), (uint128)(x_7 << 128), x_12) in
+    expr_let 18 := ADDC_256 @@ ((0), (uint128)(x_10 << 128), fst @@ x_13) in
     expr_let 22 := (uint128)(fst @@ x_18 >> 128) in
     expr_let 23 := ((uint128)fst @@ x_18 & 340282366920938463463374607431768211455) in
     expr_let 24 := MUL_256 @@ (x_22, (79228162514264337593543950335)) in
-    expr_let 25 := (uint128)(x_24 >> 128) in
     expr_let 26 := ((uint128)x_24 & 340282366920938463463374607431768211455) in
     expr_let 27 := MUL_256 @@ (x_23, (340282366841710300967557013911933812736)) in
-    expr_let 28 := (uint128)(x_27 >> 128) in
     expr_let 29 := ((uint128)x_27 & 340282366920938463463374607431768211455) in
-    expr_let 30 := (uint128)(x_26 << 128) in
     expr_let 31 := MUL_256 @@ (x_23, (79228162514264337593543950335)) in
-    expr_let 32 := ADDC_256 @@ ((0), x_30, x_31) in
+    expr_let 32 := ADDC_256 @@ ((0), (uint128)(x_26 << 128), x_31) in
     expr_let 33 := MUL_256 @@ (x_22, (340282366841710300967557013911933812736)) in
-    expr_let 34 := ADDC_256 @@ (snd @@ x_32, x_33, x_28) in
-    expr_let 35 := (uint128)(x_29 << 128) in
-    expr_let 37 := ADDC_256 @@ ((0), x_35, fst @@ x_32) in
-    expr_let 39 := ADDC_256 @@ (snd @@ x_37, x_25, fst @@ x_34) in
+    expr_let 34 := ADDC_256 @@ (snd @@ x_32, x_33, (uint128)(x_27 >> 128)) in
+    expr_let 37 := ADDC_256 @@ ((0), (uint128)(x_29 << 128), fst @@ x_32) in
+    expr_let 39 := ADDC_256 @@ (snd @@ x_37, (uint128)(x_24 >> 128), fst @@ x_34) in
     expr_let 40 := ADD_256 @@ (fst @@ x_1, fst @@ x_37) in
     expr_let 41 := ADDC_256 @@ (snd @@ x_40, snd @@ x_1, fst @@ x_39) in
     expr_let 42 := SELC @@ (snd @@ x_41, (0), (115792089210356248762697446949407573530086143415290314195533631308867097853951)) in
@@ -6604,7 +6617,7 @@ Module Montgomery256PrintingNotations.
          f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.Addc(' '$r' n ','  x ','  y ');' ']' '//' f") : nexpr_scope.
   Notation "'c.Selc(' '$r' n ',' y ',' z ');' f" :=
     (expr_let n := zselect _ _ _ uint256 @@ (_, y, z) in
-         f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.Selc(' '$r' n ',' y ','  z ');' ']' '//' f") : nexpr_scope.
+         f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.Selc(' '$r' n ','  y ','  z ');' ']' '//' f") : nexpr_scope.
   Notation "'c.Sub(' '$r' n ',' x ',' y ');' f" :=
     (expr_let n := fst @@ (sub_get_borrow_concrete _ _ uint256 _ $R @@ (x, y)) in
          f)%nexpr (at level 40, f at level 200, right associativity, format "'c.Sub(' '$r' n ','  x ','  y ');' '//' f") : nexpr_scope.
@@ -6642,30 +6655,24 @@ c.Mul128x128($r5, $r3, Lower128{RegPinv});
 c.Lower128($r7, $r5);
 c.Mul128x128($r8, $r4, RegPinv >> 128);
 c.Lower128($r10, $r8);
-c.ShiftL($r11, $r7, 128);
 c.Mul128x128($r12, $r4, Lower128{RegPinv});
-c.Addc($r13, $r11, $r12);
-c.ShiftL($r16, $r10, 128);
-c.Addc($r18, $r16, $r13_lo);
+c.Addc($r13, ($r7 << 128), $r12);
+c.Addc($r18, ($r10 << 128), $r13_lo);
 c.ShiftR($r22, $r18_lo, 128);
 c.Lower128($r23, $r18_lo);
 c.Mul128x128($r24, $r22, Lower128{RegMod});
-c.ShiftR($r25, $r24, 128);
 c.Lower128($r26, $r24);
 c.Mul128x128($r27, $r23, RegMod << 128);
-c.ShiftR($r28, $r27, 128);
 c.Lower128($r29, $r27);
-c.ShiftL($r30, $r26, 128);
 c.Mul128x128($r31, $r23, Lower128{RegMod});
-c.Addc($r32, $r30, $r31);
+c.Addc($r32, ($r26 << 128), $r31);
 c.Mul128x128($r33, $r22, RegMod << 128);
-c.Addc($r34, $r33, $r28);
-c.ShiftL($r35, $r29, 128);
-c.Addc($r37, $r35, $r32_lo);
-c.Addc($r39, $r25, $r34_lo);
+c.Addc($r34, $r33, ($r27 >> 128));
+c.Addc($r37, ($r29 << 128), $r32_lo);
+c.Addc($r39, ($r24 >> 128), $r34_lo);
 c.Add256($r40, $r1_lo, $r37_lo);
 c.Addc($r41, $r1_hi, $r39_lo);
-c.Selc($r42,RegZero, RegMod);
+c.Selc($r42, RegZero, RegMod);
 c.Sub($r43, $r41_lo, $r42);
 c.AddM($ret, $r43, RegZero, RegMod);
  *)

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -640,14 +640,6 @@ Module Columns.
       apply Positional.eval_snoc; distr_length.
     Qed. Hint Rewrite eval_snoc using (solve [distr_length]) : push_eval.
 
-    (* TODO: move to ListUtil *)
-    Lemma list_rect_to_match A (P:list A -> Type) (Pnil: P []) (PS: forall a tl, P (a :: tl)) ls :
-      @list_rect A P Pnil (fun a tl _ => PS a tl) ls = match ls with
-                                                       | cons a tl => PS a tl
-                                                       | nil => Pnil
-                                                       end.
-    Proof. destruct ls; reflexivity. Qed.
-
     Hint Rewrite <- Z.div_add' using omega : pull_Zdiv.
 
     Ltac cases :=
@@ -777,10 +769,6 @@ Module Columns.
 
       Lemma flatten_snoc x inp : flatten (inp ++ [x]) = flatten_step x (flatten inp).
       Proof. cbv [flatten]. rewrite rev_unit. reflexivity. Qed.
-
-      (* TODO: move to ZUtil *)
-      Lemma Z_divide_div_mul_exact' a b c : b <> 0 -> (b | a) -> a * c / b = c * (a / b).
-      Proof. intros. rewrite Z.mul_comm. auto using Z.divide_div_mul_exact. Qed.
 
       Lemma flatten_partitions inp:
         forall n i, length inp = n -> (i < n)%nat ->
@@ -1238,19 +1226,6 @@ Module Rows.
         let first_row := hd nil inp in
         flatten' (first_row, 0) (hd (Positional.zeros (length first_row)) (tl inp) :: tl (tl inp)).
 
-      (* TODO : move to ListUtil *)
-      Lemma rev_cons {A} x ls : @rev A (x :: ls) = rev ls ++ [x]. Proof. reflexivity. Qed. 
-      Hint Rewrite @rev_cons : list.
-      
-      (* TODO: move to ListUtil *)
-      Lemma fold_right_snoc {A B} f a x ls:
-        @fold_right A B f a (ls ++ [x]) = fold_right f (f x a) ls.
-      Proof.
-        rewrite <-(rev_involutive ls), <-rev_cons.
-        rewrite !fold_left_rev_right; reflexivity.
-      Qed.
-      Hint Rewrite @fold_right_snoc : push_fold_right.
-      
       Lemma flatten'_cons state r inp :
         flatten' state (r :: inp) = flatten' (fst (sum_rows r (fst state)), snd state + snd (sum_rows r (fst state))) inp.
       Proof. cbv [flatten']; autorewrite with list push_fold_right. reflexivity. Qed.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -5169,7 +5169,7 @@ Module Compilers.
                | shiftl _ _ offset
                  => option_map
                       (fun '(existT r args)
-		       => existT _ (ZRange.two_corners (fun v => BinInt.Z.shiftr v offset) r)
+		       => existT _ (ZRange.two_corners (fun v => BinInt.Z.shiftl v offset) r)
                                  (AppIdent (shiftl _ _ offset) args))
                | land _ _ mask
                  => option_map
@@ -6418,7 +6418,7 @@ Module MontgomeryReduction.
     Let bound := r[0 ~> (2^machine_wordsize - 1)%Z]%zrange.
 
     Definition relax_zrange_of_machine_wordsize
-      := relax_zrange_gen [machine_wordsize / 2; machine_wordsize; 2 * machine_wordsize; 4 * machine_wordsize]%Z.
+      := relax_zrange_gen [1; machine_wordsize / 2; machine_wordsize; 2 * machine_wordsize; 4 * machine_wordsize]%Z.
     Local Arguments relax_zrange_of_machine_wordsize / .
 
     Let rw := rweight machine_wordsize.
@@ -6614,7 +6614,7 @@ Module Montgomery256PrintingNotations.
     (expr_let n := shiftl _ _ count @@ (mul _ _ uint256 @@ (x, y)) in
          f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.Mul128x128(' '$r' n ','  x ','  y ')'  '<<'  count ';' ']' '//' f") : nexpr_scope.
   Notation "'c.Add256(' '$r' n ',' x ',' y ');' f" :=
-    (expr_let n := add_get_carry_concrete _ _ uint256 _ $R @@ (x, y) in
+    (expr_let n := add_get_carry_concrete _ _ uint256 r[0 ~> 1] $R @@ (x, y) in
          f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.Add256(' '$r' n ','  x ','  y ');' ']' '//' f") : nexpr_scope.
   Notation "'c.Add128(' '$r' n ',' x ',' y ');' f" :=
     (expr_let n := add_get_carry_concrete _ _ uint128 _ $R @@ (x, y) in
@@ -6623,7 +6623,7 @@ Module Montgomery256PrintingNotations.
     (expr_let n := add _ _ uint128 @@ (x, y) in
          f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.Add64(' '$r' n ','  x ','  y ');' ']' '//' f") : nexpr_scope.
   Notation "'c.Addc(' '$r' n ',' x ',' y ');' f" :=
-    (expr_let n := add_with_get_carry_concrete _ _ _ uint256 _ $R @@ (_, x, y) in
+    (expr_let n := add_with_get_carry_concrete _ _ _ uint256 r[0 ~> 1] $R @@ (_, x, y) in
          f)%nexpr (at level 40, f at level 200, right associativity, format "'[' 'c.Addc(' '$r' n ','  x ','  y ');' ']' '//' f") : nexpr_scope.
   Notation "'c.Selc(' '$r' n ',' y ',' z ');' f" :=
     (expr_let n := zselect _ _ _ uint256 @@ (_, y, z) in

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -21,6 +21,7 @@ Create HintDb simpl_skipn discriminated.
 Create HintDb simpl_fold_right discriminated.
 Create HintDb simpl_sum_firstn discriminated.
 Create HintDb push_map discriminated.
+Create HintDb push_combine discriminated.
 Create HintDb push_flat_map discriminated.
 Create HintDb push_fold_right discriminated.
 Create HintDb push_partition discriminated.
@@ -32,6 +33,7 @@ Create HintDb pull_firstn discriminated.
 Create HintDb push_firstn discriminated.
 Create HintDb pull_skipn discriminated.
 Create HintDb push_skipn discriminated.
+Create HintDb push_sum discriminated.
 Create HintDb pull_update_nth discriminated.
 Create HintDb push_update_nth discriminated.
 Create HintDb znonzero discriminated.
@@ -85,6 +87,7 @@ Module Export List.
     Proof. induction n; simpl List.repeat; simpl map; congruence. Qed.
   End Map.
   Hint Rewrite @map_cons @map_nil @map_repeat : push_map.
+  Hint Rewrite @map_app : push_map.
 
   Section FlatMap.
     Lemma flat_map_nil {A B} (f:A->list B) : List.flat_map f (@nil A) = nil.
@@ -914,6 +917,10 @@ Proof.
   induction xs; boring; discriminate.
 Qed.
 
+Lemma length_tl {A} ls : length (@tl A ls) = (length ls - 1)%nat.
+Proof. destruct ls; cbn [tl length]; omega. Qed.
+Hint Rewrite @length_tl : distr_length.
+
 Lemma length_snoc : forall {T} xs (x:T),
   length xs = pred (length (xs++x::nil)).
 Proof.
@@ -923,6 +930,7 @@ Qed.
 Lemma combine_cons : forall {A B} a b (xs:list A) (ys:list B),
   combine (a :: xs) (b :: ys) = (a,b) :: combine xs ys.
 Proof. reflexivity. Qed.
+Hint Rewrite @combine_cons : push_combine.
 
 Lemma firstn_combine : forall {A B} n (xs:list A) (ys:list B),
   firstn n (combine xs ys) = combine (firstn n xs) (firstn n ys).
@@ -938,6 +946,7 @@ Lemma combine_nil_r : forall {A B} (xs:list A),
 Proof.
   induction xs; boring.
 Qed.
+Hint Rewrite @combine_nil_r : push_combine.
 
 Lemma skipn_combine : forall {A B} n (xs:list A) (ys:list B),
   skipn n (combine xs ys) = combine (skipn n xs) (skipn n ys).
@@ -1449,9 +1458,15 @@ Hint Rewrite @sum_firstn_app_sum : simpl_sum_firstn.
 
 Lemma sum_cons xs x : sum (x :: xs) = (x + sum xs)%Z.
 Proof. reflexivity. Qed.
+Hint Rewrite sum_cons : push_sum.
 
 Lemma sum_nil : sum nil = 0%Z.
 Proof. reflexivity. Qed.
+Hint Rewrite sum_nil : push_sum.
+
+Lemma sum_app x y : sum (x ++ y) = (sum x + sum y)%Z.
+Proof. induction x; rewrite ?app_nil_l, <-?app_comm_cons; autorewrite with push_sum; omega. Qed.
+Hint Rewrite sum_app : push_sum.
 
 Lemma nth_error_skipn : forall {A} n (l : list A) m,
 nth_error (skipn n l) m = nth_error l (n + m).

--- a/src/Util/ZUtil/Div.v
+++ b/src/Util/ZUtil/Div.v
@@ -124,6 +124,9 @@ Module Z.
   Qed.
   Hint Rewrite div_add_exact using zutil_arith : zsimplify.
 
+  Lemma Z_divide_div_mul_exact' a b c : b <> 0 -> (b | a) -> a * c / b = c * (a / b).
+  Proof. intros. rewrite Z.mul_comm. auto using Z.divide_div_mul_exact. Qed.
+
   Lemma div_sub_mod_exact a b : b <> 0 -> a / b = (a - a mod b) / b.
   Proof.
     intro.


### PR DESCRIPTION
Most of the stuff in this PR is purely arithmetic stuff, but it touches compiler bits in the following ways:
- adds `Nat.max`, `List.hd`, and `List.tl` to the pipeline
- simplifies away `add_with_get_carry` to `add_get_carry` when the carry is a constant 0

@JasonGross, please review the compiler stuff when you get a chance. Just scroll down to where `Compilers` starts.

@andres-erbsen, now is a good time to take a look at the row-wise `flatten` stuff I've added if you feel like it.

Some context about row-wise vs column-wise flatten, mostly for documentation purposes and can be skipped: 
The procedure we have been calling `flatten` or `compact` is essentially a saturated-arithmetic-friendly `Positional.from_associational`. One strategy (the one we have been using so far in `Columns.flatten`) involves adding together all the terms with the same weight and accumulating their carries together, then adding those carries to the group of terms with the next weight and repeating. This is "column-wise" in the sense that we proceed one column at a time. However, we can make better use of add-with-carry by making groups of terms with *sequential* weights--"rows". We can then take two rows, add together the term from each row with the lowest weight, and then consume the carry when we add the next two terms.