### PR TITLE
Use native_compute rather than vm_compute

### DIFF
--- a/src/Experiments/NewPipeline/Toplevel1.v
+++ b/src/Experiments/NewPipeline/Toplevel1.v
@@ -1583,7 +1583,7 @@ Ltac peel_interp_app _ :=
                  => reflexivity
                | [ |- ?R (Interp ?ev) ?c ]
                  => let rc := constr:(GallinaReify.Reify c) in
-                    unify ev rc; vm_compute; reflexivity
+                    unify ev rc; native_compute; reflexivity
                end ] ]
   end.
 Ltac pre_cache_reify _ :=
@@ -1610,22 +1610,22 @@ Ltac do_inline_cache_reify do_if_not_cached :=
   | .. ].
 
 (* TODO: MOVE ME *)
-Ltac vm_compute_lhs_reflexivity :=
+Ltac native_compute_lhs_reflexivity :=
   lazymatch goal with
   | [ |- ?LHS = ?RHS ]
-    => let x := (eval vm_compute in LHS) in
+    => let x := (eval native_compute in LHS) in
        (* we cannot use the unify tactic, which just gives "not
           unifiable" as the error message, because we want to see the
           terms that were not unifable.  See also
           COQBUG(https://github.com/coq/coq/issues/7291) *)
        let _unify := constr:(ltac:(reflexivity) : RHS = x) in
-       vm_cast_no_check (eq_refl x)
+       native_cast_no_check (eq_refl x)
   end.
 
 Ltac solve_rop' rop_correct do_if_not_cached machine_wordsizev :=
   eapply rop_correct with (machine_wordsize:=machine_wordsizev);
   [ do_inline_cache_reify do_if_not_cached
-  | subst_evars; vm_compute_lhs_reflexivity (* lazy; reflexivity *) ].
+  | subst_evars; native_compute_lhs_reflexivity (* lazy; reflexivity *) ].
 Ltac solve_rop_nocache rop_correct :=
   solve_rop' rop_correct ltac:(fun _ => idtac).
 Ltac solve_rop rop_correct :=


### PR DESCRIPTION
This should hopefully speed things up.  See also https://github.com/coq/coq/pull/8055.

Except it doesn't speed things up (maybe because we are frequently computing enormous PHOAS syntax trees?), so we probably shouldn't merge this.  cc @ppedrot
```
After     | File Name                                          | Before    || Change    | % Change
--------------------------------------------------------------------------------------------------
15m44.56s | Total                                              | 10m54.17s || +4m50.38s | +44.39%
--------------------------------------------------------------------------------------------------
11m49.08s | Experiments/NewPipeline/SlowPrimeSynthesisExamples | 6m50.36s  || +4m58.72s | +72.79%
2m14.24s  | Experiments/NewPipeline/Toplevel2                  | 2m23.03s  || -0m08.78s | -6.14%
1m37.61s  | Experiments/NewPipeline/Toplevel1                  | 1m37.18s  || +0m00.42s | +0.44%
0m01.31s  | Experiments/NewPipeline/CLI                        | 0m01.30s  || +0m00.01s | +0.76%
0m01.20s  | Experiments/NewPipeline/StandaloneOCamlMain        | 0m01.20s  || +0m00.00s | +0.00%
0m01.12s  | Experiments/NewPipeline/StandaloneHaskellMain      | 0m01.10s  || +0m00.02s | +1.81%
```