### PR TITLE
Error if a display target fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,8 @@ $(DISPLAY_NON_JAVA_VO:.vo=.log) : %Display.log : %.vo src/Compilers/Z/CNotations
 
 $(DISPLAY_NON_JAVA_VO:.vo=.log) : %.log : %.v
 	$(SHOW)'COQC $< > $@'
-	$(HIDE)$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) $< | sed s'/\r\n/\n/g' > $@.tmp && mv -f $@.tmp $@
+	$(HIDE)$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) $< > $@.tmp
+	$(HIDE)sed s'/\r\n/\n/g' $@.tmp > $@ && rm -f $@.tmp
 
 DISPLAY_X25519_C64_VO := $(filter src/Specific/X25519/C64/%,$(DISPLAY_NON_JAVA_VO))
 DISPLAY_X25519_C32_VO := $(filter src/Specific/X25519/C32/%,$(DISPLAY_NON_JAVA_VO))

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ $(DISPLAY_NON_JAVA_VO:.vo=.log) : %Display.log : %.vo src/Compilers/Z/CNotations
 
 $(DISPLAY_NON_JAVA_VO:.vo=.log) : %.log : %.v
 	$(SHOW)'COQC $< > $@'
-	$(HIDE)$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) $< > $@.tmp
+	$(HIDE)$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) $(COQLIBS) $< > $@.tmp
 	$(HIDE)sed s'/\r\n/\n/g' $@.tmp > $@ && rm -f $@.tmp
 
 DISPLAY_X25519_C64_VO := $(filter src/Specific/X25519/C64/%,$(DISPLAY_NON_JAVA_VO))


### PR DESCRIPTION
Because pipes eat error codes, we were previously succeeding when
display targets fail.  This meant that we didn't catch
https://github.com/mit-plv/fiat-crypto/issues/344#issuecomment-381422896
on Travis.  Now we will.