### PR TITLE
Work around coqprime issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ COQPATH?=${CURDIR_SAFE}/$(COQPRIME_FOLDER)/src
 export COQPATH
 
 coqprime:
+	(cd $(COQPRIME_FOLDER) && $(COQBIN)coq_makefile -f _CoqProject -o Makefile)
 	$(MAKE) --no-print-directory -C $(COQPRIME_FOLDER) src/Coqprime/PrimalityTest/Zp.vo
 
 coqprime-all: coqprime


### PR DESCRIPTION
This closes #398

Since coqprime's makefile is incompatible with Coq 8.7, we blow it away
and regenerate it ourselves.