### PR TITLE
Prove admits for word-by-word Montgomery

### DIFF
--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -510,7 +510,7 @@ Module Positional. Section Positional.
 
   Lemma eval_snoc_S n x y : n = length x -> eval (S n) (x ++ [y]) = eval n x + weight n * y.
   Proof using Type. intros; erewrite eval_snoc; eauto. Qed.
-  Hint Rewrite eval_snoc_S : push_eval.
+  Hint Rewrite eval_snoc_S using (solve [distr_length]) : push_eval.
 
   (* SKIP over this: zeros, add_to_nth *)
   Local Ltac push := autorewrite with push_eval push_map distr_length
@@ -930,7 +930,7 @@ Module Positional. Section Positional.
 End Positional.
 (* Hint Rewrite disappears after the end of a section *)
 Hint Rewrite length_zeros length_add_to_nth length_from_associational @length_add @length_carry_reduce @length_chained_carries @length_encode @length_sub @length_opp @length_select @length_zselect @length_select_min @length_extend_to_length @length_drop_high_to_length : distr_length.
-Hint Rewrite @eval_zeros @eval_nil @eval_snoc_S @eval_select @eval_zselect @eval_extend_to_length (*@eval_drop_high_to_length*) : push_eval.
+Hint Rewrite @eval_zeros @eval_nil @eval_snoc_S @eval_select @eval_zselect @eval_extend_to_length (*@eval_drop_high_to_length*) using (solve [auto; distr_length]): push_eval.
 Section Positional_nonuniform.
   Context (weight weight' : nat -> Z).
 
@@ -1392,7 +1392,7 @@ Module Partition.
     Hint Rewrite length_recursive_partition : distr_length.
   End Partition.
   Hint Rewrite length_partition length_recursive_partition : distr_length.
-  Hint Rewrite eval_partition using auto : push_eval.
+  Hint Rewrite eval_partition using (solve [auto; distr_length]) : push_eval.
 End Partition.
 
 Module Columns.
@@ -1600,7 +1600,7 @@ Module Columns.
       Lemma length_from_associational n p : length (from_associational n p) = n.
       Proof using Type. cbv [from_associational Let_In]. apply fold_right_invariant; intros; distr_length. Qed.
       Hint Rewrite length_from_associational: distr_length.
-      Lemma eval_from_associational n p (n_nonzero:n<>0%nat\/p=nil):
+      Lemma eval_from_associational n p (n_nonzero:n<>0%nat\/p=nil) :
         eval n (from_associational n p) = Associational.eval p.
       Proof using wprops.
         erewrite <-Positional.eval_from_associational by eauto.
@@ -2170,26 +2170,26 @@ Module Rows.
         try reflexivity.
 
       Lemma add_partitions n p q :
-        n <> 0%nat -> length p = n -> length q = n ->
+        length p = n -> length q = n ->
         fst (add n p q) = partition weight n (Positional.eval weight n p + Positional.eval weight n q).
       Proof using wprops. solver. Qed.
 
       Lemma add_div n p q :
-        n <> 0%nat -> length p = n -> length q = n ->
+        length p = n -> length q = n ->
         snd (add n p q) = (Positional.eval weight n p + Positional.eval weight n q) / weight n.
       Proof using wprops. solver. Qed.
 
       Lemma conditional_add_partitions n mask cond p q :
-        n <> 0%nat -> length p = n -> length q = n -> map (Z.land mask) q = q ->
+        length p = n -> length q = n -> map (Z.land mask) q = q ->
         fst (conditional_add n mask cond p q)
         = partition weight n (Positional.eval weight n p + if dec (cond = 0) then 0 else Positional.eval weight n q).
       Proof using wprops.
         cbv [conditional_add]; intros; rewrite add_partitions by (distr_length; auto).
-        autorewrite with push_eval; auto.
+        autorewrite with push_eval; reflexivity.
       Qed.
 
       Lemma conditional_add_div n mask cond p q :
-        n <> 0%nat -> length p = n -> length q = n -> map (Z.land mask) q = q ->
+        length p = n -> length q = n -> map (Z.land mask) q = q ->
         snd (conditional_add n mask cond p q) = (Positional.eval weight n p + if dec (cond = 0) then 0 else Positional.eval weight n q) / weight n.
       Proof using wprops.
         cbv [conditional_add]; intros; rewrite add_div by (distr_length; auto).
@@ -2210,22 +2210,22 @@ Module Rows.
       Qed. Hint Rewrite eval_map_opp using solve [auto]: push_eval.
 
       Lemma sub_partitions n p q :
-        n <> 0%nat -> length p = n -> length q = n ->
+        length p = n -> length q = n ->
         fst (sub n p q) = partition weight n (Positional.eval weight n p - Positional.eval weight n q).
       Proof using wprops. solver. Qed.
 
       Lemma sub_div n p q :
-        n <> 0%nat -> length p = n -> length q = n ->
+        length p = n -> length q = n ->
         snd (sub n p q) = (Positional.eval weight n p - Positional.eval weight n q) / weight n.
       Proof using wprops. solver. Qed.
 
       Lemma mul_partitions base n m p q :
-        base <> 0 -> n <> 0%nat -> m <> 0%nat -> length p = n -> length q = n ->
+        base <> 0 -> m <> 0%nat -> length p = n -> length q = n ->
         fst (mul base n m p q) = partition weight m (Positional.eval weight n p * Positional.eval weight n q).
       Proof using wprops. solver. Qed.
 
       Lemma mul_div base n m p q :
-        base <> 0 -> n <> 0%nat -> m <> 0%nat -> length p = n -> length q = n ->
+        base <> 0 -> m <> 0%nat -> length p = n -> length q = n ->
         snd (mul base n m p q) = (Positional.eval weight n p * Positional.eval weight n q) / weight m.
       Proof using wprops. solver. Qed.
 
@@ -3202,7 +3202,26 @@ Module WordByWordMontgomery.
       { destruct a, b; cbn; try omega. }
       { eta_expand; intros; repeat t_step. }
     Qed.
-    Local Axiom small_addT : forall n a b, small a -> small b -> small (@addT n a b).
+    Local Lemma small_addT : forall n a b, small a -> small b -> small (@addT n a b).
+    Proof.
+      pose proof r_big as r_big.
+      clear - r_big lgr_big; autounfold with loc; intros.
+      repeat match goal with H : ?x = partition _ _ _ |- _ =>
+                   rewrite H; clear H end.
+      rewrite (surjective_pairing (Rows.add _ _ _ _)).
+      rewrite Rows.add_partitions, Rows.add_div by (auto; distr_length).
+      autorewrite with push_eval.
+      rewrite <-Z.div_mod'', partition_step by auto.
+      rewrite Z.mod_small with (b:=weight (S n)); [ reflexivity | ].
+      split; auto with zarith; [ ].
+      apply Z.lt_le_trans with (m:=2 * weight n).
+      { rewrite <-Z.add_diag.
+        auto using Z.add_lt_mono with zarith. }
+      { rewrite !UniformWeight.uweight_eq_alt by omega.
+        autorewrite with push_Zof_nat push_Zpow.
+        rewrite Z.pow_succ_r by auto.
+        auto with zarith. }
+    Qed.
     Local Lemma eval_drop_high_addT' : forall n a b, small a -> small b -> eval (@drop_high_addT' n a b) = (eval a + eval b) mod (r^Z.of_nat (S n)).
     Proof using lgr_big.
       intros n a b Ha Hb; generalize (length_small Ha); generalize (length_small Hb).

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -1352,7 +1352,7 @@ Module Partition.
 
     Lemma recursive_partition_equiv' n : forall x j,
         map (fun i => x mod weight (S i) / weight i) (seq j n) = recursive_partition n j (x / weight j).
-    Proof.
+    Proof using wprops.
       induction n; [reflexivity|].
       intros; cbn. rewrite IHn.
       pose proof (@weight_positive _ wprops j).
@@ -1368,7 +1368,7 @@ Module Partition.
 
     Lemma recursive_partition_equiv n x :
       partition n x = recursive_partition n 0%nat x.
-    Proof.
+    Proof using wprops.
       cbv [partition]. rewrite recursive_partition_equiv'.
       rewrite weight_0 by auto; autorewrite with zsimplify_fast.
       reflexivity.
@@ -1376,7 +1376,7 @@ Module Partition.
 
     Lemma length_recursive_partition n : forall i x,
       length (recursive_partition n i x) = n.
-    Proof.
+    Proof using Type.
       induction n; cbn [recursive_partition]; [reflexivity | ].
       intros; distr_length; auto.
     Qed.
@@ -1384,7 +1384,7 @@ Module Partition.
     Lemma drop_high_to_length_partition n m x :
       (n <= m)%nat ->
       Positional.drop_high_to_length n (partition m x) = partition n x.
-    Proof.
+    Proof using Type.
       cbv [Positional.drop_high_to_length partition]; intros.
       autorewrite with push_firstn.
       rewrite Nat.min_l by omega.
@@ -1515,7 +1515,7 @@ Module Columns.
           length inp = n ->
           flatten inp = (partition weight n (eval n inp),
                          eval n inp / (weight n)).
-      Proof.
+      Proof using wprops.
         induction inp using rev_ind; intros;
           destruct n; distr_length; [ reflexivity | ].
         rewrite flatten_snoc.
@@ -2225,7 +2225,7 @@ Module Rows.
         length q = n ->
         0 <= Positional.eval weight n q < weight n ->
         conditional_sub n p q = partition weight n (if Positional.eval weight n q <=? Positional.eval weight n p then Positional.eval weight n p - Positional.eval weight n q else Positional.eval weight n p).
-      Proof.
+      Proof using wprops.
         cbv [conditional_sub]; intros.
         rewrite (surjective_pairing (sub _ _ _)).
         assert (length p = n) by (rewrite Hp; distr_length).
@@ -2280,7 +2280,7 @@ Module Rows.
       Lemma adjust_s_invariant fuel s (s_nz:s<>0) :
         fst (adjust_s fuel s) mod s = 0
         /\ fst (adjust_s fuel s) <> 0.
-      Proof.
+      Proof using wprops.
         cbv [adjust_s]; rewrite fold_right_map; generalize (List.rev (seq 0 fuel)); intro ls; induction ls as [|l ls IHls];
           cbn.
         { rewrite Z.mod_same by assumption; auto. }
@@ -2901,7 +2901,7 @@ Module UniformWeight.
     length xs = n ->
     Positional.eval (fun i => uweight lgr (S i)) n xs =
     (uweight lgr 1) * Positional.eval (uweight lgr) n xs.
-  Proof.
+  Proof using Type.
     induction xs using rev_ind; destruct n; distr_length;
       intros; [cbn; ring | ].
     rewrite !Positional.eval_snoc with (n:=n) by distr_length.
@@ -2911,14 +2911,14 @@ Module UniformWeight.
     ring.
   Qed.
   Lemma uweight_S lgr (Hr : 0 <= lgr) n : uweight lgr (S n) = 2 ^ lgr * uweight lgr n.
-  Proof.
+  Proof using Type.
     rewrite !uweight_eq_alt by auto.
     autorewrite with push_Zof_nat.
     rewrite Z.pow_succ_r by auto using Nat2Z.is_nonneg.
     reflexivity.
   Qed.
   Lemma uweight_double_le lgr (Hr : 0 < lgr) n : uweight lgr n + uweight lgr n <= uweight lgr (S n).
-  Proof.
+  Proof using Type.
     rewrite uweight_S, uweight_eq_alt by omega.
     rewrite Z.add_diag.
     apply Z.mul_le_mono_nonneg_r.
@@ -2939,7 +2939,7 @@ Module UniformWeight.
     forall i j x,
       Partition.recursive_partition (uweight lgr) n i x
       = Partition.recursive_partition (uweight lgr) n j x.
-  Proof.
+  Proof using Type.
     induction n; intros; [reflexivity | ].
     cbn [Partition.recursive_partition].
     rewrite !uweight_eq_alt by omega.
@@ -2952,7 +2952,7 @@ Module UniformWeight.
   Lemma uweight_recursive_partition_equiv lgr (Hr : 0 < lgr) n i x:
     Partition.partition (uweight lgr) n x =
     Partition.recursive_partition (uweight lgr) n i x.
-  Proof.
+  Proof using Type.
     rewrite Partition.recursive_partition_equiv by auto using uwprops.
     auto using uweight_recursive_partition_change_start with omega.
   Qed.
@@ -3223,20 +3223,20 @@ Module WordByWordMontgomery.
              end.
 
     Lemma eval_div : forall n v, small v -> eval (fst (@divmod n v)) = eval v / r.
-    Proof.
+    Proof using lgr_big.
       pose proof r_big as r_big.
       clear - r_big lgr_big; intros; autounfold with loc.
       push_recursive_partition; cbn [Rows.divmod fst tl].
       autorewrite with zsimplify; reflexivity.
     Qed.
     Lemma eval_mod : forall n v, small v -> snd (@divmod n v) = eval v mod r.
-    Proof.
+    Proof using lgr_big.
       clear - lgr_big; intros; autounfold with loc.
       push_recursive_partition; cbn [Rows.divmod snd hd].
       autorewrite with zsimplify; reflexivity.
     Qed.
     Lemma small_div : forall n v, small v -> small (fst (@divmod n v)).
-    Proof.
+    Proof using lgr_big.
       pose proof r_big as r_big.
       clear - r_big lgr_big. intros; autounfold with loc.
       push_recursive_partition. cbn [Rows.divmod fst tl].

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -486,9 +486,9 @@ Module Weight.
             (weight_0 : weight 0%nat = 1)
             (weight_positive : forall i, 0 < weight i)
             (weight_multiples : forall i, weight (S i) mod weight i = 0)
-                                                                              (weight_divides : forall i : nat, 0 < weight (S i) / weight i).
+            (weight_divides : forall i : nat, 0 < weight (S i) / weight i).
 
-    Hint Resolve Z.positive_is_nonzero Z.lt_gt Nat2Z.is_nonneg.
+    Local Hint Resolve Z.positive_is_nonzero Z.lt_gt Nat2Z.is_nonneg.
 
     Lemma weight_multiples_full' j : forall i, weight (i+j) mod weight i = 0.
     Proof using weight_positive weight_multiples.
@@ -939,8 +939,10 @@ Module Positional.
       length (zselect mask cond p) = length p.
     Proof using Type. clear dependent weight. cbv [zselect Let_In]; break_match; intros; distr_length. Qed.
 
-    (* We need an explicit equality proof here, because sometimes it
-    matters that we retain the same bounds when selecting. *)
+    (** We need an explicit equality proof here, because sometimes it
+        matters that we retain the same bounds when selecting.  The
+        alternative (weaker) lemma is [eval_select], where we only
+        talk about equality under [eval]. *)
     Lemma select_eq cond n : forall p q,
         length p = n -> length q = n ->
         select cond p q = if dec (cond = 0) then p else q.
@@ -2989,7 +2991,7 @@ End UniformWeight.
 
 Module WordByWordMontgomery.
   Import Partition.
-  Hint Resolve Z.positive_is_nonzero Z.lt_gt Nat2Z.is_nonneg.
+  Local Hint Resolve Z.positive_is_nonzero Z.lt_gt Nat2Z.is_nonneg.
   Section with_args.
     Context (lgr : Z)
             (m : Z).

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -3871,8 +3871,8 @@ Module WordByWordMontgomery.
         clear dependent B; clear dependent k; clear dependent ri.
 
       Lemma small_add : small (add Av Bv).
-      Proof using small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound.
-        clear -small_Bv small_Av N_lt_R Bv_bound Av_bound partition_Proper r_big'.
+      Proof using small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound small_N ri k R_numlimbs_nz N_nz B_bounds B.
+        clear -small_Bv small_Av N_lt_R Bv_bound Av_bound partition_Proper r_big' small_N ri k R_numlimbs_nz N_nz B_bounds B sub_then_maybe_add.
         unfold add; t_small.
       Qed.
       Lemma small_sub : small (sub Av Bv).
@@ -3881,8 +3881,8 @@ Module WordByWordMontgomery.
       Proof using Type. unfold opp, sub; t_small. Qed.
 
       Lemma eval_add : eval (add Av Bv) = eval Av + eval Bv + if (eval N <=? eval Av + eval Bv) then -eval N else 0.
-      Proof using small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound.
-        clear -small_Bv small_Av N_lt_R Bv_bound Av_bound partition_Proper r_big'.
+      Proof using small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound small_N ri k R_numlimbs_nz N_nz B_bounds B.
+        clear -small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound partition_Proper r_big' small_N ri k R_numlimbs_nz N_nz B_bounds B sub_then_maybe_add.
         unfold add; autorewrite with push_mont_eval; reflexivity.
       Qed.
       Lemma eval_sub : eval (sub Av Bv) = eval Av - eval Bv + if (eval Av - eval Bv <? 0) then eval N else 0.
@@ -3903,7 +3903,7 @@ Module WordByWordMontgomery.
                      | progress (push_Zmod; pull_Zmod) ].
 
       Lemma eval_add_mod_N : eval (add Av Bv) mod eval N = (eval Av + eval Bv) mod eval N.
-      Proof using small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound.
+      Proof using small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound small_N ri k R_numlimbs_nz N_nz B_bounds B.
         generalize eval_add; clear. t_mod_N.
       Qed.
       Lemma eval_sub_mod_N : eval (sub Av Bv) mod eval N = (eval Av - eval Bv) mod eval N.
@@ -3912,7 +3912,7 @@ Module WordByWordMontgomery.
       Proof using small_Av N_nz Av_bound. generalize eval_opp; clear; t_mod_N. Qed.
 
       Lemma add_bound : 0 <= eval (add Av Bv) < eval N.
-      Proof using small_Bv small_Av lgr_big R_numlimbs_nz N_lt_R Bv_bound Av_bound.
+      Proof using small_Bv small_Av lgr_big R_numlimbs_nz N_lt_R Bv_bound Av_bound small_N ri k N_nz B_bounds B.
         generalize eval_add; break_innermost_match; Z.ltb_to_lt; lia.
       Qed.
       Lemma sub_bound : 0 <= eval (sub Av Bv) < eval N.
@@ -4120,8 +4120,10 @@ Module WordByWordMontgomery.
         push_Zmod; rewrite ?eval_from_montgomery_mod; pull_Zmod; repeat apply conj;
           cbv [valid addmod] in *; destruct_head'_and; auto;
             try rewrite m_enc_correct_montgomery;
-            try (eapply small_add || eapply add_bound); rewrite <- ?m_enc_correct_montgomery; eauto with omega; [].
-      push_Zmod; erewrite eval_add by (rewrite <- ?m_enc_correct_montgomery; eauto with omega); pull_Zmod; rewrite <- ?m_enc_correct_montgomery.
+            try (eapply small_add || eapply add_bound);
+            cbv [small]; rewrite <- ?m_enc_correct_montgomery;
+              eauto with omega; [ ].
+      push_Zmod; erewrite eval_add by (cbv [small]; rewrite <- ?m_enc_correct_montgomery; eauto with omega); pull_Zmod; rewrite <- ?m_enc_correct_montgomery.
       break_innermost_match; push_Zmod; pull_Zmod; autorewrite with zsimplify_const; apply f_equal2; nia.
     Qed.
 

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -3412,7 +3412,18 @@ Module WordByWordMontgomery.
       apply Z.mod_small.
       break_match; Z.ltb_to_lt; lia.
     Qed.
-    Local Axiom small_sub_then_maybe_add : forall a b, small (sub_then_maybe_add a b).
+    Local Lemma small_sub_then_maybe_add : forall a b, small a -> small b -> small (sub_then_maybe_add a b).
+    Proof using small_N lgr_big R_numlimbs_nz.
+      pose proof mask_r_sub1 as mask_r_sub1.
+      clear - small_N lgr_big R_numlimbs_nz mask_r_sub1.
+      intros; autounfold with loc; cbv [sub_then_maybe_add].
+      repeat match goal with H : small _ |- _ =>
+                             rewrite H; clear H end.
+      rewrite Rows.sub_then_maybe_add_partitions by (distr_length; autorewrite with push_eval; auto with zarith).
+      autorewrite with push_eval.
+      apply partition_eq_mod; auto; [ ].
+      auto with zarith.
+    Qed.
 
     Local Opaque T addT drop_high_addT' divmod zero scmul conditional_sub sub_then_maybe_add.
     Create HintDb push_mont_eval discriminated.

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -3220,7 +3220,12 @@ Module WordByWordMontgomery.
       { rewrite !UniformWeight.uweight_eq_alt by omega.
         autorewrite with push_Zof_nat push_Zpow.
         rewrite Z.pow_succ_r by auto.
-        auto with zarith. }
+        (* In versions newer than 8.7, auto with zarith is sufficient
+        to solve this from here. *)
+        apply Z.mul_le_mono_nonneg_r.
+        { auto with zarith. }
+        { transitivity (2 ^ 1); [ reflexivity | ].
+          apply Z.pow_le_mono_r; omega. } }
     Qed.
     Local Lemma eval_drop_high_addT' : forall n a b, small a -> small b -> eval (@drop_high_addT' n a b) = (eval a + eval b) mod (r^Z.of_nat (S n)).
     Proof using lgr_big.

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -3935,9 +3935,11 @@ Module WordByWordMontgomery.
         unfold add; t_small.
       Qed.
       Lemma small_sub : small (sub Av Bv).
-      Proof using Type. unfold sub; t_small. Qed.
+      Proof using small_N small_Bv small_Av partition_Proper lgr_big
+R_numlimbs_nz. unfold sub; t_small. Qed.
       Lemma small_opp : small (opp Av).
-      Proof using Type. unfold opp, sub; t_small. Qed.
+      Proof using small_N small_Bv small_Av partition_Proper lgr_big
+R_numlimbs_nz. unfold opp, sub; t_small. Qed.
 
       Lemma eval_add : eval (add Av Bv) = eval Av + eval Bv + if (eval N <=? eval Av + eval Bv) then -eval N else 0.
       Proof using small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound small_N ri k R_numlimbs_nz N_nz B_bounds B.
@@ -3945,10 +3947,10 @@ Module WordByWordMontgomery.
         unfold add; autorewrite with push_mont_eval; reflexivity.
       Qed.
       Lemma eval_sub : eval (sub Av Bv) = eval Av - eval Bv + if (eval Av - eval Bv <? 0) then eval N else 0.
-      Proof using small_Bv small_Av Bv_bound Av_bound. unfold sub; autorewrite with push_mont_eval; reflexivity. Qed.
+      Proof using small_Bv small_Av Bv_bound Av_bound small_N partition_Proper lgr_big R_numlimbs_nz N_nz N_lt_R. unfold sub; autorewrite with push_mont_eval; reflexivity. Qed.
       Lemma eval_opp : eval (opp Av) = (if (eval Av =? 0) then 0 else eval N) - eval Av.
-      Proof using Av_bound N_nz small_Av.
-        clear -Av_bound N_nz small_Av partition_Proper r_big'.
+      Proof using small_Av Av_bound small_N partition_Proper lgr_big R_numlimbs_nz N_nz N_lt_R.
+        clear -Av_bound N_nz small_Av partition_Proper r_big' small_N lgr_big R_numlimbs_nz N_nz N_lt_R.
         unfold opp, sub; autorewrite with push_mont_eval.
         break_innermost_match; Z.ltb_to_lt; lia.
       Qed.
@@ -3966,21 +3968,21 @@ Module WordByWordMontgomery.
         generalize eval_add; clear. t_mod_N.
       Qed.
       Lemma eval_sub_mod_N : eval (sub Av Bv) mod eval N = (eval Av - eval Bv) mod eval N.
-      Proof using small_Bv small_Av Bv_bound Av_bound. generalize eval_sub; clear. t_mod_N. Qed.
+      Proof using small_Bv small_Av Bv_bound Av_bound small_N r_big' partition_Proper lgr_big R_numlimbs_nz N_nz N_lt_R. generalize eval_sub; clear. t_mod_N. Qed.
       Lemma eval_opp_mod_N : eval (opp Av) mod eval N = (-eval Av) mod eval N.
-      Proof using small_Av N_nz Av_bound. generalize eval_opp; clear; t_mod_N. Qed.
+      Proof using small_Av Av_bound small_N r_big' partition_Proper lgr_big R_numlimbs_nz N_nz N_lt_R. generalize eval_opp; clear. t_mod_N. Qed.
 
       Lemma add_bound : 0 <= eval (add Av Bv) < eval N.
       Proof using small_Bv small_Av lgr_big R_numlimbs_nz N_lt_R Bv_bound Av_bound small_N ri k N_nz B_bounds B.
         generalize eval_add; break_innermost_match; Z.ltb_to_lt; lia.
       Qed.
       Lemma sub_bound : 0 <= eval (sub Av Bv) < eval N.
-      Proof using small_Bv small_Av R_numlimbs_nz Bv_bound Av_bound.
+      Proof using small_Bv small_Av R_numlimbs_nz Bv_bound Av_bound small_N r_big' partition_Proper lgr_big N_nz N_lt_R.
         generalize eval_sub; break_innermost_match; Z.ltb_to_lt; lia.
       Qed.
       Lemma opp_bound : 0 <= eval (opp Av) < eval N.
-      Proof using small_Av R_numlimbs_nz N_nz Av_bound.
-        clear Bv_bound.
+      Proof using small_Av R_numlimbs_nz Av_bound small_N r_big' partition_Proper lgr_big N_nz N_lt_R.
+        clear Bv small_Bv Bv_bound.
         generalize eval_opp; break_innermost_match; Z.ltb_to_lt; lia.
       Qed.
     End add_sub.
@@ -4195,8 +4197,10 @@ Module WordByWordMontgomery.
         push_Zmod; rewrite ?eval_from_montgomery_mod; pull_Zmod; repeat apply conj;
           cbv [valid submod] in *; destruct_head'_and; auto;
             try rewrite m_enc_correct_montgomery;
-            try (eapply small_sub || eapply sub_bound); rewrite <- ?m_enc_correct_montgomery; eauto with omega; [].
-      push_Zmod; erewrite eval_sub by (rewrite <- ?m_enc_correct_montgomery; eauto with omega); pull_Zmod; rewrite <- ?m_enc_correct_montgomery.
+            try (eapply small_sub || eapply sub_bound);
+            cbv [small]; rewrite <- ?m_enc_correct_montgomery;
+              eauto with omega; [ ].
+      push_Zmod; erewrite eval_sub by (cbv [small]; rewrite <- ?m_enc_correct_montgomery; eauto with omega); pull_Zmod; rewrite <- ?m_enc_correct_montgomery.
       break_innermost_match; push_Zmod; pull_Zmod; autorewrite with zsimplify_const; apply f_equal2; nia.
     Qed.
 
@@ -4209,8 +4213,10 @@ Module WordByWordMontgomery.
         push_Zmod; rewrite ?eval_from_montgomery_mod; pull_Zmod; repeat apply conj;
           cbv [valid oppmod] in *; destruct_head'_and; auto;
             try rewrite m_enc_correct_montgomery;
-            try (eapply small_opp || eapply opp_bound); rewrite <- ?m_enc_correct_montgomery; eauto with omega; [].
-      push_Zmod; erewrite eval_opp by (rewrite <- ?m_enc_correct_montgomery; eauto with omega); pull_Zmod; rewrite <- ?m_enc_correct_montgomery.
+            try (eapply small_opp || eapply opp_bound);
+            cbv [small]; rewrite <- ?m_enc_correct_montgomery;
+              eauto with omega; [ ].
+      push_Zmod; erewrite eval_opp by (cbv [small]; rewrite <- ?m_enc_correct_montgomery; eauto with omega); pull_Zmod; rewrite <- ?m_enc_correct_montgomery.
       break_innermost_match; push_Zmod; pull_Zmod; autorewrite with zsimplify_const; apply f_equal2; nia.
     Qed.
 

--- a/src/Experiments/NewPipeline/Arithmetic.v
+++ b/src/Experiments/NewPipeline/Arithmetic.v
@@ -3208,7 +3208,7 @@ Module WordByWordMontgomery.
       clear - r_big lgr_big; autounfold with loc; intros.
       repeat match goal with H : ?x = partition _ _ _ |- _ =>
                    rewrite H; clear H end.
-      rewrite (surjective_pairing (Rows.add _ _ _ _)).
+      rewrite (surjective_pairing (Rows.add _ _ _ _)). cbn [fst snd].
       rewrite Rows.add_partitions, Rows.add_div by (auto; distr_length).
       autorewrite with push_eval.
       rewrite <-Z.div_mod'', partition_step by auto.
@@ -3244,16 +3244,15 @@ Module WordByWordMontgomery.
     Qed.
     Lemma small_drop_high_addT' : forall n a b, small a -> small b -> small (@drop_high_addT' n a b).
     Proof using lgr_big.
-      intros n a b Ha Hb; generalize (length_small Ha); generalize (length_small Hb); generalize (@eval_drop_high_addT' n a b Ha).
-      clear -lgr_big Ha Hb.
-      cbv [small].
-      intro Heq; rewrite Heq; autounfold with loc in *.
-      rewrite Ha, Hb.
-      repeat t_step.
-      rewrite !UniformWeight.uweight_eq_alt by omega.
-      autorewrite with push_Zof_nat zsimplify_fast.
-      rewrite Z.pow_succ_r by omega.
-    Admitted.
+      pose proof r_big as r_big.
+      clear - r_big lgr_big; autounfold with loc; intros.
+      repeat match goal with H : ?x = partition _ _ _ |- _ =>
+                   rewrite H; clear H end.
+      rewrite (surjective_pairing (Rows.add _ _ _ _)). cbn [fst snd].
+      rewrite Rows.add_partitions by (distr_length; auto using length_partition).
+      autorewrite with push_eval.
+      auto using partition_eq_mod with zarith.
+    Qed.
     Local Axiom eval_conditional_sub : forall v, small v -> 0 <= eval v < eval N + R -> eval (conditional_sub v N) = eval v + if eval N <=? eval v then -eval N else 0.
     Local Axiom small_conditional_sub : forall v, small v -> 0 <= eval v < eval N + R -> small (conditional_sub v N).
     Local Axiom eval_sub_then_maybe_add : forall a b, small a -> small b -> 0 <= eval a < eval N -> 0 <= eval b < eval N -> eval (sub_then_maybe_add a b) = eval a - eval b + if eval a - eval b <? 0 then eval N else 0.

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -1297,6 +1297,7 @@ Proof.
   revert k a; induction b as [|? IHb], k; simpl; try reflexivity.
   intros; rewrite IHb; reflexivity.
 Qed.
+Hint Rewrite @firstn_seq : push_firstn.
 
 Lemma skipn_seq k a b
   : skipn k (seq a b) = seq (k + a) (b - k).


### PR DESCRIPTION
I also did a couple things along the way, like:
- relocate some proofs about weight functions (they were previously in `Saturated`, but had nothing to do with saturated weights)
- restructure the `eval` and `small` proofs a bit so that work wasn't duplicated--instead I proved that they were both at the same time and then made tiny proofs to say each separately
- remove some cruft -- unnecessary preconditions to a few lemmas and a commented-out lemma that ended up not being needed