### PR TITLE
Fix up canonical-representation arithmetic logic

### DIFF
--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -3135,7 +3135,7 @@ Module WordByWordMontgomery.
       clear - r_big lgr_big; autounfold with loc; intros.
       repeat match goal with H : ?x = partition _ _ _ |- _ =>
                    rewrite H; clear H end.
-      rewrite (surjective_pairing (Rows.add _ _ _ _)).
+      rewrite (surjective_pairing (Rows.add _ _ _ _)). cbn [fst snd].
       rewrite Rows.add_partitions, Rows.add_div by (auto; distr_length).
       autorewrite with push_eval.
       rewrite <-Z.div_mod'', partition_step by auto.
@@ -3171,16 +3171,15 @@ Module WordByWordMontgomery.
     Qed.
     Lemma small_drop_high_addT' : forall n a b, small a -> small b -> small (@drop_high_addT' n a b).
     Proof using lgr_big.
-      intros n a b Ha Hb; generalize (length_small Ha); generalize (length_small Hb); generalize (@eval_drop_high_addT' n a b Ha).
-      clear -lgr_big Ha Hb.
-      cbv [small].
-      intro Heq; rewrite Heq; autounfold with loc in *.
-      rewrite Ha, Hb.
-      repeat t_step.
-      rewrite !UniformWeight.uweight_eq_alt by omega.
-      autorewrite with push_Zof_nat zsimplify_fast.
-      rewrite Z.pow_succ_r by omega.
-    Admitted.
+      pose proof r_big as r_big.
+      clear - r_big lgr_big; autounfold with loc; intros.
+      repeat match goal with H : ?x = partition _ _ _ |- _ =>
+                   rewrite H; clear H end.
+      rewrite (surjective_pairing (Rows.add _ _ _ _)). cbn [fst snd].
+      rewrite Rows.add_partitions by (distr_length; auto using length_partition).
+      autorewrite with push_eval.
+      auto using partition_eq_mod with zarith.
+    Qed.
     Local Axiom eval_conditional_sub : forall v, small v -> 0 <= eval v < eval N + R -> eval (conditional_sub v N) = eval v + if eval N <=? eval v then -eval N else 0.
     Local Axiom small_conditional_sub : forall v, small v -> 0 <= eval v < eval N + R -> small (conditional_sub v N).
     Local Axiom eval_sub_then_maybe_add : forall a b, small a -> small b -> 0 <= eval a < eval N -> 0 <= eval b < eval N -> eval (sub_then_maybe_add a b) = eval a - eval b + if eval a - eval b <? 0 then eval N else 0.

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -1426,6 +1426,36 @@ Module Partition.
         rewrite <-!Znumtheory.Zmod_div_mod by (try apply Z.mod_divide; auto).
         rewrite Hxy, Hxyn; reflexivity. }
     Qed.
+
+    Fixpoint recursive_partition n i x :=
+      match n with
+      | O => []
+      | S n' => x mod (weight (S i) / weight i) :: recursive_partition n' (S i) (x / (weight (S i) / weight i))
+      end.
+
+    Lemma recursive_partition_equiv' n : forall x j,
+        map (fun i => x mod weight (S i) / weight i) (seq j n) = recursive_partition n j (x / weight j).
+    Proof.
+      induction n; [reflexivity|].
+      intros; cbn. rewrite IHn.
+      pose proof (@weight_positive _ wprops j).
+      pose proof (@weight_divides _ wprops j).
+      f_equal;
+        repeat match goal with
+               | _ => rewrite Z.mod_pull_div by auto using Z.lt_le_incl
+               | _ => rewrite weight_multiples by auto
+               | _ => progress autorewrite with zsimplify_fast zdiv_to_mod pull_Zdiv
+               | _ => reflexivity
+               end.
+    Qed.
+
+    Lemma recursive_partition_equiv n x :
+      partition n x = recursive_partition n 0%nat x.
+    Proof.
+      cbv [partition]. rewrite recursive_partition_equiv'.
+      rewrite weight_0 by auto; autorewrite with zsimplify_fast.
+      reflexivity.
+    Qed.
   End Partition.
 End Partition.
 

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -2013,7 +2013,7 @@ Module Rows.
                  | H : length _ = _ |- _ => rewrite H
                  | H: 0%nat = _ |- _ => rewrite <-H
                  | [p := _ |- _] => subst p
-                 | _ => progress autorewrite with cancel_pair natsimplify push_sum_rows list push_nth_default
+                 | _ => progress autorewrite with cancel_pair natsimplify push_sum_rows list
                  | _ => progress autorewrite with cancel_pair in *
                  | _ => progress distr_length
                  | _ => progress break_match
@@ -2131,7 +2131,7 @@ Module Rows.
           cbv [sum_rows]; intros. rewrite <-(Nat.add_0_r n).
           rewrite <-(app_nil_l row1), <-(app_nil_l row2).
           apply sum_rows'_partitions; intros;
-            autorewrite with cancel_pair push_eval zsimplify_fast push_nth_default; distr_length; reflexivity.
+            autorewrite with cancel_pair push_eval zsimplify_fast; distr_length; reflexivity.
         Qed.
 
         Lemma length_sum_rows row1 row2 n:

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -2595,14 +2595,14 @@ Module BaseConversion.
                       transitivity (from_associational_inlined sw dw idxs n (rev p));
                         [ | transitivity (from_associational sw dw idxs n p); [ | reflexivity ] ](* reverse to make addc chains line up *)
       end.
-      Focus 2. {
+      2: {
         rewrite from_associational_inlined_correct by (subst nout; auto).
         cbv [from_associational].
         rewrite !Rows.flatten_partitions' by eauto using Rows.length_from_associational.
         rewrite !Rows.eval_from_associational by (subst nout; auto).
         f_equal.
         rewrite !eval_carries, !Associational.bind_snd_correct, !Associational.eval_rev by auto.
-        reflexivity. } Unfocus.
+        reflexivity. }
       subst widemul_inlined_reverse; reflexivity.
     Qed.
   End widemul.

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -2432,43 +2432,6 @@ Module Rows.
       (* returns all-but-lowest-limb and lowest limb *)
       Definition divmod (p : list Z) : list Z * Z
         := (tl p, hd 0 p).
-      (*
-      Lemma eval_divmod n (p : list Z) :
-        length p = S n ->
-        (forall i, weight i = weight 1 ^ Z.of_nat i) ->
-        (forall i, (i <= n)%nat ->
-                   nth_default 0 p i = (Positional.eval weight (S n) p mod weight (S i)) / (weight i)) ->
-        let pv := Positional.eval weight (S n) p in
-        Positional.eval (fun i => weight (S i) / weight 1) n (fst (divmod p)) = pv / weight 1
-        /\ snd (divmod p) = pv mod weight 1.
-      Proof using Type.
-        cbv [is_div_mod divmod]; destruct p; cbn [fst snd hd tl length]; [ omega | ].
-        intros Hlen Hsmall.
-        split.
-        { rewrite Positional.eval_cons, weight_0 by (assumption || omega).
-          autorewrite with zsimplify_const.
-          symmetry; erewrite Positional.eval_weight_mul.
-          Print Positional.
-        2: {
-             (etransitivity; [ exact (Hsmall 0%nat ltac:(omega)) | ]).
-             rewrite weight_0 by assumption; autorewrite with zsimplify_const; reflexivity.
-             }
-
-
-        revert H0.
-        push_Zmod.
-hd 0 p).
-      Lemma eval_divmod n (p : list Z) :
-        length p = S n -> p = partition (S n) (Positional.eval weight (S n) p) ->
-        is_div_mod (Positional.eval (fun i => weight (S i) / weight 1) n)
-                   (divmod p)
-                   (Positional.eval weight (S n) p)
-                   (weight 1).
-      Proof using Type.
-        cbv [is_div_mod divmod]; destruct p; cbn [fst snd hd tl length]; [ omega | ].
-        intros.
-        rewrite eval_
-       *)
     End Ops.
   End Rows.
   Hint Rewrite length_from_columns using eassumption : distr_length.

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -2699,15 +2699,14 @@ Module BaseConversion.
                       transitivity (from_associational_inlined sw dw idxs n (rev p));
                         [ | transitivity (from_associational sw dw idxs n p); [ | reflexivity ] ](* reverse to make addc chains line up *)
       end.
-      2: {
-        rewrite from_associational_inlined_correct by (subst nout; auto).
+      { subst widemul_inlined_reverse; reflexivity. }
+      { rewrite from_associational_inlined_correct by (subst nout; auto).
         cbv [from_associational].
         rewrite !Rows.flatten_partitions' by eauto using Rows.length_from_associational.
         rewrite !Rows.eval_from_associational by (subst nout; auto).
         f_equal.
         rewrite !eval_carries, !Associational.bind_snd_correct, !Associational.eval_rev by auto.
         reflexivity. }
-      subst widemul_inlined_reverse; reflexivity.
     Qed.
   End widemul.
 End BaseConversion.

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -1296,33 +1296,6 @@ Module Partition.
     Definition partition n x :=
       map (fun i => (x mod weight (S i)) / weight i) (seq 0 n).
 
-    (* TODO : move to ListUtil *)
-    Lemma nth_default_map_seq_equiv {A} l f d n
-          (Hlength : length l = n)
-          (Hnth_default : forall i, (i < n)%nat -> @nth_default A d l i = f i) :
-      l = map f (seq 0 n).
-    Proof using Type.
-      apply list_elementwise_eq. subst n.
-      intro i; destruct (lt_dec i (length l)).
-      { rewrite !nth_error_Some_nth_default with (x:=d) by distr_length.
-        autorewrite with push_nth_default.
-        rewrite map_nth_default with (x:=0%nat) by distr_length.
-        rewrite Hnth_default by distr_length.
-        rewrite nth_default_seq_inbounds by distr_length.
-        f_equal. }
-      { rewrite !nth_error_length_error by distr_length.
-        reflexivity. }
-    Qed.
-
-    Lemma nth_default_partitions x : forall p n,
-        (forall i, (i < n)%nat -> nth_default 0 p i = (x mod weight (S i)) / weight i) ->
-        length p = n ->
-        p = partition n x.
-    Proof using Type.
-      cbv [partition]; intros.
-      eauto using nth_default_map_seq_equiv.
-    Qed.
-
     Lemma partition_step n x :
       partition (S n) x = partition n x ++ [(x mod weight (S n)) / weight n].
     Proof using Type.
@@ -1405,29 +1378,6 @@ Module Partition.
       intros; distr_length; auto.
     Qed.
     Hint Rewrite length_recursive_partition : distr_length.
-
-    (* TODO : move *)
-    Hint Rewrite Nat.sub_0_l : natsimplify.
-
-    (* TODO : remove if this ends up being unused *)
-    Lemma recursive_partition_skipn : forall m n i j x,
-        (m < n)%nat ->
-        (j = i + m)%nat ->
-        skipn m (recursive_partition n i (x / weight i)) = recursive_partition (n-m) j (x / weight j).
-    Proof.
-      induction m; destruct n; intros; subst;
-        repeat match goal with
-               | _ => progress cbn [recursive_partition]
-               | _ => rewrite weight_0 by assumption
-               | _ => rewrite weight_multiples by assumption
-               | _ => rewrite Z.div_div by auto
-               | _ => rewrite Z.mul_div_eq by auto
-               | _ => progress autorewrite with zsimplify_fast natsimplify push_skipn
-               | _ => reflexivity
-               end.
-      erewrite IHm by (auto; omega).
-      repeat (f_equal; try omega).
-    Qed.
   End Partition.
   Hint Rewrite length_partition length_recursive_partition : distr_length.
   Hint Rewrite eval_partition using auto : push_eval.

--- a/src/Experiments/NewPipeline/Toplevel1.v
+++ b/src/Experiments/NewPipeline/Toplevel1.v
@@ -3486,7 +3486,7 @@ Module BarrettReduction.
 
     Lemma partition_represents x :
       0 <= x < 2^k*2^k ->
-      represents (Rows.partition w 2 x) x.
+      represents (Partition.partition w 2 x) x.
     Proof.
       intros; cbn. change_weight.
       Z.rewrite_mod_small.
@@ -3891,7 +3891,7 @@ Module MontgomeryReduction.
       autorewrite with widemul.
       rewrite Rows.add_partitions, Rows.add_div by (distr_length; apply wprops; omega).
       rewrite R_two_pow.
-      cbv [Rows.partition seq]. rewrite !eval2.
+      cbv [Partition.partition seq]. rewrite !eval2.
       autorewrite with push_nth_default push_map.
       autorewrite with to_div_mod. rewrite ?Z.zselect_correct, ?Z.add_modulo_correct.
       change_weight.


### PR DESCRIPTION
Previously, Columns and Rows had a mishmash of different techniques and proofs trying to declare various properties of canonical representations. In preparation for proving some of the WBW Montgomery admits, I have done a long-overdue overhaul (I also used it to prove a couple of those).

Now, we use `partition (weight nat -> Z) (n : nat) : Z -> list Z`, which splits an integer across `n` digits according to the weight function.  Proofs of correctness for functions splitting out a canonical representation are phrased in terms of this function. We also have a proof that evaluating the result produces the input modulo `weight n`, so the div/mod properties of those other functions come "for free" with the canonicalization proof.