### PR TITLE
barrett quotient error

### DIFF
--- a/src/Arithmetic/BarrettReduction/Generalized.v
+++ b/src/Arithmetic/BarrettReduction/Generalized.v
@@ -210,6 +210,7 @@ Section barrett.
         autorewrite with push_Zmul zsimplify zstrip_div.
         auto with lia.
       Qed.
+      (* TODO: remove this comment *)
     End StrongerBounds.
   End barrett_algorithm.
 End barrett.

--- a/src/Arithmetic/BarrettReduction/Generalized.v
+++ b/src/Arithmetic/BarrettReduction/Generalized.v
@@ -210,7 +210,6 @@ Section barrett.
         autorewrite with push_Zmul zsimplify zstrip_div.
         auto with lia.
       Qed.
-      (* TODO: remove this comment *)
     End StrongerBounds.
   End barrett_algorithm.
 End barrett.

--- a/src/Arithmetic/BarrettReduction/Generalized.v
+++ b/src/Arithmetic/BarrettReduction/Generalized.v
@@ -145,7 +145,10 @@ Section barrett.
         autorewrite with push_Zmul. ring_simplify.
         replace (a / n * m * n) with (m * n * (a / n)) by ring.
         assert (a/n < b ^ k) by auto using Z.div_lt_upper_bound with zarith.
-        assert (b ^ (2 * k) - m * n = b ^ (2 * k) mod n) by (subst m; rewrite Z.mul_div_eq'; auto with zarith).
+        assert (b ^ (2 * k) - m * n = b ^ (2 * k) mod n).
+        { subst m.
+          rewrite Z.mul_div_eq' by (auto using Z.lt_gt with zarith).
+          auto with zarith. }
         assert (0 < b ^ (k - offset)) by auto with zarith.
         assert (b ^ (2*k) = b ^ (k - offset) * b ^ (k + offset)) by (rewrite <-Z.pow_add_r; auto with zarith).
         pose proof (Z.mod_pos_bound (b ^ (2*k)) n ltac:(lia)).

--- a/src/Util/ZUtil/Div.v
+++ b/src/Util/ZUtil/Div.v
@@ -159,4 +159,10 @@ Module Z.
     intros. rewrite Z.add_comm, div_add_mod_cond_l by auto. repeat (f_equal; try ring).
   Qed.
 
+  Lemma div_le_zero x y : 0 < y -> x / y <= 0 -> x < y.
+  Proof.
+    clear. intros.
+    apply Z.nle_gt; intro.
+    pose proof (Z.div_str_pos x y ltac:(lia)). lia.
+  Qed.
 End Z.


### PR DESCRIPTION
The estimated quotient in Barrett reduction (`q`, here) is known to have an error of at most 2--that is, using the variable names in the `Generalized.v` file, `q = a  / n - e` and `0 <= e <= 2`.

However, it turns out that for primes that fit a certain condition (see `n_good` in this PR), we can prove `0 <= e <= 1`, which lets us skip a modular reduction.

@JasonGross These proofs are significantly messier than the ones you wrote in `Generalized`--if you have tips for better utilizing the automation I'd appreciate it.