### PR TITLE
Compatibility after Coq PR#262 (continued)

### DIFF
--- a/src/Experiments/NewPipeline/CStringification.v
+++ b/src/Experiments/NewPipeline/CStringification.v
@@ -1239,7 +1239,7 @@ Module Compilers.
                | type.arrow (type.base s) d
                  => fun f
                      (x : (int.option.interp s -> ErrT (arith_expr_for_base s)))
-                   => match x int.option.None with
+                   => match x int.option.None return _ with
                      | inl x'
                        => @collect_args_and_apply_unknown_casts
                            d


### PR DESCRIPTION
This is a second instance of an incompatibility introduced by coq/coq#262 (see fiat-crypto commit 251ea49a). One fixes it the same, reducing the search space for a return clause by forbidding it to be obtained by small inversion. I did not double-check explicitly but this should be backwards-compatible.