### PR TITLE
Straightline

### DIFF
--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -1284,7 +1284,7 @@ Module Rows.
           fold_right (fun next (state : list Z * Z * nat) =>
                         let i := snd state in
                         let low_high' :=
-                            dlet_nd low_high := fst state in
+                            let low_high := fst state in
                             let low := fst low_high in
                             let high := snd low_high in
                           dlet_nd sum_carry := Z.add_with_get_carry_full (fw i) high (fst next) (snd next) in


### PR DESCRIPTION
Pass that converts code to syntactically-straightline form and a second pass that forces code to use only a particular set of operations. Seems to work for Montgomery reduction and most of Barrett reduction (it fails to translate the last few lines because of #352). No proofs yet.

I would like a review from @andres-erbsen or @JasonGross of my pass to straightline (`Module Straightline`), before I devote too much time to proofs of this version. `Module PreFancy`, the second pass, is simpler and less critical to get a review on (in particular, I imagine anything that could use improvement there would pop up in `Straightline` also).