### PR TITLE
Adapt to coq#7254

### DIFF
--- a/src/Arithmetic/BarrettReduction/RidiculousFish.v
+++ b/src/Arithmetic/BarrettReduction/RidiculousFish.v
@@ -32,7 +32,7 @@ Definition wrap (bits val : Z) : Z := val mod 2^bits.
 
 (** A [word] is a C data type with a specified bit size. *)
 Inductive word (bits : Z) :=
-| Word : Z -> word bits.
+| Word (v : Z).
 
 Definition to_Z {bits : Z} (a : word bits) : Z :=
   match a with Word v => v end.

--- a/src/Experiments/NewPipeline/Language.v
+++ b/src/Experiments/NewPipeline/Language.v
@@ -72,9 +72,8 @@ Module Compilers.
   End Reify.
 
   Module type.
-    Inductive type (base_type : Type) := base (t : base_type) | arrow (s d : type base_type).
-    Global Arguments base {_}.
-    Global Arguments arrow {_} s d.
+    Inductive type {base_type : Type} := base (t : base_type) | arrow (s d : type).
+    Global Arguments type : clear implicits.
 
     Fixpoint final_codomain {base_type} (t : type base_type) : base_type
       := match t with

--- a/src/Experiments/PartialEvaluationWithLetIn.v
+++ b/src/Experiments/PartialEvaluationWithLetIn.v
@@ -14,9 +14,8 @@ Require Import Crypto.Util.Notations.
 *)
 
 Module type.
-  Inductive type (base_type : Type) := base (t : base_type) | arrow (s d : type base_type).
-  Global Arguments base {_}.
-  Global Arguments arrow {_} s d.
+  Inductive type {base_type : Type} := base (t : base_type) | arrow (s d : type).
+  Global Arguments type : clear implicits.
 
   Fixpoint for_each_lhs_of_arrow {base_type} (f : type base_type -> Type) (t : type base_type) : Type
     := match t with
@@ -204,8 +203,9 @@ Module ident.
     | Cast {T} (upper_bound : upperboundT T) : pident (#T -> #T)%ptype
     .
 
-    Inductive wident (pident : ptype -> Type) : type -> Type :=
-    | wrap {T} (idc : pident T) : wident pident (parametric.subst T).
+    Inductive wident {pident : ptype -> Type} : type -> Type :=
+    | wrap {T} (idc : pident T) : wident (parametric.subst T).
+    Global Arguments wident : clear implicits.
     Definition ident := wident pident.
     Definition pwrap {T} (idc : pident T) : ident _ := @wrap pident T idc.
   End with_base.

--- a/src/Util/GlobalSettings.v
+++ b/src/Util/GlobalSettings.v
@@ -5,6 +5,9 @@
     => _ end]. *)
 Global Set Asymmetric Patterns.
 
+(** Enforce uniform parameters *)
+Global Set Uniform Inductive Parameters.
+
 (** Consider also: *)
 (** Judgmental η for records, faster projections *)
 (** Set Primitive Projections. *)


### PR DESCRIPTION
We make all parameters implicit, and set `Uniform Inductive Parameters`.

I expect this is backwards compatible, hopefully CI backs me up.

Not to be merged until coq/coq#7254 and coq/coq#7703 have converged.