### PR TITLE
Fix issue with Travis network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 before_install:
   - if [ ! -z "$PPA" ]; then sudo add-apt-repository "$PPA" -y; fi
   - travis_retry ./etc/ci/sudo-apt-get-update.sh -q
-  - travis_retry sudo apt-get install g++-7 libssl-dev $COQ_PACKAGE -y
+  - travis_retry sudo apt-get install g++-7 libssl-dev $COQ_PACKAGE -y --allow-unauthenticated
 
 
 before_script:


### PR DESCRIPTION
Sometimes we get logs like
[this](https://travis-ci.org/mit-plv/fiat-crypto/jobs/393628098), where
we have

```
Reading package lists...
W: GPG error: http://ppa.launchpad.net/jgross-h/many-coq-versions/ubuntu trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY E58B19DAA454A7D9
W: The repository 'http://ppa.launchpad.net/jgross-h/many-coq-versions/ubuntu trusty InRelease' is not signed.
W: There is no public key available for the following key IDs:
E58B19DAA454A7D9
W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)
```
and then
```
WARNING: The following packages cannot be authenticated!
  ocaml-base-nox ocaml-compiler-libs ocaml-interp ocaml-nox
  libcamlp4-ocaml-dev camlp4 coq-8.7.2-theories liblablgtk2-ocaml
  liblablgtksourceview2-ocaml libcoq-8.7.2-ocaml ocaml-native-compilers
  coq-8.7.2 coq-8.7.2ide libfindlib-ocaml libfindlib-ocaml-dev ocaml-findlib
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
```

I'm not sure if this is the right way to fix this...