### PR TITLE
Add some Positional Hint Rewrites

### DIFF
--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -431,7 +431,10 @@ Module Positional. Section Positional.
   End sub.
   Hint Rewrite @eval_opp @eval_sub : push_eval.
   Hint Rewrite @length_sub @length_opp : distr_length.
-End Positional. End Positional.
+End Positional.
+(* Hint Rewrite disappears after the end of a section *)
+Hint Rewrite length_zeros length_add_to_nth length_from_associational @length_add @length_carry_reduce @length_chained_carries @length_encode @length_sub @length_opp : distr_length.
+End Positional.
 
 Record weight_properties {weight : nat -> Z} :=
   {


### PR DESCRIPTION
They disappear after the end of the section, but I want them to stay in
distr_length for later proofs.