### PR TITLE
Support type variables in patterns in the rewriter

### DIFF
--- a/src/Experiments/NewPipeline/GENERATEDIdentifiersWithoutTypes.v
+++ b/src/Experiments/NewPipeline/GENERATEDIdentifiersWithoutTypes.v
@@ -1,584 +1,673 @@
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.FSets.FMapPositive.
+Require Import Coq.Lists.List.
 Require Import Crypto.Util.CPSNotations.
+Require Import Crypto.Util.Option.
 Require Import Crypto.Util.ZRange.
+Require Import Crypto.Util.PrimitiveSigma.
+Require Import Crypto.Util.Notations.
 Require Import Crypto.Experiments.NewPipeline.Language.
+Import ListNotations. Local Open Scope list_scope.
+Import PrimitiveSigma.Primitive.
 
 Module Compilers.
+  Set Boolean Equality Schemes.
+  Set Decidable Equality Schemes.
   Export Language.Compilers.
 
+  Local Notation type_of_list := (fold_right (fun A B => prod A B) unit).
+  Local Notation type_of_list_cps := (fold_right (fun a K => a -> K)).
   Module pattern.
-    Module ident.
-      Set Boolean Equality Schemes.
-      Set Decidable Equality Schemes.
-      (*
-      Set Printing Coercions.
-      Redirect "/tmp/pr" Print Compilers.ident.ident.
-      Redirect "/tmp/sm" Show Match Compilers.ident.ident.
-      *)
-      (*
+    Notation EvarMap := (PositiveMap.t Compilers.base.type).
+    Module base.
+      Local Notation einterp := type.interp.
+      Module type.
+        Inductive type := var (p : positive) | type_base (t : Compilers.base.type.base) | prod (A B : type) | list (A : type).
+      End type.
+      Notation type := type.type.
+
+      Fixpoint relax (t : Compilers.base.type) : type
+        := match t with
+           | Compilers.base.type.type_base t => type.type_base t
+           | Compilers.base.type.prod A B => type.prod (relax A) (relax B)
+           | Compilers.base.type.list A => type.list (relax A)
+           end.
+
+      Module Notations.
+        Global Coercion type.type_base : Compilers.base.type.base >-> type.type.
+        Bind Scope pbtype_scope with type.type.
+        (*Bind Scope ptype_scope with Compilers.type.type type.type.*) (* COQBUG(https://github.com/coq/coq/issues/7699) *)
+        Delimit Scope ptype_scope with ptype.
+        Delimit Scope pbtype_scope with pbtype.
+        Notation "A * B" := (type.prod A%ptype B%ptype) : ptype_scope.
+        Notation "A * B" := (type.prod A%pbtype B%pbtype) : pbtype_scope.
+        Notation "()" := (type.type_base base.type.unit) : pbtype_scope.
+        Notation "()" := (type.base (type.type_base base.type.unit)) : ptype_scope.
+        Notation "A -> B" := (type.arrow A%ptype B%ptype) : ptype_scope.
+        Notation "' n" := (type.var n) : pbtype_scope.
+        Notation "' n" := (type.base (type.var n)) : ptype_scope.
+        Notation "'1" := (type.var 1) : pbtype_scope.
+        Notation "'2" := (type.var 2) : pbtype_scope.
+        Notation "'3" := (type.var 3) : pbtype_scope.
+        Notation "'4" := (type.var 4) : pbtype_scope.
+        Notation "'5" := (type.var 5) : pbtype_scope.
+        Notation "'1" := (type.base (type.var 1)) : ptype_scope.
+        Notation "'2" := (type.base (type.var 2)) : ptype_scope.
+        Notation "'3" := (type.base (type.var 3)) : ptype_scope.
+        Notation "'4" := (type.base (type.var 4)) : ptype_scope.
+        Notation "'5" := (type.base (type.var 5)) : ptype_scope.
+      End Notations.
+    End base.
+    Notation type := (type.type base.type).
+    Export base.Notations.
+
+    Module type.
+      Fixpoint relax (t : type.type Compilers.base.type) : type
+        := match t with
+           | type.base t => type.base (base.relax t)
+           | type.arrow s d => type.arrow (relax s) (relax d)
+           end.
+    End type.
+
+    (*
+    Set Printing Coercions.
+    Redirect "/tmp/pr" Print Compilers.ident.ident.
+    Redirect "/tmp/sm" Show Match Compilers.ident.ident.
+    *)
+    (*
 <<<
 #!/usr/bin/env python2
 import re, os
 
 print_ident = r"""Inductive ident : defaults.type -> Set :=
     Literal : forall t : base.type.base,
-              base.interp (base.type.type_base t) ->
+              base.interp (Compilers.base.type.type_base t) ->
               ident
-                ((fun x : base.type => type.base x) (base.type.type_base t))
+                ((fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base t))
   | Nat_succ : ident
-                 ((fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat))
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat))%ptype
   | Nat_pred : ident
-                 ((fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat))
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat))%ptype
   | Nat_max : ident
-                ((fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat) ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat) ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat))
+                ((fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat) ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat) ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat))%ptype
   | Nat_mul : ident
-                ((fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat) ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat) ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat))
+                ((fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat) ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat) ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat))%ptype
   | Nat_add : ident
-                ((fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat) ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat) ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat))
+                ((fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat) ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat) ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat))%ptype
   | Nat_sub : ident
-                ((fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat) ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat) ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.nat))
-  | nil : forall t : base.type,
-          ident ((fun x : base.type => type.base x) (base.type.list t))
-  | cons : forall t : base.type,
-           ident
-             ((fun x : base.type => type.base x) t ->
-              (fun x : base.type => type.base x) (base.type.list t) ->
-              (fun x : base.type => type.base x) (base.type.list t))
-  | pair : forall A B : base.type,
-           ident
-             ((fun x : base.type => type.base x) A ->
-              (fun x : base.type => type.base x) B ->
-              (fun x : base.type => type.base x) (A * B)%etype)
-  | fst : forall A B : base.type,
+                ((fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat) ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat) ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.nat))%ptype
+  | nil : forall t : Compilers.base.type,
           ident
-            ((fun x : base.type => type.base x) (A * B)%etype ->
-             (fun x : base.type => type.base x) A)
-  | snd : forall A B : base.type,
+            ((fun x : Compilers.base.type => type.base x)
+               (Compilers.base.type.list t))
+  | cons : forall t : Compilers.base.type,
+           ident
+             ((fun x : Compilers.base.type => type.base x) t ->
+              (fun x : Compilers.base.type => type.base x)
+                (Compilers.base.type.list t) ->
+              (fun x : Compilers.base.type => type.base x)
+                (Compilers.base.type.list t))%ptype
+  | pair : forall A B : Compilers.base.type,
+           ident
+             ((fun x : Compilers.base.type => type.base x) A ->
+              (fun x : Compilers.base.type => type.base x) B ->
+              (fun x : Compilers.base.type => type.base x) (A * B)%etype)%ptype
+  | fst : forall A B : Compilers.base.type,
           ident
-            ((fun x : base.type => type.base x) (A * B)%etype ->
-             (fun x : base.type => type.base x) B)
-  | prod_rect : forall A B T : base.type,
+            ((fun x : Compilers.base.type => type.base x) (A * B)%etype ->
+             (fun x : Compilers.base.type => type.base x) A)%ptype
+  | snd : forall A B : Compilers.base.type,
+          ident
+            ((fun x : Compilers.base.type => type.base x) (A * B)%etype ->
+             (fun x : Compilers.base.type => type.base x) B)%ptype
+  | prod_rect : forall A B T : Compilers.base.type,
                 ident
-                  (((fun x : base.type => type.base x) A ->
-                    (fun x : base.type => type.base x) B ->
-                    (fun x : base.type => type.base x) T) ->
-                   (fun x : base.type => type.base x) (A * B)%etype ->
-                   (fun x : base.type => type.base x) T)
-  | bool_rect : forall T : base.type,
+                  (((fun x : Compilers.base.type => type.base x) A ->
+                    (fun x : Compilers.base.type => type.base x) B ->
+                    (fun x : Compilers.base.type => type.base x) T) ->
+                   (fun x : Compilers.base.type => type.base x) (A * B)%etype ->
+                   (fun x : Compilers.base.type => type.base x) T)%ptype
+  | bool_rect : forall T : Compilers.base.type,
                 ident
-                  (((fun x : base.type => type.base x) ()%etype ->
-                    (fun x : base.type => type.base x) T) ->
-                   ((fun x : base.type => type.base x) ()%etype ->
-                    (fun x : base.type => type.base x) T) ->
-                   (fun x : base.type => type.base x)
-                     (base.type.type_base base.type.bool) ->
-                   (fun x : base.type => type.base x) T)
-  | nat_rect : forall P : base.type,
+                  (((fun x : Compilers.base.type => type.base x) ()%etype ->
+                    (fun x : Compilers.base.type => type.base x) T) ->
+                   ((fun x : Compilers.base.type => type.base x) ()%etype ->
+                    (fun x : Compilers.base.type => type.base x) T) ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.bool) ->
+                   (fun x : Compilers.base.type => type.base x) T)%ptype
+  | nat_rect : forall P : Compilers.base.type,
                ident
-                 (((fun x : base.type => type.base x) ()%etype ->
-                   (fun x : base.type => type.base x) P) ->
-                  ((fun x : base.type => type.base x)
-                     (base.type.type_base base.type.nat) ->
-                   (fun x : base.type => type.base x) P ->
-                   (fun x : base.type => type.base x) P) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat) ->
-                  (fun x : base.type => type.base x) P)
-  | nat_rect_arrow : forall P Q : base.type,
+                 (((fun x : Compilers.base.type => type.base x) ()%etype ->
+                   (fun x : Compilers.base.type => type.base x) P) ->
+                  ((fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.nat) ->
+                   (fun x : Compilers.base.type => type.base x) P ->
+                   (fun x : Compilers.base.type => type.base x) P) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat) ->
+                  (fun x : Compilers.base.type => type.base x) P)%ptype
+  | nat_rect_arrow : forall P Q : Compilers.base.type,
                      ident
-                       (((fun x : base.type => type.base x) P ->
-                         (fun x : base.type => type.base x) Q) ->
-                        ((fun x : base.type => type.base x)
-                           (base.type.type_base base.type.nat) ->
-                         ((fun x : base.type => type.base x) P ->
-                          (fun x : base.type => type.base x) Q) ->
-                         (fun x : base.type => type.base x) P ->
-                         (fun x : base.type => type.base x) Q) ->
-                        (fun x : base.type => type.base x)
-                          (base.type.type_base base.type.nat) ->
-                        (fun x : base.type => type.base x) P ->
-                        (fun x : base.type => type.base x) Q)
-  | list_rect : forall A P : base.type,
+                       (((fun x : Compilers.base.type => type.base x) P ->
+                         (fun x : Compilers.base.type => type.base x) Q) ->
+                        ((fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.type_base base.type.nat) ->
+                         ((fun x : Compilers.base.type => type.base x) P ->
+                          (fun x : Compilers.base.type => type.base x) Q) ->
+                         (fun x : Compilers.base.type => type.base x) P ->
+                         (fun x : Compilers.base.type => type.base x) Q) ->
+                        (fun x : Compilers.base.type => type.base x)
+                          (Compilers.base.type.type_base base.type.nat) ->
+                        (fun x : Compilers.base.type => type.base x) P ->
+                        (fun x : Compilers.base.type => type.base x) Q)%ptype
+  | list_rect : forall A P : Compilers.base.type,
                 ident
-                  (((fun x : base.type => type.base x) ()%etype ->
-                    (fun x : base.type => type.base x) P) ->
-                   ((fun x : base.type => type.base x) A ->
-                    (fun x : base.type => type.base x) (base.type.list A) ->
-                    (fun x : base.type => type.base x) P ->
-                    (fun x : base.type => type.base x) P) ->
-                   (fun x : base.type => type.base x) (base.type.list A) ->
-                   (fun x : base.type => type.base x) P)
-  | list_case : forall A P : base.type,
+                  (((fun x : Compilers.base.type => type.base x) ()%etype ->
+                    (fun x : Compilers.base.type => type.base x) P) ->
+                   ((fun x : Compilers.base.type => type.base x) A ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.list A) ->
+                    (fun x : Compilers.base.type => type.base x) P ->
+                    (fun x : Compilers.base.type => type.base x) P) ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.list A) ->
+                   (fun x : Compilers.base.type => type.base x) P)%ptype
+  | list_case : forall A P : Compilers.base.type,
                 ident
-                  (((fun x : base.type => type.base x) ()%etype ->
-                    (fun x : base.type => type.base x) P) ->
-                   ((fun x : base.type => type.base x) A ->
-                    (fun x : base.type => type.base x) (base.type.list A) ->
-                    (fun x : base.type => type.base x) P) ->
-                   (fun x : base.type => type.base x) (base.type.list A) ->
-                   (fun x : base.type => type.base x) P)
-  | List_length : forall T : base.type,
+                  (((fun x : Compilers.base.type => type.base x) ()%etype ->
+                    (fun x : Compilers.base.type => type.base x) P) ->
+                   ((fun x : Compilers.base.type => type.base x) A ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.list A) ->
+                    (fun x : Compilers.base.type => type.base x) P) ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.list A) ->
+                   (fun x : Compilers.base.type => type.base x) P)%ptype
+  | List_length : forall T : Compilers.base.type,
                   ident
-                    ((fun x : base.type => type.base x) (base.type.list T) ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.nat))
+                    ((fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.list T) ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.nat))%ptype
   | List_seq : ident
-                 ((fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.list (base.type.type_base base.type.nat)))
-  | List_firstn : forall A : base.type,
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.list
+                       (Compilers.base.type.type_base base.type.nat)))%ptype
+  | List_firstn : forall A : Compilers.base.type,
                   ident
-                    ((fun x : base.type => type.base x)
-                       (base.type.type_base base.type.nat) ->
-                     (fun x : base.type => type.base x) (base.type.list A) ->
-                     (fun x : base.type => type.base x) (base.type.list A))
-  | List_skipn : forall A : base.type,
+                    ((fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.nat) ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.list A) ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.list A))%ptype
+  | List_skipn : forall A : Compilers.base.type,
                  ident
-                   ((fun x : base.type => type.base x)
-                      (base.type.type_base base.type.nat) ->
-                    (fun x : base.type => type.base x) (base.type.list A) ->
-                    (fun x : base.type => type.base x) (base.type.list A))
-  | List_repeat : forall A : base.type,
+                   ((fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.nat) ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.list A) ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.list A))%ptype
+  | List_repeat : forall A : Compilers.base.type,
                   ident
-                    ((fun x : base.type => type.base x) A ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.nat) ->
-                     (fun x : base.type => type.base x) (base.type.list A))
-  | List_combine : forall A B : base.type,
+                    ((fun x : Compilers.base.type => type.base x) A ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.nat) ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.list A))%ptype
+  | List_combine : forall A B : Compilers.base.type,
                    ident
-                     ((fun x : base.type => type.base x) (base.type.list A) ->
-                      (fun x : base.type => type.base x) (base.type.list B) ->
-                      (fun x : base.type => type.base x)
-                        (base.type.list (A * B)))
-  | List_map : forall A B : base.type,
+                     ((fun x : Compilers.base.type => type.base x)
+                        (Compilers.base.type.list A) ->
+                      (fun x : Compilers.base.type => type.base x)
+                        (Compilers.base.type.list B) ->
+                      (fun x : Compilers.base.type => type.base x)
+                        (Compilers.base.type.list (A * B)))%ptype
+  | List_map : forall A B : Compilers.base.type,
                ident
-                 (((fun x : base.type => type.base x) A ->
-                   (fun x : base.type => type.base x) B) ->
-                  (fun x : base.type => type.base x) (base.type.list A) ->
-                  (fun x : base.type => type.base x) (base.type.list B))
-  | List_app : forall A : base.type,
+                 (((fun x : Compilers.base.type => type.base x) A ->
+                   (fun x : Compilers.base.type => type.base x) B) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.list A) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.list B))%ptype
+  | List_app : forall A : Compilers.base.type,
                ident
-                 ((fun x : base.type => type.base x) (base.type.list A) ->
-                  (fun x : base.type => type.base x) (base.type.list A) ->
-                  (fun x : base.type => type.base x) (base.type.list A))
-  | List_rev : forall A : base.type,
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.list A) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.list A) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.list A))%ptype
+  | List_rev : forall A : Compilers.base.type,
                ident
-                 ((fun x : base.type => type.base x) (base.type.list A) ->
-                  (fun x : base.type => type.base x) (base.type.list A))
-  | List_flat_map : forall A B : base.type,
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.list A) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.list A))%ptype
+  | List_flat_map : forall A B : Compilers.base.type,
                     ident
-                      (((fun x : base.type => type.base x) A ->
-                        (fun x : base.type => type.base x) (base.type.list B)) ->
-                       (fun x : base.type => type.base x) (base.type.list A) ->
-                       (fun x : base.type => type.base x) (base.type.list B))
-  | List_partition : forall A : base.type,
+                      (((fun x : Compilers.base.type => type.base x) A ->
+                        (fun x : Compilers.base.type => type.base x)
+                          (Compilers.base.type.list B)) ->
+                       (fun x : Compilers.base.type => type.base x)
+                         (Compilers.base.type.list A) ->
+                       (fun x : Compilers.base.type => type.base x)
+                         (Compilers.base.type.list B))%ptype
+  | List_partition : forall A : Compilers.base.type,
                      ident
-                       (((fun x : base.type => type.base x) A ->
-                         (fun x : base.type => type.base x)
-                           (base.type.type_base base.type.bool)) ->
-                        (fun x : base.type => type.base x) (base.type.list A) ->
-                        (fun x : base.type => type.base x)
-                          (base.type.list A * base.type.list A)%etype)
-  | List_fold_right : forall A B : base.type,
+                       (((fun x : Compilers.base.type => type.base x) A ->
+                         (fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.type_base base.type.bool)) ->
+                        (fun x : Compilers.base.type => type.base x)
+                          (Compilers.base.type.list A) ->
+                        (fun x : Compilers.base.type => type.base x)
+                          (Compilers.base.type.list A *
+                           Compilers.base.type.list A)%etype)%ptype
+  | List_fold_right : forall A B : Compilers.base.type,
                       ident
-                        (((fun x : base.type => type.base x) B ->
-                          (fun x : base.type => type.base x) A ->
-                          (fun x : base.type => type.base x) A) ->
-                         (fun x : base.type => type.base x) A ->
-                         (fun x : base.type => type.base x)
-                           (base.type.list B) ->
-                         (fun x : base.type => type.base x) A)
-  | List_update_nth : forall T : base.type,
+                        (((fun x : Compilers.base.type => type.base x) B ->
+                          (fun x : Compilers.base.type => type.base x) A ->
+                          (fun x : Compilers.base.type => type.base x) A) ->
+                         (fun x : Compilers.base.type => type.base x) A ->
+                         (fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.list B) ->
+                         (fun x : Compilers.base.type => type.base x) A)%ptype
+  | List_update_nth : forall T : Compilers.base.type,
                       ident
-                        ((fun x : base.type => type.base x)
-                           (base.type.type_base base.type.nat) ->
-                         ((fun x : base.type => type.base x) T ->
-                          (fun x : base.type => type.base x) T) ->
-                         (fun x : base.type => type.base x)
-                           (base.type.list T) ->
-                         (fun x : base.type => type.base x)
-                           (base.type.list T))
-  | List_nth_default : forall T : base.type,
+                        ((fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.type_base base.type.nat) ->
+                         ((fun x : Compilers.base.type => type.base x) T ->
+                          (fun x : Compilers.base.type => type.base x) T) ->
+                         (fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.list T) ->
+                         (fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.list T))%ptype
+  | List_nth_default : forall T : Compilers.base.type,
                        ident
-                         ((fun x : base.type => type.base x) T ->
-                          (fun x : base.type => type.base x)
-                            (base.type.list T) ->
-                          (fun x : base.type => type.base x)
-                            (base.type.type_base base.type.nat) ->
-                          (fun x : base.type => type.base x) T)
+                         ((fun x : Compilers.base.type => type.base x) T ->
+                          (fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.list T) ->
+                          (fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.nat) ->
+                          (fun x : Compilers.base.type => type.base x) T)%ptype
   | Z_add : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_mul : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_pow : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_sub : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_opp : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_div : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_modulo : ident
-                 ((fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z))
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_log2 : ident
-               ((fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z))
+               ((fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_log2_up : ident
-                  ((fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z) ->
-                   (fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z))
+                  ((fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z) ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_eqb : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.bool))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.bool))%ptype
   | Z_leb : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.bool))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.bool))%ptype
   | Z_geb : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.bool))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.bool))%ptype
   | Z_of_nat : ident
-                 ((fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z))
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_to_nat : ident
-                 ((fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.nat))
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.nat))%ptype
   | Z_shiftr : ident
-                 ((fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z))
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_shiftl : ident
-                 ((fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z) ->
-                  (fun x : base.type => type.base x)
-                    (base.type.type_base base.type.Z))
+                 ((fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z) ->
+                  (fun x : Compilers.base.type => type.base x)
+                    (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_land : ident
-               ((fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z))
+               ((fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_lor : ident
-              ((fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z) ->
-               (fun x : base.type => type.base x)
-                 (base.type.type_base base.type.Z))
+              ((fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z) ->
+               (fun x : Compilers.base.type => type.base x)
+                 (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_bneg : ident
-               ((fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z))
+               ((fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_lnot_modulo : ident
-                      ((fun x : base.type => type.base x)
-                         (base.type.type_base base.type.Z) ->
-                       (fun x : base.type => type.base x)
-                         (base.type.type_base base.type.Z) ->
-                       (fun x : base.type => type.base x)
-                         (base.type.type_base base.type.Z))
+                      ((fun x : Compilers.base.type => type.base x)
+                         (Compilers.base.type.type_base base.type.Z) ->
+                       (fun x : Compilers.base.type => type.base x)
+                         (Compilers.base.type.type_base base.type.Z) ->
+                       (fun x : Compilers.base.type => type.base x)
+                         (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_mul_split : ident
-                    ((fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z) ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z) ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z) ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z *
-                        base.type.type_base base.type.Z)%etype)
+                    ((fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z) ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z) ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z) ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z *
+                        Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | Z_add_get_carry : ident
-                        ((fun x : base.type => type.base x)
-                           (base.type.type_base base.type.Z) ->
-                         (fun x : base.type => type.base x)
-                           (base.type.type_base base.type.Z) ->
-                         (fun x : base.type => type.base x)
-                           (base.type.type_base base.type.Z) ->
-                         (fun x : base.type => type.base x)
-                           (base.type.type_base base.type.Z *
-                            base.type.type_base base.type.Z)%etype)
+                        ((fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.type_base base.type.Z) ->
+                         (fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.type_base base.type.Z) ->
+                         (fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.type_base base.type.Z) ->
+                         (fun x : Compilers.base.type => type.base x)
+                           (Compilers.base.type.type_base base.type.Z *
+                            Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | Z_add_with_carry : ident
-                         ((fun x : base.type => type.base x)
-                            (base.type.type_base base.type.Z) ->
-                          (fun x : base.type => type.base x)
-                            (base.type.type_base base.type.Z) ->
-                          (fun x : base.type => type.base x)
-                            (base.type.type_base base.type.Z) ->
-                          (fun x : base.type => type.base x)
-                            (base.type.type_base base.type.Z))
+                         ((fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.Z) ->
+                          (fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.Z) ->
+                          (fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.Z) ->
+                          (fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_add_with_get_carry : ident
-                             ((fun x : base.type => type.base x)
-                                (base.type.type_base base.type.Z) ->
-                              (fun x : base.type => type.base x)
-                                (base.type.type_base base.type.Z) ->
-                              (fun x : base.type => type.base x)
-                                (base.type.type_base base.type.Z) ->
-                              (fun x : base.type => type.base x)
-                                (base.type.type_base base.type.Z) ->
-                              (fun x : base.type => type.base x)
-                                (base.type.type_base base.type.Z *
-                                 base.type.type_base base.type.Z)%etype)
+                             ((fun x : Compilers.base.type => type.base x)
+                                (Compilers.base.type.type_base base.type.Z) ->
+                              (fun x : Compilers.base.type => type.base x)
+                                (Compilers.base.type.type_base base.type.Z) ->
+                              (fun x : Compilers.base.type => type.base x)
+                                (Compilers.base.type.type_base base.type.Z) ->
+                              (fun x : Compilers.base.type => type.base x)
+                                (Compilers.base.type.type_base base.type.Z) ->
+                              (fun x : Compilers.base.type => type.base x)
+                                (Compilers.base.type.type_base base.type.Z *
+                                 Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | Z_sub_get_borrow : ident
-                         ((fun x : base.type => type.base x)
-                            (base.type.type_base base.type.Z) ->
-                          (fun x : base.type => type.base x)
-                            (base.type.type_base base.type.Z) ->
-                          (fun x : base.type => type.base x)
-                            (base.type.type_base base.type.Z) ->
-                          (fun x : base.type => type.base x)
-                            (base.type.type_base base.type.Z *
-                             base.type.type_base base.type.Z)%etype)
+                         ((fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.Z) ->
+                          (fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.Z) ->
+                          (fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.Z) ->
+                          (fun x : Compilers.base.type => type.base x)
+                            (Compilers.base.type.type_base base.type.Z *
+                             Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | Z_sub_with_get_borrow : ident
-                              ((fun x : base.type => type.base x)
-                                 (base.type.type_base base.type.Z) ->
-                               (fun x : base.type => type.base x)
-                                 (base.type.type_base base.type.Z) ->
-                               (fun x : base.type => type.base x)
-                                 (base.type.type_base base.type.Z) ->
-                               (fun x : base.type => type.base x)
-                                 (base.type.type_base base.type.Z) ->
-                               (fun x : base.type => type.base x)
-                                 (base.type.type_base base.type.Z *
-                                  base.type.type_base base.type.Z)%etype)
+                              ((fun x : Compilers.base.type => type.base x)
+                                 (Compilers.base.type.type_base base.type.Z) ->
+                               (fun x : Compilers.base.type => type.base x)
+                                 (Compilers.base.type.type_base base.type.Z) ->
+                               (fun x : Compilers.base.type => type.base x)
+                                 (Compilers.base.type.type_base base.type.Z) ->
+                               (fun x : Compilers.base.type => type.base x)
+                                 (Compilers.base.type.type_base base.type.Z) ->
+                               (fun x : Compilers.base.type => type.base x)
+                                 (Compilers.base.type.type_base base.type.Z *
+                                  Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | Z_zselect : ident
-                  ((fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z) ->
-                   (fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z) ->
-                   (fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z) ->
-                   (fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z))
+                  ((fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z) ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z) ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z) ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_add_modulo : ident
-                     ((fun x : base.type => type.base x)
-                        (base.type.type_base base.type.Z) ->
-                      (fun x : base.type => type.base x)
-                        (base.type.type_base base.type.Z) ->
-                      (fun x : base.type => type.base x)
-                        (base.type.type_base base.type.Z) ->
-                      (fun x : base.type => type.base x)
-                        (base.type.type_base base.type.Z))
+                     ((fun x : Compilers.base.type => type.base x)
+                        (Compilers.base.type.type_base base.type.Z) ->
+                      (fun x : Compilers.base.type => type.base x)
+                        (Compilers.base.type.type_base base.type.Z) ->
+                      (fun x : Compilers.base.type => type.base x)
+                        (Compilers.base.type.type_base base.type.Z) ->
+                      (fun x : Compilers.base.type => type.base x)
+                        (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_rshi : ident
-               ((fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z))
+               ((fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_cc_m : ident
-               ((fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z))
+               ((fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_cast : zrange ->
              ident
-               ((fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z) ->
-                (fun x : base.type => type.base x)
-                  (base.type.type_base base.type.Z))
+               ((fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z) ->
+                (fun x : Compilers.base.type => type.base x)
+                  (Compilers.base.type.type_base base.type.Z))%ptype
   | Z_cast2 : zrange * zrange ->
               ident
-                ((fun x : base.type => type.base x)
-                   (base.type.type_base base.type.Z *
-                    base.type.type_base base.type.Z)%etype ->
-                 (fun x : base.type => type.base x)
-                   (base.type.type_base base.type.Z *
-                    base.type.type_base base.type.Z)%etype)
+                ((fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.Z *
+                    Compilers.base.type.type_base base.type.Z)%etype ->
+                 (fun x : Compilers.base.type => type.base x)
+                   (Compilers.base.type.type_base base.type.Z *
+                    Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | fancy_add : Z ->
                 Z ->
                 ident
-                  ((fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z *
-                      base.type.type_base base.type.Z)%etype ->
-                   (fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z *
-                      base.type.type_base base.type.Z)%etype)
+                  ((fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z *
+                      Compilers.base.type.type_base base.type.Z)%etype ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z *
+                      Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | fancy_addc : Z ->
                  Z ->
                  ident
-                   ((fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype ->
-                    (fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype)
+                   ((fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | fancy_sub : Z ->
                 Z ->
                 ident
-                  ((fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z *
-                      base.type.type_base base.type.Z)%etype ->
-                   (fun x : base.type => type.base x)
-                     (base.type.type_base base.type.Z *
-                      base.type.type_base base.type.Z)%etype)
+                  ((fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z *
+                      Compilers.base.type.type_base base.type.Z)%etype ->
+                   (fun x : Compilers.base.type => type.base x)
+                     (Compilers.base.type.type_base base.type.Z *
+                      Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | fancy_subb : Z ->
                  Z ->
                  ident
-                   ((fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype ->
-                    (fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype)
+                   ((fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype)%ptype
   | fancy_mulll : Z ->
                   ident
-                    ((fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z *
-                        base.type.type_base base.type.Z)%etype ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z))
+                    ((fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z *
+                        Compilers.base.type.type_base base.type.Z)%etype ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z))%ptype
   | fancy_mullh : Z ->
                   ident
-                    ((fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z *
-                        base.type.type_base base.type.Z)%etype ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z))
+                    ((fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z *
+                        Compilers.base.type.type_base base.type.Z)%etype ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z))%ptype
   | fancy_mulhl : Z ->
                   ident
-                    ((fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z *
-                        base.type.type_base base.type.Z)%etype ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z))
+                    ((fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z *
+                        Compilers.base.type.type_base base.type.Z)%etype ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z))%ptype
   | fancy_mulhh : Z ->
                   ident
-                    ((fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z *
-                        base.type.type_base base.type.Z)%etype ->
-                     (fun x : base.type => type.base x)
-                       (base.type.type_base base.type.Z))
+                    ((fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z *
+                        Compilers.base.type.type_base base.type.Z)%etype ->
+                     (fun x : Compilers.base.type => type.base x)
+                       (Compilers.base.type.type_base base.type.Z))%ptype
   | fancy_rshi : Z ->
                  Z ->
                  ident
-                   ((fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype ->
-                    (fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z))
+                   ((fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z))%ptype
   | fancy_selc : ident
-                   ((fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype ->
-                    (fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z))
+                   ((fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z))%ptype
   | fancy_selm : Z ->
                  ident
-                   ((fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype ->
-                    (fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z))
+                   ((fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z))%ptype
   | fancy_sell : ident
-                   ((fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype ->
-                    (fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z))
+                   ((fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z))%ptype
   | fancy_addm : ident
-                   ((fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z *
-                       base.type.type_base base.type.Z)%etype ->
-                    (fun x : base.type => type.base x)
-                      (base.type.type_base base.type.Z))
+                   ((fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z *
+                       Compilers.base.type.type_base base.type.Z)%etype ->
+                    (fun x : Compilers.base.type => type.base x)
+                      (Compilers.base.type.type_base base.type.Z))%ptype
 
 """
 show_match_ident = r"""match # with
@@ -670,14 +759,16 @@ if remake:
   with open('/tmp/sm.out', 'r') as f: show_match_ident = f.read()
 
 prefix = 'Compilers.'
-indent = '      '
-exts = ('Unit', 'Z', 'Bool', 'Nat')
-tys = [('%sbase.type.' % prefix) + i for i in ('unit', 'Z', 'bool', 'nat')]
+indent0 = '    '
+indent1 = '  ' + indent0
+indent2 = '  ' + indent1
+#exts = ('Unit', 'Z', 'Bool', 'Nat')
+base_types = [('%sbase.type.' % prefix) + i for i in ('unit', 'Z', 'bool', 'nat')]
 type_or_set = 'Type'
 ctors = [i.strip('|=> ').split(' ') for i in show_match_ident.split('\n') if i.strip().startswith('|')]
 assert(ctors[0][0] == 'ident.Literal')
 assert(len(ctors[0]) > 1)
-ctors = [[ctors[0][0] + ext] + ctors[0][2:] for ext in exts] + ctors[1:]
+#ctors = [[ctors[0][0] + ext] + ctors[0][2:] for ext in exts] + ctors[1:]
 ctors_with_prefix = [[prefix + i[0]] + i[1:] for i in ctors]
 ctors_no_prefix = [[i[0].replace('ident.', '')] + i[1:] for i in ctors]
 pctors = [i[0] for i in ctors_no_prefix]
@@ -686,34 +777,106 @@ def get_dep_types(case):
   if len(dep_tys) == 0: return []
   dep_tys = dep_tys[0]
   return [dep_tys[-1].strip()] * len([i for i in dep_tys[0].split(' ') if i.strip()])
-ttypes = ([[] for ty in tys]
-          + [get_dep_types(case)
-             for case in print_ident.replace('\n', ' ').split('|')[1:]])
-ctypes = ([['base.interp ' + ty] for ty in tys]
-          + [[i.strip() for i in re.sub(r'forall [^:]+ : base.type,', '', i[i.find(':')+1:i.find('ident')]).strip(' ->').split('->') if i.strip()]
-             for i in print_ident.replace('\n', ' ').split('|')[1:]])
-crettypes = ([('%sident.ident (type.base (%sbase.type.type_base ' + ty + '))') % (prefix, prefix) for ty in tys]
-             + [prefix + 'ident.' + re.sub(r'\(fun x : [^ ]+ => ([^ ]+) x\)', r'\1', re.sub('  +', ' ', i[i.find('ident'):]))
-                for i in print_ident.replace('\n', ' ').split('|')[1:]])
+split_print_ident = print_ident.replace('  Literal ', ' | Literal ').replace('\n', ' ').split('|')[1:]
+ttypes = [get_dep_types(case) for case in split_print_ident]
+ctypes = [[i.strip() for i in re.sub(r'forall [^,]+,', '', i[i.find(':')+1:i.find('ident')]).strip(' ->').split('->') if i.strip()]
+          for i in split_print_ident]
+crettypes = [prefix + 'ident.' + re.sub(r'\(fun x : [^ ]+ => ([^ ]+) x\)', r'\1', re.sub('  +', ' ', i[i.find('ident'):])).strip()
+             for i in split_print_ident]
+named_ttypes_with_prefix = [[(name, ty) for name, ty in zip(ctor[1:], tys)]
+                            for ctor, tys in zip(ctors, ttypes)]
+named_ttypes = [[(name, ty.replace(prefix, '')) for name, ty in nt] for nt in named_ttypes_with_prefix]
+pctors_with_typed_args = [(pctor + ' ' + ' '.join('{%s : %s}' % name_ty for name_ty in ntys)).strip()
+                          for pctor, ntys in zip(pctors, named_ttypes)]
+pctors_with_args = [(pctor + ' ' + ' '.join(name for name, ty in ntys)).strip()
+                    for pctor, ntys in zip(pctors, named_ttypes)]
+pctors_with_underscores = [(pctor + ' ' + ' '.join('_' for name, ty in ntys)).strip()
+                           for pctor, ntys in zip(pctors, named_ttypes)]
+rettypes = [i.replace(prefix + 'ident.ident', 'ident').replace(prefix, '').replace('%etype', '%pbtype') for i in crettypes]
+
+# N.B. We assume forall-quantification in the types has names that match the arguments from Show Match
 
 retcode = r"""Require Import Coq.ZArith.ZArith.
+Require Import Coq.FSets.FMapPositive.
+Require Import Coq.Lists.List.
 Require Import Crypto.Util.CPSNotations.
+Require Import Crypto.Util.Option.
 Require Import Crypto.Util.ZRange.
+Require Import Crypto.Util.PrimitiveSigma.
+Require Import Crypto.Util.Notations.
 Require Import Crypto.Experiments.NewPipeline.Language.
+Import ListNotations. Local Open Scope list_scope.
+Import PrimitiveSigma.Primitive.
 
 Module Compilers.
+  Set Boolean Equality Schemes.
+  Set Decidable Equality Schemes.
   Export Language.Compilers.
 
+  Local Notation type_of_list := (fold_right (fun A B => prod A B) unit).
+  Local Notation type_of_list_cps := (fold_right (fun a K => a -> K)).
   Module pattern.
-    Module ident.
-      Set Boolean Equality Schemes.
-      Set Decidable Equality Schemes.
-      (""" + """*
-      Set Printing Coercions.
-      Redirect "/tmp/pr" Print Compilers.ident.ident.
-      Redirect "/tmp/sm" Show Match Compilers.ident.ident.
-      *""" + """)
+    Notation EvarMap := (PositiveMap.t Compilers.base.type).
+    Module base.
+      Local Notation einterp := type.interp.
+      Module type.
+        Inductive type := var (p : positive) | type_base (t : Compilers.base.type.base) | prod (A B : type) | list (A : type).
+      End type.
+      Notation type := type.type.
+
+      Fixpoint relax (t : Compilers.base.type) : type
+        := match t with
+           | Compilers.base.type.type_base t => type.type_base t
+           | Compilers.base.type.prod A B => type.prod (relax A) (relax B)
+           | Compilers.base.type.list A => type.list (relax A)
+           end.
+
+      Module Notations.
+        Global Coercion type.type_base : Compilers.base.type.base >-> type.type.
+        Bind Scope pbtype_scope with type.type.
+        (*Bind Scope ptype_scope with Compilers.type.type type.type.*) (* COQBUG(https://github.com/coq/coq/issues/7699) *)
+        Delimit Scope ptype_scope with ptype.
+        Delimit Scope pbtype_scope with pbtype.
+        Notation "A * B" := (type.prod A%ptype B%ptype) : ptype_scope.
+        Notation "A * B" := (type.prod A%pbtype B%pbtype) : pbtype_scope.
+        Notation "()" := (type.type_base base.type.unit) : pbtype_scope.
+        Notation "()" := (type.base (type.type_base base.type.unit)) : ptype_scope.
+        Notation "A -> B" := (type.arrow A%ptype B%ptype) : ptype_scope.
+        Notation "' n" := (type.var n) : pbtype_scope.
+        Notation "' n" := (type.base (type.var n)) : ptype_scope.
+        Notation "'1" := (type.var 1) : pbtype_scope.
+        Notation "'2" := (type.var 2) : pbtype_scope.
+        Notation "'3" := (type.var 3) : pbtype_scope.
+        Notation "'4" := (type.var 4) : pbtype_scope.
+        Notation "'5" := (type.var 5) : pbtype_scope.
+        Notation "'1" := (type.base (type.var 1)) : ptype_scope.
+        Notation "'2" := (type.base (type.var 2)) : ptype_scope.
+        Notation "'3" := (type.base (type.var 3)) : ptype_scope.
+        Notation "'4" := (type.base (type.var 4)) : ptype_scope.
+        Notation "'5" := (type.base (type.var 5)) : ptype_scope.
+      End Notations.
+    End base.
+    Notation type := (type.type base.type).
+    Export base.Notations.
+
+    Module type.
+      Fixpoint relax (t : type.type Compilers.base.type) : type
+        := match t with
+           | type.base t => type.base (base.relax t)
+           | type.arrow s d => type.arrow (relax s) (relax d)
+           end.
+    End type.
+
+    (""" + """*
+    Set Printing Coercions.
+    Redirect "/tmp/pr" Print Compilers.ident.ident.
+    Redirect "/tmp/sm" Show Match Compilers.ident.ident.
+    *""" + """)
 """
+
+def fold_right_pair(ls, tt='tt'):
+  if len(ls) == 0: return tt
+  return '(' + ls[0] + ', ' + fold_right_pair(ls[1:], tt=tt) + ')'
 
 def addnewline(s): return re.sub(r' +$', '', s + '\n', flags=re.MULTILINE)
 
@@ -729,42 +892,231 @@ retcode += addnewline(r"""%s(*
 %s
 >>>
 %s*)
-""" % (indent, get_updated_contents(), indent))
+""" % (indent0, get_updated_contents(), indent0))
+
+maxeta = max([len(ttype + ctype) for ttype, ctype in zip(ttypes, ctypes)])
+#if any(len(ttype) > 0 and len(ctype) > 0 for ttype, ctype in zip(ttypes, ctypes)):
+#  retcode += addnewline(r"""%sLocal Notation eta_sigT x := (existT _ (projT1 x) (projT2 x)) (only parsing).""" % indent1)
+if maxeta >= 2:
+  retcode += addnewline(r"""%sLocal Notation eta2 x := (Datatypes.fst x, Datatypes.snd x) (only parsing).""" % indent1)
+for i in range(3, maxeta+1):
+  retcode += addnewline(r"""%sLocal Notation eta%d x := (eta%d (Datatypes.fst x), Datatypes.snd x) (only parsing).""" % (indent1, i, i-1))
+retcode += addnewline('')
+
+def do_adjust_type(ctor, ctype):
+  return len(ctor) > 1 and 'Literal' in ctor[0]
+
+retcode += r"""
+    Module Raw.
+      Module ident.
+"""
+
 retcode += addnewline(r"""%sInductive ident :=
 %s| %s.
-""" % (indent, indent, ('\n' + indent + '| ').join(pctors)))
-#retcode += addnewline((r"""%sDefinition beq_typed {t} (X : ident) (Y : %sident.ident t) : bool
-#  := match X, Y with
-#     | %s
-#       => true
-#     | %s
-#       => false
-#     end.
-#""" % (indent, prefix,
-#       '\n     | '.join(pctor + ', ' + ' '.join([ctor[0]] + ['_'] * (len(ctor)-1))
-#                        for pctor, ctor in zip(pctors, ctors_with_prefix)),
-#       '\n     | '.join(pctor + ', _' for pctor in pctors))).replace('\n', '\n' + indent))
-retcode += addnewline((r"""%sDefinition try_make_transport_ident_cps (P : ident -> Type) (idc1 idc2 : ident) : ~> option (P idc1 -> P idc2)
-  := match idc1, idc2 with
+""" % (indent2, indent2, ('\n' + indent2 + '| ').join(pctors)))
+
+def make_prod_of_types(named_ttype, ctype):
+  if len(named_ttype + ctype) == 0: return 'unit'
+  if len(ctype) == 0: return ' * '.join(t for n, t in named_ttype)
+  if len(named_ttype) == 0: return ' * '.join(ctype)
+  if len(named_ttype) == 1: return '{ %s : %s & %s }' % (named_ttype[0][0], named_ttype[0][1], ' * '.join(ctype))
+  return "{ tys : %s & let '(%s) := eta%d tys in %s }" % (' * '.join(t for n, t in named_ttype),
+                                                          ', '.join(n for n, t in named_ttype),
+                                                          len(named_ttype),
+                                                          ' * '.join(ctype))
+
+def make_pair_of_types(named_ttype, ctype, ctor):
+  if len(named_ttype + ctype) == 0: return 'tt'
+  if len(named_ttype + ctype) == 1: return ctor[-1]
+  if len(named_ttype) == 0 or len(ctype) == 0: return '(%s)' % ', '.join(ctor[-len(named_ttype + ctype):])
+  pr1 = (named_ttype[0][0] if len(named_ttype) == 1 else '(%s)' % ', '.join(n for n, t in named_ttype))
+  pr2 = (ctor[-1] if len(ctype) == 1 else '(%s)' % ', '.join(ctor[-len(ctype):]))
+  return '(existT _ %s %s)' % (pr1, pr2)
+
+def make_fun_project(named_ttype, ctype, ctor):
+  if len(named_ttype + ctype) == 0: return 'fun _ => '
+  if len(named_ttype + ctype) == 1: return 'fun ' + ctor[-1] + ' => '
+  if len(named_ttype) == 0 or len(ctype) == 0: return "fun arg => let '(%s) := eta%d arg in " % (', '.join(ctor[-len(named_ttype + ctype):]), len(named_ttype + ctype))
+  pr1 = (named_ttype[0][0] if len(named_ttype) == 1 else '(%s)' % ', '.join(n for n, t in named_ttype))
+  pr2 = (ctor[-1] if len(ctype) == 1 else '(%s)' % ', '.join(ctor[-len(ctype):]))
+  pr1_eta = ('projT1 arg' if len(named_ttype) == 1 else 'eta%d (projT1 arg)' % len(named_ttype))
+  pr2_eta = ('projT2 arg' if len(ctype) == 1 else 'eta%d (projT2 arg)' % len(ctype))
+  return "fun arg => let '(%s, %s) := (%s, %s) in " % (pr1, pr2, pr1_eta, pr2_eta)
+
+def make_fun_project_match(named_ttype, ctype, ctor, retty, body):
+  if len(named_ttype + ctype) == 0: return 'fun _ => ' + body
+  if len(named_ttype + ctype) == 1: return 'fun ' + ctor[-1] + ' => ' + body
+  if len(named_ttype) == 0 or len(ctype) == 0:
+    return "fun arg => match eta%d arg as arg' return %s with (%s) => %s end" % (len(named_ttype + ctype), retty % "arg'", ', '.join(ctor[-len(named_ttype + ctype):]), body)
+  pr1 = (named_ttype[0][0] if len(named_ttype) == 1 else '(%s)' % ', '.join(n for n, t in named_ttype))
+  pr2 = (ctor[-1] if len(ctype) == 1 else '(%s)' % ', '.join(ctor[-len(ctype):]))
+  pr1_eta = ('projT1 arg' if len(named_ttype) == 1 else 'eta%d (projT1 arg)' % len(named_ttype))
+  pr2_eta = ('projT2 arg' if len(ctype) == 1 else 'eta%d (projT2 arg)' % len(ctype))
+  return "fun arg => match existT _ (%s) (%s) as arg' return %s with existT %s %s => %s end" % (pr1_eta, pr2_eta, retty % "arg'", pr1, pr2, body)
+
+retcode += addnewline((r"""%sDefinition full_types (idc : ident) : %s
+  := match idc return %s with
      | %s
-       => fun T k => k (Some (fun v => v))
+     end%%type.
+""" % (indent2, type_or_set, type_or_set,
+       '\n     | '.join(pctor + ' => ' + make_prod_of_types(named_ttype, ctype)
+                        for pctor, named_ttype, ctype in zip(pctors, named_ttypes_with_prefix, ctypes)))).replace('\n', '\n' + indent2))
+
+retcode += addnewline((r"""%sDefinition is_simple (idc : ident) : bool
+  := match idc with
      | %s
-       => fun T k => k None
+     end.
+""" % (indent2,
+       '\n     | '.join(pctor + ' => ' + ('true' if len(named_ttype) == 0 else 'false')
+                        for pctor, named_ttype in zip(pctors, named_ttypes_with_prefix)))).replace('\n', '\n' + indent2))
+
+retcode += addnewline((r"""%sDefinition invert_bind_args {t} (idc : %sident.ident t) (pidc : ident) : option (full_types pidc)
+  := match pidc, idc return option (full_types pidc) with
+     | %s
+     | %s
+       => None
      end%%cps.
-""" % (indent,
-       '\n     | '.join(pctor + ', ' + pctor for pctor in pctors),
-       '\n     | '.join(pctor + ', _' for pctor in pctors))).replace('\n', '\n' + indent))
+""" % (indent2, prefix,
+       '\n     | '.join(pctor + ', ' + ' '.join(ctor) + ' => Some ' + make_pair_of_types(named_ttype, ctype, ctor)
+                        for pctor, ctor, named_ttype, ctype in zip(pctors, ctors_with_prefix, named_ttypes_with_prefix, ctypes)),
+       '\n     | '.join(pctor + ', _' for pctor in pctors))).replace('\n', '\n' + indent2))
+
+retcode += addnewline((r"""%sDefinition type_of (pidc : ident) : full_types pidc -> %stype %sbase.type
+  := match pidc return full_types pidc -> _ with
+     | %s
+     end%%etype.
+""" % (indent2, prefix, prefix,
+       '\n     | '.join(pctor + ' => '
+                        + make_fun_project(named_ttype, ctype, ctor) + cretty.replace(prefix + 'ident.ident ', '')
+                        for pctor, ctor, named_ttype, ctype, cretty in zip(pctors, ctors_with_prefix, named_ttypes_with_prefix, ctypes, crettypes)))).replace('\n', '\n' + indent2))
+retcode += addnewline((r"""%sDefinition to_typed (pidc : ident) : forall args : full_types pidc, %sident.ident (type_of pidc args)
+  := match pidc return forall args : full_types pidc, %sident.ident (type_of pidc args) with
+     | %s
+     end.
+""" % (indent2, prefix, prefix,
+       '\n     | '.join(pctor + ' => '
+                        + make_fun_project_match(named_ttype, ctype, ctor, '%sident.ident (type_of %s %%s)' % (prefix, pctor), ("@" + ' '.join(ctor)))
+                        for pctor, ctor, named_ttype, ctype in zip(pctors, ctors_with_prefix, named_ttypes_with_prefix, ctypes)))).replace('\n', '\n' + indent2))
+
+retcode += r"""      End ident.
+      Notation ident := ident.ident.
+    End Raw.
+"""
+
+retcode +=r"""
+    Module ident.
+"""
 retcode += addnewline((r"""%sDefinition eta_ident_cps {T : %stype %sbase.type -> Type} {t} (idc : %sident.ident t)
            (f : forall t', %sident.ident t' -> T t')
   : T t
   := match idc with
      | %s
      end.
-""" % (indent, prefix, prefix, prefix, prefix,
+""" % (indent1, prefix, prefix, prefix, prefix,
        '\n     | '.join(' '.join(ctor) + ' => f _ '
                         + (('%s' if len(ctor) == 1 else '(@%s)')
                            % ' '.join(ctor))
-                        for ctor in ctors_with_prefix))).replace('\n', '\n' + indent))
+                        for ctor in ctors_with_prefix))).replace('\n', '\n' + indent1))
+
+retcode += addnewline(r"""%sInductive ident : type -> Set :=
+%s| %s.
+""" % (indent1, indent1, ('\n' + indent1 + '| ').join('%s : %s' % ct for ct in zip(pctors_with_typed_args, rettypes))))
+
+retcode += addnewline((r"""%sDefinition strip_types {t} (idc : ident t) : Raw.ident
+  := match idc with
+     | %s
+     end.
+""" % (indent1, '\n     | '.join('@' + pctor_with_args + ' => Raw.ident.' + pctor for pctor_with_args, pctor in zip(pctors_with_args, pctors)))).replace('\n', '\n' + indent1))
+
+# here we assume that non-dependent arguments do not depend on dependent
+# arguments which become generalized to patterns --- that is, only dependent
+# arguments of type base.type.base can show up in the types of other identifier
+# arguments.
+
+retcode += addnewline((r"""%sDefinition arg_types {t} (idc : ident t) : list %s
+  := match idc return list %s with
+     | %s
+     end%%type.
+""" % (indent1, type_or_set, type_or_set,
+       '\n     | '.join('@' + pctor + ' => [' + '; '.join(i + ' : ' + type_or_set for i in ctype) + ']'
+                        for pctor, ctype in zip(pctors_with_args, ctypes)))).replace('\n', '\n' + indent1))
+
+def to_type_var(name, ty):
+  ty = ty.replace(prefix, '')
+  return ({'base.type.base': 'type.base (base.type.type_base %s)' % name,
+           'base.type': 'type.base %s' % name,
+           'type': name,
+           'type.type base.type': name})[ty]
+
+retcode += addnewline((r"""%sDefinition type_vars {t} (idc : ident t) : list type
+  := match idc with
+     | %s
+     end%%type.
+""" % (indent1,
+       '\n     | '.join('@' + pctor + ' => [' + '; '.join(to_type_var(n, t) for n, t in named_ttype) + ']'
+                        for pctor, named_ttype in zip(pctors_with_args, named_ttypes)))).replace('\n', '\n' + indent1))
+
+assert(ctors[0][0] == 'ident.Literal')
+assert(len(ctypes[0]) == 1)
+
+retcode += addnewline((r"""%sDefinition unify {t t'} (pidc : ident t) (idc : %sident.ident t') : option (type_of_list (@arg_types t pidc))
+  := match pidc, idc return option (type_of_list (arg_types pidc)) with
+     | %s
+     | %s
+     | %s
+       => None
+     end%%cps.
+""" % (indent1, prefix,
+       '\n     | '.join('@' + pctor + ' ' + ty + ', ' + ' '.join([ctor[0], ty] + ctor[2:]) + ' => Some ' + fold_right_pair(ctor[-len(ctype):])
+                        for pctor, ctor, ctype in zip(pctors[:1], ctors_with_prefix[:1], ctypes[:1])
+                        for ty in base_types),
+       '\n     | '.join('@' + pctor + ', ' + ' '.join([ctor[0]] + [i + "'" for i in ctor[1:]]) + ' => Some ' + ('tt' if len(ctype) == 0 else fold_right_pair([i + "'" for i in ctor[-len(ctype):]]))
+                        for pctor, ctor, ctype in zip(pctors_with_args[1:], ctors_with_prefix[1:], ctypes[1:])),
+       '\n     | '.join('@' + pctor + ', _' for pctor, named_ttype in zip(pctors_with_underscores, named_ttypes)))).replace('\n', '\n' + indent1))
+
+def relax_type_var(name, ty):
+  ty = ty.replace(prefix, '')
+  return ({'base.type.base': name,
+           'base.type': '(base.relax %s)' % name,
+           'type': '(type.relax %s)' % name,
+           'type.type base.type': '(type.relax %s)' % name})[ty]
+
+retcode += addnewline((r"""%sDefinition of_typed_ident {t} (idc : %sident.ident t) : ident (type.relax t)
+  := match idc with
+     | %s
+     end.
+""" % (indent1, prefix, '\n     | '.join(' '.join(ctor) + ' => @' + pctor + ' ' + ' '.join(relax_type_var(n, t) for n, t in named_ttype) for ctor, pctor, named_ttype in zip(ctors_with_prefix, pctors, named_ttypes)))).replace('\n', '\n' + indent1))
+#
+#
+#retcode += addnewline((r"""%sDefinition retype_ident {t} (idc : %sident.ident t) : match arg_types (of_typed_ident idc) return %s with Some t => t | None => unit end -> %sident.ident t
+#  := match idc in %sident.ident t return match arg_types (of_typed_ident idc) return %s with Some t => t | None => unit end -> %sident.ident t with
+#     | %s
+#     end.
+#""" % (indent1, prefix, type_or_set, prefix, prefix, type_or_set, prefix,
+#       '\n     | '.join(' '.join(ctor) + ' => '
+#                        + ('' if not do_adjust_type(ctor, ctype) else '(')
+#                        + 'fun ' + ('_ => ' if len(ctype) == 0 else ((ctor[-1] + ' => ') if len(ctype) == 1 else "arg => let '(%s) := eta%d arg in " % (', '.join(ctor[-len(ctype):]), len(ctype)))) + "@" + ' '.join(ctor)
+#                        + ('' if not do_adjust_type(ctor, ctype) else
+#                           (') : '
+#                            + ('match arg_types (of_typed_ident %s) return %s with Some t => t | None => unit end -> _'
+#                               % (('%s' if ' ' not in ' '.join(ctor) else '(@%s)') % ' '.join(ctor),
+#                                  type_or_set))
+#                            + ' (* COQBUG(https://github.com/coq/coq/issues/7726) *)'))
+#                        for ctor, ctype in zip(ctors_with_prefix, ctypes)))).replace('\n', '\n' + indent1))
+
+
+
+
+#retcode += addnewline((r"""%sDefinition try_make_transport_ident_cps (P : ident -> Type) (idc1 idc2 : ident) : ~> option (P idc1 -> P idc2)
+#  := match idc1, idc2 with
+#     | %s
+#       => fun T k => k (Some (fun v => v))
+#     | %s
+#       => fun T k => k None
+#     end%%cps.
+#""" % (indent2,
+#       '\n     | '.join(pctor + ', ' + pctor for pctor in pctors),
+#       '\n     | '.join(pctor + ', _' for pctor in pctors))).replace('\n', '\n' + indent2))
 #retcode += addnewline((r"""%sDefinition eta_all_option_cps {T} (f : ident -> option T)
 #  : option (ident -> T)
 #  := (%s;
@@ -772,96 +1124,56 @@ retcode += addnewline((r"""%sDefinition eta_ident_cps {T : %stype %sbase.type ->
 #            => match c with
 #               | %s
 #               end))%%option.
-#""" % (indent,
+#""" % (indent2,
 #       ';\n      '.join('f' + pctor + ' <- f ' + ctor[0] for ctor, pctor in zip(ctors_no_prefix, pctors)),
-#       '\n               | '.join(ctor[0] + ' => f' + pctor for pctor, ctor in zip(pctors, ctors_no_prefix)))).replace('\n', '\n' + indent))
-retcode += addnewline((r"""%sDefinition of_typed_ident {t} (idc : %sident.ident t) : ident
-  := match idc with
-     | %s
-     end.
-""" % (indent, prefix, '\n     | '.join(' '.join(ctor) + ' => ' + pctor for ctor, pctor in zip(ctors_with_prefix, pctors)))).replace('\n', '\n' + indent))
+#       '\n               | '.join(ctor[0] + ' => f' + pctor for pctor, ctor in zip(pctors, ctors_no_prefix)))).replace('\n', '\n' + indent2))
 #retcode += addnewline((r"""%sDefinition orb (f : ident -> bool) : bool
 #  := (%s)%%bool.
-#""" % (indent, ' || '.join('f ' + pctor for pctor in pctors))).replace('\n', '\n' + indent))
-retcode += addnewline((r"""%sDefinition arg_types (idc : ident) : option %s
-  := match idc return option %s with
-     | %s
-     end%%type.
-""" % (indent, type_or_set, type_or_set,
-       '\n     | '.join(pctor + ' => ' + ('None' if len(ctype) == 0 else '@Some ' + type_or_set + ' ' + (ctype[0] if ' ' not in ' * '.join(ctype) else '(%s)' % ' * '.join(ctype)))
-                        for pctor, ctype in zip(pctors, ctypes)))).replace('\n', '\n' + indent))
-retcode += addnewline((r"""%sDefinition full_types (idc : ident) : %s
-  := match idc return %s with
-     | %s
-     end%%type.
-""" % (indent, type_or_set, type_or_set,
-       '\n     | '.join(pctor + ' => ' + (' * '.join(ttype + ctype) if len(ttype + ctype) > 0 else 'unit')
-                        for pctor, ttype, ctype in zip(pctors, ttypes, ctypes)))).replace('\n', '\n' + indent))
+#""" % (indent2, ' || '.join('f ' + pctor for pctor in pctors))).replace('\n', '\n' + indent2))
 
-retcode += addnewline((r"""%sDefinition bind_args {t} (idc : %sident.ident t) : match arg_types (of_typed_ident idc) return %s with Some t => t | None => unit end
-  := match idc return match arg_types (of_typed_ident idc) return %s with Some t => t | None => unit end with
-     | %s
-     end%%cps.
-""" % (indent, prefix, type_or_set, type_or_set,
-       '\n     | '.join(' '.join(ctor) + ' => ' + ('tt' if len(ctype) == 0 else (ctor[-1] if len(ctype) == 1 else '(%s)' % ', '.join(ctor[-len(ctype):])))
-                        for ctor, ctype in zip(ctors_with_prefix, ctypes)))).replace('\n', '\n' + indent))
-retcode += addnewline((r"""%sDefinition invert_bind_args {t} (idc : %sident.ident t) (pidc : ident) : option (full_types pidc)
-  := match pidc, idc return option (full_types pidc) with
-     | %s
-     | %s
-       => None
-     end%%cps.
-""" % (indent, prefix,
-       '\n     | '.join(pctor + ', ' + ' '.join(ctor) + ' => Some ' + ('tt' if len(ttype + ctype) == 0 else (ctor[-1] if len(ttype + ctype) == 1 else '(%s)' % ', '.join(ctor[-len(ttype + ctype):])))
-                        for pctor, ctor, ttype, ctype in zip(pctors, ctors_with_prefix, ttypes, ctypes)),
-       '\n     | '.join(pctor + ', _' for pctor in pctors))).replace('\n', '\n' + indent))
+#retcode += addnewline((r"""%sDefinition bind_args {t} (idc : %sident.ident t) : type_of_list (arg_types (of_typed_ident idc))
+#  := match idc return type_of_list (arg_types (of_typed_ident idc)) with
+#     | %s
+#     end%%cps.
+#""" % (indent1, prefix,
+#       '\n     | '.join(' '.join(ctor) + ' => ' + ('tt' if len(ttype + ctype) == 0 else fold_right_pair(ctor[-len(ttype + ctype):]))
+#                        for ctor, ttype, ctype in zip(ctors_with_prefix, ttypes, ctypes)))).replace('\n', '\n' + indent1))
+#maxeta = max([1+len(ttype + ctype) for ttype, ctype in zip(ttypes, ctypes)])
+#if maxeta >= 2:
+#  retcode += addnewline(r"""%sLocal Notation eta2r x := (Datatypes.fst x, Datatypes.snd x) (only parsing).""" % indent1)
+#for i in range(3, maxeta+1):
+#  retcode += addnewline(r"""%sLocal Notation eta%dr x := (Datatypes.fst x, eta%dr (Datatypes.snd x)) (only parsing).""" % (indent1, i, i-1))
+#retcode += addnewline('')
+#
+#def do_adjust_type(ctor, ctype):
+#  return len(ctor) > 1 and 'Literal' in ctor[0]
+#
+#retcode += addnewline((r"""%sDefinition type_of (pidc : ident) : type_of_list (arg_types pidc) -> %stype %sbase.type
+#  := match pidc return type_of_list (arg_types pidc) -> _ with
+#     | %s
+#     end%%etype.
+#""" % (indent1, prefix, prefix,
+#       '\n     | '.join(pctor + ' => '
+#                        + 'fun ' + ('_ => ' if len(ttype + ctype) == 0 else "arg => let '%s := eta%dr arg in " % (fold_right_pair(ctor[-len(ttype + ctype):], tt='_'), 1+len(ttype + ctype))) + cretty.replace(prefix + 'ident.ident ', '')
+#                        for pctor, ctor, ttype, ctype, cretty in zip(pctors, ctors_with_prefix, ttypes, ctypes, crettypes)))).replace('\n', '\n' + indent1))
+#retcode += addnewline((r"""%sDefinition to_typed (pidc : ident) : forall args : type_of_list (arg_types pidc), %sident.ident (type_of pidc args)
+#  := match pidc return forall args : type_of_list (arg_types pidc), %sident.ident (type_of pidc args) with
+#     | %s
+#     end.
+#""" % (indent1, prefix, prefix,
+#       '\n     | '.join(pctor + ' => '
+#                        + 'fun ' + (('_ => %s' if len(ttype + ctype) == 0 else "arg => match eta%dr arg as args' return %sident.ident (type_of %s args') with %s => %%s end" % (1+len(ttype + ctype), prefix, pctor, fold_right_pair(ctor[-len(ttype + ctype):], tt='_'))) % ("@" + ' '.join(ctor)))
+#                        for pctor, ctor, ttype, ctype in zip(pctors, ctors_with_prefix, ttypes, ctypes)))).replace('\n', '\n' + indent1))
 
-maxeta = max([len(ttype + ctype) for ttype, ctype in zip(ttypes, ctypes)])
-if maxeta >= 2:
-  retcode += addnewline(r"""%sLocal Notation eta2 x := (Datatypes.fst x, Datatypes.snd x) (only parsing).""" % indent)
-for i in range(3, maxeta+1):
-  retcode += addnewline(r"""%sLocal Notation eta%d x := (eta%d (Datatypes.fst x), Datatypes.snd x) (only parsing).""" % (indent, i, i-1))
-retcode += addnewline('')
 
-def do_adjust_type(ctor, ctype):
-  return len(ctor) > 1 and 'Literal' in ctor[0]
 
-retcode += addnewline((r"""%sDefinition type_of (pidc : ident) : full_types pidc -> %stype %sbase.type
-  := match pidc return full_types pidc -> _ with
-     | %s
-     end%%etype.
-""" % (indent, prefix, prefix,
-       '\n     | '.join(pctor + ' => '
-                        + 'fun ' + ('_ => ' if len(ttype + ctype) == 0 else ((ctor[-1] + ' => ') if len(ttype + ctype) == 1 else "arg => let '(%s) := eta%d arg in " % (', '.join(ctor[-len(ttype + ctype):]), len(ttype + ctype)))) + cretty.replace(prefix + 'ident.ident ', '')
-                        for pctor, ctor, ttype, ctype, cretty in zip(pctors, ctors_with_prefix, ttypes, ctypes, crettypes)))).replace('\n', '\n' + indent))
-retcode += addnewline((r"""%sDefinition to_typed (pidc : ident) : forall args : full_types pidc, %sident.ident (type_of pidc args)
-  := match pidc return forall args : full_types pidc, %sident.ident (type_of pidc args) with
-     | %s
-     end.
-""" % (indent, prefix, prefix,
-       '\n     | '.join(pctor + ' => '
-                        + 'fun ' + (('_ => %s' if len(ttype + ctype) == 0 else ((ctor[-1] + ' => %s') if len(ttype + ctype) == 1 else "arg => match eta%d arg as args' return %sident.ident (type_of %s args') with (%s) => %%s end" % (len(ttype + ctype), prefix, pctor, ', '.join(ctor[-len(ttype + ctype):])))) % ("@" + ' '.join(ctor)))
-                        for pctor, ctor, ttype, ctype in zip(pctors, ctors_with_prefix, ttypes, ctypes)))).replace('\n', '\n' + indent))
-retcode += addnewline((r"""%sDefinition retype_ident {t} (idc : %sident.ident t) : match arg_types (of_typed_ident idc) return %s with Some t => t | None => unit end -> %sident.ident t
-  := match idc in %sident.ident t return match arg_types (of_typed_ident idc) return %s with Some t => t | None => unit end -> %sident.ident t with
-     | %s
-     end.
-""" % (indent, prefix, type_or_set, prefix, prefix, type_or_set, prefix,
-       '\n     | '.join(' '.join(ctor) + ' => '
-                        + ('' if not do_adjust_type(ctor, ctype) else '(')
-                        + 'fun ' + ('_ => ' if len(ctype) == 0 else ((ctor[-1] + ' => ') if len(ctype) == 1 else "arg => let '(%s) := eta%d arg in " % (', '.join(ctor[-len(ctype):]), len(ctype)))) + "@" + ' '.join(ctor)
-                        + ('' if not do_adjust_type(ctor, ctype) else
-                           (') : '
-                            + ('match arg_types (of_typed_ident %s) return %s with Some t => t | None => unit end -> _'
-                               % (('%s' if ' ' not in ' '.join(ctor) else '(@%s)') % ' '.join(ctor),
-                                  type_or_set))
-                            + ' (* COQBUG(https://github.com/coq/coq/issues/7726) *)'))
-                        for ctor, ctype in zip(ctors_with_prefix, ctypes)))).replace('\n', '\n' + indent))
-# ctor[:len(ctor)-len(ctype)] + ['_'] * len(ctype)
 
-retcode += addnewline(indent + '\n' + indent + '(*===*)')
 
 retcode += r"""    End ident.
+"""
+
+retcode += addnewline(indent0 + '\n' + indent0 + '(*===*)')
+retcode += r"""
   End pattern.
 End Compilers.
 """
@@ -869,264 +1181,586 @@ with open('GENERATEDIdentifiersWithoutTypes.v', 'w') as f:
   f.write(retcode)
 
 >>>
-      *)
+    *)
 
-      Inductive ident :=
-      | LiteralUnit
-      | LiteralZ
-      | LiteralBool
-      | LiteralNat
-      | Nat_succ
-      | Nat_pred
-      | Nat_max
-      | Nat_mul
-      | Nat_add
-      | Nat_sub
-      | nil
-      | cons
-      | pair
-      | fst
-      | snd
-      | prod_rect
-      | bool_rect
-      | nat_rect
-      | nat_rect_arrow
-      | list_rect
-      | list_case
-      | List_length
-      | List_seq
-      | List_firstn
-      | List_skipn
-      | List_repeat
-      | List_combine
-      | List_map
-      | List_app
-      | List_rev
-      | List_flat_map
-      | List_partition
-      | List_fold_right
-      | List_update_nth
-      | List_nth_default
-      | Z_add
-      | Z_mul
-      | Z_pow
-      | Z_sub
-      | Z_opp
-      | Z_div
-      | Z_modulo
-      | Z_log2
-      | Z_log2_up
-      | Z_eqb
-      | Z_leb
-      | Z_geb
-      | Z_of_nat
-      | Z_to_nat
-      | Z_shiftr
-      | Z_shiftl
-      | Z_land
-      | Z_lor
-      | Z_bneg
-      | Z_lnot_modulo
-      | Z_mul_split
-      | Z_add_get_carry
-      | Z_add_with_carry
-      | Z_add_with_get_carry
-      | Z_sub_get_borrow
-      | Z_sub_with_get_borrow
-      | Z_zselect
-      | Z_add_modulo
-      | Z_rshi
-      | Z_cc_m
-      | Z_cast
-      | Z_cast2
-      | fancy_add
-      | fancy_addc
-      | fancy_sub
-      | fancy_subb
-      | fancy_mulll
-      | fancy_mullh
-      | fancy_mulhl
-      | fancy_mulhh
-      | fancy_rshi
-      | fancy_selc
-      | fancy_selm
-      | fancy_sell
-      | fancy_addm.
+      Local Notation eta2 x := (Datatypes.fst x, Datatypes.snd x) (only parsing).
+      Local Notation eta3 x := (eta2 (Datatypes.fst x), Datatypes.snd x) (only parsing).
 
-      Definition try_make_transport_ident_cps (P : ident -> Type) (idc1 idc2 : ident) : ~> option (P idc1 -> P idc2)
-        := match idc1, idc2 with
-           | LiteralUnit, LiteralUnit
-           | LiteralZ, LiteralZ
-           | LiteralBool, LiteralBool
-           | LiteralNat, LiteralNat
-           | Nat_succ, Nat_succ
-           | Nat_pred, Nat_pred
-           | Nat_max, Nat_max
-           | Nat_mul, Nat_mul
-           | Nat_add, Nat_add
-           | Nat_sub, Nat_sub
-           | nil, nil
-           | cons, cons
-           | pair, pair
-           | fst, fst
-           | snd, snd
-           | prod_rect, prod_rect
-           | bool_rect, bool_rect
-           | nat_rect, nat_rect
-           | nat_rect_arrow, nat_rect_arrow
-           | list_rect, list_rect
-           | list_case, list_case
-           | List_length, List_length
-           | List_seq, List_seq
-           | List_firstn, List_firstn
-           | List_skipn, List_skipn
-           | List_repeat, List_repeat
-           | List_combine, List_combine
-           | List_map, List_map
-           | List_app, List_app
-           | List_rev, List_rev
-           | List_flat_map, List_flat_map
-           | List_partition, List_partition
-           | List_fold_right, List_fold_right
-           | List_update_nth, List_update_nth
-           | List_nth_default, List_nth_default
-           | Z_add, Z_add
-           | Z_mul, Z_mul
-           | Z_pow, Z_pow
-           | Z_sub, Z_sub
-           | Z_opp, Z_opp
-           | Z_div, Z_div
-           | Z_modulo, Z_modulo
-           | Z_log2, Z_log2
-           | Z_log2_up, Z_log2_up
-           | Z_eqb, Z_eqb
-           | Z_leb, Z_leb
-           | Z_geb, Z_geb
-           | Z_of_nat, Z_of_nat
-           | Z_to_nat, Z_to_nat
-           | Z_shiftr, Z_shiftr
-           | Z_shiftl, Z_shiftl
-           | Z_land, Z_land
-           | Z_lor, Z_lor
-           | Z_bneg, Z_bneg
-           | Z_lnot_modulo, Z_lnot_modulo
-           | Z_mul_split, Z_mul_split
-           | Z_add_get_carry, Z_add_get_carry
-           | Z_add_with_carry, Z_add_with_carry
-           | Z_add_with_get_carry, Z_add_with_get_carry
-           | Z_sub_get_borrow, Z_sub_get_borrow
-           | Z_sub_with_get_borrow, Z_sub_with_get_borrow
-           | Z_zselect, Z_zselect
-           | Z_add_modulo, Z_add_modulo
-           | Z_rshi, Z_rshi
-           | Z_cc_m, Z_cc_m
-           | Z_cast, Z_cast
-           | Z_cast2, Z_cast2
-           | fancy_add, fancy_add
-           | fancy_addc, fancy_addc
-           | fancy_sub, fancy_sub
-           | fancy_subb, fancy_subb
-           | fancy_mulll, fancy_mulll
-           | fancy_mullh, fancy_mullh
-           | fancy_mulhl, fancy_mulhl
-           | fancy_mulhh, fancy_mulhh
-           | fancy_rshi, fancy_rshi
-           | fancy_selc, fancy_selc
-           | fancy_selm, fancy_selm
-           | fancy_sell, fancy_sell
-           | fancy_addm, fancy_addm
-             => fun T k => k (Some (fun v => v))
-           | LiteralUnit, _
-           | LiteralZ, _
-           | LiteralBool, _
-           | LiteralNat, _
-           | Nat_succ, _
-           | Nat_pred, _
-           | Nat_max, _
-           | Nat_mul, _
-           | Nat_add, _
-           | Nat_sub, _
-           | nil, _
-           | cons, _
-           | pair, _
-           | fst, _
-           | snd, _
-           | prod_rect, _
-           | bool_rect, _
-           | nat_rect, _
-           | nat_rect_arrow, _
-           | list_rect, _
-           | list_case, _
-           | List_length, _
-           | List_seq, _
-           | List_firstn, _
-           | List_skipn, _
-           | List_repeat, _
-           | List_combine, _
-           | List_map, _
-           | List_app, _
-           | List_rev, _
-           | List_flat_map, _
-           | List_partition, _
-           | List_fold_right, _
-           | List_update_nth, _
-           | List_nth_default, _
-           | Z_add, _
-           | Z_mul, _
-           | Z_pow, _
-           | Z_sub, _
-           | Z_opp, _
-           | Z_div, _
-           | Z_modulo, _
-           | Z_log2, _
-           | Z_log2_up, _
-           | Z_eqb, _
-           | Z_leb, _
-           | Z_geb, _
-           | Z_of_nat, _
-           | Z_to_nat, _
-           | Z_shiftr, _
-           | Z_shiftl, _
-           | Z_land, _
-           | Z_lor, _
-           | Z_bneg, _
-           | Z_lnot_modulo, _
-           | Z_mul_split, _
-           | Z_add_get_carry, _
-           | Z_add_with_carry, _
-           | Z_add_with_get_carry, _
-           | Z_sub_get_borrow, _
-           | Z_sub_with_get_borrow, _
-           | Z_zselect, _
-           | Z_add_modulo, _
-           | Z_rshi, _
-           | Z_cc_m, _
-           | Z_cast, _
-           | Z_cast2, _
-           | fancy_add, _
-           | fancy_addc, _
-           | fancy_sub, _
-           | fancy_subb, _
-           | fancy_mulll, _
-           | fancy_mullh, _
-           | fancy_mulhl, _
-           | fancy_mulhh, _
-           | fancy_rshi, _
-           | fancy_selc, _
-           | fancy_selm, _
-           | fancy_sell, _
-           | fancy_addm, _
-             => fun T k => k None
-           end%cps.
 
+    Module Raw.
+      Module ident.
+        Inductive ident :=
+        | Literal
+        | Nat_succ
+        | Nat_pred
+        | Nat_max
+        | Nat_mul
+        | Nat_add
+        | Nat_sub
+        | nil
+        | cons
+        | pair
+        | fst
+        | snd
+        | prod_rect
+        | bool_rect
+        | nat_rect
+        | nat_rect_arrow
+        | list_rect
+        | list_case
+        | List_length
+        | List_seq
+        | List_firstn
+        | List_skipn
+        | List_repeat
+        | List_combine
+        | List_map
+        | List_app
+        | List_rev
+        | List_flat_map
+        | List_partition
+        | List_fold_right
+        | List_update_nth
+        | List_nth_default
+        | Z_add
+        | Z_mul
+        | Z_pow
+        | Z_sub
+        | Z_opp
+        | Z_div
+        | Z_modulo
+        | Z_log2
+        | Z_log2_up
+        | Z_eqb
+        | Z_leb
+        | Z_geb
+        | Z_of_nat
+        | Z_to_nat
+        | Z_shiftr
+        | Z_shiftl
+        | Z_land
+        | Z_lor
+        | Z_bneg
+        | Z_lnot_modulo
+        | Z_mul_split
+        | Z_add_get_carry
+        | Z_add_with_carry
+        | Z_add_with_get_carry
+        | Z_sub_get_borrow
+        | Z_sub_with_get_borrow
+        | Z_zselect
+        | Z_add_modulo
+        | Z_rshi
+        | Z_cc_m
+        | Z_cast
+        | Z_cast2
+        | fancy_add
+        | fancy_addc
+        | fancy_sub
+        | fancy_subb
+        | fancy_mulll
+        | fancy_mullh
+        | fancy_mulhl
+        | fancy_mulhh
+        | fancy_rshi
+        | fancy_selc
+        | fancy_selm
+        | fancy_sell
+        | fancy_addm.
+
+        Definition full_types (idc : ident) : Type
+          := match idc return Type with
+             | Literal => { t : base.type.base & base.interp (Compilers.base.type.type_base t) }
+             | Nat_succ => unit
+             | Nat_pred => unit
+             | Nat_max => unit
+             | Nat_mul => unit
+             | Nat_add => unit
+             | Nat_sub => unit
+             | nil => Compilers.base.type
+             | cons => Compilers.base.type
+             | pair => Compilers.base.type * Compilers.base.type
+             | fst => Compilers.base.type * Compilers.base.type
+             | snd => Compilers.base.type * Compilers.base.type
+             | prod_rect => Compilers.base.type * Compilers.base.type * Compilers.base.type
+             | bool_rect => Compilers.base.type
+             | nat_rect => Compilers.base.type
+             | nat_rect_arrow => Compilers.base.type * Compilers.base.type
+             | list_rect => Compilers.base.type * Compilers.base.type
+             | list_case => Compilers.base.type * Compilers.base.type
+             | List_length => Compilers.base.type
+             | List_seq => unit
+             | List_firstn => Compilers.base.type
+             | List_skipn => Compilers.base.type
+             | List_repeat => Compilers.base.type
+             | List_combine => Compilers.base.type * Compilers.base.type
+             | List_map => Compilers.base.type * Compilers.base.type
+             | List_app => Compilers.base.type
+             | List_rev => Compilers.base.type
+             | List_flat_map => Compilers.base.type * Compilers.base.type
+             | List_partition => Compilers.base.type
+             | List_fold_right => Compilers.base.type * Compilers.base.type
+             | List_update_nth => Compilers.base.type
+             | List_nth_default => Compilers.base.type
+             | Z_add => unit
+             | Z_mul => unit
+             | Z_pow => unit
+             | Z_sub => unit
+             | Z_opp => unit
+             | Z_div => unit
+             | Z_modulo => unit
+             | Z_log2 => unit
+             | Z_log2_up => unit
+             | Z_eqb => unit
+             | Z_leb => unit
+             | Z_geb => unit
+             | Z_of_nat => unit
+             | Z_to_nat => unit
+             | Z_shiftr => unit
+             | Z_shiftl => unit
+             | Z_land => unit
+             | Z_lor => unit
+             | Z_bneg => unit
+             | Z_lnot_modulo => unit
+             | Z_mul_split => unit
+             | Z_add_get_carry => unit
+             | Z_add_with_carry => unit
+             | Z_add_with_get_carry => unit
+             | Z_sub_get_borrow => unit
+             | Z_sub_with_get_borrow => unit
+             | Z_zselect => unit
+             | Z_add_modulo => unit
+             | Z_rshi => unit
+             | Z_cc_m => unit
+             | Z_cast => zrange
+             | Z_cast2 => zrange * zrange
+             | fancy_add => Z * Z
+             | fancy_addc => Z * Z
+             | fancy_sub => Z * Z
+             | fancy_subb => Z * Z
+             | fancy_mulll => Z
+             | fancy_mullh => Z
+             | fancy_mulhl => Z
+             | fancy_mulhh => Z
+             | fancy_rshi => Z * Z
+             | fancy_selc => unit
+             | fancy_selm => Z
+             | fancy_sell => unit
+             | fancy_addm => unit
+             end%type.
+
+        Definition is_simple (idc : ident) : bool
+          := match idc with
+             | Literal => false
+             | Nat_succ => true
+             | Nat_pred => true
+             | Nat_max => true
+             | Nat_mul => true
+             | Nat_add => true
+             | Nat_sub => true
+             | nil => false
+             | cons => false
+             | pair => false
+             | fst => false
+             | snd => false
+             | prod_rect => false
+             | bool_rect => false
+             | nat_rect => false
+             | nat_rect_arrow => false
+             | list_rect => false
+             | list_case => false
+             | List_length => false
+             | List_seq => true
+             | List_firstn => false
+             | List_skipn => false
+             | List_repeat => false
+             | List_combine => false
+             | List_map => false
+             | List_app => false
+             | List_rev => false
+             | List_flat_map => false
+             | List_partition => false
+             | List_fold_right => false
+             | List_update_nth => false
+             | List_nth_default => false
+             | Z_add => true
+             | Z_mul => true
+             | Z_pow => true
+             | Z_sub => true
+             | Z_opp => true
+             | Z_div => true
+             | Z_modulo => true
+             | Z_log2 => true
+             | Z_log2_up => true
+             | Z_eqb => true
+             | Z_leb => true
+             | Z_geb => true
+             | Z_of_nat => true
+             | Z_to_nat => true
+             | Z_shiftr => true
+             | Z_shiftl => true
+             | Z_land => true
+             | Z_lor => true
+             | Z_bneg => true
+             | Z_lnot_modulo => true
+             | Z_mul_split => true
+             | Z_add_get_carry => true
+             | Z_add_with_carry => true
+             | Z_add_with_get_carry => true
+             | Z_sub_get_borrow => true
+             | Z_sub_with_get_borrow => true
+             | Z_zselect => true
+             | Z_add_modulo => true
+             | Z_rshi => true
+             | Z_cc_m => true
+             | Z_cast => true
+             | Z_cast2 => true
+             | fancy_add => true
+             | fancy_addc => true
+             | fancy_sub => true
+             | fancy_subb => true
+             | fancy_mulll => true
+             | fancy_mullh => true
+             | fancy_mulhl => true
+             | fancy_mulhh => true
+             | fancy_rshi => true
+             | fancy_selc => true
+             | fancy_selm => true
+             | fancy_sell => true
+             | fancy_addm => true
+             end.
+
+        Definition invert_bind_args {t} (idc : Compilers.ident.ident t) (pidc : ident) : option (full_types pidc)
+          := match pidc, idc return option (full_types pidc) with
+             | Literal, Compilers.ident.Literal t v => Some (existT _ t v)
+             | Nat_succ, Compilers.ident.Nat_succ => Some tt
+             | Nat_pred, Compilers.ident.Nat_pred => Some tt
+             | Nat_max, Compilers.ident.Nat_max => Some tt
+             | Nat_mul, Compilers.ident.Nat_mul => Some tt
+             | Nat_add, Compilers.ident.Nat_add => Some tt
+             | Nat_sub, Compilers.ident.Nat_sub => Some tt
+             | nil, Compilers.ident.nil t => Some t
+             | cons, Compilers.ident.cons t => Some t
+             | pair, Compilers.ident.pair A B => Some (A, B)
+             | fst, Compilers.ident.fst A B => Some (A, B)
+             | snd, Compilers.ident.snd A B => Some (A, B)
+             | prod_rect, Compilers.ident.prod_rect A B T => Some (A, B, T)
+             | bool_rect, Compilers.ident.bool_rect T => Some T
+             | nat_rect, Compilers.ident.nat_rect P => Some P
+             | nat_rect_arrow, Compilers.ident.nat_rect_arrow P Q => Some (P, Q)
+             | list_rect, Compilers.ident.list_rect A P => Some (A, P)
+             | list_case, Compilers.ident.list_case A P => Some (A, P)
+             | List_length, Compilers.ident.List_length T => Some T
+             | List_seq, Compilers.ident.List_seq => Some tt
+             | List_firstn, Compilers.ident.List_firstn A => Some A
+             | List_skipn, Compilers.ident.List_skipn A => Some A
+             | List_repeat, Compilers.ident.List_repeat A => Some A
+             | List_combine, Compilers.ident.List_combine A B => Some (A, B)
+             | List_map, Compilers.ident.List_map A B => Some (A, B)
+             | List_app, Compilers.ident.List_app A => Some A
+             | List_rev, Compilers.ident.List_rev A => Some A
+             | List_flat_map, Compilers.ident.List_flat_map A B => Some (A, B)
+             | List_partition, Compilers.ident.List_partition A => Some A
+             | List_fold_right, Compilers.ident.List_fold_right A B => Some (A, B)
+             | List_update_nth, Compilers.ident.List_update_nth T => Some T
+             | List_nth_default, Compilers.ident.List_nth_default T => Some T
+             | Z_add, Compilers.ident.Z_add => Some tt
+             | Z_mul, Compilers.ident.Z_mul => Some tt
+             | Z_pow, Compilers.ident.Z_pow => Some tt
+             | Z_sub, Compilers.ident.Z_sub => Some tt
+             | Z_opp, Compilers.ident.Z_opp => Some tt
+             | Z_div, Compilers.ident.Z_div => Some tt
+             | Z_modulo, Compilers.ident.Z_modulo => Some tt
+             | Z_log2, Compilers.ident.Z_log2 => Some tt
+             | Z_log2_up, Compilers.ident.Z_log2_up => Some tt
+             | Z_eqb, Compilers.ident.Z_eqb => Some tt
+             | Z_leb, Compilers.ident.Z_leb => Some tt
+             | Z_geb, Compilers.ident.Z_geb => Some tt
+             | Z_of_nat, Compilers.ident.Z_of_nat => Some tt
+             | Z_to_nat, Compilers.ident.Z_to_nat => Some tt
+             | Z_shiftr, Compilers.ident.Z_shiftr => Some tt
+             | Z_shiftl, Compilers.ident.Z_shiftl => Some tt
+             | Z_land, Compilers.ident.Z_land => Some tt
+             | Z_lor, Compilers.ident.Z_lor => Some tt
+             | Z_bneg, Compilers.ident.Z_bneg => Some tt
+             | Z_lnot_modulo, Compilers.ident.Z_lnot_modulo => Some tt
+             | Z_mul_split, Compilers.ident.Z_mul_split => Some tt
+             | Z_add_get_carry, Compilers.ident.Z_add_get_carry => Some tt
+             | Z_add_with_carry, Compilers.ident.Z_add_with_carry => Some tt
+             | Z_add_with_get_carry, Compilers.ident.Z_add_with_get_carry => Some tt
+             | Z_sub_get_borrow, Compilers.ident.Z_sub_get_borrow => Some tt
+             | Z_sub_with_get_borrow, Compilers.ident.Z_sub_with_get_borrow => Some tt
+             | Z_zselect, Compilers.ident.Z_zselect => Some tt
+             | Z_add_modulo, Compilers.ident.Z_add_modulo => Some tt
+             | Z_rshi, Compilers.ident.Z_rshi => Some tt
+             | Z_cc_m, Compilers.ident.Z_cc_m => Some tt
+             | Z_cast, Compilers.ident.Z_cast range => Some range
+             | Z_cast2, Compilers.ident.Z_cast2 range => Some range
+             | fancy_add, Compilers.ident.fancy_add log2wordmax imm => Some (log2wordmax, imm)
+             | fancy_addc, Compilers.ident.fancy_addc log2wordmax imm => Some (log2wordmax, imm)
+             | fancy_sub, Compilers.ident.fancy_sub log2wordmax imm => Some (log2wordmax, imm)
+             | fancy_subb, Compilers.ident.fancy_subb log2wordmax imm => Some (log2wordmax, imm)
+             | fancy_mulll, Compilers.ident.fancy_mulll log2wordmax => Some log2wordmax
+             | fancy_mullh, Compilers.ident.fancy_mullh log2wordmax => Some log2wordmax
+             | fancy_mulhl, Compilers.ident.fancy_mulhl log2wordmax => Some log2wordmax
+             | fancy_mulhh, Compilers.ident.fancy_mulhh log2wordmax => Some log2wordmax
+             | fancy_rshi, Compilers.ident.fancy_rshi log2wordmax x => Some (log2wordmax, x)
+             | fancy_selc, Compilers.ident.fancy_selc => Some tt
+             | fancy_selm, Compilers.ident.fancy_selm log2wordmax => Some log2wordmax
+             | fancy_sell, Compilers.ident.fancy_sell => Some tt
+             | fancy_addm, Compilers.ident.fancy_addm => Some tt
+             | Literal, _
+             | Nat_succ, _
+             | Nat_pred, _
+             | Nat_max, _
+             | Nat_mul, _
+             | Nat_add, _
+             | Nat_sub, _
+             | nil, _
+             | cons, _
+             | pair, _
+             | fst, _
+             | snd, _
+             | prod_rect, _
+             | bool_rect, _
+             | nat_rect, _
+             | nat_rect_arrow, _
+             | list_rect, _
+             | list_case, _
+             | List_length, _
+             | List_seq, _
+             | List_firstn, _
+             | List_skipn, _
+             | List_repeat, _
+             | List_combine, _
+             | List_map, _
+             | List_app, _
+             | List_rev, _
+             | List_flat_map, _
+             | List_partition, _
+             | List_fold_right, _
+             | List_update_nth, _
+             | List_nth_default, _
+             | Z_add, _
+             | Z_mul, _
+             | Z_pow, _
+             | Z_sub, _
+             | Z_opp, _
+             | Z_div, _
+             | Z_modulo, _
+             | Z_log2, _
+             | Z_log2_up, _
+             | Z_eqb, _
+             | Z_leb, _
+             | Z_geb, _
+             | Z_of_nat, _
+             | Z_to_nat, _
+             | Z_shiftr, _
+             | Z_shiftl, _
+             | Z_land, _
+             | Z_lor, _
+             | Z_bneg, _
+             | Z_lnot_modulo, _
+             | Z_mul_split, _
+             | Z_add_get_carry, _
+             | Z_add_with_carry, _
+             | Z_add_with_get_carry, _
+             | Z_sub_get_borrow, _
+             | Z_sub_with_get_borrow, _
+             | Z_zselect, _
+             | Z_add_modulo, _
+             | Z_rshi, _
+             | Z_cc_m, _
+             | Z_cast, _
+             | Z_cast2, _
+             | fancy_add, _
+             | fancy_addc, _
+             | fancy_sub, _
+             | fancy_subb, _
+             | fancy_mulll, _
+             | fancy_mullh, _
+             | fancy_mulhl, _
+             | fancy_mulhh, _
+             | fancy_rshi, _
+             | fancy_selc, _
+             | fancy_selm, _
+             | fancy_sell, _
+             | fancy_addm, _
+               => None
+             end%cps.
+
+        Definition type_of (pidc : ident) : full_types pidc -> Compilers.type Compilers.base.type
+          := match pidc return full_types pidc -> _ with
+             | Literal => fun arg => let '(t, v) := (projT1 arg, projT2 arg) in (type.base (Compilers.base.type.type_base t))
+             | Nat_succ => fun _ => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat))%ptype
+             | Nat_pred => fun _ => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat))%ptype
+             | Nat_max => fun _ => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat))%ptype
+             | Nat_mul => fun _ => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat))%ptype
+             | Nat_add => fun _ => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat))%ptype
+             | Nat_sub => fun _ => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat))%ptype
+             | nil => fun t => (type.base (Compilers.base.type.list t))
+             | cons => fun t => (type.base t -> type.base (Compilers.base.type.list t) -> type.base (Compilers.base.type.list t))%ptype
+             | pair => fun arg => let '(A, B) := eta2 arg in (type.base A -> type.base B -> type.base (A * B)%etype)%ptype
+             | fst => fun arg => let '(A, B) := eta2 arg in (type.base (A * B)%etype -> type.base A)%ptype
+             | snd => fun arg => let '(A, B) := eta2 arg in (type.base (A * B)%etype -> type.base B)%ptype
+             | prod_rect => fun arg => let '(A, B, T) := eta3 arg in ((type.base A -> type.base B -> type.base T) -> type.base (A * B)%etype -> type.base T)%ptype
+             | bool_rect => fun T => ((type.base ()%etype -> type.base T) -> (type.base ()%etype -> type.base T) -> type.base (Compilers.base.type.type_base base.type.bool) -> type.base T)%ptype
+             | nat_rect => fun P => ((type.base ()%etype -> type.base P) -> (type.base (Compilers.base.type.type_base base.type.nat) -> type.base P -> type.base P) -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base P)%ptype
+             | nat_rect_arrow => fun arg => let '(P, Q) := eta2 arg in ((type.base P -> type.base Q) -> (type.base (Compilers.base.type.type_base base.type.nat) -> (type.base P -> type.base Q) -> type.base P -> type.base Q) -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base P -> type.base Q)%ptype
+             | list_rect => fun arg => let '(A, P) := eta2 arg in ((type.base ()%etype -> type.base P) -> (type.base A -> type.base (Compilers.base.type.list A) -> type.base P -> type.base P) -> type.base (Compilers.base.type.list A) -> type.base P)%ptype
+             | list_case => fun arg => let '(A, P) := eta2 arg in ((type.base ()%etype -> type.base P) -> (type.base A -> type.base (Compilers.base.type.list A) -> type.base P) -> type.base (Compilers.base.type.list A) -> type.base P)%ptype
+             | List_length => fun T => (type.base (Compilers.base.type.list T) -> type.base (Compilers.base.type.type_base base.type.nat))%ptype
+             | List_seq => fun _ => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.list (Compilers.base.type.type_base base.type.nat)))%ptype
+             | List_firstn => fun A => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list A))%ptype
+             | List_skipn => fun A => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list A))%ptype
+             | List_repeat => fun A => (type.base A -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.list A))%ptype
+             | List_combine => fun arg => let '(A, B) := eta2 arg in (type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list B) -> type.base (Compilers.base.type.list (A * B)))%ptype
+             | List_map => fun arg => let '(A, B) := eta2 arg in ((type.base A -> type.base B) -> type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list B))%ptype
+             | List_app => fun A => (type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list A))%ptype
+             | List_rev => fun A => (type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list A))%ptype
+             | List_flat_map => fun arg => let '(A, B) := eta2 arg in ((type.base A -> type.base (Compilers.base.type.list B)) -> type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list B))%ptype
+             | List_partition => fun A => ((type.base A -> type.base (Compilers.base.type.type_base base.type.bool)) -> type.base (Compilers.base.type.list A) -> type.base (Compilers.base.type.list A * Compilers.base.type.list A)%etype)%ptype
+             | List_fold_right => fun arg => let '(A, B) := eta2 arg in ((type.base B -> type.base A -> type.base A) -> type.base A -> type.base (Compilers.base.type.list B) -> type.base A)%ptype
+             | List_update_nth => fun T => (type.base (Compilers.base.type.type_base base.type.nat) -> (type.base T -> type.base T) -> type.base (Compilers.base.type.list T) -> type.base (Compilers.base.type.list T))%ptype
+             | List_nth_default => fun T => (type.base T -> type.base (Compilers.base.type.list T) -> type.base (Compilers.base.type.type_base base.type.nat) -> type.base T)%ptype
+             | Z_add => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_mul => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_pow => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_sub => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_opp => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_div => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_modulo => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_log2 => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_log2_up => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_eqb => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.bool))%ptype
+             | Z_leb => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.bool))%ptype
+             | Z_geb => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.bool))%ptype
+             | Z_of_nat => fun _ => (type.base (Compilers.base.type.type_base base.type.nat) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_to_nat => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.nat))%ptype
+             | Z_shiftr => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_shiftl => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_land => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_lor => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_bneg => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_lnot_modulo => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_mul_split => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | Z_add_get_carry => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | Z_add_with_carry => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_add_with_get_carry => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | Z_sub_get_borrow => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | Z_sub_with_get_borrow => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | Z_zselect => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_add_modulo => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_rshi => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_cc_m => fun _ => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_cast => fun range => (type.base (Compilers.base.type.type_base base.type.Z) -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | Z_cast2 => fun range => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | fancy_add => fun arg => let '(log2wordmax, imm) := eta2 arg in (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | fancy_addc => fun arg => let '(log2wordmax, imm) := eta2 arg in (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | fancy_sub => fun arg => let '(log2wordmax, imm) := eta2 arg in (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | fancy_subb => fun arg => let '(log2wordmax, imm) := eta2 arg in (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype)%ptype
+             | fancy_mulll => fun log2wordmax => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | fancy_mullh => fun log2wordmax => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | fancy_mulhl => fun log2wordmax => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | fancy_mulhh => fun log2wordmax => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | fancy_rshi => fun arg => let '(log2wordmax, x) := eta2 arg in (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | fancy_selc => fun _ => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | fancy_selm => fun log2wordmax => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | fancy_sell => fun _ => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             | fancy_addm => fun _ => (type.base (Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z * Compilers.base.type.type_base base.type.Z)%etype -> type.base (Compilers.base.type.type_base base.type.Z))%ptype
+             end%etype.
+
+        Definition to_typed (pidc : ident) : forall args : full_types pidc, Compilers.ident.ident (type_of pidc args)
+          := match pidc return forall args : full_types pidc, Compilers.ident.ident (type_of pidc args) with
+             | Literal => fun arg => match existT _ (projT1 arg) (projT2 arg) as arg' return Compilers.ident.ident (type_of Literal arg') with existT t v => @Compilers.ident.Literal t v end
+             | Nat_succ => fun _ => @Compilers.ident.Nat_succ
+             | Nat_pred => fun _ => @Compilers.ident.Nat_pred
+             | Nat_max => fun _ => @Compilers.ident.Nat_max
+             | Nat_mul => fun _ => @Compilers.ident.Nat_mul
+             | Nat_add => fun _ => @Compilers.ident.Nat_add
+             | Nat_sub => fun _ => @Compilers.ident.Nat_sub
+             | nil => fun t => @Compilers.ident.nil t
+             | cons => fun t => @Compilers.ident.cons t
+             | pair => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of pair arg') with (A, B) => @Compilers.ident.pair A B end
+             | fst => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of fst arg') with (A, B) => @Compilers.ident.fst A B end
+             | snd => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of snd arg') with (A, B) => @Compilers.ident.snd A B end
+             | prod_rect => fun arg => match eta3 arg as arg' return Compilers.ident.ident (type_of prod_rect arg') with (A, B, T) => @Compilers.ident.prod_rect A B T end
+             | bool_rect => fun T => @Compilers.ident.bool_rect T
+             | nat_rect => fun P => @Compilers.ident.nat_rect P
+             | nat_rect_arrow => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of nat_rect_arrow arg') with (P, Q) => @Compilers.ident.nat_rect_arrow P Q end
+             | list_rect => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of list_rect arg') with (A, P) => @Compilers.ident.list_rect A P end
+             | list_case => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of list_case arg') with (A, P) => @Compilers.ident.list_case A P end
+             | List_length => fun T => @Compilers.ident.List_length T
+             | List_seq => fun _ => @Compilers.ident.List_seq
+             | List_firstn => fun A => @Compilers.ident.List_firstn A
+             | List_skipn => fun A => @Compilers.ident.List_skipn A
+             | List_repeat => fun A => @Compilers.ident.List_repeat A
+             | List_combine => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of List_combine arg') with (A, B) => @Compilers.ident.List_combine A B end
+             | List_map => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of List_map arg') with (A, B) => @Compilers.ident.List_map A B end
+             | List_app => fun A => @Compilers.ident.List_app A
+             | List_rev => fun A => @Compilers.ident.List_rev A
+             | List_flat_map => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of List_flat_map arg') with (A, B) => @Compilers.ident.List_flat_map A B end
+             | List_partition => fun A => @Compilers.ident.List_partition A
+             | List_fold_right => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of List_fold_right arg') with (A, B) => @Compilers.ident.List_fold_right A B end
+             | List_update_nth => fun T => @Compilers.ident.List_update_nth T
+             | List_nth_default => fun T => @Compilers.ident.List_nth_default T
+             | Z_add => fun _ => @Compilers.ident.Z_add
+             | Z_mul => fun _ => @Compilers.ident.Z_mul
+             | Z_pow => fun _ => @Compilers.ident.Z_pow
+             | Z_sub => fun _ => @Compilers.ident.Z_sub
+             | Z_opp => fun _ => @Compilers.ident.Z_opp
+             | Z_div => fun _ => @Compilers.ident.Z_div
+             | Z_modulo => fun _ => @Compilers.ident.Z_modulo
+             | Z_log2 => fun _ => @Compilers.ident.Z_log2
+             | Z_log2_up => fun _ => @Compilers.ident.Z_log2_up
+             | Z_eqb => fun _ => @Compilers.ident.Z_eqb
+             | Z_leb => fun _ => @Compilers.ident.Z_leb
+             | Z_geb => fun _ => @Compilers.ident.Z_geb
+             | Z_of_nat => fun _ => @Compilers.ident.Z_of_nat
+             | Z_to_nat => fun _ => @Compilers.ident.Z_to_nat
+             | Z_shiftr => fun _ => @Compilers.ident.Z_shiftr
+             | Z_shiftl => fun _ => @Compilers.ident.Z_shiftl
+             | Z_land => fun _ => @Compilers.ident.Z_land
+             | Z_lor => fun _ => @Compilers.ident.Z_lor
+             | Z_bneg => fun _ => @Compilers.ident.Z_bneg
+             | Z_lnot_modulo => fun _ => @Compilers.ident.Z_lnot_modulo
+             | Z_mul_split => fun _ => @Compilers.ident.Z_mul_split
+             | Z_add_get_carry => fun _ => @Compilers.ident.Z_add_get_carry
+             | Z_add_with_carry => fun _ => @Compilers.ident.Z_add_with_carry
+             | Z_add_with_get_carry => fun _ => @Compilers.ident.Z_add_with_get_carry
+             | Z_sub_get_borrow => fun _ => @Compilers.ident.Z_sub_get_borrow
+             | Z_sub_with_get_borrow => fun _ => @Compilers.ident.Z_sub_with_get_borrow
+             | Z_zselect => fun _ => @Compilers.ident.Z_zselect
+             | Z_add_modulo => fun _ => @Compilers.ident.Z_add_modulo
+             | Z_rshi => fun _ => @Compilers.ident.Z_rshi
+             | Z_cc_m => fun _ => @Compilers.ident.Z_cc_m
+             | Z_cast => fun range => @Compilers.ident.Z_cast range
+             | Z_cast2 => fun range => @Compilers.ident.Z_cast2 range
+             | fancy_add => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of fancy_add arg') with (log2wordmax, imm) => @Compilers.ident.fancy_add log2wordmax imm end
+             | fancy_addc => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of fancy_addc arg') with (log2wordmax, imm) => @Compilers.ident.fancy_addc log2wordmax imm end
+             | fancy_sub => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of fancy_sub arg') with (log2wordmax, imm) => @Compilers.ident.fancy_sub log2wordmax imm end
+             | fancy_subb => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of fancy_subb arg') with (log2wordmax, imm) => @Compilers.ident.fancy_subb log2wordmax imm end
+             | fancy_mulll => fun log2wordmax => @Compilers.ident.fancy_mulll log2wordmax
+             | fancy_mullh => fun log2wordmax => @Compilers.ident.fancy_mullh log2wordmax
+             | fancy_mulhl => fun log2wordmax => @Compilers.ident.fancy_mulhl log2wordmax
+             | fancy_mulhh => fun log2wordmax => @Compilers.ident.fancy_mulhh log2wordmax
+             | fancy_rshi => fun arg => match eta2 arg as arg' return Compilers.ident.ident (type_of fancy_rshi arg') with (log2wordmax, x) => @Compilers.ident.fancy_rshi log2wordmax x end
+             | fancy_selc => fun _ => @Compilers.ident.fancy_selc
+             | fancy_selm => fun log2wordmax => @Compilers.ident.fancy_selm log2wordmax
+             | fancy_sell => fun _ => @Compilers.ident.fancy_sell
+             | fancy_addm => fun _ => @Compilers.ident.fancy_addm
+             end.
+
+      End ident.
+      Notation ident := ident.ident.
+    End Raw.
+
+    Module ident.
       Definition eta_ident_cps {T : Compilers.type Compilers.base.type -> Type} {t} (idc : Compilers.ident.ident t)
                  (f : forall t', Compilers.ident.ident t' -> T t')
         : T t
         := match idc with
-           | Compilers.ident.LiteralUnit v => f _ (@Compilers.ident.LiteralUnit v)
-           | Compilers.ident.LiteralZ v => f _ (@Compilers.ident.LiteralZ v)
-           | Compilers.ident.LiteralBool v => f _ (@Compilers.ident.LiteralBool v)
-           | Compilers.ident.LiteralNat v => f _ (@Compilers.ident.LiteralNat v)
+           | Compilers.ident.Literal t v => f _ (@Compilers.ident.Literal t v)
            | Compilers.ident.Nat_succ => f _ Compilers.ident.Nat_succ
            | Compilers.ident.Nat_pred => f _ Compilers.ident.Nat_pred
            | Compilers.ident.Nat_max => f _ Compilers.ident.Nat_max
@@ -1205,764 +1839,574 @@ with open('GENERATEDIdentifiersWithoutTypes.v', 'w') as f:
            | Compilers.ident.fancy_addm => f _ Compilers.ident.fancy_addm
            end.
 
-      Definition of_typed_ident {t} (idc : Compilers.ident.ident t) : ident
+      Inductive ident : type -> Set :=
+      | Literal {t : base.type.base} : ident (type.base (base.type.type_base t))
+      | Nat_succ : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))%ptype
+      | Nat_pred : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))%ptype
+      | Nat_max : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))%ptype
+      | Nat_mul : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))%ptype
+      | Nat_add : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))%ptype
+      | Nat_sub : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))%ptype
+      | nil {t : base.type} : ident (type.base (base.type.list t))
+      | cons {t : base.type} : ident (type.base t -> type.base (base.type.list t) -> type.base (base.type.list t))%ptype
+      | pair {A : base.type} {B : base.type} : ident (type.base A -> type.base B -> type.base (A * B)%pbtype)%ptype
+      | fst {A : base.type} {B : base.type} : ident (type.base (A * B)%pbtype -> type.base A)%ptype
+      | snd {A : base.type} {B : base.type} : ident (type.base (A * B)%pbtype -> type.base B)%ptype
+      | prod_rect {A : base.type} {B : base.type} {T : base.type} : ident ((type.base A -> type.base B -> type.base T) -> type.base (A * B)%pbtype -> type.base T)%ptype
+      | bool_rect {T : base.type} : ident ((type.base ()%pbtype -> type.base T) -> (type.base ()%pbtype -> type.base T) -> type.base (base.type.type_base base.type.bool) -> type.base T)%ptype
+      | nat_rect {P : base.type} : ident ((type.base ()%pbtype -> type.base P) -> (type.base (base.type.type_base base.type.nat) -> type.base P -> type.base P) -> type.base (base.type.type_base base.type.nat) -> type.base P)%ptype
+      | nat_rect_arrow {P : base.type} {Q : base.type} : ident ((type.base P -> type.base Q) -> (type.base (base.type.type_base base.type.nat) -> (type.base P -> type.base Q) -> type.base P -> type.base Q) -> type.base (base.type.type_base base.type.nat) -> type.base P -> type.base Q)%ptype
+      | list_rect {A : base.type} {P : base.type} : ident ((type.base ()%pbtype -> type.base P) -> (type.base A -> type.base (base.type.list A) -> type.base P -> type.base P) -> type.base (base.type.list A) -> type.base P)%ptype
+      | list_case {A : base.type} {P : base.type} : ident ((type.base ()%pbtype -> type.base P) -> (type.base A -> type.base (base.type.list A) -> type.base P) -> type.base (base.type.list A) -> type.base P)%ptype
+      | List_length {T : base.type} : ident (type.base (base.type.list T) -> type.base (base.type.type_base base.type.nat))%ptype
+      | List_seq : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.list (base.type.type_base base.type.nat)))%ptype
+      | List_firstn {A : base.type} : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.list A) -> type.base (base.type.list A))%ptype
+      | List_skipn {A : base.type} : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.list A) -> type.base (base.type.list A))%ptype
+      | List_repeat {A : base.type} : ident (type.base A -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.list A))%ptype
+      | List_combine {A : base.type} {B : base.type} : ident (type.base (base.type.list A) -> type.base (base.type.list B) -> type.base (base.type.list (A * B)))%ptype
+      | List_map {A : base.type} {B : base.type} : ident ((type.base A -> type.base B) -> type.base (base.type.list A) -> type.base (base.type.list B))%ptype
+      | List_app {A : base.type} : ident (type.base (base.type.list A) -> type.base (base.type.list A) -> type.base (base.type.list A))%ptype
+      | List_rev {A : base.type} : ident (type.base (base.type.list A) -> type.base (base.type.list A))%ptype
+      | List_flat_map {A : base.type} {B : base.type} : ident ((type.base A -> type.base (base.type.list B)) -> type.base (base.type.list A) -> type.base (base.type.list B))%ptype
+      | List_partition {A : base.type} : ident ((type.base A -> type.base (base.type.type_base base.type.bool)) -> type.base (base.type.list A) -> type.base (base.type.list A * base.type.list A)%pbtype)%ptype
+      | List_fold_right {A : base.type} {B : base.type} : ident ((type.base B -> type.base A -> type.base A) -> type.base A -> type.base (base.type.list B) -> type.base A)%ptype
+      | List_update_nth {T : base.type} : ident (type.base (base.type.type_base base.type.nat) -> (type.base T -> type.base T) -> type.base (base.type.list T) -> type.base (base.type.list T))%ptype
+      | List_nth_default {T : base.type} : ident (type.base T -> type.base (base.type.list T) -> type.base (base.type.type_base base.type.nat) -> type.base T)%ptype
+      | Z_add : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_mul : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_pow : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_sub : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_opp : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_div : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_modulo : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_log2 : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_log2_up : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_eqb : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.bool))%ptype
+      | Z_leb : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.bool))%ptype
+      | Z_geb : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.bool))%ptype
+      | Z_of_nat : ident (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_to_nat : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.nat))%ptype
+      | Z_shiftr : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_shiftl : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_land : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_lor : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_bneg : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_lnot_modulo : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_mul_split : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | Z_add_get_carry : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | Z_add_with_carry : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_add_with_get_carry : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | Z_sub_get_borrow : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | Z_sub_with_get_borrow : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | Z_zselect : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_add_modulo : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_rshi : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_cc_m : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_cast : ident (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))%ptype
+      | Z_cast2 : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | fancy_add : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | fancy_addc : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | fancy_sub : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | fancy_subb : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype)%ptype
+      | fancy_mulll : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype
+      | fancy_mullh : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype
+      | fancy_mulhl : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype
+      | fancy_mulhh : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype
+      | fancy_rshi : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype
+      | fancy_selc : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype
+      | fancy_selm : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype
+      | fancy_sell : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype
+      | fancy_addm : ident (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%pbtype -> type.base (base.type.type_base base.type.Z))%ptype.
+
+      Definition strip_types {t} (idc : ident t) : Raw.ident
         := match idc with
-           | Compilers.ident.LiteralUnit v => LiteralUnit
-           | Compilers.ident.LiteralZ v => LiteralZ
-           | Compilers.ident.LiteralBool v => LiteralBool
-           | Compilers.ident.LiteralNat v => LiteralNat
-           | Compilers.ident.Nat_succ => Nat_succ
-           | Compilers.ident.Nat_pred => Nat_pred
-           | Compilers.ident.Nat_max => Nat_max
-           | Compilers.ident.Nat_mul => Nat_mul
-           | Compilers.ident.Nat_add => Nat_add
-           | Compilers.ident.Nat_sub => Nat_sub
-           | Compilers.ident.nil t => nil
-           | Compilers.ident.cons t => cons
-           | Compilers.ident.pair A B => pair
-           | Compilers.ident.fst A B => fst
-           | Compilers.ident.snd A B => snd
-           | Compilers.ident.prod_rect A B T => prod_rect
-           | Compilers.ident.bool_rect T => bool_rect
-           | Compilers.ident.nat_rect P => nat_rect
-           | Compilers.ident.nat_rect_arrow P Q => nat_rect_arrow
-           | Compilers.ident.list_rect A P => list_rect
-           | Compilers.ident.list_case A P => list_case
-           | Compilers.ident.List_length T => List_length
-           | Compilers.ident.List_seq => List_seq
-           | Compilers.ident.List_firstn A => List_firstn
-           | Compilers.ident.List_skipn A => List_skipn
-           | Compilers.ident.List_repeat A => List_repeat
-           | Compilers.ident.List_combine A B => List_combine
-           | Compilers.ident.List_map A B => List_map
-           | Compilers.ident.List_app A => List_app
-           | Compilers.ident.List_rev A => List_rev
-           | Compilers.ident.List_flat_map A B => List_flat_map
-           | Compilers.ident.List_partition A => List_partition
-           | Compilers.ident.List_fold_right A B => List_fold_right
-           | Compilers.ident.List_update_nth T => List_update_nth
-           | Compilers.ident.List_nth_default T => List_nth_default
-           | Compilers.ident.Z_add => Z_add
-           | Compilers.ident.Z_mul => Z_mul
-           | Compilers.ident.Z_pow => Z_pow
-           | Compilers.ident.Z_sub => Z_sub
-           | Compilers.ident.Z_opp => Z_opp
-           | Compilers.ident.Z_div => Z_div
-           | Compilers.ident.Z_modulo => Z_modulo
-           | Compilers.ident.Z_log2 => Z_log2
-           | Compilers.ident.Z_log2_up => Z_log2_up
-           | Compilers.ident.Z_eqb => Z_eqb
-           | Compilers.ident.Z_leb => Z_leb
-           | Compilers.ident.Z_geb => Z_geb
-           | Compilers.ident.Z_of_nat => Z_of_nat
-           | Compilers.ident.Z_to_nat => Z_to_nat
-           | Compilers.ident.Z_shiftr => Z_shiftr
-           | Compilers.ident.Z_shiftl => Z_shiftl
-           | Compilers.ident.Z_land => Z_land
-           | Compilers.ident.Z_lor => Z_lor
-           | Compilers.ident.Z_bneg => Z_bneg
-           | Compilers.ident.Z_lnot_modulo => Z_lnot_modulo
-           | Compilers.ident.Z_mul_split => Z_mul_split
-           | Compilers.ident.Z_add_get_carry => Z_add_get_carry
-           | Compilers.ident.Z_add_with_carry => Z_add_with_carry
-           | Compilers.ident.Z_add_with_get_carry => Z_add_with_get_carry
-           | Compilers.ident.Z_sub_get_borrow => Z_sub_get_borrow
-           | Compilers.ident.Z_sub_with_get_borrow => Z_sub_with_get_borrow
-           | Compilers.ident.Z_zselect => Z_zselect
-           | Compilers.ident.Z_add_modulo => Z_add_modulo
-           | Compilers.ident.Z_rshi => Z_rshi
-           | Compilers.ident.Z_cc_m => Z_cc_m
-           | Compilers.ident.Z_cast range => Z_cast
-           | Compilers.ident.Z_cast2 range => Z_cast2
-           | Compilers.ident.fancy_add log2wordmax imm => fancy_add
-           | Compilers.ident.fancy_addc log2wordmax imm => fancy_addc
-           | Compilers.ident.fancy_sub log2wordmax imm => fancy_sub
-           | Compilers.ident.fancy_subb log2wordmax imm => fancy_subb
-           | Compilers.ident.fancy_mulll log2wordmax => fancy_mulll
-           | Compilers.ident.fancy_mullh log2wordmax => fancy_mullh
-           | Compilers.ident.fancy_mulhl log2wordmax => fancy_mulhl
-           | Compilers.ident.fancy_mulhh log2wordmax => fancy_mulhh
-           | Compilers.ident.fancy_rshi log2wordmax x => fancy_rshi
-           | Compilers.ident.fancy_selc => fancy_selc
-           | Compilers.ident.fancy_selm log2wordmax => fancy_selm
-           | Compilers.ident.fancy_sell => fancy_sell
-           | Compilers.ident.fancy_addm => fancy_addm
+           | @Literal t => Raw.ident.Literal
+           | @Nat_succ => Raw.ident.Nat_succ
+           | @Nat_pred => Raw.ident.Nat_pred
+           | @Nat_max => Raw.ident.Nat_max
+           | @Nat_mul => Raw.ident.Nat_mul
+           | @Nat_add => Raw.ident.Nat_add
+           | @Nat_sub => Raw.ident.Nat_sub
+           | @nil t => Raw.ident.nil
+           | @cons t => Raw.ident.cons
+           | @pair A B => Raw.ident.pair
+           | @fst A B => Raw.ident.fst
+           | @snd A B => Raw.ident.snd
+           | @prod_rect A B T => Raw.ident.prod_rect
+           | @bool_rect T => Raw.ident.bool_rect
+           | @nat_rect P => Raw.ident.nat_rect
+           | @nat_rect_arrow P Q => Raw.ident.nat_rect_arrow
+           | @list_rect A P => Raw.ident.list_rect
+           | @list_case A P => Raw.ident.list_case
+           | @List_length T => Raw.ident.List_length
+           | @List_seq => Raw.ident.List_seq
+           | @List_firstn A => Raw.ident.List_firstn
+           | @List_skipn A => Raw.ident.List_skipn
+           | @List_repeat A => Raw.ident.List_repeat
+           | @List_combine A B => Raw.ident.List_combine
+           | @List_map A B => Raw.ident.List_map
+           | @List_app A => Raw.ident.List_app
+           | @List_rev A => Raw.ident.List_rev
+           | @List_flat_map A B => Raw.ident.List_flat_map
+           | @List_partition A => Raw.ident.List_partition
+           | @List_fold_right A B => Raw.ident.List_fold_right
+           | @List_update_nth T => Raw.ident.List_update_nth
+           | @List_nth_default T => Raw.ident.List_nth_default
+           | @Z_add => Raw.ident.Z_add
+           | @Z_mul => Raw.ident.Z_mul
+           | @Z_pow => Raw.ident.Z_pow
+           | @Z_sub => Raw.ident.Z_sub
+           | @Z_opp => Raw.ident.Z_opp
+           | @Z_div => Raw.ident.Z_div
+           | @Z_modulo => Raw.ident.Z_modulo
+           | @Z_log2 => Raw.ident.Z_log2
+           | @Z_log2_up => Raw.ident.Z_log2_up
+           | @Z_eqb => Raw.ident.Z_eqb
+           | @Z_leb => Raw.ident.Z_leb
+           | @Z_geb => Raw.ident.Z_geb
+           | @Z_of_nat => Raw.ident.Z_of_nat
+           | @Z_to_nat => Raw.ident.Z_to_nat
+           | @Z_shiftr => Raw.ident.Z_shiftr
+           | @Z_shiftl => Raw.ident.Z_shiftl
+           | @Z_land => Raw.ident.Z_land
+           | @Z_lor => Raw.ident.Z_lor
+           | @Z_bneg => Raw.ident.Z_bneg
+           | @Z_lnot_modulo => Raw.ident.Z_lnot_modulo
+           | @Z_mul_split => Raw.ident.Z_mul_split
+           | @Z_add_get_carry => Raw.ident.Z_add_get_carry
+           | @Z_add_with_carry => Raw.ident.Z_add_with_carry
+           | @Z_add_with_get_carry => Raw.ident.Z_add_with_get_carry
+           | @Z_sub_get_borrow => Raw.ident.Z_sub_get_borrow
+           | @Z_sub_with_get_borrow => Raw.ident.Z_sub_with_get_borrow
+           | @Z_zselect => Raw.ident.Z_zselect
+           | @Z_add_modulo => Raw.ident.Z_add_modulo
+           | @Z_rshi => Raw.ident.Z_rshi
+           | @Z_cc_m => Raw.ident.Z_cc_m
+           | @Z_cast => Raw.ident.Z_cast
+           | @Z_cast2 => Raw.ident.Z_cast2
+           | @fancy_add => Raw.ident.fancy_add
+           | @fancy_addc => Raw.ident.fancy_addc
+           | @fancy_sub => Raw.ident.fancy_sub
+           | @fancy_subb => Raw.ident.fancy_subb
+           | @fancy_mulll => Raw.ident.fancy_mulll
+           | @fancy_mullh => Raw.ident.fancy_mullh
+           | @fancy_mulhl => Raw.ident.fancy_mulhl
+           | @fancy_mulhh => Raw.ident.fancy_mulhh
+           | @fancy_rshi => Raw.ident.fancy_rshi
+           | @fancy_selc => Raw.ident.fancy_selc
+           | @fancy_selm => Raw.ident.fancy_selm
+           | @fancy_sell => Raw.ident.fancy_sell
+           | @fancy_addm => Raw.ident.fancy_addm
            end.
 
-      Definition arg_types (idc : ident) : option Type
-        := match idc return option Type with
-           | LiteralUnit => @Some Type (base.interp Compilers.base.type.unit)
-           | LiteralZ => @Some Type (base.interp Compilers.base.type.Z)
-           | LiteralBool => @Some Type (base.interp Compilers.base.type.bool)
-           | LiteralNat => @Some Type (base.interp Compilers.base.type.nat)
-           | Nat_succ => None
-           | Nat_pred => None
-           | Nat_max => None
-           | Nat_mul => None
-           | Nat_add => None
-           | Nat_sub => None
-           | nil => None
-           | cons => None
-           | pair => None
-           | fst => None
-           | snd => None
-           | prod_rect => None
-           | bool_rect => None
-           | nat_rect => None
-           | nat_rect_arrow => None
-           | list_rect => None
-           | list_case => None
-           | List_length => None
-           | List_seq => None
-           | List_firstn => None
-           | List_skipn => None
-           | List_repeat => None
-           | List_combine => None
-           | List_map => None
-           | List_app => None
-           | List_rev => None
-           | List_flat_map => None
-           | List_partition => None
-           | List_fold_right => None
-           | List_update_nth => None
-           | List_nth_default => None
-           | Z_add => None
-           | Z_mul => None
-           | Z_pow => None
-           | Z_sub => None
-           | Z_opp => None
-           | Z_div => None
-           | Z_modulo => None
-           | Z_log2 => None
-           | Z_log2_up => None
-           | Z_eqb => None
-           | Z_leb => None
-           | Z_geb => None
-           | Z_of_nat => None
-           | Z_to_nat => None
-           | Z_shiftr => None
-           | Z_shiftl => None
-           | Z_land => None
-           | Z_lor => None
-           | Z_bneg => None
-           | Z_lnot_modulo => None
-           | Z_mul_split => None
-           | Z_add_get_carry => None
-           | Z_add_with_carry => None
-           | Z_add_with_get_carry => None
-           | Z_sub_get_borrow => None
-           | Z_sub_with_get_borrow => None
-           | Z_zselect => None
-           | Z_add_modulo => None
-           | Z_rshi => None
-           | Z_cc_m => None
-           | Z_cast => @Some Type zrange
-           | Z_cast2 => @Some Type (zrange * zrange)
-           | fancy_add => @Some Type (Z * Z)
-           | fancy_addc => @Some Type (Z * Z)
-           | fancy_sub => @Some Type (Z * Z)
-           | fancy_subb => @Some Type (Z * Z)
-           | fancy_mulll => @Some Type Z
-           | fancy_mullh => @Some Type Z
-           | fancy_mulhl => @Some Type Z
-           | fancy_mulhh => @Some Type Z
-           | fancy_rshi => @Some Type (Z * Z)
-           | fancy_selc => None
-           | fancy_selm => @Some Type Z
-           | fancy_sell => None
-           | fancy_addm => None
+      Definition arg_types {t} (idc : ident t) : list Type
+        := match idc return list Type with
+           | @Literal t => [base.interp (Compilers.base.type.type_base t) : Type]
+           | @Nat_succ => []
+           | @Nat_pred => []
+           | @Nat_max => []
+           | @Nat_mul => []
+           | @Nat_add => []
+           | @Nat_sub => []
+           | @nil t => []
+           | @cons t => []
+           | @pair A B => []
+           | @fst A B => []
+           | @snd A B => []
+           | @prod_rect A B T => []
+           | @bool_rect T => []
+           | @nat_rect P => []
+           | @nat_rect_arrow P Q => []
+           | @list_rect A P => []
+           | @list_case A P => []
+           | @List_length T => []
+           | @List_seq => []
+           | @List_firstn A => []
+           | @List_skipn A => []
+           | @List_repeat A => []
+           | @List_combine A B => []
+           | @List_map A B => []
+           | @List_app A => []
+           | @List_rev A => []
+           | @List_flat_map A B => []
+           | @List_partition A => []
+           | @List_fold_right A B => []
+           | @List_update_nth T => []
+           | @List_nth_default T => []
+           | @Z_add => []
+           | @Z_mul => []
+           | @Z_pow => []
+           | @Z_sub => []
+           | @Z_opp => []
+           | @Z_div => []
+           | @Z_modulo => []
+           | @Z_log2 => []
+           | @Z_log2_up => []
+           | @Z_eqb => []
+           | @Z_leb => []
+           | @Z_geb => []
+           | @Z_of_nat => []
+           | @Z_to_nat => []
+           | @Z_shiftr => []
+           | @Z_shiftl => []
+           | @Z_land => []
+           | @Z_lor => []
+           | @Z_bneg => []
+           | @Z_lnot_modulo => []
+           | @Z_mul_split => []
+           | @Z_add_get_carry => []
+           | @Z_add_with_carry => []
+           | @Z_add_with_get_carry => []
+           | @Z_sub_get_borrow => []
+           | @Z_sub_with_get_borrow => []
+           | @Z_zselect => []
+           | @Z_add_modulo => []
+           | @Z_rshi => []
+           | @Z_cc_m => []
+           | @Z_cast => [zrange : Type]
+           | @Z_cast2 => [zrange * zrange : Type]
+           | @fancy_add => [Z : Type; Z : Type]
+           | @fancy_addc => [Z : Type; Z : Type]
+           | @fancy_sub => [Z : Type; Z : Type]
+           | @fancy_subb => [Z : Type; Z : Type]
+           | @fancy_mulll => [Z : Type]
+           | @fancy_mullh => [Z : Type]
+           | @fancy_mulhl => [Z : Type]
+           | @fancy_mulhh => [Z : Type]
+           | @fancy_rshi => [Z : Type; Z : Type]
+           | @fancy_selc => []
+           | @fancy_selm => [Z : Type]
+           | @fancy_sell => []
+           | @fancy_addm => []
            end%type.
 
-      Definition full_types (idc : ident) : Type
-        := match idc return Type with
-           | LiteralUnit => base.interp Compilers.base.type.unit
-           | LiteralZ => base.interp Compilers.base.type.Z
-           | LiteralBool => base.interp Compilers.base.type.bool
-           | LiteralNat => base.interp Compilers.base.type.nat
-           | Nat_succ => unit
-           | Nat_pred => unit
-           | Nat_max => unit
-           | Nat_mul => unit
-           | Nat_add => unit
-           | Nat_sub => unit
-           | nil => base.type
-           | cons => base.type
-           | pair => base.type * base.type
-           | fst => base.type * base.type
-           | snd => base.type * base.type
-           | prod_rect => base.type * base.type * base.type
-           | bool_rect => base.type
-           | nat_rect => base.type
-           | nat_rect_arrow => base.type * base.type
-           | list_rect => base.type * base.type
-           | list_case => base.type * base.type
-           | List_length => base.type
-           | List_seq => unit
-           | List_firstn => base.type
-           | List_skipn => base.type
-           | List_repeat => base.type
-           | List_combine => base.type * base.type
-           | List_map => base.type * base.type
-           | List_app => base.type
-           | List_rev => base.type
-           | List_flat_map => base.type * base.type
-           | List_partition => base.type
-           | List_fold_right => base.type * base.type
-           | List_update_nth => base.type
-           | List_nth_default => base.type
-           | Z_add => unit
-           | Z_mul => unit
-           | Z_pow => unit
-           | Z_sub => unit
-           | Z_opp => unit
-           | Z_div => unit
-           | Z_modulo => unit
-           | Z_log2 => unit
-           | Z_log2_up => unit
-           | Z_eqb => unit
-           | Z_leb => unit
-           | Z_geb => unit
-           | Z_of_nat => unit
-           | Z_to_nat => unit
-           | Z_shiftr => unit
-           | Z_shiftl => unit
-           | Z_land => unit
-           | Z_lor => unit
-           | Z_bneg => unit
-           | Z_lnot_modulo => unit
-           | Z_mul_split => unit
-           | Z_add_get_carry => unit
-           | Z_add_with_carry => unit
-           | Z_add_with_get_carry => unit
-           | Z_sub_get_borrow => unit
-           | Z_sub_with_get_borrow => unit
-           | Z_zselect => unit
-           | Z_add_modulo => unit
-           | Z_rshi => unit
-           | Z_cc_m => unit
-           | Z_cast => zrange
-           | Z_cast2 => zrange * zrange
-           | fancy_add => Z * Z
-           | fancy_addc => Z * Z
-           | fancy_sub => Z * Z
-           | fancy_subb => Z * Z
-           | fancy_mulll => Z
-           | fancy_mullh => Z
-           | fancy_mulhl => Z
-           | fancy_mulhh => Z
-           | fancy_rshi => Z * Z
-           | fancy_selc => unit
-           | fancy_selm => Z
-           | fancy_sell => unit
-           | fancy_addm => unit
+      Definition type_vars {t} (idc : ident t) : list type
+        := match idc with
+           | @Literal t => [type.base (base.type.type_base t)]
+           | @Nat_succ => []
+           | @Nat_pred => []
+           | @Nat_max => []
+           | @Nat_mul => []
+           | @Nat_add => []
+           | @Nat_sub => []
+           | @nil t => [type.base t]
+           | @cons t => [type.base t]
+           | @pair A B => [type.base A; type.base B]
+           | @fst A B => [type.base A; type.base B]
+           | @snd A B => [type.base A; type.base B]
+           | @prod_rect A B T => [type.base A; type.base B; type.base T]
+           | @bool_rect T => [type.base T]
+           | @nat_rect P => [type.base P]
+           | @nat_rect_arrow P Q => [type.base P; type.base Q]
+           | @list_rect A P => [type.base A; type.base P]
+           | @list_case A P => [type.base A; type.base P]
+           | @List_length T => [type.base T]
+           | @List_seq => []
+           | @List_firstn A => [type.base A]
+           | @List_skipn A => [type.base A]
+           | @List_repeat A => [type.base A]
+           | @List_combine A B => [type.base A; type.base B]
+           | @List_map A B => [type.base A; type.base B]
+           | @List_app A => [type.base A]
+           | @List_rev A => [type.base A]
+           | @List_flat_map A B => [type.base A; type.base B]
+           | @List_partition A => [type.base A]
+           | @List_fold_right A B => [type.base A; type.base B]
+           | @List_update_nth T => [type.base T]
+           | @List_nth_default T => [type.base T]
+           | @Z_add => []
+           | @Z_mul => []
+           | @Z_pow => []
+           | @Z_sub => []
+           | @Z_opp => []
+           | @Z_div => []
+           | @Z_modulo => []
+           | @Z_log2 => []
+           | @Z_log2_up => []
+           | @Z_eqb => []
+           | @Z_leb => []
+           | @Z_geb => []
+           | @Z_of_nat => []
+           | @Z_to_nat => []
+           | @Z_shiftr => []
+           | @Z_shiftl => []
+           | @Z_land => []
+           | @Z_lor => []
+           | @Z_bneg => []
+           | @Z_lnot_modulo => []
+           | @Z_mul_split => []
+           | @Z_add_get_carry => []
+           | @Z_add_with_carry => []
+           | @Z_add_with_get_carry => []
+           | @Z_sub_get_borrow => []
+           | @Z_sub_with_get_borrow => []
+           | @Z_zselect => []
+           | @Z_add_modulo => []
+           | @Z_rshi => []
+           | @Z_cc_m => []
+           | @Z_cast => []
+           | @Z_cast2 => []
+           | @fancy_add => []
+           | @fancy_addc => []
+           | @fancy_sub => []
+           | @fancy_subb => []
+           | @fancy_mulll => []
+           | @fancy_mullh => []
+           | @fancy_mulhl => []
+           | @fancy_mulhh => []
+           | @fancy_rshi => []
+           | @fancy_selc => []
+           | @fancy_selm => []
+           | @fancy_sell => []
+           | @fancy_addm => []
            end%type.
 
-      Definition bind_args {t} (idc : Compilers.ident.ident t) : match arg_types (of_typed_ident idc) return Type with Some t => t | None => unit end
-        := match idc return match arg_types (of_typed_ident idc) return Type with Some t => t | None => unit end with
-           | Compilers.ident.LiteralUnit v => v
-           | Compilers.ident.LiteralZ v => v
-           | Compilers.ident.LiteralBool v => v
-           | Compilers.ident.LiteralNat v => v
-           | Compilers.ident.Nat_succ => tt
-           | Compilers.ident.Nat_pred => tt
-           | Compilers.ident.Nat_max => tt
-           | Compilers.ident.Nat_mul => tt
-           | Compilers.ident.Nat_add => tt
-           | Compilers.ident.Nat_sub => tt
-           | Compilers.ident.nil t => tt
-           | Compilers.ident.cons t => tt
-           | Compilers.ident.pair A B => tt
-           | Compilers.ident.fst A B => tt
-           | Compilers.ident.snd A B => tt
-           | Compilers.ident.prod_rect A B T => tt
-           | Compilers.ident.bool_rect T => tt
-           | Compilers.ident.nat_rect P => tt
-           | Compilers.ident.nat_rect_arrow P Q => tt
-           | Compilers.ident.list_rect A P => tt
-           | Compilers.ident.list_case A P => tt
-           | Compilers.ident.List_length T => tt
-           | Compilers.ident.List_seq => tt
-           | Compilers.ident.List_firstn A => tt
-           | Compilers.ident.List_skipn A => tt
-           | Compilers.ident.List_repeat A => tt
-           | Compilers.ident.List_combine A B => tt
-           | Compilers.ident.List_map A B => tt
-           | Compilers.ident.List_app A => tt
-           | Compilers.ident.List_rev A => tt
-           | Compilers.ident.List_flat_map A B => tt
-           | Compilers.ident.List_partition A => tt
-           | Compilers.ident.List_fold_right A B => tt
-           | Compilers.ident.List_update_nth T => tt
-           | Compilers.ident.List_nth_default T => tt
-           | Compilers.ident.Z_add => tt
-           | Compilers.ident.Z_mul => tt
-           | Compilers.ident.Z_pow => tt
-           | Compilers.ident.Z_sub => tt
-           | Compilers.ident.Z_opp => tt
-           | Compilers.ident.Z_div => tt
-           | Compilers.ident.Z_modulo => tt
-           | Compilers.ident.Z_log2 => tt
-           | Compilers.ident.Z_log2_up => tt
-           | Compilers.ident.Z_eqb => tt
-           | Compilers.ident.Z_leb => tt
-           | Compilers.ident.Z_geb => tt
-           | Compilers.ident.Z_of_nat => tt
-           | Compilers.ident.Z_to_nat => tt
-           | Compilers.ident.Z_shiftr => tt
-           | Compilers.ident.Z_shiftl => tt
-           | Compilers.ident.Z_land => tt
-           | Compilers.ident.Z_lor => tt
-           | Compilers.ident.Z_bneg => tt
-           | Compilers.ident.Z_lnot_modulo => tt
-           | Compilers.ident.Z_mul_split => tt
-           | Compilers.ident.Z_add_get_carry => tt
-           | Compilers.ident.Z_add_with_carry => tt
-           | Compilers.ident.Z_add_with_get_carry => tt
-           | Compilers.ident.Z_sub_get_borrow => tt
-           | Compilers.ident.Z_sub_with_get_borrow => tt
-           | Compilers.ident.Z_zselect => tt
-           | Compilers.ident.Z_add_modulo => tt
-           | Compilers.ident.Z_rshi => tt
-           | Compilers.ident.Z_cc_m => tt
-           | Compilers.ident.Z_cast range => range
-           | Compilers.ident.Z_cast2 range => range
-           | Compilers.ident.fancy_add log2wordmax imm => (log2wordmax, imm)
-           | Compilers.ident.fancy_addc log2wordmax imm => (log2wordmax, imm)
-           | Compilers.ident.fancy_sub log2wordmax imm => (log2wordmax, imm)
-           | Compilers.ident.fancy_subb log2wordmax imm => (log2wordmax, imm)
-           | Compilers.ident.fancy_mulll log2wordmax => log2wordmax
-           | Compilers.ident.fancy_mullh log2wordmax => log2wordmax
-           | Compilers.ident.fancy_mulhl log2wordmax => log2wordmax
-           | Compilers.ident.fancy_mulhh log2wordmax => log2wordmax
-           | Compilers.ident.fancy_rshi log2wordmax x => (log2wordmax, x)
-           | Compilers.ident.fancy_selc => tt
-           | Compilers.ident.fancy_selm log2wordmax => log2wordmax
-           | Compilers.ident.fancy_sell => tt
-           | Compilers.ident.fancy_addm => tt
-           end%cps.
-
-      Definition invert_bind_args {t} (idc : Compilers.ident.ident t) (pidc : ident) : option (full_types pidc)
-        := match pidc, idc return option (full_types pidc) with
-           | LiteralUnit, Compilers.ident.LiteralUnit v => Some v
-           | LiteralZ, Compilers.ident.LiteralZ v => Some v
-           | LiteralBool, Compilers.ident.LiteralBool v => Some v
-           | LiteralNat, Compilers.ident.LiteralNat v => Some v
-           | Nat_succ, Compilers.ident.Nat_succ => Some tt
-           | Nat_pred, Compilers.ident.Nat_pred => Some tt
-           | Nat_max, Compilers.ident.Nat_max => Some tt
-           | Nat_mul, Compilers.ident.Nat_mul => Some tt
-           | Nat_add, Compilers.ident.Nat_add => Some tt
-           | Nat_sub, Compilers.ident.Nat_sub => Some tt
-           | nil, Compilers.ident.nil t => Some t
-           | cons, Compilers.ident.cons t => Some t
-           | pair, Compilers.ident.pair A B => Some (A, B)
-           | fst, Compilers.ident.fst A B => Some (A, B)
-           | snd, Compilers.ident.snd A B => Some (A, B)
-           | prod_rect, Compilers.ident.prod_rect A B T => Some (A, B, T)
-           | bool_rect, Compilers.ident.bool_rect T => Some T
-           | nat_rect, Compilers.ident.nat_rect P => Some P
-           | nat_rect_arrow, Compilers.ident.nat_rect_arrow P Q => Some (P, Q)
-           | list_rect, Compilers.ident.list_rect A P => Some (A, P)
-           | list_case, Compilers.ident.list_case A P => Some (A, P)
-           | List_length, Compilers.ident.List_length T => Some T
-           | List_seq, Compilers.ident.List_seq => Some tt
-           | List_firstn, Compilers.ident.List_firstn A => Some A
-           | List_skipn, Compilers.ident.List_skipn A => Some A
-           | List_repeat, Compilers.ident.List_repeat A => Some A
-           | List_combine, Compilers.ident.List_combine A B => Some (A, B)
-           | List_map, Compilers.ident.List_map A B => Some (A, B)
-           | List_app, Compilers.ident.List_app A => Some A
-           | List_rev, Compilers.ident.List_rev A => Some A
-           | List_flat_map, Compilers.ident.List_flat_map A B => Some (A, B)
-           | List_partition, Compilers.ident.List_partition A => Some A
-           | List_fold_right, Compilers.ident.List_fold_right A B => Some (A, B)
-           | List_update_nth, Compilers.ident.List_update_nth T => Some T
-           | List_nth_default, Compilers.ident.List_nth_default T => Some T
-           | Z_add, Compilers.ident.Z_add => Some tt
-           | Z_mul, Compilers.ident.Z_mul => Some tt
-           | Z_pow, Compilers.ident.Z_pow => Some tt
-           | Z_sub, Compilers.ident.Z_sub => Some tt
-           | Z_opp, Compilers.ident.Z_opp => Some tt
-           | Z_div, Compilers.ident.Z_div => Some tt
-           | Z_modulo, Compilers.ident.Z_modulo => Some tt
-           | Z_log2, Compilers.ident.Z_log2 => Some tt
-           | Z_log2_up, Compilers.ident.Z_log2_up => Some tt
-           | Z_eqb, Compilers.ident.Z_eqb => Some tt
-           | Z_leb, Compilers.ident.Z_leb => Some tt
-           | Z_geb, Compilers.ident.Z_geb => Some tt
-           | Z_of_nat, Compilers.ident.Z_of_nat => Some tt
-           | Z_to_nat, Compilers.ident.Z_to_nat => Some tt
-           | Z_shiftr, Compilers.ident.Z_shiftr => Some tt
-           | Z_shiftl, Compilers.ident.Z_shiftl => Some tt
-           | Z_land, Compilers.ident.Z_land => Some tt
-           | Z_lor, Compilers.ident.Z_lor => Some tt
-           | Z_bneg, Compilers.ident.Z_bneg => Some tt
-           | Z_lnot_modulo, Compilers.ident.Z_lnot_modulo => Some tt
-           | Z_mul_split, Compilers.ident.Z_mul_split => Some tt
-           | Z_add_get_carry, Compilers.ident.Z_add_get_carry => Some tt
-           | Z_add_with_carry, Compilers.ident.Z_add_with_carry => Some tt
-           | Z_add_with_get_carry, Compilers.ident.Z_add_with_get_carry => Some tt
-           | Z_sub_get_borrow, Compilers.ident.Z_sub_get_borrow => Some tt
-           | Z_sub_with_get_borrow, Compilers.ident.Z_sub_with_get_borrow => Some tt
-           | Z_zselect, Compilers.ident.Z_zselect => Some tt
-           | Z_add_modulo, Compilers.ident.Z_add_modulo => Some tt
-           | Z_rshi, Compilers.ident.Z_rshi => Some tt
-           | Z_cc_m, Compilers.ident.Z_cc_m => Some tt
-           | Z_cast, Compilers.ident.Z_cast range => Some range
-           | Z_cast2, Compilers.ident.Z_cast2 range => Some range
-           | fancy_add, Compilers.ident.fancy_add log2wordmax imm => Some (log2wordmax, imm)
-           | fancy_addc, Compilers.ident.fancy_addc log2wordmax imm => Some (log2wordmax, imm)
-           | fancy_sub, Compilers.ident.fancy_sub log2wordmax imm => Some (log2wordmax, imm)
-           | fancy_subb, Compilers.ident.fancy_subb log2wordmax imm => Some (log2wordmax, imm)
-           | fancy_mulll, Compilers.ident.fancy_mulll log2wordmax => Some log2wordmax
-           | fancy_mullh, Compilers.ident.fancy_mullh log2wordmax => Some log2wordmax
-           | fancy_mulhl, Compilers.ident.fancy_mulhl log2wordmax => Some log2wordmax
-           | fancy_mulhh, Compilers.ident.fancy_mulhh log2wordmax => Some log2wordmax
-           | fancy_rshi, Compilers.ident.fancy_rshi log2wordmax x => Some (log2wordmax, x)
-           | fancy_selc, Compilers.ident.fancy_selc => Some tt
-           | fancy_selm, Compilers.ident.fancy_selm log2wordmax => Some log2wordmax
-           | fancy_sell, Compilers.ident.fancy_sell => Some tt
-           | fancy_addm, Compilers.ident.fancy_addm => Some tt
-           | LiteralUnit, _
-           | LiteralZ, _
-           | LiteralBool, _
-           | LiteralNat, _
-           | Nat_succ, _
-           | Nat_pred, _
-           | Nat_max, _
-           | Nat_mul, _
-           | Nat_add, _
-           | Nat_sub, _
-           | nil, _
-           | cons, _
-           | pair, _
-           | fst, _
-           | snd, _
-           | prod_rect, _
-           | bool_rect, _
-           | nat_rect, _
-           | nat_rect_arrow, _
-           | list_rect, _
-           | list_case, _
-           | List_length, _
-           | List_seq, _
-           | List_firstn, _
-           | List_skipn, _
-           | List_repeat, _
-           | List_combine, _
-           | List_map, _
-           | List_app, _
-           | List_rev, _
-           | List_flat_map, _
-           | List_partition, _
-           | List_fold_right, _
-           | List_update_nth, _
-           | List_nth_default, _
-           | Z_add, _
-           | Z_mul, _
-           | Z_pow, _
-           | Z_sub, _
-           | Z_opp, _
-           | Z_div, _
-           | Z_modulo, _
-           | Z_log2, _
-           | Z_log2_up, _
-           | Z_eqb, _
-           | Z_leb, _
-           | Z_geb, _
-           | Z_of_nat, _
-           | Z_to_nat, _
-           | Z_shiftr, _
-           | Z_shiftl, _
-           | Z_land, _
-           | Z_lor, _
-           | Z_bneg, _
-           | Z_lnot_modulo, _
-           | Z_mul_split, _
-           | Z_add_get_carry, _
-           | Z_add_with_carry, _
-           | Z_add_with_get_carry, _
-           | Z_sub_get_borrow, _
-           | Z_sub_with_get_borrow, _
-           | Z_zselect, _
-           | Z_add_modulo, _
-           | Z_rshi, _
-           | Z_cc_m, _
-           | Z_cast, _
-           | Z_cast2, _
-           | fancy_add, _
-           | fancy_addc, _
-           | fancy_sub, _
-           | fancy_subb, _
-           | fancy_mulll, _
-           | fancy_mullh, _
-           | fancy_mulhl, _
-           | fancy_mulhh, _
-           | fancy_rshi, _
-           | fancy_selc, _
-           | fancy_selm, _
-           | fancy_sell, _
-           | fancy_addm, _
+      Definition unify {t t'} (pidc : ident t) (idc : Compilers.ident.ident t') : option (type_of_list (@arg_types t pidc))
+        := match pidc, idc return option (type_of_list (arg_types pidc)) with
+           | @Literal Compilers.base.type.unit, Compilers.ident.Literal Compilers.base.type.unit v => Some (v, tt)
+           | @Literal Compilers.base.type.Z, Compilers.ident.Literal Compilers.base.type.Z v => Some (v, tt)
+           | @Literal Compilers.base.type.bool, Compilers.ident.Literal Compilers.base.type.bool v => Some (v, tt)
+           | @Literal Compilers.base.type.nat, Compilers.ident.Literal Compilers.base.type.nat v => Some (v, tt)
+           | @Nat_succ, Compilers.ident.Nat_succ => Some tt
+           | @Nat_pred, Compilers.ident.Nat_pred => Some tt
+           | @Nat_max, Compilers.ident.Nat_max => Some tt
+           | @Nat_mul, Compilers.ident.Nat_mul => Some tt
+           | @Nat_add, Compilers.ident.Nat_add => Some tt
+           | @Nat_sub, Compilers.ident.Nat_sub => Some tt
+           | @nil t, Compilers.ident.nil t' => Some tt
+           | @cons t, Compilers.ident.cons t' => Some tt
+           | @pair A B, Compilers.ident.pair A' B' => Some tt
+           | @fst A B, Compilers.ident.fst A' B' => Some tt
+           | @snd A B, Compilers.ident.snd A' B' => Some tt
+           | @prod_rect A B T, Compilers.ident.prod_rect A' B' T' => Some tt
+           | @bool_rect T, Compilers.ident.bool_rect T' => Some tt
+           | @nat_rect P, Compilers.ident.nat_rect P' => Some tt
+           | @nat_rect_arrow P Q, Compilers.ident.nat_rect_arrow P' Q' => Some tt
+           | @list_rect A P, Compilers.ident.list_rect A' P' => Some tt
+           | @list_case A P, Compilers.ident.list_case A' P' => Some tt
+           | @List_length T, Compilers.ident.List_length T' => Some tt
+           | @List_seq, Compilers.ident.List_seq => Some tt
+           | @List_firstn A, Compilers.ident.List_firstn A' => Some tt
+           | @List_skipn A, Compilers.ident.List_skipn A' => Some tt
+           | @List_repeat A, Compilers.ident.List_repeat A' => Some tt
+           | @List_combine A B, Compilers.ident.List_combine A' B' => Some tt
+           | @List_map A B, Compilers.ident.List_map A' B' => Some tt
+           | @List_app A, Compilers.ident.List_app A' => Some tt
+           | @List_rev A, Compilers.ident.List_rev A' => Some tt
+           | @List_flat_map A B, Compilers.ident.List_flat_map A' B' => Some tt
+           | @List_partition A, Compilers.ident.List_partition A' => Some tt
+           | @List_fold_right A B, Compilers.ident.List_fold_right A' B' => Some tt
+           | @List_update_nth T, Compilers.ident.List_update_nth T' => Some tt
+           | @List_nth_default T, Compilers.ident.List_nth_default T' => Some tt
+           | @Z_add, Compilers.ident.Z_add => Some tt
+           | @Z_mul, Compilers.ident.Z_mul => Some tt
+           | @Z_pow, Compilers.ident.Z_pow => Some tt
+           | @Z_sub, Compilers.ident.Z_sub => Some tt
+           | @Z_opp, Compilers.ident.Z_opp => Some tt
+           | @Z_div, Compilers.ident.Z_div => Some tt
+           | @Z_modulo, Compilers.ident.Z_modulo => Some tt
+           | @Z_log2, Compilers.ident.Z_log2 => Some tt
+           | @Z_log2_up, Compilers.ident.Z_log2_up => Some tt
+           | @Z_eqb, Compilers.ident.Z_eqb => Some tt
+           | @Z_leb, Compilers.ident.Z_leb => Some tt
+           | @Z_geb, Compilers.ident.Z_geb => Some tt
+           | @Z_of_nat, Compilers.ident.Z_of_nat => Some tt
+           | @Z_to_nat, Compilers.ident.Z_to_nat => Some tt
+           | @Z_shiftr, Compilers.ident.Z_shiftr => Some tt
+           | @Z_shiftl, Compilers.ident.Z_shiftl => Some tt
+           | @Z_land, Compilers.ident.Z_land => Some tt
+           | @Z_lor, Compilers.ident.Z_lor => Some tt
+           | @Z_bneg, Compilers.ident.Z_bneg => Some tt
+           | @Z_lnot_modulo, Compilers.ident.Z_lnot_modulo => Some tt
+           | @Z_mul_split, Compilers.ident.Z_mul_split => Some tt
+           | @Z_add_get_carry, Compilers.ident.Z_add_get_carry => Some tt
+           | @Z_add_with_carry, Compilers.ident.Z_add_with_carry => Some tt
+           | @Z_add_with_get_carry, Compilers.ident.Z_add_with_get_carry => Some tt
+           | @Z_sub_get_borrow, Compilers.ident.Z_sub_get_borrow => Some tt
+           | @Z_sub_with_get_borrow, Compilers.ident.Z_sub_with_get_borrow => Some tt
+           | @Z_zselect, Compilers.ident.Z_zselect => Some tt
+           | @Z_add_modulo, Compilers.ident.Z_add_modulo => Some tt
+           | @Z_rshi, Compilers.ident.Z_rshi => Some tt
+           | @Z_cc_m, Compilers.ident.Z_cc_m => Some tt
+           | @Z_cast, Compilers.ident.Z_cast range' => Some (range', tt)
+           | @Z_cast2, Compilers.ident.Z_cast2 range' => Some (range', tt)
+           | @fancy_add, Compilers.ident.fancy_add log2wordmax' imm' => Some (log2wordmax', (imm', tt))
+           | @fancy_addc, Compilers.ident.fancy_addc log2wordmax' imm' => Some (log2wordmax', (imm', tt))
+           | @fancy_sub, Compilers.ident.fancy_sub log2wordmax' imm' => Some (log2wordmax', (imm', tt))
+           | @fancy_subb, Compilers.ident.fancy_subb log2wordmax' imm' => Some (log2wordmax', (imm', tt))
+           | @fancy_mulll, Compilers.ident.fancy_mulll log2wordmax' => Some (log2wordmax', tt)
+           | @fancy_mullh, Compilers.ident.fancy_mullh log2wordmax' => Some (log2wordmax', tt)
+           | @fancy_mulhl, Compilers.ident.fancy_mulhl log2wordmax' => Some (log2wordmax', tt)
+           | @fancy_mulhh, Compilers.ident.fancy_mulhh log2wordmax' => Some (log2wordmax', tt)
+           | @fancy_rshi, Compilers.ident.fancy_rshi log2wordmax' x' => Some (log2wordmax', (x', tt))
+           | @fancy_selc, Compilers.ident.fancy_selc => Some tt
+           | @fancy_selm, Compilers.ident.fancy_selm log2wordmax' => Some (log2wordmax', tt)
+           | @fancy_sell, Compilers.ident.fancy_sell => Some tt
+           | @fancy_addm, Compilers.ident.fancy_addm => Some tt
+           | @Literal _, _
+           | @Nat_succ, _
+           | @Nat_pred, _
+           | @Nat_max, _
+           | @Nat_mul, _
+           | @Nat_add, _
+           | @Nat_sub, _
+           | @nil _, _
+           | @cons _, _
+           | @pair _ _, _
+           | @fst _ _, _
+           | @snd _ _, _
+           | @prod_rect _ _ _, _
+           | @bool_rect _, _
+           | @nat_rect _, _
+           | @nat_rect_arrow _ _, _
+           | @list_rect _ _, _
+           | @list_case _ _, _
+           | @List_length _, _
+           | @List_seq, _
+           | @List_firstn _, _
+           | @List_skipn _, _
+           | @List_repeat _, _
+           | @List_combine _ _, _
+           | @List_map _ _, _
+           | @List_app _, _
+           | @List_rev _, _
+           | @List_flat_map _ _, _
+           | @List_partition _, _
+           | @List_fold_right _ _, _
+           | @List_update_nth _, _
+           | @List_nth_default _, _
+           | @Z_add, _
+           | @Z_mul, _
+           | @Z_pow, _
+           | @Z_sub, _
+           | @Z_opp, _
+           | @Z_div, _
+           | @Z_modulo, _
+           | @Z_log2, _
+           | @Z_log2_up, _
+           | @Z_eqb, _
+           | @Z_leb, _
+           | @Z_geb, _
+           | @Z_of_nat, _
+           | @Z_to_nat, _
+           | @Z_shiftr, _
+           | @Z_shiftl, _
+           | @Z_land, _
+           | @Z_lor, _
+           | @Z_bneg, _
+           | @Z_lnot_modulo, _
+           | @Z_mul_split, _
+           | @Z_add_get_carry, _
+           | @Z_add_with_carry, _
+           | @Z_add_with_get_carry, _
+           | @Z_sub_get_borrow, _
+           | @Z_sub_with_get_borrow, _
+           | @Z_zselect, _
+           | @Z_add_modulo, _
+           | @Z_rshi, _
+           | @Z_cc_m, _
+           | @Z_cast, _
+           | @Z_cast2, _
+           | @fancy_add, _
+           | @fancy_addc, _
+           | @fancy_sub, _
+           | @fancy_subb, _
+           | @fancy_mulll, _
+           | @fancy_mullh, _
+           | @fancy_mulhl, _
+           | @fancy_mulhh, _
+           | @fancy_rshi, _
+           | @fancy_selc, _
+           | @fancy_selm, _
+           | @fancy_sell, _
+           | @fancy_addm, _
              => None
            end%cps.
 
-      Local Notation eta2 x := (Datatypes.fst x, Datatypes.snd x) (only parsing).
-      Local Notation eta3 x := (eta2 (Datatypes.fst x), Datatypes.snd x) (only parsing).
-
-      Definition type_of (pidc : ident) : full_types pidc -> Compilers.type Compilers.base.type
-        := match pidc return full_types pidc -> _ with
-           | LiteralUnit => fun v => (type.base (Compilers.base.type.type_base Compilers.base.type.unit))
-           | LiteralZ => fun v => (type.base (Compilers.base.type.type_base Compilers.base.type.Z))
-           | LiteralBool => fun v => (type.base (Compilers.base.type.type_base Compilers.base.type.bool))
-           | LiteralNat => fun v => (type.base (Compilers.base.type.type_base Compilers.base.type.nat))
-           | Nat_succ => fun _ => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))
-           | Nat_pred => fun _ => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))
-           | Nat_max => fun _ => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))
-           | Nat_mul => fun _ => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))
-           | Nat_add => fun _ => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))
-           | Nat_sub => fun _ => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat))
-           | nil => fun t => (type.base (base.type.list t))
-           | cons => fun t => (type.base t -> type.base (base.type.list t) -> type.base (base.type.list t))
-           | pair => fun arg => let '(A, B) := eta2 arg in (type.base A -> type.base B -> type.base (A * B)%etype)
-           | fst => fun arg => let '(A, B) := eta2 arg in (type.base (A * B)%etype -> type.base A)
-           | snd => fun arg => let '(A, B) := eta2 arg in (type.base (A * B)%etype -> type.base B)
-           | prod_rect => fun arg => let '(A, B, T) := eta3 arg in ((type.base A -> type.base B -> type.base T) -> type.base (A * B)%etype -> type.base T)
-           | bool_rect => fun T => ((type.base ()%etype -> type.base T) -> (type.base ()%etype -> type.base T) -> type.base (base.type.type_base base.type.bool) -> type.base T)
-           | nat_rect => fun P => ((type.base ()%etype -> type.base P) -> (type.base (base.type.type_base base.type.nat) -> type.base P -> type.base P) -> type.base (base.type.type_base base.type.nat) -> type.base P)
-           | nat_rect_arrow => fun arg => let '(P, Q) := eta2 arg in ((type.base P -> type.base Q) -> (type.base (base.type.type_base base.type.nat) -> (type.base P -> type.base Q) -> type.base P -> type.base Q) -> type.base (base.type.type_base base.type.nat) -> type.base P -> type.base Q)
-           | list_rect => fun arg => let '(A, P) := eta2 arg in ((type.base ()%etype -> type.base P) -> (type.base A -> type.base (base.type.list A) -> type.base P -> type.base P) -> type.base (base.type.list A) -> type.base P)
-           | list_case => fun arg => let '(A, P) := eta2 arg in ((type.base ()%etype -> type.base P) -> (type.base A -> type.base (base.type.list A) -> type.base P) -> type.base (base.type.list A) -> type.base P)
-           | List_length => fun T => (type.base (base.type.list T) -> type.base (base.type.type_base base.type.nat))
-           | List_seq => fun _ => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.list (base.type.type_base base.type.nat)))
-           | List_firstn => fun A => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.list A) -> type.base (base.type.list A))
-           | List_skipn => fun A => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.list A) -> type.base (base.type.list A))
-           | List_repeat => fun A => (type.base A -> type.base (base.type.type_base base.type.nat) -> type.base (base.type.list A))
-           | List_combine => fun arg => let '(A, B) := eta2 arg in (type.base (base.type.list A) -> type.base (base.type.list B) -> type.base (base.type.list (A * B)))
-           | List_map => fun arg => let '(A, B) := eta2 arg in ((type.base A -> type.base B) -> type.base (base.type.list A) -> type.base (base.type.list B))
-           | List_app => fun A => (type.base (base.type.list A) -> type.base (base.type.list A) -> type.base (base.type.list A))
-           | List_rev => fun A => (type.base (base.type.list A) -> type.base (base.type.list A))
-           | List_flat_map => fun arg => let '(A, B) := eta2 arg in ((type.base A -> type.base (base.type.list B)) -> type.base (base.type.list A) -> type.base (base.type.list B))
-           | List_partition => fun A => ((type.base A -> type.base (base.type.type_base base.type.bool)) -> type.base (base.type.list A) -> type.base (base.type.list A * base.type.list A)%etype)
-           | List_fold_right => fun arg => let '(A, B) := eta2 arg in ((type.base B -> type.base A -> type.base A) -> type.base A -> type.base (base.type.list B) -> type.base A)
-           | List_update_nth => fun T => (type.base (base.type.type_base base.type.nat) -> (type.base T -> type.base T) -> type.base (base.type.list T) -> type.base (base.type.list T))
-           | List_nth_default => fun T => (type.base T -> type.base (base.type.list T) -> type.base (base.type.type_base base.type.nat) -> type.base T)
-           | Z_add => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_mul => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_pow => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_sub => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_opp => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_div => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_modulo => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_log2 => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_log2_up => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_eqb => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.bool))
-           | Z_leb => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.bool))
-           | Z_geb => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.bool))
-           | Z_of_nat => fun _ => (type.base (base.type.type_base base.type.nat) -> type.base (base.type.type_base base.type.Z))
-           | Z_to_nat => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.nat))
-           | Z_shiftr => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_shiftl => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_land => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_lor => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_bneg => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_lnot_modulo => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_mul_split => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | Z_add_get_carry => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | Z_add_with_carry => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_add_with_get_carry => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | Z_sub_get_borrow => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | Z_sub_with_get_borrow => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | Z_zselect => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_add_modulo => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_rshi => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_cc_m => fun _ => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_cast => fun range => (type.base (base.type.type_base base.type.Z) -> type.base (base.type.type_base base.type.Z))
-           | Z_cast2 => fun range => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | fancy_add => fun arg => let '(log2wordmax, imm) := eta2 arg in (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | fancy_addc => fun arg => let '(log2wordmax, imm) := eta2 arg in (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | fancy_sub => fun arg => let '(log2wordmax, imm) := eta2 arg in (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | fancy_subb => fun arg => let '(log2wordmax, imm) := eta2 arg in (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype)
-           | fancy_mulll => fun log2wordmax => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           | fancy_mullh => fun log2wordmax => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           | fancy_mulhl => fun log2wordmax => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           | fancy_mulhh => fun log2wordmax => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           | fancy_rshi => fun arg => let '(log2wordmax, x) := eta2 arg in (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           | fancy_selc => fun _ => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           | fancy_selm => fun log2wordmax => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           | fancy_sell => fun _ => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           | fancy_addm => fun _ => (type.base (base.type.type_base base.type.Z * base.type.type_base base.type.Z * base.type.type_base base.type.Z)%etype -> type.base (base.type.type_base base.type.Z))
-           end%etype.
-
-      Definition to_typed (pidc : ident) : forall args : full_types pidc, Compilers.ident.ident (type_of pidc args)
-        := match pidc return forall args : full_types pidc, Compilers.ident.ident (type_of pidc args) with
-           | LiteralUnit => fun v => @Compilers.ident.LiteralUnit v
-           | LiteralZ => fun v => @Compilers.ident.LiteralZ v
-           | LiteralBool => fun v => @Compilers.ident.LiteralBool v
-           | LiteralNat => fun v => @Compilers.ident.LiteralNat v
-           | Nat_succ => fun _ => @Compilers.ident.Nat_succ
-           | Nat_pred => fun _ => @Compilers.ident.Nat_pred
-           | Nat_max => fun _ => @Compilers.ident.Nat_max
-           | Nat_mul => fun _ => @Compilers.ident.Nat_mul
-           | Nat_add => fun _ => @Compilers.ident.Nat_add
-           | Nat_sub => fun _ => @Compilers.ident.Nat_sub
-           | nil => fun t => @Compilers.ident.nil t
-           | cons => fun t => @Compilers.ident.cons t
-           | pair => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of pair args') with (A, B) => @Compilers.ident.pair A B end
-           | fst => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of fst args') with (A, B) => @Compilers.ident.fst A B end
-           | snd => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of snd args') with (A, B) => @Compilers.ident.snd A B end
-           | prod_rect => fun arg => match eta3 arg as args' return Compilers.ident.ident (type_of prod_rect args') with (A, B, T) => @Compilers.ident.prod_rect A B T end
-           | bool_rect => fun T => @Compilers.ident.bool_rect T
-           | nat_rect => fun P => @Compilers.ident.nat_rect P
-           | nat_rect_arrow => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of nat_rect_arrow args') with (P, Q) => @Compilers.ident.nat_rect_arrow P Q end
-           | list_rect => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of list_rect args') with (A, P) => @Compilers.ident.list_rect A P end
-           | list_case => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of list_case args') with (A, P) => @Compilers.ident.list_case A P end
-           | List_length => fun T => @Compilers.ident.List_length T
-           | List_seq => fun _ => @Compilers.ident.List_seq
-           | List_firstn => fun A => @Compilers.ident.List_firstn A
-           | List_skipn => fun A => @Compilers.ident.List_skipn A
-           | List_repeat => fun A => @Compilers.ident.List_repeat A
-           | List_combine => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of List_combine args') with (A, B) => @Compilers.ident.List_combine A B end
-           | List_map => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of List_map args') with (A, B) => @Compilers.ident.List_map A B end
-           | List_app => fun A => @Compilers.ident.List_app A
-           | List_rev => fun A => @Compilers.ident.List_rev A
-           | List_flat_map => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of List_flat_map args') with (A, B) => @Compilers.ident.List_flat_map A B end
-           | List_partition => fun A => @Compilers.ident.List_partition A
-           | List_fold_right => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of List_fold_right args') with (A, B) => @Compilers.ident.List_fold_right A B end
-           | List_update_nth => fun T => @Compilers.ident.List_update_nth T
-           | List_nth_default => fun T => @Compilers.ident.List_nth_default T
-           | Z_add => fun _ => @Compilers.ident.Z_add
-           | Z_mul => fun _ => @Compilers.ident.Z_mul
-           | Z_pow => fun _ => @Compilers.ident.Z_pow
-           | Z_sub => fun _ => @Compilers.ident.Z_sub
-           | Z_opp => fun _ => @Compilers.ident.Z_opp
-           | Z_div => fun _ => @Compilers.ident.Z_div
-           | Z_modulo => fun _ => @Compilers.ident.Z_modulo
-           | Z_log2 => fun _ => @Compilers.ident.Z_log2
-           | Z_log2_up => fun _ => @Compilers.ident.Z_log2_up
-           | Z_eqb => fun _ => @Compilers.ident.Z_eqb
-           | Z_leb => fun _ => @Compilers.ident.Z_leb
-           | Z_geb => fun _ => @Compilers.ident.Z_geb
-           | Z_of_nat => fun _ => @Compilers.ident.Z_of_nat
-           | Z_to_nat => fun _ => @Compilers.ident.Z_to_nat
-           | Z_shiftr => fun _ => @Compilers.ident.Z_shiftr
-           | Z_shiftl => fun _ => @Compilers.ident.Z_shiftl
-           | Z_land => fun _ => @Compilers.ident.Z_land
-           | Z_lor => fun _ => @Compilers.ident.Z_lor
-           | Z_bneg => fun _ => @Compilers.ident.Z_bneg
-           | Z_lnot_modulo => fun _ => @Compilers.ident.Z_lnot_modulo
-           | Z_mul_split => fun _ => @Compilers.ident.Z_mul_split
-           | Z_add_get_carry => fun _ => @Compilers.ident.Z_add_get_carry
-           | Z_add_with_carry => fun _ => @Compilers.ident.Z_add_with_carry
-           | Z_add_with_get_carry => fun _ => @Compilers.ident.Z_add_with_get_carry
-           | Z_sub_get_borrow => fun _ => @Compilers.ident.Z_sub_get_borrow
-           | Z_sub_with_get_borrow => fun _ => @Compilers.ident.Z_sub_with_get_borrow
-           | Z_zselect => fun _ => @Compilers.ident.Z_zselect
-           | Z_add_modulo => fun _ => @Compilers.ident.Z_add_modulo
-           | Z_rshi => fun _ => @Compilers.ident.Z_rshi
-           | Z_cc_m => fun _ => @Compilers.ident.Z_cc_m
-           | Z_cast => fun range => @Compilers.ident.Z_cast range
-           | Z_cast2 => fun range => @Compilers.ident.Z_cast2 range
-           | fancy_add => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of fancy_add args') with (log2wordmax, imm) => @Compilers.ident.fancy_add log2wordmax imm end
-           | fancy_addc => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of fancy_addc args') with (log2wordmax, imm) => @Compilers.ident.fancy_addc log2wordmax imm end
-           | fancy_sub => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of fancy_sub args') with (log2wordmax, imm) => @Compilers.ident.fancy_sub log2wordmax imm end
-           | fancy_subb => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of fancy_subb args') with (log2wordmax, imm) => @Compilers.ident.fancy_subb log2wordmax imm end
-           | fancy_mulll => fun log2wordmax => @Compilers.ident.fancy_mulll log2wordmax
-           | fancy_mullh => fun log2wordmax => @Compilers.ident.fancy_mullh log2wordmax
-           | fancy_mulhl => fun log2wordmax => @Compilers.ident.fancy_mulhl log2wordmax
-           | fancy_mulhh => fun log2wordmax => @Compilers.ident.fancy_mulhh log2wordmax
-           | fancy_rshi => fun arg => match eta2 arg as args' return Compilers.ident.ident (type_of fancy_rshi args') with (log2wordmax, x) => @Compilers.ident.fancy_rshi log2wordmax x end
-           | fancy_selc => fun _ => @Compilers.ident.fancy_selc
-           | fancy_selm => fun log2wordmax => @Compilers.ident.fancy_selm log2wordmax
-           | fancy_sell => fun _ => @Compilers.ident.fancy_sell
-           | fancy_addm => fun _ => @Compilers.ident.fancy_addm
+      Definition of_typed_ident {t} (idc : Compilers.ident.ident t) : ident (type.relax t)
+        := match idc with
+           | Compilers.ident.Literal t v => @Literal t
+           | Compilers.ident.Nat_succ => @Nat_succ
+           | Compilers.ident.Nat_pred => @Nat_pred
+           | Compilers.ident.Nat_max => @Nat_max
+           | Compilers.ident.Nat_mul => @Nat_mul
+           | Compilers.ident.Nat_add => @Nat_add
+           | Compilers.ident.Nat_sub => @Nat_sub
+           | Compilers.ident.nil t => @nil (base.relax t)
+           | Compilers.ident.cons t => @cons (base.relax t)
+           | Compilers.ident.pair A B => @pair (base.relax A) (base.relax B)
+           | Compilers.ident.fst A B => @fst (base.relax A) (base.relax B)
+           | Compilers.ident.snd A B => @snd (base.relax A) (base.relax B)
+           | Compilers.ident.prod_rect A B T => @prod_rect (base.relax A) (base.relax B) (base.relax T)
+           | Compilers.ident.bool_rect T => @bool_rect (base.relax T)
+           | Compilers.ident.nat_rect P => @nat_rect (base.relax P)
+           | Compilers.ident.nat_rect_arrow P Q => @nat_rect_arrow (base.relax P) (base.relax Q)
+           | Compilers.ident.list_rect A P => @list_rect (base.relax A) (base.relax P)
+           | Compilers.ident.list_case A P => @list_case (base.relax A) (base.relax P)
+           | Compilers.ident.List_length T => @List_length (base.relax T)
+           | Compilers.ident.List_seq => @List_seq
+           | Compilers.ident.List_firstn A => @List_firstn (base.relax A)
+           | Compilers.ident.List_skipn A => @List_skipn (base.relax A)
+           | Compilers.ident.List_repeat A => @List_repeat (base.relax A)
+           | Compilers.ident.List_combine A B => @List_combine (base.relax A) (base.relax B)
+           | Compilers.ident.List_map A B => @List_map (base.relax A) (base.relax B)
+           | Compilers.ident.List_app A => @List_app (base.relax A)
+           | Compilers.ident.List_rev A => @List_rev (base.relax A)
+           | Compilers.ident.List_flat_map A B => @List_flat_map (base.relax A) (base.relax B)
+           | Compilers.ident.List_partition A => @List_partition (base.relax A)
+           | Compilers.ident.List_fold_right A B => @List_fold_right (base.relax A) (base.relax B)
+           | Compilers.ident.List_update_nth T => @List_update_nth (base.relax T)
+           | Compilers.ident.List_nth_default T => @List_nth_default (base.relax T)
+           | Compilers.ident.Z_add => @Z_add
+           | Compilers.ident.Z_mul => @Z_mul
+           | Compilers.ident.Z_pow => @Z_pow
+           | Compilers.ident.Z_sub => @Z_sub
+           | Compilers.ident.Z_opp => @Z_opp
+           | Compilers.ident.Z_div => @Z_div
+           | Compilers.ident.Z_modulo => @Z_modulo
+           | Compilers.ident.Z_log2 => @Z_log2
+           | Compilers.ident.Z_log2_up => @Z_log2_up
+           | Compilers.ident.Z_eqb => @Z_eqb
+           | Compilers.ident.Z_leb => @Z_leb
+           | Compilers.ident.Z_geb => @Z_geb
+           | Compilers.ident.Z_of_nat => @Z_of_nat
+           | Compilers.ident.Z_to_nat => @Z_to_nat
+           | Compilers.ident.Z_shiftr => @Z_shiftr
+           | Compilers.ident.Z_shiftl => @Z_shiftl
+           | Compilers.ident.Z_land => @Z_land
+           | Compilers.ident.Z_lor => @Z_lor
+           | Compilers.ident.Z_bneg => @Z_bneg
+           | Compilers.ident.Z_lnot_modulo => @Z_lnot_modulo
+           | Compilers.ident.Z_mul_split => @Z_mul_split
+           | Compilers.ident.Z_add_get_carry => @Z_add_get_carry
+           | Compilers.ident.Z_add_with_carry => @Z_add_with_carry
+           | Compilers.ident.Z_add_with_get_carry => @Z_add_with_get_carry
+           | Compilers.ident.Z_sub_get_borrow => @Z_sub_get_borrow
+           | Compilers.ident.Z_sub_with_get_borrow => @Z_sub_with_get_borrow
+           | Compilers.ident.Z_zselect => @Z_zselect
+           | Compilers.ident.Z_add_modulo => @Z_add_modulo
+           | Compilers.ident.Z_rshi => @Z_rshi
+           | Compilers.ident.Z_cc_m => @Z_cc_m
+           | Compilers.ident.Z_cast range => @Z_cast
+           | Compilers.ident.Z_cast2 range => @Z_cast2
+           | Compilers.ident.fancy_add log2wordmax imm => @fancy_add
+           | Compilers.ident.fancy_addc log2wordmax imm => @fancy_addc
+           | Compilers.ident.fancy_sub log2wordmax imm => @fancy_sub
+           | Compilers.ident.fancy_subb log2wordmax imm => @fancy_subb
+           | Compilers.ident.fancy_mulll log2wordmax => @fancy_mulll
+           | Compilers.ident.fancy_mullh log2wordmax => @fancy_mullh
+           | Compilers.ident.fancy_mulhl log2wordmax => @fancy_mulhl
+           | Compilers.ident.fancy_mulhh log2wordmax => @fancy_mulhh
+           | Compilers.ident.fancy_rshi log2wordmax x => @fancy_rshi
+           | Compilers.ident.fancy_selc => @fancy_selc
+           | Compilers.ident.fancy_selm log2wordmax => @fancy_selm
+           | Compilers.ident.fancy_sell => @fancy_sell
+           | Compilers.ident.fancy_addm => @fancy_addm
            end.
 
-      Definition retype_ident {t} (idc : Compilers.ident.ident t) : match arg_types (of_typed_ident idc) return Type with Some t => t | None => unit end -> Compilers.ident.ident t
-        := match idc in Compilers.ident.ident t return match arg_types (of_typed_ident idc) return Type with Some t => t | None => unit end -> Compilers.ident.ident t with
-           | Compilers.ident.LiteralUnit v => (fun v => @Compilers.ident.LiteralUnit v) : match arg_types (of_typed_ident (@Compilers.ident.LiteralUnit v)) return Type with Some t => t | None => unit end -> _ (* COQBUG(https://github.com/coq/coq/issues/7726) *)
-           | Compilers.ident.LiteralZ v => (fun v => @Compilers.ident.LiteralZ v) : match arg_types (of_typed_ident (@Compilers.ident.LiteralZ v)) return Type with Some t => t | None => unit end -> _ (* COQBUG(https://github.com/coq/coq/issues/7726) *)
-           | Compilers.ident.LiteralBool v => (fun v => @Compilers.ident.LiteralBool v) : match arg_types (of_typed_ident (@Compilers.ident.LiteralBool v)) return Type with Some t => t | None => unit end -> _ (* COQBUG(https://github.com/coq/coq/issues/7726) *)
-           | Compilers.ident.LiteralNat v => (fun v => @Compilers.ident.LiteralNat v) : match arg_types (of_typed_ident (@Compilers.ident.LiteralNat v)) return Type with Some t => t | None => unit end -> _ (* COQBUG(https://github.com/coq/coq/issues/7726) *)
-           | Compilers.ident.Nat_succ => fun _ => @Compilers.ident.Nat_succ
-           | Compilers.ident.Nat_pred => fun _ => @Compilers.ident.Nat_pred
-           | Compilers.ident.Nat_max => fun _ => @Compilers.ident.Nat_max
-           | Compilers.ident.Nat_mul => fun _ => @Compilers.ident.Nat_mul
-           | Compilers.ident.Nat_add => fun _ => @Compilers.ident.Nat_add
-           | Compilers.ident.Nat_sub => fun _ => @Compilers.ident.Nat_sub
-           | Compilers.ident.nil t => fun _ => @Compilers.ident.nil t
-           | Compilers.ident.cons t => fun _ => @Compilers.ident.cons t
-           | Compilers.ident.pair A B => fun _ => @Compilers.ident.pair A B
-           | Compilers.ident.fst A B => fun _ => @Compilers.ident.fst A B
-           | Compilers.ident.snd A B => fun _ => @Compilers.ident.snd A B
-           | Compilers.ident.prod_rect A B T => fun _ => @Compilers.ident.prod_rect A B T
-           | Compilers.ident.bool_rect T => fun _ => @Compilers.ident.bool_rect T
-           | Compilers.ident.nat_rect P => fun _ => @Compilers.ident.nat_rect P
-           | Compilers.ident.nat_rect_arrow P Q => fun _ => @Compilers.ident.nat_rect_arrow P Q
-           | Compilers.ident.list_rect A P => fun _ => @Compilers.ident.list_rect A P
-           | Compilers.ident.list_case A P => fun _ => @Compilers.ident.list_case A P
-           | Compilers.ident.List_length T => fun _ => @Compilers.ident.List_length T
-           | Compilers.ident.List_seq => fun _ => @Compilers.ident.List_seq
-           | Compilers.ident.List_firstn A => fun _ => @Compilers.ident.List_firstn A
-           | Compilers.ident.List_skipn A => fun _ => @Compilers.ident.List_skipn A
-           | Compilers.ident.List_repeat A => fun _ => @Compilers.ident.List_repeat A
-           | Compilers.ident.List_combine A B => fun _ => @Compilers.ident.List_combine A B
-           | Compilers.ident.List_map A B => fun _ => @Compilers.ident.List_map A B
-           | Compilers.ident.List_app A => fun _ => @Compilers.ident.List_app A
-           | Compilers.ident.List_rev A => fun _ => @Compilers.ident.List_rev A
-           | Compilers.ident.List_flat_map A B => fun _ => @Compilers.ident.List_flat_map A B
-           | Compilers.ident.List_partition A => fun _ => @Compilers.ident.List_partition A
-           | Compilers.ident.List_fold_right A B => fun _ => @Compilers.ident.List_fold_right A B
-           | Compilers.ident.List_update_nth T => fun _ => @Compilers.ident.List_update_nth T
-           | Compilers.ident.List_nth_default T => fun _ => @Compilers.ident.List_nth_default T
-           | Compilers.ident.Z_add => fun _ => @Compilers.ident.Z_add
-           | Compilers.ident.Z_mul => fun _ => @Compilers.ident.Z_mul
-           | Compilers.ident.Z_pow => fun _ => @Compilers.ident.Z_pow
-           | Compilers.ident.Z_sub => fun _ => @Compilers.ident.Z_sub
-           | Compilers.ident.Z_opp => fun _ => @Compilers.ident.Z_opp
-           | Compilers.ident.Z_div => fun _ => @Compilers.ident.Z_div
-           | Compilers.ident.Z_modulo => fun _ => @Compilers.ident.Z_modulo
-           | Compilers.ident.Z_log2 => fun _ => @Compilers.ident.Z_log2
-           | Compilers.ident.Z_log2_up => fun _ => @Compilers.ident.Z_log2_up
-           | Compilers.ident.Z_eqb => fun _ => @Compilers.ident.Z_eqb
-           | Compilers.ident.Z_leb => fun _ => @Compilers.ident.Z_leb
-           | Compilers.ident.Z_geb => fun _ => @Compilers.ident.Z_geb
-           | Compilers.ident.Z_of_nat => fun _ => @Compilers.ident.Z_of_nat
-           | Compilers.ident.Z_to_nat => fun _ => @Compilers.ident.Z_to_nat
-           | Compilers.ident.Z_shiftr => fun _ => @Compilers.ident.Z_shiftr
-           | Compilers.ident.Z_shiftl => fun _ => @Compilers.ident.Z_shiftl
-           | Compilers.ident.Z_land => fun _ => @Compilers.ident.Z_land
-           | Compilers.ident.Z_lor => fun _ => @Compilers.ident.Z_lor
-           | Compilers.ident.Z_bneg => fun _ => @Compilers.ident.Z_bneg
-           | Compilers.ident.Z_lnot_modulo => fun _ => @Compilers.ident.Z_lnot_modulo
-           | Compilers.ident.Z_mul_split => fun _ => @Compilers.ident.Z_mul_split
-           | Compilers.ident.Z_add_get_carry => fun _ => @Compilers.ident.Z_add_get_carry
-           | Compilers.ident.Z_add_with_carry => fun _ => @Compilers.ident.Z_add_with_carry
-           | Compilers.ident.Z_add_with_get_carry => fun _ => @Compilers.ident.Z_add_with_get_carry
-           | Compilers.ident.Z_sub_get_borrow => fun _ => @Compilers.ident.Z_sub_get_borrow
-           | Compilers.ident.Z_sub_with_get_borrow => fun _ => @Compilers.ident.Z_sub_with_get_borrow
-           | Compilers.ident.Z_zselect => fun _ => @Compilers.ident.Z_zselect
-           | Compilers.ident.Z_add_modulo => fun _ => @Compilers.ident.Z_add_modulo
-           | Compilers.ident.Z_rshi => fun _ => @Compilers.ident.Z_rshi
-           | Compilers.ident.Z_cc_m => fun _ => @Compilers.ident.Z_cc_m
-           | Compilers.ident.Z_cast range => fun range => @Compilers.ident.Z_cast range
-           | Compilers.ident.Z_cast2 range => fun range => @Compilers.ident.Z_cast2 range
-           | Compilers.ident.fancy_add log2wordmax imm => fun arg => let '(log2wordmax, imm) := eta2 arg in @Compilers.ident.fancy_add log2wordmax imm
-           | Compilers.ident.fancy_addc log2wordmax imm => fun arg => let '(log2wordmax, imm) := eta2 arg in @Compilers.ident.fancy_addc log2wordmax imm
-           | Compilers.ident.fancy_sub log2wordmax imm => fun arg => let '(log2wordmax, imm) := eta2 arg in @Compilers.ident.fancy_sub log2wordmax imm
-           | Compilers.ident.fancy_subb log2wordmax imm => fun arg => let '(log2wordmax, imm) := eta2 arg in @Compilers.ident.fancy_subb log2wordmax imm
-           | Compilers.ident.fancy_mulll log2wordmax => fun log2wordmax => @Compilers.ident.fancy_mulll log2wordmax
-           | Compilers.ident.fancy_mullh log2wordmax => fun log2wordmax => @Compilers.ident.fancy_mullh log2wordmax
-           | Compilers.ident.fancy_mulhl log2wordmax => fun log2wordmax => @Compilers.ident.fancy_mulhl log2wordmax
-           | Compilers.ident.fancy_mulhh log2wordmax => fun log2wordmax => @Compilers.ident.fancy_mulhh log2wordmax
-           | Compilers.ident.fancy_rshi log2wordmax x => fun arg => let '(log2wordmax, x) := eta2 arg in @Compilers.ident.fancy_rshi log2wordmax x
-           | Compilers.ident.fancy_selc => fun _ => @Compilers.ident.fancy_selc
-           | Compilers.ident.fancy_selm log2wordmax => fun log2wordmax => @Compilers.ident.fancy_selm log2wordmax
-           | Compilers.ident.fancy_sell => fun _ => @Compilers.ident.fancy_sell
-           | Compilers.ident.fancy_addm => fun _ => @Compilers.ident.fancy_addm
-           end.
-
-
-      (*===*)
     End ident.
+
+    (*===*)
+
   End pattern.
 End Compilers.

--- a/src/Experiments/NewPipeline/GENERATEDIdentifiersWithoutTypesProofs.v
+++ b/src/Experiments/NewPipeline/GENERATEDIdentifiersWithoutTypesProofs.v
@@ -14,65 +14,101 @@ Module Compilers.
 
   Module pattern.
     Import GENERATEDIdentifiersWithoutTypes.Compilers.pattern.
+
+    Local Lemma quick_invert_eq_option {A} (P : Type) (x y : option A) (H : x = y)
+      : match x, y return Type with
+        | Some _, None => P
+        | None, Some _ => P
+        | _, _ => True
+        end.
+    Proof. subst y; destruct x; constructor. Qed.
+
+    Local Lemma quick_invert_neq_option {A} (P : Type) (x y : option A) (H : x <> y)
+      : match x, y return Type with
+        | Some _, None => True
+        | None, Some _ => True
+        | None, None => P
+        | Some x, Some y => x <> y
+        end.
+    Proof. destruct x, y; try congruence; trivial. Qed.
+
+    Local Lemma Some_neq_None {A x} : @Some A x <> None. Proof. congruence. Qed.
+
+    Module Raw.
+      Module ident.
+        Import GENERATEDIdentifiersWithoutTypes.Compilers.pattern.Raw.ident.
+
+        Global Instance eq_ident_Decidable : DecidableRel (@eq ident) := ident_eq_dec.
+
+        Lemma to_typed_invert_bind_args_gen t idc p f
+          : @invert_bind_args t idc p = Some f
+            -> { pf : t = type_of p f | @to_typed p f = rew [Compilers.ident.ident] pf in idc }.
+        Proof.
+          cbv [invert_bind_args type_of full_types].
+          repeat first [ reflexivity
+                       | (exists eq_refl)
+                       | progress intros
+                       | match goal with
+                         | [ H : Some _ = None |- ?P ] => exact (@quick_invert_eq_option _ P _ _ H)
+                         | [ H : None = Some _ |- ?P ] => exact (@quick_invert_eq_option _ P _ _ H)
+                         end
+                       | progress inversion_option
+                       | progress subst
+                       | break_innermost_match_step
+                       | break_innermost_match_hyps_step ].
+        Qed.
+
+        Lemma type_of_invert_bind_args t idc p f
+          : @invert_bind_args t idc p = Some f -> t = type_of p f.
+        Proof.
+          intro pf; exact (proj1_sig (@to_typed_invert_bind_args_gen t idc p f pf)).
+        Defined.
+
+        Lemma to_typed_invert_bind_args t idc p f (pf : @invert_bind_args t idc p = Some f)
+          : @to_typed p f = rew [Compilers.ident.ident] @type_of_invert_bind_args t idc p f pf in idc.
+        Proof.
+          exact (proj2_sig (@to_typed_invert_bind_args_gen t idc p f pf)).
+        Defined.
+
+        Lemma is_simple_correct p
+          : is_simple p = true
+            <-> (forall t1 idc1 t2 idc2, @invert_bind_args t1 idc1 p <> None -> @invert_bind_args t2 idc2 p <> None -> t1 = t2).
+        Proof.
+          split; intro H;
+            [ | specialize (fun f1 f2 => H _ (@to_typed p f1) _ (@to_typed p f2)) ];
+            destruct p; cbn in *; try solve [ reflexivity | exfalso; discriminate ];
+              repeat first [ progress intros *
+                           | match goal with
+                             | [ |- ?x = ?x ] => reflexivity
+                             | [ |- ?x = ?x -> _ ] => intros _
+                             | [ |- None <> None -> ?P ] => exact (@quick_invert_neq_option _ P None None)
+                             | [ |- Some _ <> None -> _ ] => intros _
+                             | [ |- None <> Some _ -> _ ] => intros _
+                             | [ H : forall x y, Some _ <> None -> _ |- _ ] => specialize (fun x y => H x y Some_neq_None)
+                             | [ H : nat -> ?A |- _ ] => specialize (H O)
+                             | [ H : unit -> ?A |- _ ] => specialize (H tt)
+                             | [ H : forall x y : Datatypes.prod _ _, _ |- _ ] => specialize (fun x1 y1 x2 y2 => H (Datatypes.pair x1 x2) (Datatypes.pair y1 y2)); cbn in H
+                             | [ H : forall x y : PrimitiveSigma.Primitive.sigT ?P, _ |- _ ] => specialize (fun x1 y1 x2 y2 => H (PrimitiveSigma.Primitive.existT P x1 x2) (PrimitiveSigma.Primitive.existT P y1 y2)); cbn in H
+                             | [ H : forall x y : Compilers.base.type, _ |- _ ] => specialize (fun x y => H (Compilers.base.type.type_base x) (Compilers.base.type.type_base y))
+                             | [ H : forall x y : Compilers.base.type.base, _ |- _ ] => specialize (H Compilers.base.type.unit Compilers.base.type.nat); try congruence; cbn in H
+                             end
+                           | break_innermost_match_step
+                           | congruence ].
+        Qed.
+      End ident.
+    End Raw.
+
     Module ident.
       Import GENERATEDIdentifiersWithoutTypes.Compilers.pattern.ident.
-
-      Local Lemma quick_invert_eq_option {A} (P : Type) (x y : option A) (H : x = y)
-        : match x, y return Type with
-          | Some _, None => P
-          | None, Some _ => P
-          | _, _ => True
-          end.
-      Proof. subst y; destruct x; constructor. Qed.
 
       Lemma eta_ident_cps_correct T t idc f
         : @eta_ident_cps T t idc f = f t idc.
       Proof. cbv [eta_ident_cps]; break_innermost_match; reflexivity. Qed.
 
-      Lemma to_typed_invert_bind_args_gen t idc p f
-        : @invert_bind_args t idc p = Some f
-          -> { pf : t = type_of p f | @to_typed p f = rew [Compilers.ident.ident] pf in idc }.
-      Proof.
-        cbv [invert_bind_args type_of full_types].
-        repeat first [ reflexivity
-                     | (exists eq_refl)
-                     | progress intros
-                     | match goal with
-                       | [ H : Some _ = None |- ?P ] => exact (@quick_invert_eq_option _ P _ _ H)
-                       | [ H : None = Some _ |- ?P ] => exact (@quick_invert_eq_option _ P _ _ H)
-                       end
-                     | progress inversion_option
-                     | progress subst
-                     | break_innermost_match_step
-                     | break_innermost_match_hyps_step ].
-      Qed.
-
-      Lemma type_of_invert_bind_args t idc p f
-        : @invert_bind_args t idc p = Some f -> t = type_of p f.
-      Proof.
-        intro pf; exact (proj1_sig (@to_typed_invert_bind_args_gen t idc p f pf)).
-      Defined.
-
-      Lemma to_typed_invert_bind_args t idc p f (pf : @invert_bind_args t idc p = Some f)
-        : @to_typed p f = rew [Compilers.ident.ident] @type_of_invert_bind_args t idc p f pf in idc.
-      Proof.
-        exact (proj2_sig (@to_typed_invert_bind_args_gen t idc p f pf)).
-      Defined.
-
-      Lemma try_make_transport_ident_cps_correct P idc1 idc2 T k
-        : try_make_transport_ident_cps P idc1 idc2 T k
-          = k (match Sumbool.sumbool_of_bool (ident_beq idc1 idc2) with
-               | left pf => Some (fun v => rew [P] internal_ident_dec_bl _ _ pf in v)
-               | right _ => None
-               end).
-      Proof.
-        destruct (Sumbool.sumbool_of_bool (ident_beq idc1 idc2)) as [pf|pf].
-        { generalize (internal_ident_dec_bl idc1 idc2 pf); clear pf; intro; subst idc2; cbn [eq_rect].
-          destruct idc1; reflexivity. }
-        { destruct idc1, idc2; try reflexivity; solve [ inversion pf ]. }
-      Qed.
-
-      Global Instance eq_ident_Decidable : DecidableRel (@eq pattern.ident.ident) := pattern.ident.ident_eq_dec.
+      Lemma is_simple_strip_types_iff_type_vars_nil {t} idc
+        : Raw.ident.is_simple (@strip_types t idc) = true
+          <-> type_vars idc = List.nil.
+      Proof. destruct idc; cbn; intuition congruence. Qed.
     End ident.
   End pattern.
 End Compilers.

--- a/src/Experiments/NewPipeline/Rewriter.v
+++ b/src/Experiments/NewPipeline/Rewriter.v
@@ -1,4 +1,6 @@
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.FSets.FMapPositive.
+Require Import Coq.MSets.MSetPositive.
 Require Import Crypto.Util.ListUtil Coq.Lists.List Crypto.Util.ListUtil.FoldBool.
 Require Import Crypto.Util.Option.
 Require Import Crypto.Util.OptionList.
@@ -12,64 +14,377 @@ Require Import Crypto.Util.LetIn.
 Require Import Crypto.Util.Notations.
 Import ListNotations. Local Open Scope bool_scope. Local Open Scope Z_scope.
 
+Local Set Primitive Projections.
+Import EqNotations.
 Module Compilers.
   Export Language.Compilers.
   Export UnderLets.Compilers.
   Export GENERATEDIdentifiersWithoutTypes.Compilers.
   Import invert_expr.
 
+  Notation EvarMap := (PositiveMap.t Compilers.base.type).
   Module pattern.
     Export GENERATEDIdentifiersWithoutTypes.Compilers.pattern.
 
     Module base.
-      Local Notation einterp := type.interp.
-      Module type.
-        Inductive type := any | type_base (t : Compilers.base.type.base) | prod (A B : type) | list (A : type).
-      End type.
-      Notation type := type.type.
+      Import GENERATEDIdentifiersWithoutTypes.Compilers.pattern.base.
 
-      Module Notations.
-        Global Coercion type.type_base : Compilers.base.type.base >-> type.type.
-        Bind Scope pbtype_scope with type.type.
-        (*Bind Scope ptype_scope with Compilers.type.type type.type.*) (* COQBUG(https://github.com/coq/coq/issues/7699) *)
-        Delimit Scope ptype_scope with ptype.
-        Delimit Scope pbtype_scope with pbtype.
-        Notation "A * B" := (type.prod A%ptype B%ptype) : ptype_scope.
-        Notation "A * B" := (type.prod A%pbtype B%pbtype) : pbtype_scope.
-        Notation "()" := (type.type_base base.type.unit) : pbtype_scope.
-        Notation "()" := (type.base (type.type_base base.type.unit)) : ptype_scope.
-        Notation "A -> B" := (type.arrow A%ptype B%ptype) : ptype_scope.
-        Notation "??" := type.any : pbtype_scope.
-        Notation "??" := (type.base type.any) : ptype_scope.
-      End Notations.
+      Fixpoint partial_subst (ptype : type) (evar_map : EvarMap) : type
+        := match ptype with
+           | type.var p => match PositiveMap.find p evar_map with
+                           | Some t => relax t
+                           | None => type.var p
+                           end
+           | type.type_base t => type.type_base t
+           | type.prod A B => type.prod (partial_subst A evar_map) (partial_subst B evar_map)
+           | type.list A => type.list (partial_subst A evar_map)
+           end.
+
+      Fixpoint subst (ptype : type) (evar_map : EvarMap) : option Compilers.base.type
+        := match ptype with
+           | type.var p => PositiveMap.find p evar_map
+           | type.type_base t => Some (Compilers.base.type.type_base t)
+           | type.prod A B
+             => (A' <- subst A evar_map;
+                   B' <- subst B evar_map;
+                   Some (Compilers.base.type.prod A' B'))
+           | type.list A => option_map Compilers.base.type.list (subst A evar_map)
+           end%option.
+
+      Fixpoint subst_default (ptype : type) (evar_map : EvarMap) : Compilers.base.type
+        := match ptype with
+           | type.var p => match PositiveMap.find p evar_map with
+                           | Some t => t
+                           | None => Compilers.base.type.type_base base.type.unit
+                           end
+           | type.type_base t => Compilers.base.type.type_base t
+           | type.prod A B
+             => Compilers.base.type.prod (subst_default A evar_map) (subst_default B evar_map)
+           | type.list A => Compilers.base.type.list (subst_default A evar_map)
+           end.
+
+      Fixpoint subst_default_relax P {t evm} : P t -> P (subst_default (relax t) evm)
+        := match t return P t -> P (subst_default (relax t) evm) with
+           | Compilers.base.type.type_base t => fun x => x
+           | Compilers.base.type.prod A B
+             => fun v
+                => @subst_default_relax
+                     (fun A' => P (Compilers.base.type.prod A' _)) A evm
+                     (@subst_default_relax
+                        (fun B' => P (Compilers.base.type.prod _ B')) B evm
+                        v)
+           | Compilers.base.type.list A
+             => @subst_default_relax (fun t => P (Compilers.base.type.list t)) A evm
+           end.
+
+      Fixpoint var_types_of (t : type) : Set
+        := match t with
+           | type.var _ => Compilers.base.type
+           | type.type_base _ => unit
+           | type.prod A B => var_types_of A * var_types_of B
+           | type.list A => var_types_of A
+           end%type.
+
+      Fixpoint add_var_types_cps {t : type} (v : var_types_of t) (evm : EvarMap) : ~> EvarMap
+        := fun T k
+           => match t return var_types_of t -> T with
+              | type.var p => fun t => k (PositiveMap.add p t evm)
+              | type.prod A B
+                => fun '(a, b) => @add_var_types_cps A a evm _ (fun evm => @add_var_types_cps B b evm _ k)
+              | type.list A => fun t => @add_var_types_cps A t evm _ k
+              | type.type_base _ => fun _ => k evm
+              end v.
+
+      Fixpoint unify_extracted_cps
+               (ptype : type) (etype : Compilers.base.type)
+        : ~> option (var_types_of ptype)
+        := match ptype return ~> option (var_types_of ptype) with
+           | type.var p => fun T k => k (Some etype)
+           | type.type_base t
+             => fun T k
+                => match etype with
+                   | Compilers.base.type.type_base t'
+                     => if base.type.base_beq t t'
+                        then k (Some tt)
+                        else k None
+                   | _ => k None
+                   end
+           | type.prod A B
+             => fun T k
+                => match etype with
+                   | Compilers.base.type.prod A' B'
+                     => unify_extracted_cps
+                          A A' _
+                          (fun a
+                           => match a with
+                              | Some a
+                                => unify_extracted_cps
+                                     B B' _
+                                     (fun b
+                                      => match b with
+                                         | Some b => k (Some (a, b))
+                                         | None => k None
+                                         end)
+                              | None => k None
+                              end)
+                   | _ => k None
+                   end
+           | type.list A
+             => fun T k
+                => match etype with
+                   | Compilers.base.type.list A'
+                     => unify_extracted_cps A A' _ k
+                   | _ => k None
+                   end
+           end%cps.
+
+      Fixpoint collect_vars (t : type) : PositiveSet.t
+        := match t with
+           | type.var p => PositiveSet.add p PositiveSet.empty
+           | type.type_base t => PositiveSet.empty
+           | type.prod A B => PositiveSet.union (collect_vars A) (collect_vars B)
+           | type.list A => collect_vars A
+           end.
     End base.
-    Notation type := (type.type base.type).
-    Export base.Notations.
 
-    Inductive pattern {ident : Type} :=
-    | Wildcard (t : type)
-    | Ident (idc : ident)
-    | App (f x : pattern).
+    Module type.
+      Fixpoint partial_subst (ptype : type) (evar_map : EvarMap) : type
+        := match ptype with
+           | type.base t => type.base (base.partial_subst t evar_map)
+           | type.arrow s d => type.arrow (partial_subst s evar_map) (partial_subst d evar_map)
+           end.
+
+      Fixpoint subst (ptype : type) (evar_map : EvarMap) : option (type.type Compilers.base.type)
+        := match ptype with
+           | type.base t => option_map type.base (base.subst t evar_map)
+           | type.arrow s d
+             => (s' <- subst s evar_map;
+                   d' <- subst d evar_map;
+                   Some (type.arrow s' d'))
+           end%option.
+
+      Fixpoint subst_default (ptype : type) (evar_map : EvarMap) : type.type Compilers.base.type
+        := match ptype with
+           | type.base t => type.base (base.subst_default t evar_map)
+           | type.arrow A B => type.arrow (subst_default A evar_map) (subst_default B evar_map)
+           end.
+
+      Fixpoint subst_default_relax P {t evm} : P t -> P (subst_default (type.relax t) evm)
+        := match t return P t -> P (subst_default (type.relax t) evm) with
+           | type.base t => base.subst_default_relax (fun t => P (type.base t))
+           | type.arrow A B
+             => fun v
+                => @subst_default_relax
+                     (fun A' => P (type.arrow A' _)) A evm
+                     (@subst_default_relax
+                        (fun B' => P (type.arrow _ B')) B evm
+                        v)
+           end.
+
+      Fixpoint var_types_of (t : type) : Set
+        := match t with
+           | type.base t => base.var_types_of t
+           | type.arrow s d => var_types_of s * var_types_of d
+           end%type.
+
+      Fixpoint add_var_types_cps {t : type} (v : var_types_of t) (evm : EvarMap) : ~> EvarMap
+        := fun T k
+           => match t return var_types_of t -> T with
+              | type.base t => fun v => @base.add_var_types_cps t v evm _ k
+              | type.arrow A B
+                => fun '(a, b) => @add_var_types_cps A a evm _ (fun evm => @add_var_types_cps B b evm _ k)
+              end v.
+
+      Fixpoint unify_extracted_cps
+               (ptype : type) (etype : type.type Compilers.base.type)
+        : ~> option (var_types_of ptype)
+        := match ptype return ~> option (var_types_of ptype) with
+           | type.base t
+             => fun T k
+                => match etype with
+                   | type.base t' => base.unify_extracted_cps t t' T k
+                   | type.arrow _ _ => k None
+                   end
+           | type.arrow A B
+             => fun T k
+                => match etype with
+                   | type.arrow A' B'
+                     => unify_extracted_cps
+                          A A' _
+                          (fun a
+                           => match a with
+                              | Some a
+                                => unify_extracted_cps
+                                     B B' _
+                                     (fun b
+                                      => match b with
+                                         | Some b => k (Some (a, b))
+                                         | None => k None
+                                         end)
+                              | None => k None
+                              end)
+                   | type.base _ => k None
+                   end
+           end%cps.
+
+      Notation unify_extracted ptype etype := (unify_extracted_cps ptype etype _ id).
+
+      Fixpoint collect_vars (t : type) : PositiveSet.t
+        := match t with
+           | type.base t => base.collect_vars t
+           | type.arrow s d => PositiveSet.union (collect_vars s) (collect_vars d)
+           end.
+
+      Local Notation forall_vars_body K LS EVM0
+        := (fold_right
+              (fun i k evm => forall t : Compilers.base.type, k (PositiveMap.add i t evm))
+              K
+              LS
+              EVM0).
+
+      Definition forall_vars (p : PositiveSet.t) (k : EvarMap -> Type)
+        := forall_vars_body k (List.rev (PositiveSet.elements p)) (PositiveMap.empty _).
+
+      Definition under_forall_vars {p k1 k2}
+                 (F : forall evm, k1 evm -> k2 evm)
+        : forall_vars p k1 -> forall_vars p k2
+        := list_rect
+             (fun ls
+              => forall evm0, forall_vars_body k1 ls evm0 -> forall_vars_body k2 ls evm0)
+             F
+             (fun x xs rec evm0 K1 t => rec _ (K1 t))
+             (List.rev (PositiveSet.elements p))
+             (PositiveMap.empty _).
+
+      Definition under_forall_vars_relation {p k1 k2}
+                 (F : forall evm, k1 evm -> k2 evm -> Prop)
+        : forall_vars p k1 -> forall_vars p k2 -> Prop
+        := list_rect
+             (fun ls
+              => forall evm0, forall_vars_body k1 ls evm0 -> forall_vars_body k2 ls evm0 -> Prop)
+             F
+             (fun x xs rec evm0 K1 K2 => forall t, rec _ (K1 t) (K2 t))
+             (List.rev (PositiveSet.elements p))
+             (PositiveMap.empty _).
+
+      Definition app_forall_vars {p : PositiveSet.t} {k : EvarMap -> Type}
+                 (f : forall_vars p k)
+                 (evm : EvarMap)
+        : option (k (fold_right (fun i k evm'
+                                 => k (match PositiveMap.find i evm with Some v => PositiveMap.add i v evm' | None => evm' end))
+                                (fun evm => evm)
+                                (List.rev (PositiveSet.elements p))
+                                (PositiveMap.empty _)))
+        := list_rect
+             (fun ls
+              => forall evm0, forall_vars_body k ls evm0
+                  -> option (k (fold_right (fun i k evm'
+                                            => k (match PositiveMap.find i evm with Some v => PositiveMap.add i v evm' | None => evm' end))
+                                           (fun evm => evm)
+                                           ls
+                                           evm0)))
+             (fun evm0 val => Some val)
+             (fun x xs rec
+              => match PositiveMap.find x evm as xt
+                       return (forall evm0,
+                                  (forall t, fold_right _ k xs (PositiveMap.add x t evm0))
+                                  -> option (k (fold_right
+                                                  _ _ xs
+                                                  match xt with
+                                                  | Some v => PositiveMap.add x v evm0
+                                                  | None => evm0
+                                                  end)))
+                 with
+                 | Some v => fun evm0 val => rec _ (val v)
+                 | None => fun evm0 val => None
+                 end)
+             (List.rev (PositiveSet.elements p))
+             (PositiveMap.empty _)
+             f.
+
+      Definition lam_forall_vars {p : PositiveSet.t} {k : EvarMap -> Type}
+                 (f : forall evm, k evm)
+        : forall_vars p k
+        := list_rect
+             (fun ls => forall evm0, forall_vars_body k ls evm0)
+             f
+             (fun x xs rec evm t => rec _)
+             _
+             _.
+    End type.
+
+    Inductive pattern {ident : type -> Type} : type -> Type :=
+    | Wildcard (t : type) : pattern t
+    | Ident {t} (idc : ident t) : pattern t
+    | App {s d} (f : pattern (s -> d)) (x : pattern s) : pattern d.
+
+    Record > anypattern {ident : type -> Type}
+      := { type_of_anypattern : type;
+           pattern_of_anypattern :> @pattern ident type_of_anypattern }.
+
+    Module Raw.
+      Inductive pattern {ident : Type} :=
+      | Wildcard
+      | Ident (idc : ident)
+      | App (f x : pattern).
+    End Raw.
 
     Global Arguments Wildcard {ident%type} t%ptype.
 
+    Fixpoint to_raw {ident raw_ident}
+             {to_raw_ident : forall t, ident t -> raw_ident}
+             {t} (p : @pattern ident t) : @Raw.pattern raw_ident
+      := match p with
+         | Wildcard t => Raw.Wildcard
+         | Ident t idc => Raw.Ident (to_raw_ident t idc)
+         | App s d f x => Raw.App (@to_raw _ _ to_raw_ident _ f) (@to_raw _ _ to_raw_ident _ x)
+         end.
+
+    Fixpoint collect_vars {ident} {ident_collect_vars : forall t, ident t -> PositiveSet.t}
+             {t} (p : @pattern ident t) : PositiveSet.t
+      := match p with
+         | Wildcard t => type.collect_vars t
+         | Ident t idc => ident_collect_vars t idc
+         | App s d f x => PositiveSet.union (@collect_vars _ ident_collect_vars _ x) (@collect_vars _ ident_collect_vars _ f)
+         end.
+
     Notation ident := ident.ident.
+
+    Fixpoint unify_list {A B} (unif : A -> B -> EvarMap -> option EvarMap) (ls1 : list A) (ls2 : list B) (evm : EvarMap)
+      : option EvarMap
+      := match ls1, ls2 with
+         | nil, nil => Some evm
+         | cons x xs, cons y ys
+           => (evm <- unif x y evm;
+                @unify_list A B unif xs ys evm)%option
+         | nil, _
+         | cons _ _, _
+           => None
+         end.
 
     Module Export Notations.
       Export base.Notations.
       Delimit Scope pattern_scope with pattern.
       Bind Scope pattern_scope with pattern.
       Local Open Scope pattern_scope.
-      Notation "#?()" := (Ident ident.LiteralUnit) : pattern_scope.
-      Notation "#?N" := (Ident ident.LiteralNat) : pattern_scope.
-      Notation "#?ℕ" := (Ident ident.LiteralNat) : pattern_scope.
-      Notation "#?Z" := (Ident ident.LiteralZ) : pattern_scope.
-      Notation "#?ℤ" := (Ident ident.LiteralZ) : pattern_scope.
-      Notation "#?B" := (Ident ident.LiteralBool) : pattern_scope.
-      Notation "#?𝔹" := (Ident ident.LiteralBool) : pattern_scope.
-      Notation "??{ t }" := (Wildcard t) (format "??{ t }") : pattern_scope.
-      Notation "??" := (??{??})%pattern : pattern_scope.
       Notation "# idc" := (Ident idc) : pattern_scope.
+      Notation "#?" := (Ident (@ident.Literal _)) : pattern_scope.
+      Notation "#?{ t }" := (Ident (@ident.Literal t)) (format "#?{ t }") : pattern_scope.
+      Notation "#?()" := (#?{base.type.unit}) : pattern_scope.
+      Notation "#?N" := (#?{base.type.nat}) : pattern_scope.
+      Notation "#?ℕ" := (#?{base.type.nat}) : pattern_scope.
+      Notation "#?Z" := (#?{base.type.Z}) : pattern_scope.
+      Notation "#?ℤ" := (#?{base.type.Z}) : pattern_scope.
+      Notation "#?B" := (#?{base.type.bool}) : pattern_scope.
+      Notation "#?𝔹" := (#?{base.type.bool}) : pattern_scope.
+      Notation "??" := (Wildcard _) : pattern_scope.
+      Notation "??{ t }" := (Wildcard t) (format "??{ t }") : pattern_scope.
+      Notation "' n" := (??{' n})%pattern : pattern_scope.
+      Notation "'1" := (' 1) : pattern_scope.
+      Notation "'2" := (' 2) : pattern_scope.
+      Notation "'3" := (' 3) : pattern_scope.
+      Notation "'4" := (' 4) : pattern_scope.
+      Notation "'5" := (' 5) : pattern_scope.
       Infix "@" := App : pattern_scope.
       Notation "( x , y , .. , z )" := (#ident.pair @ .. (#ident.pair @ x @ y) .. @ z) : pattern_scope.
       Notation "x :: xs" := (#ident.cons @ x @ xs) : pattern_scope.
@@ -92,12 +407,6 @@ Module Compilers.
   Notation pattern := (@pattern.pattern pattern.ident).
 
   Module RewriteRules.
-    Module Import AnyExpr.
-      Record anyexpr {base_type} {ident var : type.type base_type -> Type}
-        := wrap { anyexpr_ty : base_type ; unwrap :> @expr.expr base_type ident var (type.base anyexpr_ty) }.
-      Global Arguments wrap {base_type ident var _} _.
-    End AnyExpr.
-
     Module Compile.
       Section with_var0.
         Context {base_type} {ident var : type.type base_type -> Type}.
@@ -137,27 +446,35 @@ Module Compilers.
              | type.base _ => fun e k => e <--- e; k e
              end%under_lets.
       End with_var0.
+      Local Notation EvarMap := pattern.EvarMap.
       Section with_var.
+        Local Notation type_of_list
+          := (fold_right (fun a b => prod a b) unit).
+        Local Notation type_of_list_cps
+          := (fold_right (fun a K => a -> K)).
         Context {ident var : type.type base.type -> Type}
-                {pident : Type}
-                (*(invert_Literal_cps : forall t, ident t ~> option (type.interp base.interp t))*)
-                (*(beq_typed : forall t (X : pident) (Y : ident t), bool)*)
-                (full_types : pident -> Type)
-                (invert_bind_args : forall t (idc : ident t) (pidc : pident), option (full_types pidc))
-                (type_of_pident : forall (pidc : pident), full_types pidc -> type.type base.type)
-                (pident_to_typed : forall (pidc : pident) (args : full_types pidc), ident (type_of_pident pidc args))
                 (eta_ident_cps : forall {T : type.type base.type -> Type} {t} (idc : ident t)
                                         (f : forall t', ident t' -> T t'),
                     T t)
-                (of_typed_ident : forall {t}, ident t -> pident)
-                (arg_types : pident -> option Type)
-                (bind_args : forall {t} (idc : ident t), match arg_types (of_typed_ident idc) return Type with Some t => t | None => unit end)
-                (pident_beq : pident -> pident -> bool)
-                (try_make_transport_ident_cps : forall (P : pident -> Type) (idc1 idc2 : pident), ~> option (P idc1 -> P idc2)).
+                {pident : type.type pattern.base.type -> Type}
+                (pident_arg_types : forall t, pident t -> list Type)
+                (pident_unify pident_unify_unknown : forall t t' (idc : pident t) (idc' : ident t'), option (type_of_list (pident_arg_types t idc)))
+                {raw_pident : Type}
+                (strip_types : forall t, pident t -> raw_pident)
+                (raw_pident_beq : raw_pident -> raw_pident -> bool)
+                (type_vars_of_pident : forall t, pident t -> list (type.type pattern.base.type))
+
+                (full_types : raw_pident -> Type)
+                (invert_bind_args invert_bind_args_unknown : forall t (idc : ident t) (pidc : raw_pident), option (full_types pidc))
+                (type_of_raw_pident : forall (pidc : raw_pident), full_types pidc -> type.type base.type)
+                (raw_pident_to_typed : forall (pidc : raw_pident) (args : full_types pidc), ident (type_of_raw_pident pidc args))
+                (raw_pident_is_simple : raw_pident -> bool).
+
         Local Notation type := (type.type base.type).
         Local Notation expr := (@expr.expr base.type ident var).
-        Local Notation anyexpr := (@anyexpr ident var).
         Local Notation pattern := (@pattern.pattern pident).
+        Local Notation rawpattern := (@pattern.Raw.pattern raw_pident).
+        Local Notation anypattern := (@pattern.anypattern pident).
         Local Notation UnderLets := (@UnderLets.UnderLets base.type ident var).
         Local Notation ptype := (type.type pattern.base.type).
         Local Notation value' := (@value' base.type ident var).
@@ -166,10 +483,31 @@ Module Compilers.
         Local Notation Base_value := (@Base_value base.type ident var).
         Local Notation splice_under_lets_with_value := (@splice_under_lets_with_value base.type ident var).
         Local Notation splice_value_with_lets := (@splice_value_with_lets base.type ident var).
+        Local Notation to_raw_pattern := (@pattern.to_raw pident raw_pident (@strip_types)).
         Let type_base (t : base.type) : type := type.base t.
         Coercion type_base : base.type >-> type.
 
         Context (reify_and_let_binds_base_cps : forall (t : base.type), expr t -> forall T, (expr t -> UnderLets T) -> UnderLets T).
+
+        Definition under_type_of_list_cps {A1 A2 ls}
+                   (F : A1 -> A2)
+          : type_of_list_cps A1 ls -> type_of_list_cps A2 ls
+          := list_rect
+               (fun ls
+                => type_of_list_cps A1 ls -> type_of_list_cps A2 ls)
+               F
+               (fun T Ts rec f x => rec (f x))
+               ls.
+
+        Definition app_type_of_list {K} {ls : list Type} (f : type_of_list_cps K ls) (args : type_of_list ls) : K
+          := list_rect
+               (fun ls
+                => type_of_list_cps K ls -> type_of_list ls -> K)
+               (fun v _ => v)
+               (fun T Ts rec f x
+                => rec (f (fst x)) (snd x))
+               ls
+               f args.
 
         Local Notation "e <---- e' ; f" := (splice_value_with_lets e' (fun e => f%under_lets)) : under_lets_scope.
         Local Notation "e <----- e' ; f" := (splice_under_lets_with_value e' (fun e => f%under_lets)) : under_lets_scope.
@@ -199,21 +537,21 @@ Module Compilers.
              end%expr%under_lets%cps.
 
         Inductive rawexpr : Type :=
-        | rIdent {t} (idc : ident t) {t'} (alt : expr t')
+        | rIdent (known : bool) {t} (idc : ident t) {t'} (alt : expr t')
         | rApp (f x : rawexpr) {t} (alt : expr t)
         | rExpr {t} (e : expr t)
         | rValue {t} (e : value t).
 
         Definition type_of_rawexpr (e : rawexpr) : type
           := match e with
-             | rIdent t idc t' alt => t'
+             | rIdent _ t idc t' alt => t'
              | rApp f x t alt => t
              | rExpr t e => t
              | rValue t e => t
              end.
         Definition expr_of_rawexpr (e : rawexpr) : expr (type_of_rawexpr e)
           := match e with
-             | rIdent t idc t' alt => alt
+             | rIdent _ t idc t' alt => alt
              | rApp f x t alt => alt
              | rExpr t e => e
              | rValue t e => reify e
@@ -244,139 +582,134 @@ Module Compilers.
         Definition reveal_rawexpr_cps (e : rawexpr) : ~> rawexpr
           := fun T k
              => match e with
-               | rExpr _ e as r
-               | rValue (type.base _) e as r
-                 => match e with
-                   | expr.Ident t idc => k (rIdent idc e)
-                   | expr.App s d f x => k (rApp (rExpr f) (rExpr x) e)
-                   | _ => k r
-                   end
-               | e' => k e'
-               end.
+                | rExpr _ e as r
+                | rValue (type.base _) e as r
+                  => match e with
+                     | expr.Ident t idc => k (rIdent false idc e)
+                     | expr.App s d f x => k (rApp (rExpr f) (rExpr x) e)
+                     | _ => k r
+                     end
+                | e' => k e'
+                end.
 
-        Inductive quant_type := qforall | qexists.
-
-        (* p for pattern *)
-        Fixpoint pbase_type_interp_cps (quant : quant_type) (t : pattern.base.type) (K : base.type -> Type) : Type
-          := match t with
-             | pattern.base.type.any
-               => match quant with
-                 | qforall => forall t : base.type, K t
-                 | qexists => { t : base.type & K t }
-                 end
-             | pattern.base.type.type_base t => K t
-             | pattern.base.type.prod A B
-               => @pbase_type_interp_cps
-                   quant A
-                   (fun A'
-                    => @pbase_type_interp_cps
-                        quant B (fun B' => K (A' * B')%etype))
-             | pattern.base.type.list A
-               => @pbase_type_interp_cps
-                   quant A (fun A' => K (base.type.list A'))
-             end.
-
-        Fixpoint ptype_interp_cps (quant : quant_type) (t : ptype) (K : type -> Type) {struct t} : Type
-          := match t with
-             | type.base t
-               => pbase_type_interp_cps quant t (fun t => K (type.base t))
-             | type.arrow s d
-               => @ptype_interp_cps
-                   quant s
-                   (fun s => @ptype_interp_cps
-                            quant d (fun d => K (type.arrow s d)))
-             end.
-
-        Definition ptype_interp (quant : quant_type) (t : ptype) (K : Type -> Type) : Type
-          := ptype_interp_cps quant t (fun t => K (value t)).
-
-        Fixpoint binding_dataT (p : pattern) : Type
+        Fixpoint with_unification_resultT' {t} (p : pattern t) (evm : EvarMap) (K : Type) : Type
           := match p return Type with
-             | pattern.Wildcard t => ptype_interp qexists t id
-             | pattern.Ident idc => match arg_types idc return Type with
-                                   | Some t => t
-                                   | None => unit
-                                   end
-             | pattern.App f x => binding_dataT f * binding_dataT x
+             | pattern.Wildcard t => value (pattern.type.subst_default t evm) -> K
+             | pattern.Ident t idc => type_of_list_cps K (pident_arg_types t idc)
+             | pattern.App s d f x
+               => @with_unification_resultT' _ f evm (@with_unification_resultT' _ x evm K)
              end%type.
 
-        Fixpoint bind_base_cps {t1 t2}
-                 (K : base.type -> Type)
-                 (v : K t2)
-                 {struct t1}
-          : ~> option (pbase_type_interp_cps qexists t1 K)
-          := match t1 return ~> option (pbase_type_interp_cps qexists t1 K) with
-             | pattern.base.type.any
-               => (return (Some (existT K t2 v)))
-             | pattern.base.type.type_base t
-               => (tr <-- base.try_make_transport_cps _ _ _;
-                  return (Some (tr v)))
-             | pattern.base.type.prod A B
-               => fun T k
-                 => match t2 return K t2 -> T with
-                   | base.type.prod A' B'
-                     => fun v
-                       => (v' <-- @bind_base_cps B B' (fun B' => K (A' * B')%etype) v;
-                            v'' <-- @bind_base_cps A A' (fun A' => pbase_type_interp_cps qexists B (fun B' => K (A' * B')%etype)) v';
-                          return (Some v''))
-                           T k
-                   | _ => fun _ => k None
-                   end v
-             | pattern.base.type.list A
-               => fun T k
-                 => match t2 return K t2 -> T with
-                   | base.type.list A'
-                     => fun v => @bind_base_cps A A' (fun A' => K (base.type.list A')) v T k
-                   | _ => fun _ => k None
-                   end v
-             end%cps.
+        Fixpoint under_with_unification_resultT' {t p evm K1 K2}
+                 (F : K1 -> K2)
+                 {struct p}
+          : @with_unification_resultT' t p evm K1 -> @with_unification_resultT' t p evm K2
+          := match p return with_unification_resultT' p evm K1 -> with_unification_resultT' p evm K2 with
+             | pattern.Wildcard t => fun f v => F (f v)
+             | pattern.Ident t idc => under_type_of_list_cps F
+             | pattern.App s d f x
+               => @under_with_unification_resultT'
+                    _ f evm _ _
+                    (@under_with_unification_resultT' _ x evm _ _ F)
+             end.
 
-        Fixpoint bind_value_cps {t1 t2}
-                 (K : type -> Type)
-                 (v : K t2)
-                 {struct t1}
-          : ~> option (ptype_interp_cps qexists t1 K)
-          := match t1 return ~> option (ptype_interp_cps qexists t1 K) with
-             | type.base t1
-               => fun T k
-                 => match t2 return K t2 -> T with
-                   | type.base t2
-                     => fun v => bind_base_cps (fun t => K (type.base t)) v T k
-                   | _ => fun _ => k None
-                   end v
-             | type.arrow A B
-               => fun T k
-                 => match t2 return K t2 -> T with
-                   | type.arrow A' B'
-                     => fun v
-                       => (v' <-- @bind_value_cps B B' (fun B' => K (A' -> B')%etype) v;
-                            v'' <-- @bind_value_cps A A' (fun A' => ptype_interp_cps qexists B (fun B' => K (A' -> B')%etype)) v';
-                          return (Some v''))
-                           T k
-                   | _ => fun _ => k None
-                   end v
-             end%cps.
+        Definition ident_collect_vars := (fun t idc => fold_right PositiveSet.union PositiveSet.empty (List.map pattern.type.collect_vars (type_vars_of_pident t idc))).
 
-        Fixpoint bind_data_cps (e : rawexpr) (p : pattern)
-          : ~> option (binding_dataT p)
-          := match p, e return ~> option (binding_dataT p) with
+        Definition with_unification_resultT {t} (p : pattern t) (K : type -> Type) : Type
+          := pattern.type.forall_vars
+               (@pattern.collect_vars
+                  _ ident_collect_vars
+                  t p)
+               (fun evm => with_unification_resultT' p evm (K (pattern.type.subst_default t evm))).
+
+        Definition under_with_unification_resultT {t p K1 K2}
+                 (F : forall evm, K1 (pattern.type.subst_default t evm) -> K2 (pattern.type.subst_default t evm))
+          : @with_unification_resultT t p K1 -> @with_unification_resultT t p K2
+          := pattern.type.under_forall_vars
+               (fun evm => under_with_unification_resultT' (F evm)).
+
+        Fixpoint preunify_types {t} (e : rawexpr) (p : pattern t) {struct p}
+          : option (option (ptype * type))
+          := match p, e with
              | pattern.Wildcard t, _
-               => bind_value_cps value (value_of_rawexpr e)
-             | pattern.Ident pidc, rIdent _ idc _ _
-               => (tr <-- (try_make_transport_ident_cps
-                             (fun idc => match arg_types idc with
-                                         | Some t1 => t1
-                                         | None => unit
-                                         end) _ _);
-                     return (Some (tr (bind_args _ idc))))
-             | pattern.App pf px, rApp f x _ _
-               => (f' <-- bind_data_cps f pf;
-                     x' <-- bind_data_cps x px;
-                   return (Some (f', x')))
-             | pattern.Ident _, _
-             | pattern.App _ _, _
-               => (return None)
+               => Some (Some (t, type_of_rawexpr e))
+             | pattern.Ident pt pidc, rIdent known t idc _ _
+               => if andb known (type.type_beq _ pattern.base.type.type_beq pt (pattern.type.relax t)) (* relies on evaluating to [false] if [known] is [false] *)
+                  then Some None
+                  else Some (Some (pt, t))
+             | pattern.App s d pf px, rApp f x _ _
+               => (resa <- @preunify_types _ f pf;
+                     resb <- @preunify_types _ x px;
+                     Some match resa, resb with
+                          | None, None => None
+                          | None, Some t
+                          | Some t, None => Some t
+                          | Some (a, a'), Some (b, b')
+                            => Some (type.arrow a b, type.arrow a' b')
+                          end)
+             | pattern.Ident _ _, _
+             | pattern.App _ _ _ _, _
+               => None
+             end%option.
+
+        Definition unify_types {t} (e : rawexpr) (p : pattern t) : ~> option EvarMap
+          := fun T k
+             => match preunify_types e p with
+                | Some (Some (pt, t))
+                  => match pattern.type.unify_extracted pt t with
+                     | Some vars => pattern.type.add_var_types_cps vars (PositiveMap.empty _) _ (fun evm => k (Some evm))
+                     | None => k None
+                     end
+                | Some None
+                  => k (Some (PositiveMap.empty _))
+                | None => k None
+                end.
+
+        Definition option_bind' {A B} := @Option.bind A B. (* for help with unfolding *)
+
+        Fixpoint unify_pattern' {t} (e : rawexpr) (p : pattern t) {evm : EvarMap} {K : type -> Type} {struct p}
+          : (with_unification_resultT' p evm (K (pattern.type.subst_default t evm)))
+            -> forall T, (K (pattern.type.subst_default t evm) -> option T) -> option T
+          := match p in pattern.pattern t, e return with_unification_resultT' p evm (K (pattern.type.subst_default t evm)) -> forall T, (K (pattern.type.subst_default t evm) -> option T) -> option T with
+             | pattern.Wildcard t', _
+               => fun k T k'
+                  => (tro <- type.try_make_transport_cps (@base.try_make_transport_cps) value _ _;
+                        (tr <- tro;
+                           k' (k (tr (value_of_rawexpr e))))%option)
+             | pattern.Ident t pidc, rIdent known _ idc _ _
+               => fun k T k'
+                  => (if known
+                      then Option.bind (pident_unify _ _ pidc idc)
+                      else option_bind' (pident_unify_unknown _ _ pidc idc))
+                       (fun idc_args
+                        => k' (app_type_of_list k idc_args))
+             | pattern.App s d pf px, rApp f x _ _
+               => fun k T k'
+                  => @unify_pattern'
+                       _ f pf evm (fun t => with_unification_resultT' px evm (K (type.codomain t))) k T
+                       (fun f'
+                        => @unify_pattern'
+                             _ x px evm (fun _ => K _) f' T k')
+             | pattern.Ident _ _, _
+             | pattern.App _ _ _ _, _
+               => fun _ _ k => None
              end%cps.
+
+        Definition unify_pattern {t} (e : rawexpr) (p : pattern t) {K : type -> Type}
+                   (k : with_unification_resultT p K)
+          : forall T, (K (type_of_rawexpr e) -> option T) -> option T
+          := fun T cont
+             => unify_types
+                  e p _
+                  (fun evm
+                   => evm <- evm;
+                        k' <- pattern.type.app_forall_vars k evm;
+                        unify_pattern'
+                          e p k' _
+                          (fun res
+                           => tr <- type.try_make_transport_cps (@base.try_make_transport_cps) K _ _;
+                                (tr <- tr;
+                                   cont (tr res))%option)%cps)%option.
 
         (** We follow
             http://moscova.inria.fr/~maranget/papers/ml05e-maranget.pdf,
@@ -405,7 +738,7 @@ Module Compilers.
         Inductive decision_tree :=
         | TryLeaf (k : nat) (onfailure : decision_tree)
         | Failure
-        | Switch (icases : list (pident * decision_tree))
+        | Switch (icases : list (raw_pident * decision_tree))
                  (app_case : option decision_tree)
                  (default : decision_tree)
         | Swap (i : nat) (cont : decision_tree).
@@ -415,8 +748,6 @@ Module Compilers.
              | Some vi, Some vj => Some (set_nth i vj (set_nth j vi ls))
              | _, _ => None
              end.
-
-        Definition option_bind' {A B} := @Option.bind A B. (* for help with rewriting *)
 
         Fixpoint eval_decision_tree {T} (ctx : list rawexpr) (d : decision_tree) (cont : nat -> list rawexpr -> option T) {struct d} : option T
           := match d with
@@ -436,17 +767,30 @@ Module Compilers.
                                 ctx0 _
                                 (fun ctx0'
                                  => match ctx0' with
-                                    | rIdent t idc t' alt
+                                    | rIdent known t idc t' alt
                                       => fold_right
                                            (fun '(pidc, icase) rest
                                             => let res
-                                                   := option_bind'
-                                                        (invert_bind_args _ idc pidc)
-                                                        (fun args
-                                                         => @eval_decision_tree
-                                                              T ctx' icase
-                                                              (fun k ctx''
-                                                               => cont k (rIdent (pident_to_typed pidc args) alt :: ctx''))) in
+                                                   := if known
+                                                      then
+                                                        (args <- invert_bind_args _ idc pidc;
+                                                           @eval_decision_tree
+                                                             T ctx' icase
+                                                             (fun k ctx''
+                                                              => cont k (rIdent
+                                                                           (raw_pident_is_simple pidc)
+                                                                           (raw_pident_to_typed pidc args) alt :: ctx'')))
+                                                      else
+                                                        @eval_decision_tree
+                                                          T ctx' icase
+                                                          (fun k ctx''
+                                                           => option_bind'
+                                                                (invert_bind_args_unknown _ idc pidc)
+                                                                (fun args
+                                                                 => cont k (rIdent
+                                                                              (raw_pident_is_simple pidc)
+                                                                              (raw_pident_to_typed pidc args) alt :: ctx'')))
+                                               in
                                                match rest with
                                                | None => Some res
                                                | Some rest => Some (res ;; rest)
@@ -490,64 +834,102 @@ Module Compilers.
                   end
              end%option.
 
-        Local Notation opt_anyexprP ivar
-          := (fun should_do_again : bool => UnderLets (@AnyExpr.anyexpr base.type ident (if should_do_again then ivar else var)))
-               (only parsing).
-        Local Notation opt_anyexpr ivar
-          := (option (sigT (opt_anyexprP ivar))) (only parsing).
+        Local Notation deep_rewrite_ruleTP_gen' should_do_again with_opt under_lets is_cps t
+          := ((if is_cps
+               then fun T => forall T', (T -> option T') -> option T'
+               else fun T => T)
+                match (@expr.expr base.type ident (if should_do_again then value else var) t) with
+                | x0 => match (if under_lets then UnderLets x0 else x0) with
+                        | x1 => if with_opt then option x1 else x1
+                        end
+                end).
+
+        Definition deep_rewrite_ruleTP_gen (should_do_again : bool) (with_opt : bool) (under_lets : bool) (is_cps : bool) t
+          := deep_rewrite_ruleTP_gen' should_do_again with_opt under_lets is_cps t.
+
+        Definition normalize_deep_rewrite_rule {should_do_again with_opt under_lets is_cps t}
+          : deep_rewrite_ruleTP_gen should_do_again with_opt under_lets is_cps t
+            -> deep_rewrite_ruleTP_gen should_do_again true true true t
+          := match with_opt, under_lets, is_cps with
+             | true, true, true => fun x => x
+             | false, true, true => fun x_cps _ k => x_cps _ (fun x => k (Some x))
+             | true, false, true => fun x_cps _ k => x_cps _ (fun x => x <- x; k (Some (UnderLets.Base x)))%option
+             | false, false, true => fun x_cps _ k => x_cps _ (fun x => k (Some (UnderLets.Base x)))
+             | true, true, false => fun x _ k => k x
+             | false, true, false => fun x _ k => k (Some x)
+             | true, false, false => fun x _ k => (x <- x; k (Some (UnderLets.Base x)))%option
+             | false, false, false => fun x _ k => k (Some (UnderLets.Base x))
+             end%cps.
+
+        Definition with_unif_rewrite_ruleTP_gen {t} (p : pattern t) (should_do_again : bool) (with_opt : bool) (under_lets : bool) (is_cps : bool)
+          := with_unification_resultT p (fun t => deep_rewrite_ruleTP_gen' should_do_again with_opt under_lets is_cps t).
+
+        Record rewrite_rule_data {t} {p : pattern t} :=
+          { rew_should_do_again : bool;
+            rew_with_opt : bool;
+            rew_under_lets : bool;
+            rew_is_cps : bool;
+            rew_replacement : with_unif_rewrite_ruleTP_gen p rew_should_do_again rew_with_opt rew_under_lets rew_is_cps }.
 
         Definition rewrite_ruleTP
-          := (fun p : pattern => binding_dataT p -> forall T, (opt_anyexpr value -> T) -> T).
+          := (fun p : anypattern => @rewrite_rule_data _ (pattern.pattern_of_anypattern p)).
         Definition rewrite_ruleT := sigT rewrite_ruleTP.
         Definition rewrite_rulesT
           := (list rewrite_ruleT).
 
-        Definition ERROR_BAD_REWRITE_RULE {t} (pat : pattern) (value : expr t) : expr t := value.
-        Global Opaque ERROR_BAD_REWRITE_RULE.
+        Local Notation base_type_of t
+          := (match t with type.base t' => t' | type.arrow _ __ => base.type.unit end).
+
+        Definition maybe_do_againT (should_do_again : bool) (t : base.type)
+          := ((@expr.expr base.type ident (if should_do_again then value else var) t) -> UnderLets (expr t)).
+        Definition maybe_do_again
+                   (do_again : forall t : base.type, @expr.expr base.type ident value t -> UnderLets (expr t))
+                   (should_do_again : bool) (t : base.type)
+          := if should_do_again return maybe_do_againT should_do_again t
+             then do_again t
+             else UnderLets.Base.
 
         Section eval_rewrite_rules.
           Context (do_again : forall t : base.type, @expr.expr base.type ident value t -> UnderLets (expr t)).
 
-          Let maybe_do_again
-            := fun (should_do_again : bool) (t : base.type)
-               => if should_do_again return ((@expr.expr base.type ident (if should_do_again then value else var) t) -> UnderLets (expr t))
-                  then do_again t
-                  else UnderLets.Base.
+          Local Notation maybe_do_again := (maybe_do_again do_again).
 
           Definition rewrite_with_rule {t} (defaulte : expr t) e' (pf : rewrite_ruleT)
+            : option (UnderLets (expr t))
             := let 'existT p f := pf in
-               bind_data_cps
-                 e' p _
-                 (fun v
-                  => v <- v;
-                       f v _
-                         (fun fv
-                          => fv <- fv;
-                               let 'existT should_do_again fv := fv in
-                               Some
-                                 (fv <-- fv;
-                                    fv <-- maybe_do_again should_do_again _ fv;
-                                    type.try_transport_cps
-                                      base.try_make_transport_cps _ _ _ fv _
-                                      (fun fv'
-                                       => UnderLets.Base
-                                            (fv' ;;; (ERROR_BAD_REWRITE_RULE p defaulte))))%under_lets))%option.
+               let should_do_again := rew_should_do_again f in
+               unify_pattern
+                 e' (pattern.pattern_of_anypattern p) (rew_replacement f) _
+                 (fun fv
+                  => normalize_deep_rewrite_rule
+                       fv _
+                       (fun fv
+                        => option_bind'
+                             fv
+                             (fun fv
+                              => (tr <- type.try_make_transport_cps (@base.try_make_transport_cps) _ _ _;
+                                    (tr <- tr;
+                                       (tr' <- type.try_make_transport_cps (@base.try_make_transport_cps) _ _ _;
+                                          (tr' <- tr';
+                                             Some (fv <-- fv;
+                                                     fv <-- maybe_do_again should_do_again (base_type_of (type_of_rawexpr e')) (tr fv);
+                                                     UnderLets.Base (tr' fv))%under_lets)%option)%cps)%option)%cps)%cps)).
 
-          Definition eval_rewrite_rules
-                     (d : decision_tree)
-                     (rew : rewrite_rulesT)
-                     (e : rawexpr)
-            : UnderLets (expr (type_of_rawexpr e))
-            := let defaulte := expr_of_rawexpr e in
-               (eval_decision_tree
-                  (e::nil) d
-                  (fun k ctx
-                   => match ctx return option (UnderLets (expr (type_of_rawexpr e))) with
-                      | e'::nil
-                        => (pf <- nth_error rew k; rewrite_with_rule defaulte e' pf)%option
-                      | _ => None
-                      end);;;
-                  (UnderLets.Base defaulte))%option.
+        Definition eval_rewrite_rules
+                   (d : decision_tree)
+                   (rews : rewrite_rulesT)
+                   (e : rawexpr)
+          : UnderLets (expr (type_of_rawexpr e))
+          := let defaulte := expr_of_rawexpr e in
+              (eval_decision_tree
+                 (e::nil) d
+                 (fun k ctx
+                  => match ctx return option (UnderLets (expr (type_of_rawexpr e))) with
+                    | e'::nil
+                      => (pf <- nth_error rews k; rewrite_with_rule defaulte e' pf)%option
+                    | _ => None
+                    end);;;
+                 (UnderLets.Base defaulte))%option.
         End eval_rewrite_rules.
 
         Local Notation enumerate ls
@@ -563,81 +945,77 @@ Module Compilers.
                  end
              end.
 
-        Definition get_index_of_first_non_wildcard (p : list pattern) : option nat
+        Definition get_index_of_first_non_wildcard (p : list rawpattern) : option nat
           := first_satisfying_helper
                (fun '(n, x) => match x with
-                            | pattern.Wildcard _ => None
+                            | pattern.Raw.Wildcard => None
                             | _ => Some n
                             end)
                (enumerate p).
 
-        Definition starts_with_wildcard : nat * list pattern -> bool
+        Definition starts_with_wildcard : nat * list rawpattern -> bool
           := fun '(_, p) => match p with
-                            | pattern.Wildcard _::_ => true
+                            | pattern.Raw.Wildcard::_ => true
                             | _ => false
                             end.
 
-        Definition not_starts_with_wildcard : nat * list pattern -> bool
+        Definition not_starts_with_wildcard : nat * list rawpattern -> bool
           := fun p => negb (starts_with_wildcard p).
 
-        Definition filter_pattern_wildcard (p : list (nat * list pattern)) : list (nat * list pattern)
+        Definition filter_pattern_wildcard (p : list (nat * list rawpattern)) : list (nat * list rawpattern)
           := filter starts_with_wildcard p.
 
-        Definition split_at_first_pattern_wildcard (p : list (nat * list pattern)) : list (nat * list pattern) * list (nat * list pattern)
+        Definition split_at_first_pattern_wildcard (p : list (nat * list rawpattern)) : list (nat * list rawpattern) * list (nat * list rawpattern)
           := (take_while not_starts_with_wildcard p, drop_while not_starts_with_wildcard p).
 
-        Fixpoint get_unique_pattern_ident' (p : list (nat * list pattern)) (so_far : list pident) : list pident
+        Fixpoint get_unique_pattern_ident' (p : list (nat * list rawpattern)) (so_far : list raw_pident) : list raw_pident
           := match p with
              | nil => List.rev so_far
-             | (_, pattern.Ident pidc :: _) :: ps
-               => let so_far' := if existsb (pident_beq pidc) so_far
+             | (_, pattern.Raw.Ident pidc :: _) :: ps
+               => let so_far' := if existsb (raw_pident_beq pidc) so_far
                                  then so_far
                                  else pidc :: so_far in
                   get_unique_pattern_ident' ps so_far'
              | _ :: ps => get_unique_pattern_ident' ps so_far
              end.
 
-        Definition get_unique_pattern_ident p : list pident := get_unique_pattern_ident' p nil.
+        Definition get_unique_pattern_ident p : list raw_pident := get_unique_pattern_ident' p nil.
 
-        Definition contains_pattern_pident (pidc : pident) (p : list (nat * list pattern)) : bool
+        Definition contains_pattern_pident (pidc : raw_pident) (p : list (nat * list rawpattern)) : bool
           := existsb (fun '(n, p) => match p with
-                                  | pattern.Ident pidc'::_ => pident_beq pidc pidc'
+                                  | pattern.Raw.Ident pidc'::_ => raw_pident_beq pidc pidc'
                                   | _ => false
                                   end)
                      p.
 
-        Definition contains_pattern_app (p : list (nat * list pattern)) : bool
+        Definition contains_pattern_app (p : list (nat * list rawpattern)) : bool
           := existsb (fun '(n, p) => match p with
-                                  | pattern.App _ _::_ => true
+                                  | pattern.Raw.App _ _::_ => true
                                   | _ => false
                                   end)
                      p.
 
-        Definition filter_pattern_app (p : nat * list pattern) : option (nat * list pattern)
+        Definition filter_pattern_app (p : nat * list rawpattern) : option (nat * list rawpattern)
           := match p with
-             | (n, pattern.App f x :: ps)
+             | (n, pattern.Raw.App f x :: ps)
                => Some (n, f :: x :: ps)
-             | (_, pattern.Ident _::_)
-             | (_, pattern.Wildcard _::_)
-             | (_, nil)
+             | _
                => None
              end.
 
-        Definition filter_pattern_pident (pidc : pident) (p : nat * list pattern) : option (nat * list pattern)
+        Definition filter_pattern_pident (pidc : raw_pident) (p : nat * list rawpattern) : option (nat * list rawpattern)
           := match p with
-             | (n, pattern.Ident pidc'::ps)
-               => if pident_beq pidc pidc'
+             | (n, pattern.Raw.Ident pidc'::ps)
+               => if raw_pident_beq pidc pidc'
                  then Some (n, ps)
                  else None
-             | (_, pattern.Wildcard _::_)
-             | (_, pattern.App _ _::_)
-             | (_, nil)
+             | _
                => None
              end.
 
         Definition compile_rewrites_step
-                   (compile_rewrites : list (nat * list pattern) -> option decision_tree)
-                   (pattern_matrix : list (nat * list pattern))
+                   (compile_rewrites : list (nat * list rawpattern) -> option decision_tree)
+                   (pattern_matrix : list (nat * list rawpattern))
           : option decision_tree
           := match pattern_matrix with
              | nil => Some Failure
@@ -672,7 +1050,7 @@ Module Compilers.
                  end
              end%option.
 
-        Fixpoint compile_rewrites' (fuel : nat) (pattern_matrix : list (nat * list pattern))
+        Fixpoint compile_rewrites' (fuel : nat) (pattern_matrix : list (nat * list rawpattern))
           : option decision_tree
           := match fuel with
              | Datatypes.O => None
@@ -680,160 +1058,7 @@ Module Compilers.
              end.
 
         Definition compile_rewrites (fuel : nat) (ps : rewrite_rulesT)
-          := compile_rewrites' fuel (enumerate (List.map (fun p => projT1 p :: nil) ps)).
-
-
-        Fixpoint with_bindingsT (p : pattern) (T : Type)
-          := match p return Type with
-             | pattern.Wildcard t => ptype_interp qforall t (fun eT => eT -> T)
-             | pattern.Ident idc
-               => match arg_types idc with
-                 | Some t => t -> T
-                 | None => T
-                 end
-             | pattern.App f x => with_bindingsT f (with_bindingsT x T)
-             end.
-
-        Fixpoint lift_pbase_type_interp_cps {K1 K2} {quant} (F : forall t : base.type, K1 t -> K2 t) {t}
-          : pbase_type_interp_cps quant t K1
-            -> pbase_type_interp_cps quant t K2
-          := match t, quant return pbase_type_interp_cps quant t K1
-                                   -> pbase_type_interp_cps quant t K2 with
-             | pattern.base.type.any, qforall
-               => fun f t => F t (f t)
-             | pattern.base.type.any, qexists
-               => fun tf => existT _ _ (F _ (projT2 tf))
-             | pattern.base.type.type_base t, _
-               => F _
-             | pattern.base.type.prod A B, _
-               => @lift_pbase_type_interp_cps
-                   _ _ quant
-                   (fun A'
-                    => @lift_pbase_type_interp_cps
-                        _ _ quant (fun _ => F _) B)
-                   A
-             | pattern.base.type.list A, _
-               => @lift_pbase_type_interp_cps
-                   _ _ quant (fun _ => F _) A
-             end.
-
-        Fixpoint lift_ptype_interp_cps {K1 K2} {quant} (F : forall t : type.type base.type, K1 t -> K2 t) {t}
-          : ptype_interp_cps quant t K1
-            -> ptype_interp_cps quant t K2
-          := match t return ptype_interp_cps quant t K1
-                                   -> ptype_interp_cps quant t K2 with
-             | type.base t
-               => lift_pbase_type_interp_cps F
-             | type.arrow A B
-               => @lift_ptype_interp_cps
-                   _ _ quant
-                   (fun A'
-                    => @lift_ptype_interp_cps
-                        _ _ quant (fun _ => F _) B)
-                   A
-             end.
-
-        Fixpoint lift_with_bindings {p} {A B : Type} (F : A -> B) {struct p} : with_bindingsT p A -> with_bindingsT p B
-          := match p return with_bindingsT p A -> with_bindingsT p B with
-             | pattern.Wildcard t
-               => lift_ptype_interp_cps
-                   (K1:=fun t => value t -> A)
-                   (K2:=fun t => value t -> B)
-                   (fun _ f v => F (f v))
-             | pattern.Ident idc
-               => match arg_types idc as ty
-                       return match ty with
-                              | Some t => t -> A
-                              | None => A
-                              end -> match ty with
-                                    | Some t => t -> B
-                                    | None => B
-                                    end
-                 with
-                 | Some _ => fun f v => F (f v)
-                 | None => F
-                 end
-             | pattern.App f x
-               => @lift_with_bindings
-                   f _ _
-                   (@lift_with_bindings x _ _ F)
-             end.
-
-        Fixpoint app_pbase_type_interp_cps {T : Type} {K1 K2 : base.type -> Type}
-                 (F : forall t, K1 t -> K2 t -> T)
-                 {t}
-          : pbase_type_interp_cps qforall t K1
-            -> pbase_type_interp_cps qexists t K2 -> T
-          := match t return pbase_type_interp_cps qforall t K1
-                            -> pbase_type_interp_cps qexists t K2 -> T with
-             | pattern.base.type.any
-               => fun f tv => F _ (f _) (projT2 tv)
-             | pattern.base.type.type_base t
-               => fun f v => F _ f v
-             | pattern.base.type.prod A B
-               => @app_pbase_type_interp_cps
-                   _
-                   (fun A' => pbase_type_interp_cps qforall B (fun B' => K1 (A' * B')%etype))
-                   (fun A' => pbase_type_interp_cps qexists B (fun B' => K2 (A' * B')%etype))
-                   (fun A'
-                    => @app_pbase_type_interp_cps
-                        _
-                        (fun B' => K1 (A' * B')%etype)
-                        (fun B' => K2 (A' * B')%etype)
-                        (fun _ => F _)
-                        B)
-                   A
-             | pattern.base.type.list A
-               => @app_pbase_type_interp_cps T (fun A' => K1 (base.type.list A')) (fun A' => K2 (base.type.list A')) (fun _ => F _) A
-             end.
-
-        Fixpoint app_ptype_interp_cps {T : Type} {K1 K2 : type -> Type}
-                 (F : forall t, K1 t -> K2 t -> T)
-                 {t}
-          : ptype_interp_cps qforall t K1
-            -> ptype_interp_cps qexists t K2 -> T
-          := match t return ptype_interp_cps qforall t K1
-                            -> ptype_interp_cps qexists t K2 -> T with
-             | type.base t => app_pbase_type_interp_cps F
-             | type.arrow A B
-               => @app_ptype_interp_cps
-                   _
-                   (fun A' => ptype_interp_cps qforall B (fun B' => K1 (A' -> B')%etype))
-                   (fun A' => ptype_interp_cps qexists B (fun B' => K2 (A' -> B')%etype))
-                   (fun A'
-                    => @app_ptype_interp_cps
-                        _
-                        (fun B' => K1 (A' -> B')%etype)
-                        (fun B' => K2 (A' -> B')%etype)
-                        (fun _ => F _)
-                        B)
-                   A
-             end.
-
-        Fixpoint app_binding_data {T p} : forall (f : with_bindingsT p T) (v : binding_dataT p), T
-          := match p return forall (f : with_bindingsT p T) (v : binding_dataT p), T with
-             | pattern.Wildcard t
-               => app_ptype_interp_cps
-                   (K1:=fun t => value t -> T)
-                   (K2:=fun t => value t)
-                   (fun _ f v => f v)
-             | pattern.Ident idc
-               => match arg_types idc as ty
-                       return match ty with
-                              | Some t => t -> T
-                              | None => T
-                              end -> match ty return Type with
-                                    | Some t => t
-                                    | None => unit
-                                    end -> T
-                 with
-                 | Some t => fun f x => f x
-                 | None => fun v 'tt => v
-                 end
-             | pattern.App f x
-               => fun F '(vf, vx)
-                 => @app_binding_data _ x (@app_binding_data _ f F vf) vx
-             end.
+          := compile_rewrites' fuel (enumerate (List.map (fun p => to_raw_pattern (pattern.pattern_of_anypattern (projT1 p)) :: nil) ps)).
 
         (** XXX MOVEME? *)
         Definition mkcast {P : type -> Type} {t1 t2 : type} : ~> (option (P t1 -> P t2))
@@ -867,7 +1092,7 @@ Module Compilers.
                end%under_lets.
 
           Definition assemble_identifier_rewriters {t} (idc : ident t) : value_with_lets t
-            := eta_ident_cps _ _ idc (fun t' idc' => assemble_identifier_rewriters' t' (rIdent idc' #idc') (fun _ => id)).
+            := eta_ident_cps _ _ idc (fun t' idc' => assemble_identifier_rewriters' t' (rIdent true idc' #idc') (fun _ => id)).
         End with_do_again.
       End with_var.
 
@@ -928,7 +1153,6 @@ Module Compilers.
         Local Notation type := (type.type base.type).
         Local Notation expr := (@expr.expr base.type ident var).
         Local Notation value := (@value base.type ident var).
-        Local Notation anyexpr := (@anyexpr ident var).
         Local Notation pattern := (@pattern.pattern pattern.ident).
         Local Notation UnderLets := (@UnderLets.UnderLets base.type ident var).
         Local Notation ptype := (type.type pattern.base.type).
@@ -938,100 +1162,234 @@ Module Compilers.
         Coercion ptype_base' : base.type.base >-> ptype.
         Coercion type_base : base.type >-> type.
         Coercion ptype_base : pattern.base.type >-> ptype.
-        Local Notation opt_anyexprP ivar
-          := (fun should_do_again : bool => UnderLets (@AnyExpr.anyexpr base.type ident (if should_do_again then ivar else var))).
-        Local Notation opt_anyexpr ivar
-          := (option (sigT (opt_anyexprP ivar))).
-        Local Notation binding_dataT := (@binding_dataT ident var pattern.ident pattern.ident.arg_types).
-        Local Notation lift_with_bindings := (@lift_with_bindings ident var pattern.ident pattern.ident.arg_types).
-        Local Notation app_binding_data := (@app_binding_data ident var pattern.ident pattern.ident.arg_types).
-        Local Notation rewrite_rulesT := (@rewrite_rulesT ident var pattern.ident pattern.ident.arg_types).
-        Local Notation rewrite_ruleT := (@rewrite_ruleT ident var pattern.ident pattern.ident.arg_types).
+        Local Notation ident_collect_vars := (@ident_collect_vars pattern.ident (@pattern.ident.type_vars)).
+        Local Notation collect_vars := (@pattern.collect_vars pattern.ident (@ident_collect_vars)).
+        Local Notation with_unification_resultT' := (@with_unification_resultT' ident var pattern.ident (@pattern.ident.arg_types)).
+        Local Notation with_unification_resultT := (@with_unification_resultT ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
+        Local Notation under_with_unification_resultT' := (@under_with_unification_resultT' ident var pattern.ident (@pattern.ident.arg_types)).
+        Local Notation under_with_unification_resultT := (@under_with_unification_resultT ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
+        Local Notation rewrite_ruleTP := (@rewrite_ruleTP ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
+        Local Notation rewrite_ruleT := (@rewrite_ruleT ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
+        Local Notation rewrite_rule_data := (@rewrite_rule_data ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
         Local Notation castv := (@castv ident var).
 
-        Definition make_base_Literal_pattern (t : base.type.base) : pattern
+        Definition make_base_Literal_pattern (t : base.type.base) : pattern t
           := Eval cbv [pattern.ident.of_typed_ident] in
               pattern.Ident (pattern.ident.of_typed_ident (@ident.Literal t DefaultValue.type.base.default)).
 
-        Definition bind_base_Literal_pattern (t : base.type.base) : binding_dataT (make_base_Literal_pattern t) ~> base.interp t
-          := match t return binding_dataT (make_base_Literal_pattern t) ~> base.interp t with
-             | base.type.unit
-             | base.type.Z
-             | base.type.bool
-             | base.type.nat
-               => fun v => (return v)
-             end%cps.
-
-        Fixpoint make_Literal_pattern (t : base.type) : option { p : pattern & binding_dataT p ~> base.interp t }
-          := match t return option { p : pattern & binding_dataT p ~> base.interp t } with
-             | base.type.type_base t => Some (existT _ (make_base_Literal_pattern t) (bind_base_Literal_pattern t))
-             | base.type.prod A B
+        Fixpoint make_Literal_pattern (t : pattern.base.type) : option (pattern t)
+          := match t return option (pattern t) with
+             | pattern.base.type.var _ => None
+             | pattern.base.type.type_base t => Some (make_base_Literal_pattern t)
+             | pattern.base.type.prod A B
                => (a <- make_Literal_pattern A;
                     b <- make_Literal_pattern B;
-                    Some (existT
-                            (fun p : pattern => binding_dataT p ~> base.interp (A * B))
-                            (#pattern.ident.pair @ (projT1 a) @ (projT1 b))%pattern
-                            (fun '(args : unit * binding_dataT (projT1 a) * binding_dataT (projT1 b))
-                             => (av <--- projT2 a (snd (fst args));
-                                  bv <--- projT2 b (snd args);
-                                return (av, bv)))))
-             | base.type.list A => None
+                    Some ((#pattern.ident.pair @ a @ b)%pattern))
+             | pattern.base.type.list A => None
              end%option%cps.
 
-        Fixpoint make_interp_rewrite' (t : type) (p : pattern) (rew : binding_dataT p ~> type.interp base.interp t) {struct t}
-          : option rewrite_ruleT
-          := match t return (_ ~> type.interp base.interp t) -> _ with
+        Fixpoint make_interp_rewrite_pattern {t}
+          : pattern t -> option (pattern (type.final_codomain t))
+          := match t return pattern t -> option (pattern (type.final_codomain t)) with
              | type.base t
-               => fun rew
-                 => Some (existT _ p (fun args => v <--- rew args;
-                                     return (Some (existT _ false (UnderLets.Base (AnyExpr.wrap (ident.smart_Literal v)))))))
+               => fun p => Some p
              | type.arrow (type.base s) d
-               => fun rew
-                 => (lit_s <- make_Literal_pattern s;
-                      @make_interp_rewrite'
-                        d
-                        (pattern.App p (projT1 lit_s))
-                        (fun (args : binding_dataT p * binding_dataT (projT1 lit_s))
-                         => (rewp <--- rew (fst args);
-                              sv <--- projT2 lit_s (snd args);
-                            return (rewp sv))))
+               => fun p => (x <- make_Literal_pattern s; @make_interp_rewrite_pattern d (pattern.App p x))%option
              | type.arrow _ _ => fun _ => None
-             end%option%cps rew.
+             end.
+
+        Lemma collect_vars_literal_empty {t}
+          : match make_Literal_pattern t with
+            | Some p => collect_vars p = PositiveSet.empty /\ pattern.base.collect_vars t = PositiveSet.empty
+            | None => True
+            end.
+        Proof using Type.
+          induction t; cbn; cbv [Option.bind ptype_base] in *; break_innermost_match; cbn; auto.
+          destruct_head'_and.
+          repeat match goal with H : _ |- _ => rewrite H end; cbn; auto.
+        Qed.
+
+        Fixpoint make_Literal_pattern_interp_helper {t evm T}
+                 {struct t}
+          : match make_Literal_pattern t with
+            | Some x
+              => (base.interp (pattern.base.subst_default t evm) -> T)
+                 -> with_unification_resultT' x evm T
+            | None => True
+            end.
+        Proof.
+          refine match t return match make_Literal_pattern t with
+                                | Some x
+                                  => (base.interp (pattern.base.subst_default t evm) -> T)
+                                     -> with_unification_resultT' x evm T
+                                | None => True
+                                end
+                 with
+                 | pattern.base.type.var _
+                 | pattern.base.type.list _
+                   => I
+                 | pattern.base.type.type_base t
+                   => fun f x => f x
+                 | pattern.base.type.prod A B
+                   => let recA := @make_Literal_pattern_interp_helper
+                                    A evm
+                                    (match make_Literal_pattern A, make_Literal_pattern B return Type with
+                                     | Some a, Some b => _
+                                     | _, _ => unit
+                                     end) in
+                      let recB := @make_Literal_pattern_interp_helper
+                                    B evm
+                                    (match make_Literal_pattern A, make_Literal_pattern B return Type with
+                                     | Some a, Some b => _
+                                     | _, _ => unit
+                                     end) in
+                      _
+                 end;
+            clearbody recA recB;
+            cbn in *.
+          destruct (make_Literal_pattern A) as [a|], (make_Literal_pattern B) as [b|]; try exact I; cbn.
+          refine (fun f
+                  => recA (fun a' => recB (fun b' => f (a', b')))).
+        Defined.
+
+        (** We can only do this because we're dealing with literal patterns that have no variables *)
+        Definition strip_collect_vars
+                 {s : pattern.base.type} {d : ptype}
+                 {p : pattern (type.base s -> d)%ptype}
+                 (p_res : pattern.type.forall_vars
+                            (collect_vars p)
+                            (fun evm =>
+                               with_unification_resultT'
+                                 p evm
+                                 (type.interp base.interp (pattern.type.subst_default (type.base s -> d)%ptype evm))))
+          : forall (rec : forall x : pattern (type.base s),
+                       pattern.type.forall_vars (PositiveSet.union (collect_vars x) (collect_vars p))
+                                                (fun evm =>
+                                                   with_unification_resultT'
+                                                     p evm
+                                                     (with_unification_resultT'
+                                                        x evm
+                                                        (type.interp base.interp (pattern.type.subst_default d evm))))
+                       -> match make_interp_rewrite_pattern (p @ x) with
+                          | Some p' => @rewrite_rule_data _ p'
+                          | None => True
+                          end),
+            match (x <- make_Literal_pattern s;
+                     make_interp_rewrite_pattern (p @ x))%option with
+            | Some p' => @rewrite_rule_data _ p'
+            | None => True
+            end.
+        Proof.
+          intro rec_call.
+          pose proof (@collect_vars_literal_empty s) as H.
+          pose proof (@make_Literal_pattern_interp_helper s) as F.
+          destruct (make_Literal_pattern s) as [x|]; [ | exact I ]; cbn [Option.bind].
+          cbv [ptype_base] in *.
+          refine (rec_call x _); clear rec_call.
+          destruct (pattern.collect_vars x); [ | exfalso; clear -H; abstract (destruct H as [H _]; cbv in H; discriminate) ].
+          refine (pattern.type.under_forall_vars (fun evm => under_with_unification_resultT' (F _ _)) p_res).
+        Defined.
+
+        Fixpoint make_interp_rewrite'_helper {t}
+          : forall (p : pattern t)
+                   (base_rewrite : with_unification_resultT p (type.interp base.interp))
+                   (p' := make_interp_rewrite_pattern p),
+            match p' return Type with
+            | Some p' => rewrite_ruleTP {| pattern.pattern_of_anypattern := p' |}
+            | None => True
+            end
+          := match t return (forall (p : pattern t)
+                                    (base_rewrite : with_unification_resultT p (type.interp base.interp))
+                                    (p' := make_interp_rewrite_pattern p),
+                                match p' return Type with
+                                | Some p' => rewrite_ruleTP {| pattern.pattern_of_anypattern := p' |}
+                                | None => True
+                                end)
+             with
+             | type.base t
+               => fun p base_rewrite
+                  => {| rew_should_do_again := false;
+                        rew_with_opt := false;
+                        rew_under_lets := false;
+                        rew_is_cps := false;
+                        rew_replacement
+                        := under_with_unification_resultT
+                             (fun evm v => ident.smart_Literal v)
+                             base_rewrite |}
+             | type.arrow (type.base s) d
+               => fun p base_rewrite
+                  => let rec_call
+                         := fun x => @make_interp_rewrite'_helper d (p @ x)%pattern in
+                     strip_collect_vars base_rewrite rec_call
+             | type.arrow _ _
+               => fun _ _ => I
+             end.
+
+        Definition make_interp_rewrite' {t} (idc : ident t)
+                   (pidc := pattern.Ident (pattern.ident.of_typed_ident idc))
+                   (val : with_unification_resultT pidc (type.interp base.interp))
+          : option rewrite_ruleT
+          := match make_interp_rewrite_pattern pidc as p
+                   return match p return Type with
+                          | Some p' => rewrite_ruleTP {| pattern.pattern_of_anypattern := p' |}
+                          | None => True
+                          end
+                          -> option rewrite_ruleT
+             with
+             | Some p'
+               => fun r
+                  => Some (existT _ {| pattern.pattern_of_anypattern := p' |} r)
+             | None => fun _ => None
+             end (make_interp_rewrite'_helper pidc val).
+
+        Definition make_default_with_unification_resultT {t vs ls} (v : type.interp base.interp t)
+          : pattern.type.forall_vars
+              vs
+              (fun evm =>
+                 fold_right (fun a K : Type => a -> K)
+                            (type.interp base.interp (pattern.type.subst_default (pattern.type.relax t) evm))
+                            ls)
+          := pattern.type.lam_forall_vars
+               (fun evm
+                => list_rect
+                     (fun ls => fold_right (fun a K => a -> K) _ ls)
+                     (@pattern.type.subst_default_relax _ t _ v)
+                     (fun x xs rec _ => rec)
+                     _).
 
         Definition make_interp_rewrite'' {t} (idc : ident t) : option rewrite_ruleT
-          := make_interp_rewrite'
-               t
-               (pattern.Ident (pattern.ident.of_typed_ident idc))
-               (fun iargs => return (ident.interp (pattern.ident.retype_ident idc iargs)))%cps.
-        (*
-        Definition make_interp_rewrite {t} (idc : ident t)
-          := invert_Some (make_interp_rewrite'' idc).
-         *)
+          := @make_interp_rewrite'
+               t idc (make_default_with_unification_resultT (ident.interp idc)).
 
-        Local Ltac get_all_valid_interp_rules_from body so_far :=
+        Local Ltac collect_id body so_far :=
           let next := match body with
-                      | context[@Some (sigT (fun x : pattern => binding_dataT x ~> opt_anyexpr value)) ?rew]
+                      | context[@id ?t ?v]
                         => lazymatch so_far with
-                          | context[cons rew _] => constr:(I : I)
-                          | _ => lazymatch rew with
-                                | existT _ _ _ => constr:(Some rew)
-                                | _ => constr:(I : I)
-                                end
-                          end
+                           | context[cons (existT _ _ v) _] => constr:(I : I)
+                           | _ => constr:(@Some _ v)
+                           end
                       | _ => constr:(@None unit)
                       end in
           lazymatch next with
-          | Some ?rew => get_all_valid_interp_rules_from body (cons rew so_far)
+          | @Some (ident ?t) ?v => collect_id body (cons (existT ident t v) so_far)
           | None => (eval cbv [List.rev List.app] in (List.rev so_far))
           end.
-        Local Ltac make_valid_interp_rules :=
-          let body := constr:(fun t idc => @pattern.ident.eta_ident_cps _ t idc (@make_interp_rewrite'')) in
-          let body := (eval cbv [pattern.ident.eta_ident_cps make_interp_rewrite'' make_interp_rewrite' make_Literal_pattern pattern.ident.of_typed_ident Option.bind projT1 projT2 cpsbind cpsreturn cpscall ident.interp pattern.ident.retype_ident ident.gen_interp bind_base_Literal_pattern make_base_Literal_pattern] in body) in
-          let body := (eval cbn [base.interp binding_dataT pattern.ident.arg_types base.base_interp ident.smart_Literal fold_right map] in body) in
-          let retv := get_all_valid_interp_rules_from body (@nil rewrite_ruleT) in
-          exact retv.
-        Definition interp_rewrite_rules : rewrite_rulesT
-          := ltac:(make_valid_interp_rules).
+
+        Definition simple_idents : list (sigT ident)
+          := ltac:(let v := constr:(fun t idc => @pattern.ident.eta_ident_cps _ t idc (fun _ => id)) in
+                   let v := (eval cbv [pattern.ident.eta_ident_cps] in v) in
+                   let ls := collect_id v (@nil (sigT ident)) in
+                   exact ls).
+
+        Let interp_rewrite_rules'
+          := Eval cbv -[ident.interp ident.gen_interp ident.smart_Literal] in
+              Option.List.map
+               (fun '(existT _ idc) => make_interp_rewrite'' idc)
+               (simple_idents).
+
+        Definition interp_rewrite_rules
+          := Eval cbv [interp_rewrite_rules' ident.interp ident.gen_interp ident.smart_Literal] in
+              interp_rewrite_rules'.
       End make_rewrite_rules.
     End Make.
 
@@ -1041,7 +1399,6 @@ Module Compilers.
       Local Notation type := (type.type base.type).
       Local Notation expr := (@expr.expr base.type ident var).
       Local Notation value := (@value base.type ident var).
-      Local Notation anyexpr := (@anyexpr ident var).
       Local Notation pattern := (@pattern.pattern pattern.ident).
       Local Notation UnderLets := (@UnderLets.UnderLets base.type ident var).
       Local Notation ptype := (type.type pattern.base.type).
@@ -1051,109 +1408,108 @@ Module Compilers.
       Coercion ptype_base' : base.type.base >-> ptype.
       Coercion type_base : base.type >-> type.
       Coercion ptype_base : pattern.base.type >-> ptype.
-      Local Notation opt_anyexprP ivar
-        := (fun should_do_again : bool => UnderLets (@AnyExpr.anyexpr base.type ident (if should_do_again then ivar else var))).
-      Local Notation opt_anyexpr ivar
-        := (option (sigT (opt_anyexprP ivar))).
-      Local Notation binding_dataT := (@binding_dataT ident var pattern.ident pattern.ident.arg_types).
-      Local Notation lift_with_bindings := (@lift_with_bindings ident var pattern.ident pattern.ident.arg_types).
-      Local Notation app_binding_data := (@app_binding_data ident var pattern.ident pattern.ident.arg_types).
-      Local Notation rewrite_ruleTP := (@rewrite_ruleTP ident var pattern.ident pattern.ident.arg_types).
-      Local Notation rewrite_rulesT := (@rewrite_rulesT ident var pattern.ident pattern.ident.arg_types).
+      Local Notation Build_rewrite_rule_data := (@Build_rewrite_rule_data ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
+      Local Notation Build_anypattern := (@pattern.Build_anypattern pattern.ident).
+      Local Notation rewrite_ruleTP := (@rewrite_ruleTP ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
+      Local Notation rewrite_ruleT := (@rewrite_ruleT ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
+      Local Notation rewrite_rulesT := (@rewrite_rulesT ident var pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars)).
       Local Notation castv := (@castv ident var).
-      Local Notation assemble_identifier_rewriters := (@assemble_identifier_rewriters ident var pattern.ident pattern.ident.full_types (@pattern.ident.invert_bind_args) pattern.ident.type_of pattern.ident.to_typed (@pattern.ident.eta_ident_cps) (@pattern.ident.of_typed_ident) pattern.ident.arg_types (@pattern.ident.bind_args) pattern.ident.try_make_transport_ident_cps).
+      Definition pident_unify_unknown := @pattern.ident.unify.
+      Definition invert_bind_args_unknown := @pattern.Raw.ident.invert_bind_args.
+      Local Notation assemble_identifier_rewriters := (@assemble_identifier_rewriters ident var (@pattern.ident.eta_ident_cps) (@pattern.ident) (@pattern.ident.arg_types) (@pattern.ident.unify) pident_unify_unknown pattern.Raw.ident (@pattern.ident.type_vars) (@pattern.Raw.ident.full_types) (@pattern.Raw.ident.invert_bind_args) invert_bind_args_unknown (@pattern.Raw.ident.type_of) (@pattern.Raw.ident.to_typed) pattern.Raw.ident.is_simple).
 
-      Let UnderLetsExpr {btype bident ivar} t := @UnderLets.UnderLets base.type ident var (@expr.expr btype bident ivar t).
-      Let UnderLetsAnyExpr {btype ident ivar} := @UnderLets.UnderLets btype ident ivar (@AnyExpr.anyexpr btype ident ivar).
-      Let UnderLetsAnyExprCpsOpt {btype bident ivar} := ~> option (@UnderLets.UnderLets base.type ident var (@AnyExpr.anyexpr btype bident ivar)).
-      (*Let UnderLetsAnyAnyExpr {btype ident ivar} := @UnderLets.UnderLets btype ident ivar (@AnyAnyExpr.anyexpr btype ident ivar).*)
-      Let BaseWrapUnderLetsAnyExpr {btype bident ivar t} : @UnderLetsExpr btype bident ivar t -> @UnderLetsAnyExprCpsOpt btype bident ivar
-        := fun e T k
-           => k (match t return @UnderLets.UnderLets _ _ _ (@expr.expr _ _ _ t) -> _ with
-                | type.base _ => fun e => Some (e <-- e; UnderLets.Base (AnyExpr.wrap e))%under_lets
-                | type.arrow _ _ => fun _ => None
-                end e)%cps.
-      Let BaseExpr {btype ident ivar t} : @expr.expr btype ident ivar t -> @UnderLetsExpr btype ident ivar t := UnderLets.Base.
-      (*Let BaseAnyAnyExpr {btype ident ivar t} : @expr.expr btype ident ivar t -> @UnderLets.UnderLets btype ident ivar (@expr.expr btype ident ivar t) := UnderLets.Base.*)
-      Coercion BaseWrapUnderLetsAnyExpr : UnderLetsExpr >-> UnderLetsAnyExprCpsOpt.
-      Coercion BaseExpr : expr >-> UnderLetsExpr.
-      Notation ret v := ((v : UnderLetsExpr _) : UnderLetsAnyExprCpsOpt).
-      Notation oret v := (fun T k => k (Some v)).
-      (*Coercion BaseExpr : expr >-> UnderLets.*)
-      Notation make_rewrite'_cps p f
+      Delimit Scope rewrite_scope with rewrite.
+      Delimit Scope rewrite_opt_scope with rewrite_opt.
+      Delimit Scope rewrite_lets_scope with rewrite_lets.
+      Local Open Scope rewrite_opt_scope.
+      Local Open Scope rewrite_lets_scope.
+      Local Open Scope rewrite_scope.
+
+      Notation make_rewrite_gen should_do_again with_opt under_lets p f
         := (existT
-              (fun p' : pattern => binding_dataT p' ~> (opt_anyexpr value))
-              p%pattern
-              (fun v T (k : opt_anyexpr value -> T)
-               => @app_binding_data _ p%pattern f%expr v T k)).
-      Notation make_rewrite' p f
-        := (existT
-              (fun p' : pattern => binding_dataT p' ~> (opt_anyexpr value))
-              p%pattern
-              (fun v T (k : opt_anyexpr value -> T)
-               => k (@app_binding_data _ p%pattern f%expr v))).
+              rewrite_ruleTP
+              (@Build_anypattern _ p%pattern)
+              (@Build_rewrite_rule_data _ p%pattern should_do_again with_opt under_lets false (* is_cps *) f)).
+      (* %cps%option%under_lets *)
       Notation make_rewrite p f
-        := (let f' := (@lift_with_bindings p _ _ (fun x:@UnderLetsAnyExprCpsOpt base.type ident var => (x' <-- x; oret (existT (opt_anyexprP value) false x'))%cps) f%expr) in
-            make_rewrite'_cps p f').
+        := (make_rewrite_gen false false false p f%rewrite%expr%list%Z%bool).
+      Notation make_rewritel p f
+        := (make_rewrite_gen false false true p f%rewrite_lets%rewrite%expr%list%Z%bool%under_lets).
+      Notation make_rewriteo p f
+        := (make_rewrite_gen false true false p f%rewrite_opt%rewrite%expr%list%Z%bool).
+      Notation make_rewriteol p f
+        := (make_rewrite_gen false true true p f%rewrite_lets%rewrite_opt%rewrite%expr%list%Z%bool%under_lets).
       Notation make_rewrite_step p f
-        := (let f' := (@lift_with_bindings p _ _ (fun x:@UnderLetsAnyExprCpsOpt base.type ident value => (x' <-- x; oret (existT (opt_anyexprP value) true x'))%cps) f%expr) in
-            make_rewrite'_cps p f').
+        := (make_rewrite_gen true false false p f%rewrite%expr%list%Z%bool).
+      Notation make_rewritel_step p f
+        := (make_rewrite_gen true false true p f%rewrite_lets%rewrite%expr%list%Z%bool%under_lets).
+      Notation make_rewriteo_step p f
+        := (make_rewrite_gen true true false p f%rewrite_opt%rewrite%expr%list%Z%bool).
+      Notation make_rewriteol_step p f
+        := (make_rewrite_gen true true true p f%rewrite_lets%rewrite_opt%rewrite%expr%list%Z%bool%under_lets).
+      Let UnderLetsExpr {btype bident ivar} t := @UnderLets.UnderLets base.type ident var (@expr.expr btype bident ivar t).
+      Let OptExpr {btype bident ivar} t := option (@expr.expr btype bident ivar t).
+      Let OptUnderLetsExpr {btype bident ivar} t := option (@UnderLets.UnderLets base.type ident var (@expr.expr btype bident ivar t)).
+      Let BaseExpr {btype ident ivar t} : @expr.expr btype ident ivar t -> @UnderLetsExpr btype ident ivar t := UnderLets.Base.
+      Let SomeExpr {btype ident ivar t} : @expr.expr btype ident ivar t -> @OptExpr btype ident ivar t := Some.
+      Let SomeUnderLetsExpr {btype ident ivar t} : @UnderLetsExpr btype ident ivar t -> @OptUnderLetsExpr btype ident ivar t := Some.
+      Coercion BaseExpr : expr >-> UnderLetsExpr.
+      Coercion SomeExpr : expr >-> OptExpr.
+      Coercion SomeUnderLetsExpr : UnderLetsExpr >-> OptUnderLetsExpr.
 
-      Local Notation "x' <- v ; C" := (fun T k => v%cps T (fun x' => Option.sequence_return (Compile.option_bind' x' (fun x' => Some ((C%cps : UnderLetsAnyExprCpsOpt) T k))) (k None))) : cps_scope.
-      Local Notation "x <-- y ; f" := (UnderLets.splice y (fun x => (f%cps : UnderLetsExpr _))) : cps_scope.
-      Local Notation "x <--- y ; f" := (UnderLets.splice_list y (fun x => (f%cps : UnderLetsExpr _))) : cps_scope.
-      Local Notation "x <---- y ; f" := (fun T k => Option.sequence_return (Compile.option_bind' y (fun x => Some ((f%cps : UnderLetsAnyExprCpsOpt) T k))) (k None)) : cps_scope.
+      Local Notation "x <- y ; f" := (Compile.option_bind' y%rewrite_lets%rewrite_opt%rewrite (fun x => f%rewrite_lets%rewrite_opt%rewrite : OptUnderLetsExpr _)) : rewrite_lets_scope.
+      Local Notation "x <- y ; f" := (Compile.option_bind' y%rewrite_opt%rewrite (fun x => f%rewrite_opt%rewrite : OptExpr _)) : rewrite_opt_scope.
+      Local Notation "x <-- y ; f" := (UnderLets.splice y%rewrite_lets%rewrite (fun x => (f%rewrite_lets%rewrite : UnderLetsExpr _))) : rewrite_lets_scope.
+      Local Notation "x <--- y ; f" := (UnderLets.splice_list y%rewrite_lets%rewrite (fun x => (f%rewrite_lets%rewrite : UnderLetsExpr _))) : rewrite_lets_scope.
+      Local Notation "x <---- y ; f" := (Compile.option_bind' y%rewrite_lets%rewrite_opt%rewrite (fun x => (f%rewrite_lets%rewrite : UnderLetsExpr _) : OptUnderLetsExpr _)) : rewrite_lets_scope.
+      Local Notation "'llet' x := y 'in' f" := (UnderLets.UnderLet y%rewrite_lets%rewrite (fun x => (f%rewrite_lets%rewrite : UnderLetsExpr _))) : rewrite_lets_scope.
 
       Definition rlist_rect {A P}
                  {ivar}
                  (Pnil : @UnderLetsExpr base.type ident ivar (type.base P))
                  (Pcons : expr (type.base A) -> list (expr (type.base A)) -> @expr.expr base.type ident ivar (type.base P) -> @UnderLetsExpr base.type ident ivar (type.base P))
                  (e : expr (type.base (base.type.list A)))
-        : @UnderLetsAnyExprCpsOpt base.type ident ivar
-        := (ls <- reflect_list_cps e;
+        : @OptUnderLetsExpr base.type ident ivar P
+        := (ls <- reflect_list e;
               list_rect
                 (fun _ => UnderLetsExpr (type.base P))
                 Pnil
                 (fun x xs rec => rec' <-- rec; Pcons x xs rec')
-                ls)%cps.
+                ls).
 
-      Definition rlist_rect_cast {A A' P}
-                 {ivar}
-                 (Pnil : @UnderLetsExpr base.type ident ivar (type.base P))
-                 (Pcons : expr (type.base A) -> list (expr (type.base A)) -> @expr.expr base.type ident ivar (type.base P) -> @UnderLetsExpr base.type ident ivar (type.base P))
-                 (e : expr (type.base A'))
-        : @UnderLetsAnyExprCpsOpt base.type ident ivar
-        := (e <- castbe e; rlist_rect Pnil Pcons e)%cps.
+      Definition rwhen {ivar t} (v : @OptExpr base.type ident ivar t) (cond : bool)
+        : @OptExpr base.type ident ivar t
+        := if cond then v else None.
+      Definition rwhenl {ivar t} (v : @OptUnderLetsExpr base.type ident ivar t) (cond : bool)
+        : @OptUnderLetsExpr base.type ident ivar t
+        := if cond then v else None.
 
-      Definition rwhen {ivar} (v : @UnderLetsAnyExprCpsOpt base.type ident ivar) (cond : bool)
-        : @UnderLetsAnyExprCpsOpt base.type ident ivar
-        := fun T k => if cond then v T k else k None.
-
-      Local Notation "e 'when' cond" := (rwhen e%cps cond) (only parsing, at level 100).
+      Local Notation "e 'when' cond" := (rwhen e%rewrite_opt%rewrite cond) (only parsing, at level 100) : rewrite_opt_scope.
+      Local Notation "e 'owhen' cond" := (rwhenl e%rewrite_lets%rewrite_opt%rewrite cond) (only parsing, at level 100) : rewrite_lets_scope.
+      Local Notation "e 'when' cond" := (rwhenl (e%rewrite_lets%rewrite : UnderLetsExpr _)  cond) (only parsing, at level 100) : rewrite_lets_scope.
 
       Local Notation ℤ := base.type.Z.
       Local Notation ℕ := base.type.nat.
       Local Notation bool := base.type.bool.
       Local Notation list := pattern.base.type.list.
 
+      (*
       Local Arguments Make.interp_rewrite_rules / .
-
+      *)
       (**
          The follow are rules for rewriting expressions. On the left is a pattern to match:
            ??: any expression whose type contains no arrows.
            ??{x}: any expression whose type is x.
-           ??{pattern.base.type.list ??}: for example, a list with elements of a captured type. (The captured type does not match a type with arrows.)
+           ??{list '1}: for example, a list with elements of a type variable '1.
            x @ y: x applied to y.
            #?x: a value, know at compile time, with type x. (Where x is one of {ℕ or N (nat), 𝔹 or B (bool), ℤ or Z (integers)}.)
            #x: the identifer x.
 
-         A matched expression is replaced with the right-hand-side, which is a function that returns a syntax tree, or None to indicate that the match didn't really match. The syntax tree is under three monads: continuation, option, and custom UnderLets monad.
+         A matched expression is replaced with the right-hand-side, which is a function that returns a syntax tree, or None to indicate that the match didn't really match. The syntax tree is under two monads: option, and custom UnderLets monad.
 
-         The function takes the elements that where matched on the LHS as arguments. The arguments are given in the same order as on the LHS, but where wildcards in a type appear before the outer wildcard for that element. So ??{??} results in two arguments, the second wildcard comes first, and ??{?? -> ??} gives arguments in the order 2, 3, 1.
+         The function takes first any types that appeared as type variables (e.g., '1, '2, etc), and then the elements that where matched on the LHS as arguments. The arguments are given in the same order as on the LHS.
 
-         Sometimes matching an identifer will also result in arguments. Depends on the identifer. Good luck!
-
-In the RHS, the follow notation applies:
+         In the RHS, the follow notation applies:
            ##x: the literal value x
            #x: the identifier x
            x @ y: x applied to y
@@ -1161,62 +1517,53 @@ In the RHS, the follow notation applies:
            λ: PHOAS abstraction / functions
 
          On the RHS, since we're returning a value under three monads, there's some fun notion for dealing with different levels of the monad stack in a single expression:
-           ret: return something of type [UnderLets expr]
-           <-: bind, under the CPS+Option monad.
+           <-: bind, under the Option monad.
            <--: bind, under the UnderLets monad
-           <---: bind, under the UnderLets+List monad
-           <----: bind, under the Option monad.
+           <---: bind, under the UnderLets+List monad.
+           <----: bind+ret, under the Option monad.
 
-         If you have an expression of type expr or UnderLetsExpr or UnderLetsAnyExprCpsOpt, coercions will handle it; if you have an expression of type [UnderLets expr], you will need [ret].
+         There are eight choices for kinds of rewrite rules:
+         - [make_rewrite] for rules returning [expr]
+         - [make_rewriteo] for rules returning [option expr]
+         - [make_rewritel] for rules returning [UnderLets expr]
+         - [make_rewriteol] for rules returning [option (UnderLets expr)]
+         - [make_rewrite*_step] as [make_rewrite*] above, but indicating that rewriting should happen again in the result of rewriting with this rule.
 
          If stuck, email Jason.
        *)
+      Local Arguments pattern.anypattern : clear implicits.
+      Local Arguments Make.interp_rewrite_rules / .
+      Let myapp {A} := Eval cbv [List.app] in @List.app A.
       Definition nbe_rewrite_rules : rewrite_rulesT
-        := Eval cbn [Make.interp_rewrite_rules List.app] in
-            Make.interp_rewrite_rules
-              ++ [
-                make_rewrite (#pattern.ident.fst @ (??, ??)) (fun _ x _ y => x)
-                ; make_rewrite (#pattern.ident.snd @ (??, ??)) (fun _ x _ y => y)
-                ; make_rewrite (#pattern.ident.List_repeat @ ?? @ #?ℕ) (fun _ x n => reify_list (repeat x n))
-                ; make_rewrite
-                    (#pattern.ident.bool_rect @ ??{() -> ??} @ ??{() -> ??} @ #?𝔹)
-                    (fun _ t _ f b
-                     => if b return UnderLetsExpr (type.base (if b then _ else _))
-                        then t ##tt
-                        else f ##tt)
-                ; make_rewrite
-                    (#pattern.ident.prod_rect @ ??{?? -> ?? -> ??} @ (??, ??))
-                    (fun _ _ _ f _ x _ y
-                     => x <- castbe x; y <- castbe y; ret (f x y))
-                ; make_rewrite
-                    (??{list ??} ++ ??{list ??})
-                    (fun _ xs _ ys => rlist_rect_cast ys (fun x _ xs_ys => x :: xs_ys) xs)
-                ; make_rewrite
-                    (#pattern.ident.List_firstn @ #?ℕ @ ??{list ??})
-                    (fun n _ xs
-                     => xs <- reflect_list_cps xs;
-                          reify_list (List.firstn n xs))
-                ; make_rewrite
-                    (#pattern.ident.List_skipn @ #?ℕ @ ??{list ??})
-                    (fun n _ xs
-                     => xs <- reflect_list_cps xs;
-                          reify_list (List.skipn n xs))
-                ; make_rewrite
-                    (#pattern.ident.List_rev @ ??{list ??})
-                    (fun _ xs
-                     => xs <- reflect_list_cps xs;
-                          reify_list (List.rev xs))
-                ; make_rewrite_step
-                    (#pattern.ident.List_flat_map @ ??{?? -> list ??} @ ??{list ??})
-                    (fun _ B f _ xs
-                     => rlist_rect_cast
-                          []
-                          (fun x _ flat_map_tl => fx <-- f x; UnderLets.Base ($fx ++ flat_map_tl))
-                          xs)
-                ; make_rewrite_step
-                    (#pattern.ident.List_partition @ ??{?? -> base.type.bool} @ ??{list ??})
-                    (fun _ f _ xs
-                     => rlist_rect_cast
+        := Eval cbv [Make.interp_rewrite_rules myapp] in
+            myapp
+              Make.interp_rewrite_rules
+              [make_rewrite (#(@pattern.ident.fst '1 '2) @ (??, ??)) (fun _ _ x y => x)
+               ; make_rewrite (#(@pattern.ident.snd '1 '2) @ (??, ??)) (fun _ x _ y => y)
+               ; make_rewrite (#(@pattern.ident.List_repeat '1) @ ?? @ #?ℕ) (fun _ x n => reify_list (repeat x n))
+               ; make_rewritel (#(@pattern.ident.bool_rect '1) @ ?? @ ?? @ #?𝔹) (fun _ t f b => if b then t ##tt else f ##tt)
+               ; make_rewritel (#(@pattern.ident.prod_rect '1 '2 '3) @ ?? @ (??, ??)) (fun _ _ _ f x y => f x y)
+               ; make_rewriteol (??{list '1} ++ ??{list '1}) (fun _ xs ys => rlist_rect ys (fun x _ xs_ys => x :: xs_ys) xs)
+               ; make_rewriteol
+                   (#(@pattern.ident.List_firstn '1) @ #?ℕ @ ??)
+                   (fun _ n xs => xs <- reflect_list xs; reify_list (List.firstn n xs))
+               ; make_rewriteol
+                   (#(@pattern.ident.List_skipn '1) @ #?ℕ @ ??)
+                   (fun _ n xs => xs <- reflect_list xs; reify_list (List.skipn n xs))
+               ; make_rewriteol
+                   (#(@pattern.ident.List_rev '1) @ ??)
+                   (fun _ xs => xs <- reflect_list xs; reify_list (List.rev xs))
+               ; make_rewriteol_step
+                   (#(@pattern.ident.List_flat_map '1 '2) @ ?? @ ??)
+                   (fun _ _ f xs
+                    => rlist_rect
+                         []
+                         (fun x _ flat_map_tl => fx <-- f x; ($fx ++ flat_map_tl))
+                         xs)
+               ; make_rewriteol_step
+                    (#(@pattern.ident.List_partition '1) @ ?? @ ??)
+                    (fun _ f xs
+                     => rlist_rect
                           ([], [])
                           (fun x tl partition_tl
                            => fx <-- f x;
@@ -1227,290 +1574,254 @@ In the RHS, the follow notation applies:
                                              @ $fx)
                                   @ partition_tl))
                           xs)
-                ; make_rewrite
-                    (#pattern.ident.List_fold_right @ ??{?? -> ?? -> ??} @ ?? @ ??{list ??})
-                    (fun _ _ _ f B init A xs
-                     => f <- @castv _ (A -> B -> B)%etype f;
-                          rlist_rect
-                            init
-                            (fun x _ y => f x y)
-                            xs)
-                ; make_rewrite
-                    (#pattern.ident.list_rect @ ??{() -> ??} @ ??{?? -> ?? -> ?? -> ??} @ ??{list ??})
-                    (fun P Pnil _ _ _ _ Pcons A xs
-                     => Pcons <- @castv _ (A -> base.type.list A -> P -> P) Pcons;
-                          rlist_rect
-                            (Pnil ##tt)
-                            (fun x' xs' rec => Pcons x' (reify_list xs') rec)
-                            xs)
-                ; make_rewrite
-                    (#pattern.ident.list_case @ ??{() -> ??} @ ??{?? -> ?? -> ??} @ []) (fun _ Pnil _ _ _ Pcons => ret (Pnil ##tt))
-                ; make_rewrite
-                    (#pattern.ident.list_case @ ??{() -> ??} @ ??{?? -> ?? -> ??} @ (?? :: ??))
-                    (fun _ Pnil _ _ _ Pcons _ x _ xs
-                     => x <- castbe x; xs <- castbe xs; ret (Pcons x xs))
-                ; make_rewrite
-                    (#pattern.ident.List_map @ ??{?? -> ??} @ ??{list ??})
-                    (fun _ _ f _ xs
-                     => rlist_rect_cast
-                          []
-                          (fun x _ fxs => fx <-- f x; fx :: fxs)
-                          xs)
-                ; make_rewrite
-                    (#pattern.ident.List_nth_default @ ?? @ ??{list ??} @ #?ℕ)
-                    (fun _ default _ ls n
-                     => default <- castbe default;
-                          ls <- reflect_list_cps ls;
-                          nth_default default ls n)
-                ; make_rewrite
-                    (#pattern.ident.nat_rect @ ??{() -> ??} @ ??{base.type.nat -> ?? -> ??} @ #?ℕ)
-                    (fun P O_case _ _ S_case n
-                     => S_case <- @castv _ (@type.base base.type base.type.nat -> type.base P -> type.base P) S_case;
-                          ret (nat_rect _ (O_case ##tt) (fun n' rec => rec <-- rec; S_case ##n' rec) n))
-                ; make_rewrite
-                    (#pattern.ident.nat_rect_arrow @ ??{?? -> ??} @ ??{base.type.nat -> (?? -> ??) -> (?? -> ??)} @ #?ℕ @ ??)
-                    (fun P Q O_case _ _ _ _ S_case n _ v
-                     => S_case <- @castv _ (@type.base base.type base.type.nat -> (type.base P -> type.base Q) -> (type.base P -> type.base Q)) S_case;
-                          v <- castbe v;
-                          ret (nat_rect _ O_case (fun n' rec v => S_case ##n' rec v) n v))
-                ; make_rewrite
-                    (#pattern.ident.List_length @ ??{list ??})
-                    (fun _ xs => xs <- reflect_list_cps xs; ##(List.length xs))
-                ; make_rewrite
-                    (#pattern.ident.List_combine @ ??{list ??} @ ??{list ??})
-                    (fun _ xs _ ys
-                     => xs <- reflect_list_cps xs;
-                          ys <- reflect_list_cps ys;
-                          reify_list (List.map (fun '((x, y)%core) => (x, y)) (List.combine xs ys)))
-                ; make_rewrite
-                    (#pattern.ident.List_update_nth @ #?ℕ @ ??{?? -> ??} @ ??{list ??})
-                    (fun n _ _ f A ls
-                     => f <- @castv _ (A -> A) f;
-                          ls <- reflect_list_cps ls;
-                          ret
-                            (retv <--- (update_nth
-                                          n
-                                          (fun x => x <-- x; f x)
-                                          (List.map UnderLets.Base ls));
-                               reify_list retv))
-              ]%list%pattern%cps%option%under_lets%Z%bool.
+               ; make_rewriteol
+                    (#(@pattern.ident.List_fold_right '1 '2) @ ?? @ ?? @ ??)
+                    (fun _ _ f init xs => rlist_rect init (fun x _ y => f x y) xs)
+               ; make_rewriteol
+                   (#(@pattern.ident.list_rect '1 '2) @ ?? @ ?? @ ??)
+                   (fun _ _ Pnil Pcons xs
+                    => rlist_rect (Pnil ##tt) (fun x' xs' rec => Pcons x' (reify_list xs') rec) xs)
+               ; make_rewritel
+                   (#(@pattern.ident.list_case '1 '2) @ ?? @ ?? @ [])
+                   (fun _ _ Pnil Pcons => Pnil ##tt)
+               ; make_rewritel
+                   (#(@pattern.ident.list_case '1 '2) @ ?? @ ?? @ (?? :: ??))
+                   (fun _ _ Pnil Pcons x xs => Pcons x xs)
+               ; make_rewriteol
+                   (#(@pattern.ident.List_map '1 '2) @ ?? @ ??)
+                   (fun _ _ f xs => rlist_rect [] (fun x _ fxs => fx <-- f x; fx :: fxs) xs)
+               ; make_rewriteo
+                   (#(@pattern.ident.List_nth_default '1) @ ?? @ ?? @ #?ℕ)
+                   (fun _ default ls n => ls <- reflect_list ls; nth_default default ls n)
+               ; make_rewritel
+                   (#(@pattern.ident.nat_rect '1) @ ?? @ ?? @ #?ℕ)
+                   (fun _ O_case S_case n
+                    => nat_rect _ (O_case ##tt) (fun n' rec => rec <-- rec; S_case ##n' rec) n)
+               ; make_rewritel
+                   (#(@pattern.ident.nat_rect_arrow '1 '2) @ ?? @ ?? @ #?ℕ @ ??)
+                   (fun _ _ O_case S_case n v
+                    => nat_rect _ O_case (fun n' rec v => S_case ##n' rec v) n v)
+               ; make_rewriteo
+                   (#(@pattern.ident.List_length '1) @ ??)
+                   (fun _ xs => xs <- reflect_list xs; ##(List.length xs))
+               ; make_rewriteo
+                   (#(@pattern.ident.List_combine '1 '2) @ ?? @ ??)
+                   (fun _ _ xs ys
+                    => xs <- reflect_list xs;
+                         ys <- reflect_list ys;
+                         reify_list (List.map (fun '((x, y)%core) => (x, y)) (List.combine xs ys)))
+               ; make_rewriteol
+                   (#(@pattern.ident.List_update_nth '1) @ #?ℕ @ ?? @ ??)
+                   (fun _ n f ls
+                    => ls <---- reflect_list ls;
+                         retv <--- (update_nth
+                                      n
+                                      (fun x => x <-- x; f x)
+                                      (List.map UnderLets.Base ls));
+                         reify_list retv)
+              ].
 
       Definition arith_rewrite_rules (max_const_val : Z) : rewrite_rulesT
-        := [make_rewrite (#pattern.ident.fst @ (??, ??)) (fun _ x _ y => x)
-            ; make_rewrite (#pattern.ident.snd @ (??, ??)) (fun _ x _ y => y)
-            ; make_rewrite (#?ℤ   + ??{ℤ}) (fun z v => v  when  Z.eqb z 0)
-            ; make_rewrite (??{ℤ} + #?ℤ  ) (fun v z => v  when  Z.eqb z 0)
-            ; make_rewrite (#?ℤ   + (-??{ℤ})) (fun z v => ##z - v  when  Z.gtb z 0)
-            ; make_rewrite ((-??{ℤ}) + #?ℤ  ) (fun v z => ##z - v  when  Z.gtb z 0)
-            ; make_rewrite (#?ℤ   + (-??{ℤ})) (fun z v => -(##((-z)%Z) + v)  when  Z.ltb z 0)
-            ; make_rewrite ((-??{ℤ}) + #?ℤ  ) (fun v z => -(v + ##((-z)%Z))  when  Z.ltb z 0)
-            ; make_rewrite ((-??{ℤ}) + (-??{ℤ})) (fun x y => -(x + y))
-            ; make_rewrite ((-??{ℤ}) +   ??{ℤ} ) (fun x y => y - x)
-            ; make_rewrite (  ??{ℤ}  + (-??{ℤ})) (fun x y => x - y)
+        := [make_rewrite (#(@pattern.ident.fst '1 '2) @ (??, ??)) (fun _ _ x y => x)
+            ; make_rewrite (#(@pattern.ident.snd '1 '2) @ (??, ??)) (fun _ x _ y => y)
+            ; make_rewriteo (#?ℤ   + ??) (fun z v => v  when  z =? 0)
+            ; make_rewriteo (?? + #?ℤ  ) (fun v z => v  when  z =? 0)
+            ; make_rewriteo (#?ℤ   + (-??)) (fun z v => ##z - v  when  z >? 0)
+            ; make_rewriteo ((-??) + #?ℤ  ) (fun v z => ##z - v  when  z >? 0)
+            ; make_rewriteo (#?ℤ   + (-??)) (fun z v => -(##((-z)%Z) + v)  when  z <? 0)
+            ; make_rewriteo ((-??) + #?ℤ  ) (fun v z => -(v + ##((-z)%Z))  when  z <? 0)
+            ; make_rewrite ((-??) + (-??)) (fun x y => -(x + y))
+            ; make_rewrite ((-??) +   ?? ) (fun x y => y - x)
+            ; make_rewrite (  ??  + (-??)) (fun x y => x - y)
 
-            ; make_rewrite (#?ℤ   - (-??{ℤ})) (fun z v =>  v  when  Z.eqb z 0)
-            ; make_rewrite (#?ℤ   -   ??{ℤ} ) (fun z v => -v  when  Z.eqb z 0)
-            ; make_rewrite (??{ℤ} - #?ℤ     ) (fun v z =>  v  when  Z.eqb z 0)
-            ; make_rewrite (#?ℤ   - (-??{ℤ})) (fun z v => ##z + v  when  Z.gtb z 0)
-            ; make_rewrite (#?ℤ   - (-??{ℤ})) (fun z v => v - ##((-z)%Z)     when  Z.ltb z 0)
-            ; make_rewrite (#?ℤ   -   ??{ℤ} ) (fun z v => -(##((-z)%Z) + v)  when  Z.ltb z 0)
-            ; make_rewrite ((-??{ℤ}) - #?ℤ  ) (fun v z => -(v + ##((-z)%Z))  when  Z.gtb z 0)
-            ; make_rewrite ((-??{ℤ}) - #?ℤ  ) (fun v z => ##((-z)%Z) - v     when  Z.ltb z 0)
-            ; make_rewrite (  ??{ℤ}  - #?ℤ  ) (fun v z => v + ##((-z)%Z)     when  Z.ltb z 0)
-            ; make_rewrite ((-??{ℤ}) - (-??{ℤ})) (fun x y => y - x)
-            ; make_rewrite ((-??{ℤ}) -   ??{ℤ} ) (fun x y => -(x + y))
-            ; make_rewrite (  ??{ℤ}  - (-??{ℤ})) (fun x y => x + y)
+            ; make_rewriteo (#?ℤ   - (-??)) (fun z v =>  v  when  z =? 0)
+            ; make_rewriteo (#?ℤ   -   ?? ) (fun z v => -v  when  z =? 0)
+            ; make_rewriteo (?? - #?ℤ     ) (fun v z =>  v  when  z =? 0)
+            ; make_rewriteo (#?ℤ   - (-??)) (fun z v => ##z + v  when  z >? 0)
+            ; make_rewriteo (#?ℤ   - (-??)) (fun z v => v - ##((-z)%Z)     when  z <? 0)
+            ; make_rewriteo (#?ℤ   -   ?? ) (fun z v => -(##((-z)%Z) + v)  when  z <? 0)
+            ; make_rewriteo ((-??) - #?ℤ  ) (fun v z => -(v + ##((-z)%Z))  when  z >? 0)
+            ; make_rewriteo ((-??) - #?ℤ  ) (fun v z => ##((-z)%Z) - v     when  z <? 0)
+            ; make_rewriteo (  ??  - #?ℤ  ) (fun v z => v + ##((-z)%Z)     when  z <? 0)
+            ; make_rewrite ((-??) - (-??)) (fun x y => y - x)
+            ; make_rewrite ((-??) -   ?? ) (fun x y => -(x + y))
+            ; make_rewrite (  ??  - (-??)) (fun x y => x + y)
 
             ; make_rewrite (#?ℤ   *  #?ℤ ) (fun x y => ##((x*y)%Z))
-            ; make_rewrite (#?ℤ   * ??{ℤ}) (fun z v => ##0  when  Z.eqb z 0)
-            ; make_rewrite (??{ℤ} * #?ℤ  ) (fun v z => ##0  when  Z.eqb z 0)
-            ; make_rewrite (#?ℤ   * ??{ℤ}) (fun z v => v  when  Z.eqb z 1)
-            ; make_rewrite (??{ℤ} * #?ℤ  ) (fun v z => v  when  Z.eqb z 1)
-            ; make_rewrite (#?ℤ      * (-??{ℤ})) (fun z v =>  v  when  Z.eqb z (-1))
-            ; make_rewrite ((-??{ℤ}) * #?ℤ     ) (fun v z =>  v  when  Z.eqb z (-1))
-            ; make_rewrite (#?ℤ      *   ??{ℤ} ) (fun z v => -v  when  Z.eqb z (-1))
-            ; make_rewrite (??{ℤ}    * #?ℤ     ) (fun v z => -v  when  Z.eqb z (-1))
-            ; make_rewrite (#?ℤ      * ??{ℤ}   ) (fun z v => -(##((-z)%Z) * v)  when  Z.ltb z 0)
-            ; make_rewrite (??{ℤ}    * #?ℤ     ) (fun v z => -(v * ##((-z)%Z))  when  Z.ltb z 0)
-            ; make_rewrite ((-??{ℤ}) * (-??{ℤ})) (fun x y => x * y)
-            ; make_rewrite ((-??{ℤ}) *   ??{ℤ} ) (fun x y => -(x * y))
-            ; make_rewrite (  ??{ℤ}  * (-??{ℤ})) (fun x y => -(x * y))
+            ; make_rewriteo (#?ℤ   * ??) (fun z v => ##0  when  z =? 0)
+            ; make_rewriteo (?? * #?ℤ  ) (fun v z => ##0  when  z =? 0)
+            ; make_rewriteo (#?ℤ   * ??) (fun z v => v  when  z =? 1)
+            ; make_rewriteo (?? * #?ℤ  ) (fun v z => v  when  z =? 1)
+            ; make_rewriteo (#?ℤ      * (-??)) (fun z v =>  v  when  z =? (-1))
+            ; make_rewriteo ((-??) * #?ℤ     ) (fun v z =>  v  when  z =? (-1))
+            ; make_rewriteo (#?ℤ      *   ?? ) (fun z v => -v  when  z =? (-1))
+            ; make_rewriteo (??    * #?ℤ     ) (fun v z => -v  when  z =? (-1))
+            ; make_rewriteo (#?ℤ      * ??   ) (fun z v => -(##((-z)%Z) * v)  when  z <? 0)
+            ; make_rewriteo (??    * #?ℤ     ) (fun v z => -(v * ##((-z)%Z))  when  z <? 0)
+            ; make_rewrite ((-??) * (-??)) (fun x y => x * y)
+            ; make_rewrite ((-??) *   ?? ) (fun x y => -(x * y))
+            ; make_rewrite (  ??  * (-??)) (fun x y => -(x * y))
 
-            ; make_rewrite (??{ℤ} &' #?ℤ) (fun x mask => ##(0)%Z  when  mask =? 0)
-            ; make_rewrite (#?ℤ &' ??{ℤ}) (fun mask x => ##(0)%Z  when  mask =? 0)
+            ; make_rewriteo (?? &' #?ℤ) (fun x mask => ##(0)%Z  when  mask =? 0)
+            ; make_rewriteo (#?ℤ &' ??) (fun mask x => ##(0)%Z  when  mask =? 0)
 
-            ; make_rewrite (??{ℤ} * #?ℤ)   (fun x y => x << ##(Z.log2 y)  when  (y =? (2^Z.log2 y)) && (negb (y =? 2)))
-            ; make_rewrite (#?ℤ * ??{ℤ})   (fun y x => x << ##(Z.log2 y)  when  (y =? (2^Z.log2 y)) && (negb (y =? 2)))
-            ; make_rewrite (??{ℤ} / #?ℤ)   (fun x y => x                  when  (y =? 1))
-            ; make_rewrite (??{ℤ} mod #?ℤ) (fun x y => ##(0)%Z            when  (y =? 1))
-            ; make_rewrite (??{ℤ} / #?ℤ)   (fun x y => x >> ##(Z.log2 y)  when  (y =? (2^Z.log2 y)))
-            ; make_rewrite (??{ℤ} mod #?ℤ) (fun x y => x &' ##(y-1)%Z     when  (y =? (2^Z.log2 y)))
-            ; make_rewrite (-(-??{ℤ})) (fun v => v)
+            ; make_rewriteo (?? * #?ℤ)   (fun x y => x << ##(Z.log2 y)  when  (y =? (2^Z.log2 y)) && (negb (y =? 2)))
+            ; make_rewriteo (#?ℤ * ??)   (fun y x => x << ##(Z.log2 y)  when  (y =? (2^Z.log2 y)) && (negb (y =? 2)))
+            ; make_rewriteo (?? / #?ℤ)   (fun x y => x                  when  (y =? 1))
+            ; make_rewriteo (?? mod #?ℤ) (fun x y => ##(0)%Z            when  (y =? 1))
+            ; make_rewriteo (?? / #?ℤ)   (fun x y => x >> ##(Z.log2 y)  when  (y =? (2^Z.log2 y)))
+            ; make_rewriteo (?? mod #?ℤ) (fun x y => x &' ##(y-1)%Z     when  (y =? (2^Z.log2 y)))
+            ; make_rewrite (-(-??)) (fun v => v)
 
             (* We reassociate some multiplication of small constants  *)
-            ; make_rewrite (#?ℤ * (#?ℤ * (??{ℤ} * ??{ℤ}))) (fun c1 c2 x y => (x * (y * (##c1 * ##c2))) when  (Z.abs c1 <=? Z.abs max_const_val) && (Z.abs c2 <=? Z.abs max_const_val))
-            ; make_rewrite (#?ℤ * (??{ℤ} * (??{ℤ} * #?ℤ))) (fun c1 x y c2 => (x * (y * (##c1 * ##c2))) when  (Z.abs c1 <=? Z.abs max_const_val) && (Z.abs c2 <=? Z.abs max_const_val))
-            ; make_rewrite (#?ℤ * (??{ℤ} * ??{ℤ})) (fun c x y => (x * (y * ##c)) when  (Z.abs c <=? Z.abs max_const_val))
-            ; make_rewrite (#?ℤ * ??{ℤ}) (fun c x => (x * ##c) when  (Z.abs c <=? Z.abs max_const_val))
+            ; make_rewriteo (#?ℤ * (#?ℤ * (?? * ??))) (fun c1 c2 x y => (x * (y * (##c1 * ##c2))) when  (Z.abs c1 <=? Z.abs max_const_val) && (Z.abs c2 <=? Z.abs max_const_val))
+            ; make_rewriteo (#?ℤ * (?? * (?? * #?ℤ))) (fun c1 x y c2 => (x * (y * (##c1 * ##c2))) when  (Z.abs c1 <=? Z.abs max_const_val) && (Z.abs c2 <=? Z.abs max_const_val))
+            ; make_rewriteo (#?ℤ * (?? * ??)) (fun c x y => (x * (y * ##c)) when  (Z.abs c <=? Z.abs max_const_val))
+            ; make_rewriteo (#?ℤ * ??) (fun c x => (x * ##c) when  (Z.abs c <=? Z.abs max_const_val))
 
-            ; make_rewrite (#pattern.ident.Z_mul_split @ #?ℤ @ #?ℤ @ ??{ℤ}) (fun s xx y => (##0, ##0)%Z  when  Z.eqb xx 0)
-            ; make_rewrite (#pattern.ident.Z_mul_split @ #?ℤ @ ??{ℤ} @ #?ℤ) (fun s y xx => (##0, ##0)%Z  when  Z.eqb xx 0)
-            ; make_rewrite (#pattern.ident.Z_mul_split @ #?ℤ @ #?ℤ @ ??{ℤ}) (fun s xx y => (y, ##0)%Z  when  Z.eqb xx 1)
-            ; make_rewrite (#pattern.ident.Z_mul_split @ #?ℤ @ ??{ℤ} @ #?ℤ) (fun s y xx => (y, ##0)%Z  when  Z.eqb xx 1)
-            ; make_rewrite (#pattern.ident.Z_mul_split @ #?ℤ @ #?ℤ @ ??{ℤ}) (fun s xx y => (-y, ##0%Z)  when  Z.eqb xx (-1))
-            ; make_rewrite (#pattern.ident.Z_mul_split @ #?ℤ @ ??{ℤ} @ #?ℤ) (fun s y xx => (-y, ##0%Z)  when  Z.eqb xx (-1))
+            ; make_rewriteo (#pattern.ident.Z_mul_split @ #?ℤ @ #?ℤ @ ??) (fun s xx y => (##0, ##0)%Z  when  xx =? 0)
+            ; make_rewriteo (#pattern.ident.Z_mul_split @ #?ℤ @ ?? @ #?ℤ) (fun s y xx => (##0, ##0)%Z  when  xx =? 0)
+            ; make_rewriteo (#pattern.ident.Z_mul_split @ #?ℤ @ #?ℤ @ ??) (fun s xx y => (y, ##0)%Z  when  xx =? 1)
+            ; make_rewriteo (#pattern.ident.Z_mul_split @ #?ℤ @ ?? @ #?ℤ) (fun s y xx => (y, ##0)%Z  when  xx =? 1)
+            ; make_rewriteo (#pattern.ident.Z_mul_split @ #?ℤ @ #?ℤ @ ??) (fun s xx y => (-y, ##0%Z)  when  xx =? (-1))
+            ; make_rewriteo (#pattern.ident.Z_mul_split @ #?ℤ @ ?? @ #?ℤ) (fun s y xx => (-y, ##0%Z)  when  xx =? (-1))
 
-            ; make_rewrite
-                (#pattern.ident.Z_add_get_carry @ ??{ℤ} @ (-??{ℤ}) @ ??{ℤ})
-                (fun s y x => ret (UnderLets.UnderLet
-                                     (#ident.Z_sub_get_borrow @ s @ x @ y)
-                                     (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc)))))
-            ; make_rewrite
-                (#pattern.ident.Z_add_get_carry @ ??{ℤ} @ ??{ℤ} @ (-??{ℤ}))
-                (fun s x y => ret (UnderLets.UnderLet
-                                     (#ident.Z_sub_get_borrow @ s @ x @ y)
-                                     (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc)))))
-            ; make_rewrite
-                (#pattern.ident.Z_add_get_carry @ ??{ℤ} @ #?ℤ @ ??{ℤ})
-                (fun s yy x => ret (UnderLets.UnderLet
-                                      (#ident.Z_sub_get_borrow @ s @ x @ ##(-yy)%Z)
-                                      (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                   when  yy <? 0)
-            ; make_rewrite
-                (#pattern.ident.Z_add_get_carry @ ??{ℤ} @ ??{ℤ} @ #?ℤ)
-                (fun s x yy => ret (UnderLets.UnderLet
-                                      (#ident.Z_sub_get_borrow @ s @ x @ ##(-yy)%Z)
-                                      (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                   when  yy <? 0)
+            ; make_rewritel
+                (#pattern.ident.Z_add_get_carry @ ?? @ (-??) @ ??)
+                (fun s y x => (llet vc := #ident.Z_sub_get_borrow @ s @ x @ y in
+                                   (#ident.fst @ $vc, -(#ident.snd @ $vc))))
+            ; make_rewritel
+                (#pattern.ident.Z_add_get_carry @ ?? @ ?? @ (-??))
+                (fun s x y => (llet vc := #ident.Z_sub_get_borrow @ s @ x @ y in
+                                   (#ident.fst @ $vc, -(#ident.snd @ $vc))))
+            ; make_rewriteol
+                (#pattern.ident.Z_add_get_carry @ ?? @ #?ℤ @ ??)
+                (fun s yy x => (llet vc := #ident.Z_sub_get_borrow @ s @ x @ ##(-yy)%Z in
+                                    (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                 when  yy <? 0)
+            ; make_rewriteol
+                (#pattern.ident.Z_add_get_carry @ ?? @ ?? @ #?ℤ)
+                (fun s x yy => (llet vc := #ident.Z_sub_get_borrow @ s @ x @ ##(-yy)%Z in
+                                    (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                 when  yy <? 0)
 
 
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ (-??{ℤ}) @ (-??{ℤ}) @ ??{ℤ})
-                (fun s c y x => ret (UnderLets.UnderLet
-                                       (#ident.Z_sub_with_get_borrow @ s @ c @ x @ y)
-                                       (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc)))))
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ (-??{ℤ}) @ ??{ℤ} @ (-??{ℤ}))
-                (fun s c x y => ret (UnderLets.UnderLet
-                                       (#ident.Z_sub_with_get_borrow @ s @ c @ x @ y)
-                                       (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc)))))
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ #?ℤ @ (-??{ℤ}) @ ??{ℤ})
-                (fun s cc y x => ret (UnderLets.UnderLet
-                                        (#ident.Z_sub_get_borrow @ s @ x @ y)
-                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                     when  cc =? 0)
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ #?ℤ @ (-??{ℤ}) @ ??{ℤ})
-                (fun s cc y x => ret (UnderLets.UnderLet
-                                        (#ident.Z_sub_with_get_borrow @ s @ ##(-cc)%Z @ x @ y)
-                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                     when  cc <? 0)
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ #?ℤ @ ??{ℤ} @ (-??{ℤ}))
-                (fun s cc x y => ret (UnderLets.UnderLet
-                                        (#ident.Z_sub_get_borrow @ s @ x @ y)
-                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                     when  cc =? 0)
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ #?ℤ @ ??{ℤ} @ (-??{ℤ}))
-                (fun s cc x y => ret (UnderLets.UnderLet
-                                        (#ident.Z_sub_with_get_borrow @ s @ ##(-cc)%Z @ x @ y)
-                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                     when  cc <? 0)
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ (-??{ℤ}) @ #?ℤ @ ??{ℤ})
-                (fun s c yy x => ret (UnderLets.UnderLet
-                                        (#ident.Z_sub_with_get_borrow @ s @ c @ x @ ##(-yy)%Z)
-                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                     when  yy <=? 0)
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ (-??{ℤ}) @ ??{ℤ} @ #?ℤ)
-                (fun s c x yy => ret (UnderLets.UnderLet
-                                        (#ident.Z_sub_with_get_borrow @ s @ c @ x @ ##(-yy)%Z)
-                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                     when  yy <=? 0)
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ #?ℤ @ #?ℤ @ ??{ℤ})
-                (fun s cc yy x => ret (UnderLets.UnderLet
-                                         (#ident.Z_sub_with_get_borrow @ s @ ##(-cc)%Z @ x @ ##(-yy)%Z)
-                                         (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                      when  (yy <=? 0) && (cc <=? 0) && ((yy + cc) <? 0)) (* at least one must be strictly negative *)
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ #?ℤ @ ??{ℤ} @ #?ℤ)
-                (fun s cc x yy => ret (UnderLets.UnderLet
-                                         (#ident.Z_sub_with_get_borrow @ s @ ##(-cc)%Z @ x @ ##(-yy)%Z)
-                                         (fun vc => UnderLets.Base (#ident.fst @ $vc, -(#ident.snd @ $vc))))
-                                      when  (yy <=? 0) && (cc <=? 0) && ((yy + cc) <? 0)) (* at least one must be strictly negative *)
+            ; make_rewritel
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ (-??) @ (-??) @ ??)
+                (fun s c y x => (llet vc := #ident.Z_sub_with_get_borrow @ s @ c @ x @ y in
+                                     (#ident.fst @ $vc, -(#ident.snd @ $vc))))
+            ; make_rewritel
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ (-??) @ ?? @ (-??))
+                (fun s c x y => (llet vc := #ident.Z_sub_with_get_borrow @ s @ c @ x @ y in
+                                     (#ident.fst @ $vc, -(#ident.snd @ $vc))))
+            ; make_rewriteol
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ #?ℤ @ (-??) @ ??)
+                (fun s cc y x => (llet vc := #ident.Z_sub_get_borrow @ s @ x @ y in
+                                      (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                   when  cc =? 0)
+            ; make_rewriteol
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ #?ℤ @ (-??) @ ??)
+                (fun s cc y x => (llet vc := #ident.Z_sub_with_get_borrow @ s @ ##(-cc)%Z @ x @ y in
+                                      (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                   when  cc <? 0)
+            ; make_rewriteol
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ #?ℤ @ ?? @ (-??))
+                (fun s cc x y => (llet vc := #ident.Z_sub_get_borrow @ s @ x @ y in
+                                      (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                   when  cc =? 0)
+            ; make_rewriteol
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ #?ℤ @ ?? @ (-??))
+                (fun s cc x y => (llet vc := #ident.Z_sub_with_get_borrow @ s @ ##(-cc)%Z @ x @ y in
+                                      (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                   when  cc <? 0)
+            ; make_rewriteol
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ (-??) @ #?ℤ @ ??)
+                (fun s c yy x => (llet vc := #ident.Z_sub_with_get_borrow @ s @ c @ x @ ##(-yy)%Z in
+                                      (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                   when  yy <=? 0)
+            ; make_rewriteol
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ (-??) @ ?? @ #?ℤ)
+                (fun s c x yy => (llet vc := #ident.Z_sub_with_get_borrow @ s @ c @ x @ ##(-yy)%Z in
+                                      (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                   when  yy <=? 0)
+            ; make_rewriteol
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ #?ℤ @ #?ℤ @ ??)
+                (fun s cc yy x => (llet vc := #ident.Z_sub_with_get_borrow @ s @ ##(-cc)%Z @ x @ ##(-yy)%Z in
+                                       (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                    when  (yy <=? 0) && (cc <=? 0) && ((yy + cc) <? 0)) (* at least one must be strictly negative *)
+            ; make_rewriteol
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ #?ℤ @ ?? @ #?ℤ)
+                (fun s cc x yy => (llet vc := #ident.Z_sub_with_get_borrow @ s @ ##(-cc)%Z @ x @ ##(-yy)%Z in
+                                       (#ident.fst @ $vc, -(#ident.snd @ $vc)))
+                                    when  (yy <=? 0) && (cc <=? 0) && ((yy + cc) <? 0)) (* at least one must be strictly negative *)
 
 
-            ; make_rewrite (#pattern.ident.Z_add_get_carry @ ??{ℤ} @ #?ℤ @ ??{ℤ}) (fun s xx y => (y, ##0)  when  xx =? 0)
-            ; make_rewrite (#pattern.ident.Z_add_get_carry @ ??{ℤ} @ ??{ℤ} @ #?ℤ) (fun s y xx => (y, ##0)  when  xx =? 0)
+            ; make_rewriteo (#pattern.ident.Z_add_get_carry @ ?? @ #?ℤ @ ??) (fun s xx y => (y, ##0)  when  xx =? 0)
+            ; make_rewriteo (#pattern.ident.Z_add_get_carry @ ?? @ ?? @ #?ℤ) (fun s y xx => (y, ##0)  when  xx =? 0)
 
-            ; make_rewrite (#pattern.ident.Z_add_with_carry @ #?ℤ @ ??{ℤ} @ ??{ℤ}) (fun cc x y => x + y  when  cc =? 0)
-            (*; make_rewrite_step (#pattern.ident.Z_add_with_carry @ ??{ℤ} @ ??{ℤ} @ ??{ℤ}) (fun x y z => $x + $y + $z)*)
+            ; make_rewriteo (#pattern.ident.Z_add_with_carry @ #?ℤ @ ?? @ ??) (fun cc x y => x + y  when  cc =? 0)
+            (*; make_rewrite_step (#pattern.ident.Z_add_with_carry @ ?? @ ?? @ ??) (fun x y z => $x + $y + $z)*)
 
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ #?ℤ @ #?ℤ @ ??{ℤ}) (fun s cc xx y => (y, ##0)   when   (cc =? 0) && (xx =? 0))
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ #?ℤ @ ??{ℤ} @ #?ℤ) (fun s cc y xx => (y, ##0)   when   (cc =? 0) && (xx =? 0))
-            (*; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ ??{ℤ} @ #?ℤ @ #?ℤ) (fun s c xx yy => (c, ##0) when   (xx =? 0) && (yy =? 0))*)
-            ; make_rewrite (* carry = 0: ADC x y -> ADD x y *)
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ #?ℤ @ ??{ℤ} @ ??{ℤ})
-                (fun s cc x y => ret (UnderLets.UnderLet
-                                        (#ident.Z_add_get_carry @ s @ x @ y)
-                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, #ident.snd @ $vc)))
-                                     when  cc =? 0)
-            ; make_rewrite (* ADC 0 0 -> (ADX 0 0, 0) *) (* except we don't do ADX, because C stringification doesn't handle it *)
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ ??{ℤ} @ #?ℤ @ #?ℤ)
-                (fun s c xx yy => ret (UnderLets.UnderLet
-                                         (#ident.Z_add_with_get_carry @ s @ c @ ##xx @ ##yy)
-                                         (fun vc => UnderLets.Base (#ident.fst @ $vc, ##0)))
-                                      when  (xx =? 0) && (yy =? 0))
+            ; make_rewriteo
+                (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ #?ℤ @ #?ℤ @ ??) (fun s cc xx y => (y, ##0)   when   (cc =? 0) && (xx =? 0))
+            ; make_rewriteo
+                (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ #?ℤ @ ?? @ #?ℤ) (fun s cc y xx => (y, ##0)   when   (cc =? 0) && (xx =? 0))
+            (*; make_rewriteo
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ ?? @ #?ℤ @ #?ℤ) (fun s c xx yy => (c, ##0) when   (xx =? 0) && (yy =? 0))*)
+            ; make_rewriteol (* carry = 0: ADC x y -> ADD x y *)
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ #?ℤ @ ?? @ ??)
+                (fun s cc x y => (llet vc := #ident.Z_add_get_carry @ s @ x @ y in
+                                      (#ident.fst @ $vc, #ident.snd @ $vc))
+                                   when  cc =? 0)
+            ; make_rewriteol (* ADC 0 0 -> (ADX 0 0, 0) *) (* except we don't do ADX, because C stringification doesn't handle it *)
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ ?? @ #?ℤ @ #?ℤ)
+                (fun s c xx yy => (llet vc := #ident.Z_add_with_get_carry @ s @ c @ ##xx @ ##yy in
+                                       (#ident.fst @ $vc, ##0))
+                                    when  (xx =? 0) && (yy =? 0))
 
 
             (* let-bind any adc/sbb/mulx *)
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_get_carry @ ??{ℤ} @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
-                (fun s c x y => ret (UnderLets.UnderLet (#ident.Z_add_with_get_carry @ s @ c @ x @ y)
-                                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, #ident.snd @ $vc))))
-            ; make_rewrite
-                (#pattern.ident.Z_add_with_carry @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
-                (fun c x y => ret (UnderLets.UnderLet (#ident.Z_add_with_carry @ c @ x @ y)
-                                                      (fun vc => UnderLets.Base ($vc))))
-            ; make_rewrite
-                (#pattern.ident.Z_add_get_carry @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
-                (fun s x y => ret (UnderLets.UnderLet (#ident.Z_add_get_carry @ s @ x @ y)
-                                                      (fun vc => UnderLets.Base (#ident.fst @ $vc, #ident.snd @ $vc))))
-            ; make_rewrite
-                (#pattern.ident.Z_sub_with_get_borrow @ ??{ℤ} @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
-                (fun s c x y => ret (UnderLets.UnderLet (#ident.Z_sub_with_get_borrow @ s @ c @ x @ y)
-                                                        (fun vc => UnderLets.Base (#ident.fst @ $vc, #ident.snd @ $vc))))
-            ; make_rewrite
-                (#pattern.ident.Z_sub_get_borrow @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
-                (fun s x y => ret (UnderLets.UnderLet (#ident.Z_sub_get_borrow @ s @ x @ y)
-                                                      (fun vc => UnderLets.Base (#ident.fst @ $vc, #ident.snd @ $vc))))
-            ; make_rewrite
-                (#pattern.ident.Z_mul_split @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
-                (fun s x y => ret (UnderLets.UnderLet (#ident.Z_mul_split @ s @ x @ y)
-                                                      (fun v => UnderLets.Base (#ident.fst @ $v, #ident.snd @ $v))))
+            ; make_rewritel
+                (#pattern.ident.Z_add_with_get_carry @ ?? @ ?? @ ?? @ ??)
+                (fun s c x y => (llet vc := #ident.Z_add_with_get_carry @ s @ c @ x @ y in
+                                     (#ident.fst @ $vc, #ident.snd @ $vc)))
+            ; make_rewritel
+                (#pattern.ident.Z_add_with_carry @ ?? @ ?? @ ??)
+                (fun c x y => (llet vc := #ident.Z_add_with_carry @ c @ x @ y in
+                                   ($vc)))
+            ; make_rewritel
+                (#pattern.ident.Z_add_get_carry @ ?? @ ?? @ ??)
+                (fun s x y => (llet vc := #ident.Z_add_get_carry @ s @ x @ y in
+                                   (#ident.fst @ $vc, #ident.snd @ $vc)))
+            ; make_rewritel
+                (#pattern.ident.Z_sub_with_get_borrow @ ?? @ ?? @ ?? @ ??)
+                (fun s c x y => (llet vc := #ident.Z_sub_with_get_borrow @ s @ c @ x @ y in
+                                     (#ident.fst @ $vc, #ident.snd @ $vc)))
+            ; make_rewritel
+                (#pattern.ident.Z_sub_get_borrow @ ?? @ ?? @ ??)
+                (fun s x y => (llet vc := #ident.Z_sub_get_borrow @ s @ x @ y in
+                                   (#ident.fst @ $vc, #ident.snd @ $vc)))
+            ; make_rewritel
+                (#pattern.ident.Z_mul_split @ ?? @ ?? @ ??)
+                (fun s x y => (llet vc := #ident.Z_mul_split @ s @ x @ y in
+                                   (#ident.fst @ $vc, #ident.snd @ $vc)))
 
 
             ; make_rewrite_step (* _step, so that if one of the arguments is concrete, we automatically get the rewrite rule for [Z_cast] applying to it *)
-                (#pattern.ident.Z_cast2 @ (??{ℤ}, ??{ℤ})) (fun r x y => (#(ident.Z_cast (fst r)) @ $x, #(ident.Z_cast (snd r)) @ $y))
+                (#pattern.ident.Z_cast2 @ (??, ??)) (fun r x y => (#(ident.Z_cast (fst r)) @ $x, #(ident.Z_cast (snd r)) @ $y))
 
-            ; make_rewrite (-??{ℤ}) (fun e => ret (UnderLets.UnderLet e (fun v => UnderLets.Base (-$v)))  when  negb (SubstVarLike.is_var_fst_snd_pair_opp e)) (* inline negation when the rewriter wouldn't already inline it *)
-           ]%list%pattern%cps%option%under_lets%Z%bool.
+            ; make_rewriteol (-??) (fun e => (llet v := e in -$v)  when  negb (SubstVarLike.is_var_fst_snd_pair_opp e)) (* inline negation when the rewriter wouldn't already inline it *)
+           ].
 
       Definition nbe_dtree'
-        := Eval compute in @compile_rewrites ident var pattern.ident pattern.ident.arg_types pattern.ident.ident_beq 100 nbe_rewrite_rules.
+        := Eval compute in @compile_rewrites ident var pattern.ident (@pattern.ident.arg_types) pattern.Raw.ident (@pattern.ident.strip_types) pattern.Raw.ident.ident_beq (@pattern.ident.type_vars) 100 nbe_rewrite_rules.
       Definition arith_dtree'
-        := Eval compute in @compile_rewrites ident var pattern.ident pattern.ident.arg_types pattern.ident.ident_beq 100 (arith_rewrite_rules 0%Z (* dummy val *)).
+        := Eval compute in @compile_rewrites ident var pattern.ident (@pattern.ident.arg_types) pattern.Raw.ident (@pattern.ident.strip_types) pattern.Raw.ident.ident_beq (@pattern.ident.type_vars) 100 (arith_rewrite_rules 0%Z (* dummy val *)).
       Definition nbe_dtree : decision_tree
         := Eval compute in invert_Some nbe_dtree'.
       Definition arith_dtree : decision_tree
         := Eval compute in invert_Some arith_dtree'.
+
       Definition nbe_default_fuel := Eval compute in List.length nbe_rewrite_rules.
       Definition arith_default_fuel := Eval compute in List.length (arith_rewrite_rules 0%Z (* dummy val *)).
 
@@ -1536,10 +1847,8 @@ In the RHS, the follow notation applies:
       Definition arith_pr1_rewrite_rules max_const_val := Eval hnf in projT1 (arith_split_rewrite_rules max_const_val).
       Definition arith_pr2_rewrite_rules max_const_val := Eval hnf in projT2 (arith_split_rewrite_rules max_const_val).
       Definition arith_all_rewrite_rules max_const_val := combine_hlist (P:=rewrite_ruleTP) (arith_pr1_rewrite_rules max_const_val) (arith_pr2_rewrite_rules max_const_val).
-
       Definition nbe_rewrite_head0 do_again {t} (idc : ident t) : value_with_lets t
         := @assemble_identifier_rewriters nbe_dtree nbe_all_rewrite_rules do_again t idc.
-
       Definition arith_rewrite_head0 max_const_val do_again {t} (idc : ident t) : value_with_lets t
         := @assemble_identifier_rewriters arith_dtree (arith_all_rewrite_rules max_const_val) do_again t idc.
 
@@ -1554,20 +1863,20 @@ In the RHS, the follow notation applies:
 (Z.add_get_carry_concrete 2^256) @@ (?x >> 128, ?y) --> (add (- 128)) @@ (y, x)
 (Z.add_get_carry_concrete 2^256) @@ (?x, ?y)        --> (add 0) @@ (y, x)
 *)
-              make_rewrite
-                (#pattern.ident.Z_add_get_carry @ #?ℤ @ ??{ℤ} @ (#pattern.ident.Z_shiftl @ ??{ℤ} @ #?ℤ))
+              make_rewriteo
+                (#pattern.ident.Z_add_get_carry @ #?ℤ @ ?? @ (#pattern.ident.Z_shiftl @ ?? @ #?ℤ))
                 (fun s x y offset => #(ident.fancy_add (Z.log2 s) offset) @ (x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_get_carry @ #?ℤ @ (#pattern.ident.Z_shiftl @ ??{ℤ} @ #?ℤ) @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_get_carry @ #?ℤ @ (#pattern.ident.Z_shiftl @ ?? @ #?ℤ) @ ??)
                   (fun s y offset x => #(ident.fancy_add (Z.log2 s) offset) @ (x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_get_carry @ #?ℤ @ ??{ℤ} @ (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_get_carry @ #?ℤ @ ?? @ (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
                   (fun s x y offset => #(ident.fancy_add (Z.log2 s) (-offset)) @ (x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_get_carry @ #?ℤ @ (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ) @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_get_carry @ #?ℤ @ (#pattern.ident.Z_shiftr @ ?? @ #?ℤ) @ ??)
                   (fun s y offset x => #(ident.fancy_add (Z.log2 s) (-offset)) @ (x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_get_carry @ #?ℤ @ ??{ℤ} @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_get_carry @ #?ℤ @ ?? @ ??)
                   (fun s x y => #(ident.fancy_add (Z.log2 s) 0) @ (x, y)  when  s =? 2^Z.log2 s)
 (*
 (Z.add_with_get_carry_concrete 2^256) @@ (?c, ?x, ?y << 128) --> (addc 128) @@ (c, x, y)
@@ -1576,73 +1885,73 @@ In the RHS, the follow notation applies:
 (Z.add_with_get_carry_concrete 2^256) @@ (?c, ?x >> 128, ?y) --> (addc (- 128)) @@ (c, y, x)
 (Z.add_with_get_carry_concrete 2^256) @@ (?c, ?x, ?y)        --> (addc 0) @@ (c, y, x)
  *)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ??{ℤ} @ ??{ℤ} @ (#pattern.ident.Z_shiftl @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ?? @ ?? @ (#pattern.ident.Z_shiftl @ ?? @ #?ℤ))
                   (fun s c x y offset => #(ident.fancy_addc (Z.log2 s) offset) @ (c, x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ??{ℤ} @ (#pattern.ident.Z_shiftl @ ??{ℤ} @ #?ℤ) @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ?? @ (#pattern.ident.Z_shiftl @ ?? @ #?ℤ) @ ??)
                   (fun s c y offset x => #(ident.fancy_addc (Z.log2 s) offset) @ (c, x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ??{ℤ} @ ??{ℤ} @ (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ?? @ ?? @ (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
                   (fun s c x y offset => #(ident.fancy_addc (Z.log2 s) (-offset)) @ (c, x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ??{ℤ} @ (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ) @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ?? @ (#pattern.ident.Z_shiftr @ ?? @ #?ℤ) @ ??)
                   (fun s c y offset x => #(ident.fancy_addc (Z.log2 s) (-offset)) @ (c, x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_add_with_get_carry @ #?ℤ @ ?? @ ?? @ ??)
                   (fun s c x y => #(ident.fancy_addc (Z.log2 s) 0) @ (c, x, y)  when  s =? 2^Z.log2 s)
 (*
 (Z.sub_get_borrow_concrete 2^256) @@ (?x, ?y << 128) --> (sub 128) @@ (x, y)
 (Z.sub_get_borrow_concrete 2^256) @@ (?x, ?y >> 128) --> (sub (- 128)) @@ (x, y)
 (Z.sub_get_borrow_concrete 2^256) @@ (?x, ?y)        --> (sub 0) @@ (y, x)
  *)
-              ; make_rewrite
-                  (#pattern.ident.Z_sub_get_borrow @ #?ℤ @ ??{ℤ} @ (#pattern.ident.Z_shiftl @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  (#pattern.ident.Z_sub_get_borrow @ #?ℤ @ ?? @ (#pattern.ident.Z_shiftl @ ?? @ #?ℤ))
                   (fun s x y offset => #(ident.fancy_sub (Z.log2 s) offset) @ (x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_sub_get_borrow @ #?ℤ @ ??{ℤ} @ (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  (#pattern.ident.Z_sub_get_borrow @ #?ℤ @ ?? @ (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
                   (fun s x y offset => #(ident.fancy_sub (Z.log2 s) (-offset)) @ (x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_sub_get_borrow @ #?ℤ @ ??{ℤ} @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_sub_get_borrow @ #?ℤ @ ?? @ ??)
                   (fun s x y => #(ident.fancy_sub (Z.log2 s) 0) @ (x, y)  when  s =? 2^Z.log2 s)
 (*
 (Z.sub_with_get_borrow_concrete 2^256) @@ (?c, ?x, ?y << 128) --> (subb 128) @@ (c, x, y)
 (Z.sub_with_get_borrow_concrete 2^256) @@ (?c, ?x, ?y >> 128) --> (subb (- 128)) @@ (c, x, y)
 (Z.sub_with_get_borrow_concrete 2^256) @@ (?c, ?x, ?y)        --> (subb 0) @@ (c, y, x)
  *)
-              ; make_rewrite
-                  (#pattern.ident.Z_sub_with_get_borrow @ #?ℤ @ ??{ℤ} @ ??{ℤ} @ (#pattern.ident.Z_shiftl @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  (#pattern.ident.Z_sub_with_get_borrow @ #?ℤ @ ?? @ ?? @ (#pattern.ident.Z_shiftl @ ?? @ #?ℤ))
                   (fun s b x y offset => #(ident.fancy_subb (Z.log2 s) offset) @ (b, x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_sub_with_get_borrow @ #?ℤ @ ??{ℤ} @ ??{ℤ} @ (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  (#pattern.ident.Z_sub_with_get_borrow @ #?ℤ @ ?? @ ?? @ (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
                   (fun s b x y offset => #(ident.fancy_subb (Z.log2 s) (-offset)) @ (b, x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_sub_with_get_borrow @ #?ℤ @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_sub_with_get_borrow @ #?ℤ @ ?? @ ?? @ ??)
                   (fun s b x y => #(ident.fancy_subb (Z.log2 s) 0) @ (b, x, y)  when  s =? 2^Z.log2 s)
               (*(Z.rshi_concrete 2^256 ?n) @@ (?c, ?x, ?y) --> (rshi n) @@ (x, y)*)
-              ; make_rewrite
-                  (#pattern.ident.Z_rshi @ #?ℤ @ ??{ℤ} @ ??{ℤ} @ #?ℤ)
+              ; make_rewriteo
+                  (#pattern.ident.Z_rshi @ #?ℤ @ ?? @ ?? @ #?ℤ)
                   (fun s x y n => #(ident.fancy_rshi (Z.log2 s) n) @ (x, y)  when  s =? 2^Z.log2 s)
 (*
 Z.zselect @@ (Z.cc_m_concrete 2^256 ?c, ?x, ?y) --> selm @@ (c, x, y)
 Z.zselect @@ (?c &' 1, ?x, ?y)                  --> sell @@ (c, x, y)
 Z.zselect @@ (?c, ?x, ?y)                       --> selc @@ (c, x, y)
  *)
-              ; make_rewrite
-                  (#pattern.ident.Z_zselect @ (#pattern.ident.Z_cc_m @ #?ℤ @ ??{ℤ}) @ ??{ℤ} @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_zselect @ (#pattern.ident.Z_cc_m @ #?ℤ @ ??) @ ?? @ ??)
                   (fun s c x y => #(ident.fancy_selm (Z.log2 s)) @ (c, x, y)  when  s =? 2^Z.log2 s)
-              ; make_rewrite
-                  (#pattern.ident.Z_zselect @ (#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}) @ ??{ℤ} @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_zselect @ (#pattern.ident.Z_land @ #?ℤ @ ??) @ ?? @ ??)
                   (fun mask c x y => #ident.fancy_sell @ (c, x, y)  when  mask =? 1)
-              ; make_rewrite
-                  (#pattern.ident.Z_zselect @ (#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ) @ ??{ℤ} @ ??{ℤ})
+              ; make_rewriteo
+                  (#pattern.ident.Z_zselect @ (#pattern.ident.Z_land @ ?? @ #?ℤ) @ ?? @ ??)
                   (fun c mask x y => #ident.fancy_sell @ (c, x, y)  when  mask =? 1)
               ; make_rewrite
-                  (#pattern.ident.Z_zselect @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
+                  (#pattern.ident.Z_zselect @ ?? @ ?? @ ??)
                   (fun c x y => #ident.fancy_selc @ (c, x, y))
 (*Z.add_modulo @@ (?x, ?y, ?m) --> addm @@ (x, y, m)*)
               ; make_rewrite
-                  (#pattern.ident.Z_add_modulo @ ??{ℤ} @ ??{ℤ} @ ??{ℤ})
+                  (#pattern.ident.Z_add_modulo @ ?? @ ?? @ ??)
                   (fun x y m => #ident.fancy_addm @ (x, y, m))
 (*
 Z.mul @@ (?x &' (2^128-1), ?y &' (2^128-1)) --> mulll @@ (x, y)
@@ -1651,139 +1960,148 @@ Z.mul @@ (?x >> 128, ?y &' (2^128-1))       --> mulhl @@ (x, y)
 Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
  *)
               (* literal on left *)
-              ; make_rewrite
-                  (#?ℤ * (#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ))
-                  (fun x y mask => let s := (2*Z.log2_up mask)%Z in x <---- invert_low s x; #(ident.fancy_mulll s) @ (##x, y)  when  (mask =? 2^(s/2)-1))
-              ; make_rewrite
-                  (#?ℤ * (#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}))
-                  (fun x mask y => let s := (2*Z.log2_up mask)%Z in x <---- invert_low s x; #(ident.fancy_mulll s) @ (##x, y)  when  (mask =? 2^(s/2)-1))
-              ; make_rewrite
-                  (#?ℤ * (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
-                  (fun x y offset => let s := (2*offset)%Z in x <---- invert_low s x; #(ident.fancy_mullh s) @ (##x, y))
-              ; make_rewrite
-                  (#?ℤ * (#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}))
-                  (fun x mask y => let s := (2*Z.log2_up mask)%Z in x <---- invert_high s x; #(ident.fancy_mulhl s) @ (##x, y)  when  mask =? 2^(s/2)-1)
-              ; make_rewrite
-                  (#?ℤ * (#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ))
-                  (fun x y mask => let s := (2*Z.log2_up mask)%Z in x <---- invert_high s x; #(ident.fancy_mulhl s) @ (##x, y)  when  mask =? 2^(s/2)-1)
-              ; make_rewrite
-                  (#?ℤ * (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
-                  (fun x y offset => let s := (2*offset)%Z in x <---- invert_high s x; #(ident.fancy_mulhh s) @ (##x, y))
-
+              ; make_rewriteo
+                  (#?ℤ * (#pattern.ident.Z_land @ ?? @ #?ℤ))
+                  (fun x y mask => let s := (2*Z.log2_up mask)%Z in x <- invert_low s x; #(ident.fancy_mulll s) @ (##x, y)  when  (mask =? 2^(s/2)-1))
+              ; make_rewriteo
+                  (#?ℤ * (#pattern.ident.Z_land @ #?ℤ @ ??))
+                  (fun x mask y => let s := (2*Z.log2_up mask)%Z in x <- invert_low s x; #(ident.fancy_mulll s) @ (##x, y)  when  (mask =? 2^(s/2)-1))
+              ; make_rewriteo
+                  (#?ℤ * (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
+                  (fun x y offset => let s := (2*offset)%Z in x <- invert_low s x; #(ident.fancy_mullh s) @ (##x, y))
+              ; make_rewriteo
+                  (#?ℤ * (#pattern.ident.Z_land @ #?ℤ @ ??))
+                  (fun x mask y => let s := (2*Z.log2_up mask)%Z in x <- invert_high s x; #(ident.fancy_mulhl s) @ (##x, y)  when  mask =? 2^(s/2)-1)
+              ; make_rewriteo
+                  (#?ℤ * (#pattern.ident.Z_land @ ?? @ #?ℤ))
+                  (fun x y mask => let s := (2*Z.log2_up mask)%Z in x <- invert_high s x; #(ident.fancy_mulhl s) @ (##x, y)  when  mask =? 2^(s/2)-1)
+              ; make_rewriteo
+                  (#?ℤ * (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
+                  (fun x y offset => let s := (2*offset)%Z in x <- invert_high s x; #(ident.fancy_mulhh s) @ (##x, y))
               (* literal on right *)
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}) * #?ℤ)
-                  (fun mask x y => let s := (2*Z.log2_up mask)%Z in y <---- invert_low s y; #(ident.fancy_mulll s) @ (x, ##y)  when  (mask =? 2^(s/2)-1))
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ) * #?ℤ)
-                  (fun x mask y => let s := (2*Z.log2_up mask)%Z in y <---- invert_low s y; #(ident.fancy_mulll s) @ (x, ##y)  when  (mask =? 2^(s/2)-1))
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}) * #?ℤ)
-                  (fun mask x y => let s := (2*Z.log2_up mask)%Z in y <---- invert_high s y; #(ident.fancy_mullh s) @ (x, ##y)  when  mask =? 2^(s/2)-1)
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ) * #?ℤ)
-                  (fun x mask y => let s := (2*Z.log2_up mask)%Z in y <---- invert_high s y; #(ident.fancy_mullh s) @ (x, ##y)  when  mask =? 2^(s/2)-1)
-              ; make_rewrite
-                  ((#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ) * #?ℤ)
-                  (fun x offset y => let s := (2*offset)%Z in y <---- invert_low s y; #(ident.fancy_mulhl s) @ (x, ##y))
-              ; make_rewrite
-                  ((#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ) * #?ℤ)
-                  (fun x offset y => let s := (2*offset)%Z in y <---- invert_high s y; #(ident.fancy_mulhh s) @ (x, ##y))
-
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ #?ℤ @ ??) * #?ℤ)
+                  (fun mask x y => let s := (2*Z.log2_up mask)%Z in y <- invert_low s y; #(ident.fancy_mulll s) @ (x, ##y)  when  (mask =? 2^(s/2)-1))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ ?? @ #?ℤ) * #?ℤ)
+                  (fun x mask y => let s := (2*Z.log2_up mask)%Z in y <- invert_low s y; #(ident.fancy_mulll s) @ (x, ##y)  when  (mask =? 2^(s/2)-1))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ #?ℤ @ ??) * #?ℤ)
+                  (fun mask x y => let s := (2*Z.log2_up mask)%Z in y <- invert_high s y; #(ident.fancy_mullh s) @ (x, ##y)  when  mask =? 2^(s/2)-1)
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ ?? @ #?ℤ) * #?ℤ)
+                  (fun x mask y => let s := (2*Z.log2_up mask)%Z in y <- invert_high s y; #(ident.fancy_mullh s) @ (x, ##y)  when  mask =? 2^(s/2)-1)
+              ; make_rewriteo
+                  ((#pattern.ident.Z_shiftr @ ?? @ #?ℤ) * #?ℤ)
+                  (fun x offset y => let s := (2*offset)%Z in y <- invert_low s y; #(ident.fancy_mulhl s) @ (x, ##y))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_shiftr @ ?? @ #?ℤ) * #?ℤ)
+                  (fun x offset y => let s := (2*offset)%Z in y <- invert_high s y; #(ident.fancy_mulhh s) @ (x, ##y))
               (* no literal *)
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}) * (#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ #?ℤ @ ??) * (#pattern.ident.Z_land @ #?ℤ @ ??))
                   (fun mask1 x mask2 y => let s := (2*Z.log2_up mask1)%Z in #(ident.fancy_mulll s) @ (x, y)  when  (mask1 =? 2^(s/2)-1) && (mask2 =? 2^(s/2)-1))
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ) * (#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ ?? @ #?ℤ) * (#pattern.ident.Z_land @ #?ℤ @ ??))
                   (fun x mask1 mask2 y => let s := (2*Z.log2_up mask1)%Z in #(ident.fancy_mulll s) @ (x, y)  when  (mask1 =? 2^(s/2)-1) && (mask2 =? 2^(s/2)-1))
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}) * (#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ #?ℤ @ ??) * (#pattern.ident.Z_land @ ?? @ #?ℤ))
                   (fun mask1 x y mask2 => let s := (2*Z.log2_up mask1)%Z in #(ident.fancy_mulll s) @ (x, y)  when  (mask1 =? 2^(s/2)-1) && (mask2 =? 2^(s/2)-1))
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ) * (#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ ?? @ #?ℤ) * (#pattern.ident.Z_land @ ?? @ #?ℤ))
                   (fun x mask1 y mask2 => let s := (2*Z.log2_up mask1)%Z in #(ident.fancy_mulll s) @ (x, y)  when  (mask1 =? 2^(s/2)-1) && (mask2 =? 2^(s/2)-1))
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}) * (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ #?ℤ @ ??) * (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
                   (fun mask x y offset => let s := (2*offset)%Z in #(ident.fancy_mullh s) @ (x, y)  when  mask =? 2^(s/2)-1)
-              ; make_rewrite
-                  ((#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ) * (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_land @ ?? @ #?ℤ) * (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
                   (fun x mask y offset => let s := (2*offset)%Z in #(ident.fancy_mullh s) @ (x, y)  when  mask =? 2^(s/2)-1)
-              ; make_rewrite
-                  ((#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ) * (#pattern.ident.Z_land @ #?ℤ @ ??{ℤ}))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_shiftr @ ?? @ #?ℤ) * (#pattern.ident.Z_land @ #?ℤ @ ??))
                   (fun x offset mask y => let s := (2*offset)%Z in #(ident.fancy_mulhl s) @ (x, y)  when  mask =? 2^(s/2)-1)
-              ; make_rewrite
-                  ((#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ) * (#pattern.ident.Z_land @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_shiftr @ ?? @ #?ℤ) * (#pattern.ident.Z_land @ ?? @ #?ℤ))
                   (fun x offset y mask => let s := (2*offset)%Z in #(ident.fancy_mulhl s) @ (x, y)  when  mask =? 2^(s/2)-1)
-              ; make_rewrite
-                  ((#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ) * (#pattern.ident.Z_shiftr @ ??{ℤ} @ #?ℤ))
+              ; make_rewriteo
+                  ((#pattern.ident.Z_shiftr @ ?? @ #?ℤ) * (#pattern.ident.Z_shiftr @ ?? @ #?ℤ))
                   (fun x offset1 y offset2 => let s := (2*offset1)%Z in #(ident.fancy_mulhh s) @ (x, y)  when  offset1 =? offset2)
-
-            ]%list%pattern%cps%option%under_lets%Z%bool.
-
+            ].
         Definition fancy_dtree'
-          := Eval compute in @compile_rewrites ident var pattern.ident pattern.ident.arg_types pattern.ident.ident_beq 100 fancy_rewrite_rules.
+          := Eval compute in @compile_rewrites ident var pattern.ident (@pattern.ident.arg_types) pattern.Raw.ident (@pattern.ident.strip_types) pattern.Raw.ident.ident_beq (@pattern.ident.type_vars) 100 fancy_rewrite_rules.
         Definition fancy_dtree : decision_tree
           := Eval compute in invert_Some fancy_dtree'.
         Definition fancy_default_fuel := Eval compute in List.length fancy_rewrite_rules.
-
         Import PrimitiveHList.
         Definition fancy_split_rewrite_rules := Eval cbv [split_list projT1 projT2 fancy_rewrite_rules] in split_list fancy_rewrite_rules.
         Definition fancy_pr1_rewrite_rules := Eval hnf in projT1 fancy_split_rewrite_rules.
         Definition fancy_pr2_rewrite_rules := Eval hnf in projT2 fancy_split_rewrite_rules.
         Definition fancy_all_rewrite_rules := combine_hlist (P:=rewrite_ruleTP) fancy_pr1_rewrite_rules fancy_pr2_rewrite_rules.
-
         Definition fancy_rewrite_head0 do_again {t} (idc : ident t) : value_with_lets t
           := @assemble_identifier_rewriters fancy_dtree fancy_all_rewrite_rules do_again t idc.
       End fancy.
     End with_var.
-
+    Module RewriterPrintingNotations.
+      Arguments base.try_make_base_transport_cps _ !_ !_.
+      Arguments base.try_make_transport_cps _ !_ !_.
+      Arguments type.try_make_transport_cps _ _ _ !_ !_.
+      Arguments Option.sequence {A} !v1 v2.
+      Arguments Option.sequence_return {A} !v1 v2.
+      Arguments Option.bind {A B} !_ _.
+      Arguments pattern.Raw.ident.invert_bind_args {t} !_ !_.
+      Arguments base.try_make_transport_cps {P} t1 t2 {_} _.
+      Arguments type.try_make_transport_cps {base_type _ P} t1 t2 {_} _.
+      Export pattern.Raw.ident.
+      Export GENERATEDIdentifiersWithoutTypes.Compilers.pattern.Raw.
+      Export GENERATEDIdentifiersWithoutTypes.Compilers.pattern.
+      Export UnderLets.
+      Export Compilers.ident.
+      Export Language.Compilers.
+      Export Language.Compilers.defaults.
+      Export PrimitiveSigma.Primitive.
+      Notation "'llet' x := v 'in' f" := (Let_In v (fun x => f)).
+      Notation "x <- 'type.try_make_transport_cps' t1 t2 ; f" := (type.try_make_transport_cps t1 t2 (fun y => match y with Some x => f | None => None end)) (at level 70, t1 at next level, t2 at next level, right associativity, format "'[v' x  <-  'type.try_make_transport_cps'  t1  t2 ; '/' f ']'").
+      Notation "x <- 'base.try_make_transport_cps' t1 t2 ; f" := (base.try_make_transport_cps t1 t2 (fun y => match y with Some x => f | None => None end)) (at level 70, t1 at next level, t2 at next level, right associativity, format "'[v' x  <-  'base.try_make_transport_cps'  t1  t2 ; '/' f ']'").
+    End RewriterPrintingNotations.
     Section red_fancy.
       Context (invert_low invert_high : Z (*log2wordmax*) -> Z -> option Z)
               {var : type.type base.type -> Type}
               (do_again : forall t : base.type, @expr base.type ident (@Compile.value base.type ident var) (type.base t)
                                                 -> UnderLets.UnderLets base.type ident var (@expr base.type ident var (type.base t)))
               {t} (idc : ident t).
-
       Time Let rewrite_head1
         := Eval cbv -[fancy_pr2_rewrite_rules
                         base.interp base.try_make_transport_cps
                         type.try_make_transport_cps type.try_transport_cps
-                        pattern.ident.invert_bind_args
+                        pattern.type.unify_extracted_cps
                         Let_In Option.sequence Option.sequence_return
                         UnderLets.splice UnderLets.to_expr
-                        Compile.option_bind'
-                        Compile.reflect Compile.reify Compile.reify_and_let_binds_cps UnderLets.reify_and_let_binds_base_cps
-                        Compile.value' SubstVarLike.is_var_fst_snd_pair_opp
+                        Compile.option_bind' pident_unify_unknown invert_bind_args_unknown Compile.normalize_deep_rewrite_rule
+                        Compile.reflect UnderLets.reify_and_let_binds_base_cps Compile.reify Compile.reify_and_let_binds_cps
+                        Compile.value'
+                        SubstVarLike.is_var_fst_snd_pair_opp
                      ] in @fancy_rewrite_head0 var invert_low invert_high do_again t idc.
-      (* Finished transaction in 1.434 secs (1.432u,0.s) (successful) *)
+      (* Finished transaction in 3.395 secs (3.395u,0.s) (successful) *)
 
       Time Local Definition fancy_rewrite_head2
         := Eval cbv [id
                        rewrite_head1 fancy_pr2_rewrite_rules
                        projT1 projT2
                        cpsbind cpscall cps_option_bind cpsreturn
+                       PrimitiveProd.Primitive.fst PrimitiveProd.Primitive.snd
                        pattern.ident.arg_types
-                       Compile.app_binding_data
-                       Compile.app_pbase_type_interp_cps
-                       Compile.app_ptype_interp_cps
-                       Compile.bind_base_cps
-                       Compile.bind_data_cps
-                       Compile.binding_dataT
-                       Compile.bind_value_cps
                        Compile.eval_decision_tree
                        Compile.eval_rewrite_rules
                        Compile.expr_of_rawexpr
-                       Compile.lift_pbase_type_interp_cps
-                       Compile.lift_ptype_interp_cps
-                       Compile.lift_with_bindings
-                       Compile.option_bind'
-                       Compile.pbase_type_interp_cps
-                       Compile.ptype_interp
-                       Compile.ptype_interp_cps
+                       Compile.normalize_deep_rewrite_rule
+                       Compile.option_bind' pident_unify_unknown invert_bind_args_unknown Compile.normalize_deep_rewrite_rule
                        (*Compile.reflect*)
                        (*Compile.reify*)
                        Compile.reveal_rawexpr_cps
+                       Compile.rew_should_do_again
+                       Compile.rew_with_opt
+                       Compile.rew_under_lets
+                       Compile.rew_replacement
+                       Compile.rew_is_cps
                        Compile.rValueOrExpr
                        Compile.swap_list
                        Compile.type_of_rawexpr
@@ -1791,12 +2109,11 @@ Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
                        (*Compile.value'*)
                        Compile.value_of_rawexpr
                        Compile.value_with_lets
-                       Compile.with_bindingsT
                        ident.smart_Literal
                        type.try_transport_cps
-                       rlist_rect rlist_rect_cast rwhen
+                       rlist_rect rwhen rwhenl
                     ] in rewrite_head1.
-      (* Finished transaction in 1.347 secs (1.343u,0.s) (successful) *)
+      (* Finished transaction in 10.793 secs (10.796u,0.s) (successful) *)
 
       Local Arguments base.try_make_base_transport_cps _ !_ !_.
       Local Arguments base.try_make_transport_cps _ !_ !_.
@@ -1804,28 +2121,40 @@ Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
       Local Arguments Option.sequence {A} !v1 v2.
       Local Arguments Option.sequence_return {A} !v1 v2.
       Local Arguments Option.bind {A B} !_ _.
-      Local Arguments pattern.ident.invert_bind_args {t} !_ !_.
+      Local Arguments pattern.Raw.ident.invert_bind_args {t} !_ !_.
       Local Arguments base.try_make_transport_cps {P} t1 t2 {_} _.
+      Local Arguments type.try_make_transport_cps {base_type _ P} t1 t2 {_} _.
+      Local Arguments base.type.base_beq !_ !_.
+      Local Arguments option {_}.
+      Local Arguments id / .
       Local Arguments fancy_rewrite_head2 / .
+      Local Arguments UnderLets.UnderLets {_ _ _}.
+      Local Arguments expr.expr {_ _ _}.
+      Local Notation ℤ := base.type.Z.
+      Local Notation ℕ := base.type.nat.
+      Local Notation bool := base.type.bool.
+      Local Notation unit := base.type.unit.
+      Local Notation list := base.type.list.
+      Local Notation "x" := (type.base x) (only printing, at level 9).
 
       Time Definition fancy_rewrite_head
         := Eval cbn [id
                        fancy_rewrite_head2
                        cpsbind cpscall cps_option_bind cpsreturn
-                       pattern.ident.invert_bind_args
                        Compile.reify Compile.reify_and_let_binds_cps Compile.reflect Compile.value'
                        Option.sequence Option.sequence_return Option.bind
                        UnderLets.reify_and_let_binds_base_cps
                        UnderLets.splice UnderLets.splice_list UnderLets.to_expr
                        base.interp base.base_interp
+                       base.type.base_beq
                        type.try_make_transport_cps base.try_make_transport_cps base.try_make_base_transport_cps
-                       PrimitiveProd.Primitive.fst PrimitiveProd.Primitive.snd Datatypes.fst Datatypes.snd
+                       Datatypes.fst Datatypes.snd
                     ] in fancy_rewrite_head2.
-      (* Finished transaction in 13.298 secs (13.283u,0.s) (successful) *)
+      (* Finished transaction in 1.892 secs (1.891u,0.s) (successful) *)
 
       Local Set Printing Depth 1000000.
       Local Set Printing Width 200.
-      Local Notation "'llet' x := v 'in' f" := (Let_In v (fun x => f)).
+      Import RewriterPrintingNotations.
       Redirect "/tmp/fancy_rewrite_head" Print fancy_rewrite_head.
     End red_fancy.
 
@@ -1839,42 +2168,36 @@ Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
         := Eval cbv -[nbe_pr2_rewrite_rules
                         base.interp base.try_make_transport_cps
                         type.try_make_transport_cps type.try_transport_cps
-                        pattern.ident.invert_bind_args
+                        pattern.type.unify_extracted_cps
                         Let_In Option.sequence Option.sequence_return
                         UnderLets.splice UnderLets.to_expr
-                        Compile.option_bind'
+                        Compile.option_bind' pident_unify_unknown invert_bind_args_unknown Compile.normalize_deep_rewrite_rule
                         Compile.reflect UnderLets.reify_and_let_binds_base_cps Compile.reify Compile.reify_and_let_binds_cps
                         Compile.value'
                         SubstVarLike.is_var_fst_snd_pair_opp
                      ] in @nbe_rewrite_head0 var do_again t idc.
-      (* Finished transaction in 16.593 secs (16.567u,0.s) (successful) *)
+      (* Finished transaction in 7.035 secs (7.036u,0.s) (successful) *)
 
       Time Local Definition nbe_rewrite_head2
         := Eval cbv [id
                        rewrite_head1 nbe_pr2_rewrite_rules
                        projT1 projT2
                        cpsbind cpscall cps_option_bind cpsreturn
+                       PrimitiveProd.Primitive.fst PrimitiveProd.Primitive.snd
                        pattern.ident.arg_types
-                       Compile.app_binding_data
-                       Compile.app_pbase_type_interp_cps
-                       Compile.app_ptype_interp_cps
-                       Compile.bind_base_cps
-                       Compile.bind_data_cps
-                       Compile.binding_dataT
-                       Compile.bind_value_cps
                        Compile.eval_decision_tree
                        Compile.eval_rewrite_rules
                        Compile.expr_of_rawexpr
-                       Compile.option_bind'
-                       Compile.lift_pbase_type_interp_cps
-                       Compile.lift_ptype_interp_cps
-                       Compile.lift_with_bindings
-                       Compile.pbase_type_interp_cps
-                       Compile.ptype_interp
-                       Compile.ptype_interp_cps
+                       Compile.normalize_deep_rewrite_rule
+                       Compile.option_bind' pident_unify_unknown invert_bind_args_unknown Compile.normalize_deep_rewrite_rule
                        (*Compile.reflect*)
                        (*Compile.reify*)
                        Compile.reveal_rawexpr_cps
+                       Compile.rew_should_do_again
+                       Compile.rew_with_opt
+                       Compile.rew_under_lets
+                       Compile.rew_replacement
+                       Compile.rew_is_cps
                        Compile.rValueOrExpr
                        Compile.swap_list
                        Compile.type_of_rawexpr
@@ -1882,12 +2205,11 @@ Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
                        (*Compile.value'*)
                        Compile.value_of_rawexpr
                        Compile.value_with_lets
-                       Compile.with_bindingsT
                        ident.smart_Literal
                        type.try_transport_cps
-                       rlist_rect rlist_rect_cast rwhen
+                       rlist_rect rwhen rwhenl
                     ] in rewrite_head1.
-      (* Finished transaction in 29.683 secs (29.592u,0.048s) (successful) *)
+      (* Finished transaction in 29.297 secs (29.284u,0.016s) (successful) *)
 
       Local Arguments base.try_make_base_transport_cps _ !_ !_.
       Local Arguments base.try_make_transport_cps _ !_ !_.
@@ -1895,28 +2217,40 @@ Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
       Local Arguments Option.sequence {A} !v1 v2.
       Local Arguments Option.sequence_return {A} !v1 v2.
       Local Arguments Option.bind {A B} !_ _.
-      Local Arguments pattern.ident.invert_bind_args {t} !_ !_.
+      Local Arguments pattern.Raw.ident.invert_bind_args {t} !_ !_.
       Local Arguments base.try_make_transport_cps {P} t1 t2 {_} _.
+      Local Arguments type.try_make_transport_cps {base_type _ P} t1 t2 {_} _.
+      Local Arguments base.type.base_beq !_ !_.
+      Local Arguments option {_}.
+      Local Arguments id / .
       Local Arguments nbe_rewrite_head2 / .
+      Local Arguments UnderLets.UnderLets {_ _ _}.
+      Local Arguments expr.expr {_ _ _}.
+      Local Notation ℤ := base.type.Z.
+      Local Notation ℕ := base.type.nat.
+      Local Notation bool := base.type.bool.
+      Local Notation unit := base.type.unit.
+      Local Notation list := base.type.list.
+      Local Notation "x" := (type.base x) (only printing, at level 9).
 
       Time Definition nbe_rewrite_head
         := Eval cbn [id
                        nbe_rewrite_head2
                        cpsbind cpscall cps_option_bind cpsreturn
-                       pattern.ident.invert_bind_args
                        Compile.reify Compile.reify_and_let_binds_cps Compile.reflect Compile.value'
                        Option.sequence Option.sequence_return Option.bind
                        UnderLets.reify_and_let_binds_base_cps
                        UnderLets.splice UnderLets.splice_list UnderLets.to_expr
                        base.interp base.base_interp
+                       base.type.base_beq
                        type.try_make_transport_cps base.try_make_transport_cps base.try_make_base_transport_cps
                        PrimitiveProd.Primitive.fst PrimitiveProd.Primitive.snd Datatypes.fst Datatypes.snd
                     ] in nbe_rewrite_head2.
-      (* Finished transaction in 16.561 secs (16.54u,0.s) (successful) *)
+      (* Finished transaction in 1.998 secs (2.u,0.s) (successful) *)
 
       Local Set Printing Depth 1000000.
       Local Set Printing Width 200.
-      Local Notation "'llet' x := v 'in' f" := (Let_In v (fun x => f)).
+      Import RewriterPrintingNotations.
       Redirect "/tmp/nbe_rewrite_head" Print nbe_rewrite_head.
     End red_nbe.
 
@@ -1931,42 +2265,36 @@ Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
         := Eval cbv -[arith_pr2_rewrite_rules
                         base.interp base.try_make_transport_cps
                         type.try_make_transport_cps type.try_transport_cps
-                        pattern.ident.invert_bind_args
+                        pattern.type.unify_extracted_cps
                         Let_In Option.sequence Option.sequence_return
                         UnderLets.splice UnderLets.to_expr
-                        Compile.option_bind'
+                        Compile.option_bind' pident_unify_unknown invert_bind_args_unknown Compile.normalize_deep_rewrite_rule
                         Compile.reflect UnderLets.reify_and_let_binds_base_cps Compile.reify Compile.reify_and_let_binds_cps
                         Compile.value'
                         SubstVarLike.is_var_fst_snd_pair_opp
                      ] in @arith_rewrite_head0 var max_const_val do_again t idc.
-      (* Finished transaction in 16.593 secs (16.567u,0.s) (successful) *)
+      (* Finished transaction in 15.381 secs (15.379u,0.s) (successful) *)
 
       Time Local Definition arith_rewrite_head2
         := Eval cbv [id
                        rewrite_head1 arith_pr2_rewrite_rules
                        projT1 projT2
                        cpsbind cpscall cps_option_bind cpsreturn
+                       PrimitiveProd.Primitive.fst PrimitiveProd.Primitive.snd
                        pattern.ident.arg_types
-                       Compile.app_binding_data
-                       Compile.app_pbase_type_interp_cps
-                       Compile.app_ptype_interp_cps
-                       Compile.bind_base_cps
-                       Compile.bind_data_cps
-                       Compile.binding_dataT
-                       Compile.bind_value_cps
                        Compile.eval_decision_tree
                        Compile.eval_rewrite_rules
                        Compile.expr_of_rawexpr
-                       Compile.option_bind'
-                       Compile.lift_pbase_type_interp_cps
-                       Compile.lift_ptype_interp_cps
-                       Compile.lift_with_bindings
-                       Compile.pbase_type_interp_cps
-                       Compile.ptype_interp
-                       Compile.ptype_interp_cps
+                       Compile.normalize_deep_rewrite_rule
+                       Compile.option_bind' pident_unify_unknown invert_bind_args_unknown Compile.normalize_deep_rewrite_rule
                        (*Compile.reflect*)
                        (*Compile.reify*)
                        Compile.reveal_rawexpr_cps
+                       Compile.rew_should_do_again
+                       Compile.rew_with_opt
+                       Compile.rew_under_lets
+                       Compile.rew_replacement
+                       Compile.rew_is_cps
                        Compile.rValueOrExpr
                        Compile.swap_list
                        Compile.type_of_rawexpr
@@ -1974,12 +2302,11 @@ Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
                        (*Compile.value'*)
                        Compile.value_of_rawexpr
                        Compile.value_with_lets
-                       Compile.with_bindingsT
                        ident.smart_Literal
                        type.try_transport_cps
-                       rlist_rect rlist_rect_cast rwhen
+                       rlist_rect rwhen rwhenl
                     ] in rewrite_head1.
-      (* Finished transaction in 29.683 secs (29.592u,0.048s) (successful) *)
+      (* Finished transaction in 83.667 secs (83.564u,0.115s) (successful) *)
 
       Local Arguments base.try_make_base_transport_cps _ !_ !_.
       Local Arguments base.try_make_transport_cps _ !_ !_.
@@ -1987,28 +2314,40 @@ Z.mul @@ (?x >> 128, ?y >> 128)             --> mulhh @@ (x, y)
       Local Arguments Option.sequence {A} !v1 v2.
       Local Arguments Option.sequence_return {A} !v1 v2.
       Local Arguments Option.bind {A B} !_ _.
-      Local Arguments pattern.ident.invert_bind_args {t} !_ !_.
+      Local Arguments pattern.Raw.ident.invert_bind_args {t} !_ !_.
       Local Arguments base.try_make_transport_cps {P} t1 t2 {_} _.
+      Local Arguments type.try_make_transport_cps {base_type _ P} t1 t2 {_} _.
+      Local Arguments base.type.base_beq !_ !_.
+      Local Arguments option {_}.
+      Local Arguments id / .
       Local Arguments arith_rewrite_head2 / .
+      Local Arguments UnderLets.UnderLets {_ _ _}.
+      Local Arguments expr.expr {_ _ _}.
+      Local Notation ℤ := base.type.Z.
+      Local Notation ℕ := base.type.nat.
+      Local Notation bool := base.type.bool.
+      Local Notation unit := base.type.unit.
+      Local Notation list := base.type.list.
+      Local Notation "x" := (type.base x) (only printing, at level 9).
 
       Time Definition arith_rewrite_head
         := Eval cbn [id
                        arith_rewrite_head2
                        cpsbind cpscall cps_option_bind cpsreturn
-                       pattern.ident.invert_bind_args
                        Compile.reify Compile.reify_and_let_binds_cps Compile.reflect Compile.value'
                        Option.sequence Option.sequence_return Option.bind
                        UnderLets.reify_and_let_binds_base_cps
                        UnderLets.splice UnderLets.splice_list UnderLets.to_expr
                        base.interp base.base_interp
+                       base.type.base_beq
                        type.try_make_transport_cps base.try_make_transport_cps base.try_make_base_transport_cps
                        PrimitiveProd.Primitive.fst PrimitiveProd.Primitive.snd Datatypes.fst Datatypes.snd
                     ] in arith_rewrite_head2.
-      (* Finished transaction in 16.561 secs (16.54u,0.s) (successful) *)
+      (* Finished transaction in 3.967 secs (3.968u,0.s) (successful) *)
 
       Local Set Printing Depth 1000000.
       Local Set Printing Width 200.
-      Local Notation "'llet' x := v 'in' f" := (Let_In v (fun x => f)).
+      Import RewriterPrintingNotations.
       Redirect "/tmp/arith_rewrite_head" Print arith_rewrite_head.
     End red_arith.
 

--- a/src/Experiments/NewPipeline/RewriterProofs.v
+++ b/src/Experiments/NewPipeline/RewriterProofs.v
@@ -61,12 +61,9 @@ Module Compilers.
       (intros ? ? ? ? wf_do_again ? ?);
       eapply @Compile.wf_assemble_identifier_rewriters;
       eauto using
-            pattern.ident.to_typed_invert_bind_args,
-      pattern.ident.ident_beq,
-      pattern.ident.internal_ident_dec_bl,
-      pattern.ident.try_make_transport_ident_cps_correct,
-      pattern.ident.eta_ident_cps_correct
-        with nocore.
+            pattern.Raw.ident.to_typed_invert_bind_args, pattern.ident.eta_ident_cps_correct
+        with nocore;
+      try reflexivity.
     Local Ltac start_Interp_proof rewrite_head_eq all_rewrite_rules_eq rewrite_head0 :=
       start_Wf_or_interp_proof rewrite_head_eq all_rewrite_rules_eq rewrite_head0.
 

--- a/src/Experiments/NewPipeline/RewriterRulesGood.v
+++ b/src/Experiments/NewPipeline/RewriterRulesGood.v
@@ -65,38 +65,25 @@ Module Compilers.
     Section good.
       Context {var1 var2 : type -> Type}.
 
-      Local Notation rewrite_rules_goodT := (@Compile.rewrite_rules_goodT ident pattern.ident pattern.ident.arg_types var1 var2).
+      Local Notation rewrite_rules_goodT := (@Compile.rewrite_rules_goodT ident pattern.ident (@pattern.ident.arg_types) (@pattern.ident.type_vars) var1 var2).
 
-      Lemma rlist_rect_cps_id {var} A P {ivar} N_case C_case ls T k
-        : @rlist_rect var A P ivar N_case C_case ls T k = k (@rlist_rect var A P ivar N_case C_case ls _ id).
-      Proof.
-        cbv [rlist_rect id Compile.option_bind']; rewrite !expr.reflect_list_cps_id.
-        destruct (invert_expr.reflect_list ls) eqn:?; cbn [Option.bind Option.sequence_return]; reflexivity.
-      Qed.
-      Lemma rlist_rect_cast_cps_id {var} A A' P {ivar} N_case C_case ls T k
-        : @rlist_rect_cast var A A' P ivar N_case C_case ls T k = k (@rlist_rect_cast var A A' P ivar N_case C_case ls _ id).
-      Proof.
-        cbv [rlist_rect_cast Compile.castbe Compile.castb id Compile.option_bind']; rewrite_type_transport_correct;
-          break_innermost_match; type_beq_to_eq; subst; cbn [eq_rect Option.bind Option.sequence_return]; [ | reflexivity ].
-        apply rlist_rect_cps_id.
-      Qed.
-
-      Lemma wf_rlist_rect {A P}
+      Lemma wf_rlist_rect_gen
+            {ivar1 ivar2 A P}
+            Q
             N1 N2 C1 C2 ls1 ls2 G
             (Hwf : expr.wf G ls1 ls2)
-            (HN : UnderLets.wf (fun G' => expr.wf G') G N1 N2)
+            (HN : UnderLets.wf Q G N1 N2)
             (HC : forall G' x xs y ys rec1 rec2,
                 (exists seg, G' = (seg ++ G)%list)
                 -> expr.wf G x y
                 -> expr.wf G (reify_list xs) (reify_list ys)
-                -> expr.wf G' rec1 rec2
-                -> UnderLets.wf (fun G'' => expr.wf G'') G' (C1 x xs rec1) (C2 y ys rec2))
-        : option_eq (UnderLets.wf (fun G' => Compile.wf_anyexpr G' (type.base P)) G)
-                    (@rlist_rect var1 A P var1 N1 C1 ls1 _ id)
-                    (@rlist_rect var2 A P var2 N2 C2 ls2 _ id).
-      Proof.
+                -> Q G' rec1 rec2
+                -> UnderLets.wf Q G' (C1 x xs rec1) (C2 y ys rec2))
+        : option_eq (UnderLets.wf Q G)
+                    (@rlist_rect var1 A P ivar1 N1 C1 ls1)
+                    (@rlist_rect var2 A P ivar2 N2 C2 ls2).
+      Proof using Type.
         cbv [rlist_rect].
-        rewrite !expr.reflect_list_cps_id; cbv [id].
         cbv [Compile.option_bind' Option.bind].
         break_innermost_match.
         all: repeat first [ match goal with
@@ -105,7 +92,6 @@ Module Compilers.
                                       | erewrite -> expr.wf_reflect_list in H' by eassumption ];
                                 exfalso; clear -H H'; congruence
                             | [ |- UnderLets.wf _ _ _ _ ] => constructor
-                            | [ |- Compile.wf_anyexpr _ _ _ _ ] => constructor
                             end
                           | progress expr.invert_subst
                           | progress cbn [sequence_return option_eq]
@@ -133,35 +119,26 @@ Module Compilers.
                           | reflexivity
                           | solve [ auto ]
                           | progress subst
-                          | apply @UnderLets.wf_splice with (P:=fun G' => expr.wf G')
+                          | apply @UnderLets.wf_splice with (P:=Q)
                           | progress intros
                           | wf_safe_t_step
                           | progress type.inversion_type
                           | progress expr.inversion_wf_constr ].
       Qed.
-
-      Lemma wf_rlist_rect_cast {A A' P}
+      Lemma wf_rlist_rect {A P}
             N1 N2 C1 C2 ls1 ls2 G
             (Hwf : expr.wf G ls1 ls2)
-            (HN : UnderLets.wf (fun G' x1 x2 => Compile.wf_anyexpr G' (type.base P) (AnyExpr.wrap x1) (AnyExpr.wrap x2)) G N1 N2)
+            (HN : UnderLets.wf (fun G' => expr.wf G') G N1 N2)
             (HC : forall G' x xs y ys rec1 rec2,
                 (exists seg, G' = (seg ++ G)%list)
                 -> expr.wf G x y
                 -> expr.wf G (reify_list xs) (reify_list ys)
                 -> expr.wf G' rec1 rec2
                 -> UnderLets.wf (fun G'' => expr.wf G'') G' (C1 x xs rec1) (C2 y ys rec2))
-        : option_eq (UnderLets.wf (fun G' => Compile.wf_anyexpr G' (type.base P)) G)
-                    (@rlist_rect_cast var1 A A' P var1 N1 C1 ls1 _ id)
-                    (@rlist_rect_cast var2 A A' P var2 N2 C2 ls2 _ id).
-      Proof.
-        cbv [rlist_rect_cast].
-        cbv [Compile.castbe Compile.castb id Compile.option_bind' Option.bind sequence_return]; rewrite_type_transport_correct; break_innermost_match;
-          type_beq_to_eq; subst; [ | reflexivity ].
-        apply wf_rlist_rect; auto.
-        eapply UnderLets.wf_Proper_list_impl; [ | | eassumption ]; trivial; cbn; intros ? ? ? H.
-        inversion H; inversion_sigma; type.inversion_type; subst; assumption.
-      Qed.
-
+        : option_eq (UnderLets.wf (fun G' => expr.wf G') G)
+                    (@rlist_rect var1 A P var1 N1 C1 ls1)
+                    (@rlist_rect var2 A P var2 N2 C2 ls2).
+      Proof using Type. apply wf_rlist_rect_gen; assumption. Qed.
       Lemma wf_rlist_rectv {A P}
             N1 N2 C1 C2 ls1 ls2 G
             (Hwf : expr.wf G ls1 ls2)
@@ -182,107 +159,13 @@ Module Compilers.
                                 G' (C1 x xs rec1) (C2 y ys rec2))
         : option_eq (UnderLets.wf
                        (fun G' v1 v2
-                        => exists (pf1 : AnyExpr.anyexpr_ty v1 = P) (pf2 : AnyExpr.anyexpr_ty v2 = P) G'',
+                        => exists G'',
                             (forall t' v1' v2', List.In (existT _ t' (v1', v2')) G'' -> Compile.wf_value G' v1' v2')
-                            /\ expr.wf G''
-                                       (rew [fun t : base.type => expr t] pf1 in AnyExpr.unwrap v1)
-                                       (rew [fun t : base.type => expr t] pf2 in AnyExpr.unwrap v2))
+                            /\ expr.wf G'' v1 v2)
                        G)
-                    (@rlist_rect var1 A P (@Compile.value _ ident var1) N1 C1 ls1 _ id)
-                    (@rlist_rect var2 A P (@Compile.value _ ident var2) N2 C2 ls2 _ id).
-      Proof.
-        cbv [rlist_rect].
-        rewrite !expr.reflect_list_cps_id; cbv [id].
-        cbv [Compile.option_bind' Option.bind].
-        break_innermost_match.
-        all: repeat first [ match goal with
-                            | [ H : invert_expr.reflect_list ?v = Some _, H' : invert_expr.reflect_list ?v' = None |- _ ]
-                              => first [ erewrite <- expr.wf_reflect_list in H' by eassumption
-                                       | erewrite -> expr.wf_reflect_list in H' by eassumption ];
-                                 exfalso; clear -H H'; congruence
-                            | [ |- UnderLets.wf _ _ _ _ ] => constructor
-                            | [ |- Compile.wf_anyexpr _ _ _ _ ] => constructor
-                            end
-                          | progress expr.invert_subst
-                          | progress cbn [sequence_return option_eq]
-                          | assumption
-                          | reflexivity
-                          | (exists eq_refl)
-                          | apply @UnderLets.wf_splice with (P:=fun G' v1 v2
-                                                                => exists G'',
-                                                                    (forall t' v1' v2', List.In (existT _ t' (v1', v2')) G'' -> Compile.wf_value G' v1' v2')
-                                                                    /\ expr.wf G'' v1 v2)
-                          | progress intros ].
-        lazymatch goal with
-        | [ H : expr.wf _ (reify_list ?l) (reify_list ?l') |- _ ]
-          => revert dependent l'; intro l2; revert dependent l; intro l1
-        end.
-        revert l2; induction l1 as [|l1 ls1 IHls1], l2; cbn [list_rect];
-          rewrite ?expr.reify_list_cons, ?expr.reify_list_nil;
-          intros; expr.inversion_wf_constr; [ assumption | ].
-        all: repeat first [ match goal with
-                            | [ H : invert_expr.reflect_list ?v = Some _, H' : invert_expr.reflect_list ?v' = None |- _ ]
-                              => first [ erewrite <- expr.wf_reflect_list in H' by eassumption
-                                       | erewrite -> expr.wf_reflect_list in H' by eassumption ];
-                                 exfalso; clear -H H'; congruence
-                            | [ |- UnderLets.wf _ _ _ _ ] => constructor
-                            end
-                          | progress expr.invert_subst
-                          | progress cbn [sequence_return option_eq AnyExpr.anyexpr_ty eq_rect]
-                          | (exists eq_refl)
-                          | assumption
-                          | reflexivity
-                          | solve [ auto ]
-                          | progress subst
-                          | apply @UnderLets.wf_splice with (P:=fun G' v1 v2
-                                                                => exists G'',
-                                                                    (forall t' v1' v2', List.In (existT _ t' (v1', v2')) G'' -> Compile.wf_value G' v1' v2')
-                                                                    /\ expr.wf G'' v1 v2)
-                          | progress intros
-                          | wf_safe_t_step
-                          | progress type.inversion_type
-                          | progress expr.inversion_wf_constr ].
-      Qed.
-
-      Lemma wf_rlist_rect_castv {A A' P}
-            N1 N2 C1 C2 ls1 ls2 G
-            (Hwf : expr.wf G ls1 ls2)
-            (HN : UnderLets.wf (fun G' x1 x2
-                                => exists G'',
-                                    (forall t' v1' v2', List.In (existT _ t' (v1', v2')) G'' -> Compile.wf_value G' v1' v2')
-                                    /\ Compile.wf_anyexpr G'' (type.base P) (AnyExpr.wrap x1) (AnyExpr.wrap x2)) G N1 N2)
-            (HC : forall G' x xs y ys rec1 rec2,
-                (exists seg, G' = (seg ++ G)%list)
-                -> expr.wf G x y
-                -> expr.wf G (reify_list xs) (reify_list ys)
-                -> (exists G'', (forall t' v1' v2', List.In (existT _ t' (v1', v2')) G'' -> Compile.wf_value G' v1' v2')
-                                /\ expr.wf G'' rec1 rec2)
-                -> UnderLets.wf (fun G' v1 v2
-                                => exists G'',
-                                    (forall t' v1' v2', List.In (existT _ t' (v1', v2')) G'' -> Compile.wf_value G' v1' v2')
-                                    /\ expr.wf G'' v1 v2)
-                               G' (C1 x xs rec1) (C2 y ys rec2))
-        : option_eq (UnderLets.wf
-                       (fun G' v1 v2
-                        => exists (pf1 : AnyExpr.anyexpr_ty v1 = P) (pf2 : AnyExpr.anyexpr_ty v2 = P) G'',
-                            (forall t' v1' v2', List.In (existT _ t' (v1', v2')) G'' -> Compile.wf_value G' v1' v2')
-                            /\ expr.wf G''
-                                       (rew [fun t : base.type => expr t] pf1 in AnyExpr.unwrap v1)
-                                       (rew [fun t : base.type => expr t] pf2 in AnyExpr.unwrap v2))
-                       G)
-                    (@rlist_rect_cast var1 A A' P (@Compile.value _ ident var1) N1 C1 ls1 _ id)
-                    (@rlist_rect_cast var2 A A' P (@Compile.value _ ident var2) N2 C2 ls2 _ id).
-      Proof.
-        cbv [rlist_rect_cast].
-        cbv [Compile.castbe Compile.castb id Compile.option_bind' Option.bind sequence_return]; rewrite_type_transport_correct; break_innermost_match;
-          type_beq_to_eq; subst; [ | reflexivity ].
-        apply wf_rlist_rectv; auto.
-        eapply UnderLets.wf_Proper_list_impl; [ | | eassumption ]; trivial; cbn; intros ? ? ? H.
-        repeat let x := fresh in intro x; specialize (H x).
-        destruct H as [? [H0 H1] ].
-        inversion H1; inversion_sigma; type.inversion_type; subst; eauto.
-      Qed.
-
+                    (@rlist_rect var1 A P (@Compile.value _ ident var1) N1 C1 ls1)
+                    (@rlist_rect var2 A P (@Compile.value _ ident var2) N2 C2 ls2).
+      Proof using Type. apply wf_rlist_rect_gen; assumption. Qed.
 
       Lemma wf_nat_rect {A}
             G O1 O2 S1 S2 n
@@ -327,60 +210,6 @@ Module Compilers.
         eapply fold_right_impl_Proper; [ | | refine IHxs ]; intuition (subst; eauto).
       Qed.
 
-      Local Ltac start_cps_id :=
-        lazymatch goal with
-        | [ |- forall x p, In (@existT ?A ?P x p) ?ls -> @?Q x p ]
-          => apply (@forall_In_existT A P Q ls); cbn [projT1 projT2]; cbv [id]
-        end;
-        try reflexivity.
-
-      Local Ltac cps_id_step :=
-        first [ reflexivity
-              | progress intros
-              | progress destruct_head' False
-              | progress subst
-              | progress inversion_option
-              | progress cbn [Compile.value' UnderLets.splice eq_rect projT1 projT2 Option.bind Option.sequence Option.sequence_return] in *
-              | progress destruct_head'_sigT
-              | progress destruct_head'_prod
-              | progress destruct_head'_unit
-              | progress cbv [id Compile.binding_dataT pattern.ident.arg_types Compile.ptype_interp Compile.ptype_interp_cps Compile.pbase_type_interp_cps Compile.value Compile.app_binding_data Compile.app_ptype_interp_cps Compile.app_pbase_type_interp_cps Compile.lift_with_bindings Compile.lift_ptype_interp_cps Compile.lift_pbase_type_interp_cps cpsbind cpscall cpsreturn cps_option_bind type_base rwhen] in *
-              | progress type_beq_to_eq
-              | progress rewrite_type_transport_correct
-              | break_match_step ltac:(fun v => match type of v with sumbool _ _ => idtac end)
-              | progress cbv [Compile.option_bind' Compile.castbe Compile.castb Compile.castv] in *
-              | progress break_innermost_match
-              | rewrite !expr.reflect_list_cps_id
-              | match goal with
-                | [ |- context[@rlist_rect_cast ?var ?A ?A' ?P ?ivar ?N_case ?C_case ?ls ?T ?k] ]
-                  => (tryif (let __ := constr:(eq_refl : k = (fun x => x)) in idtac)
-                       then fail
-                       else rewrite (@rlist_rect_cast_cps_id var A A' P ivar N_case C_case ls T k))
-                | [ |- context[@rlist_rect ?var ?A ?P ?ivar ?N_case ?C_case ?ls ?T ?k] ]
-                  => (tryif (let __ := constr:(eq_refl : k = (fun x => x)) in idtac)
-                       then fail
-                       else rewrite (@rlist_rect_cps_id var A P ivar N_case C_case ls T k))
-                end
-              | progress cbv [Option.bind] in *
-              | break_match_step ltac:(fun _ => idtac) ].
-
-      Local Ltac cps_id_t := start_cps_id; repeat cps_id_step.
-
-      Lemma nbe_cps_id {var}
-        : forall p r, In (existT _ p r) (@nbe_rewrite_rules var)
-                      -> forall v T k, r v T k = k (r v _ id).
-      Proof. Time cps_id_t. Time Qed.
-
-      Lemma arith_cps_id max_const {var}
-        : forall p r, In (existT _ p r) (@arith_rewrite_rules var max_const)
-                 -> forall v T k, r v T k = k (r v _ id).
-      Proof. Time cps_id_t. Time Qed.
-
-      Lemma fancy_cps_id invert_low invert_high {var}
-        : forall p r, In (existT _ p r) (@fancy_rewrite_rules var invert_low invert_high)
-                 -> forall v T k, r v T k = k (r v _ id).
-      Proof. Time cps_id_t. Time Qed.
-
       (** TODO: MOVE ME? *)
       Lemma forall_In_pair_existT {A A' P P'} {Q : forall (a : A) (a' : A'), P a -> P' a' -> Prop} ls
         : fold_right
@@ -394,14 +223,21 @@ Module Compilers.
         eapply fold_right_impl_Proper; [ | | refine IHxs ]; intuition (inversion_prod; subst; eauto).
       Qed.
 
-      Local Ltac start_good cps_id rewrite_rules :=
+      Local Ltac start_good :=
         split; [ reflexivity | ];
-        repeat apply conj; try solve [ eapply cps_id ]; [];
         lazymatch goal with
         | [ |- forall x p x' p', In (@existT ?A ?P x p, @existT ?A' ?P' x' p') ?ls -> @?Q x x' p p' ]
           => apply (@forall_In_pair_existT A A' P P' Q ls); cbn [projT1 projT2 fst snd]; cbv [id]
         end;
-        intros; (split; [ reflexivity | ]).
+        (exists eq_refl);
+        cbn [eq_rect];
+        cbv [Compile.wf_deep_rewrite_ruleTP_gen Compile.wf_rewrite_rule_data Compile.rew_replacement Compile.rew_is_cps Compile.rew_should_do_again Compile.rew_with_opt Compile.rew_under_lets Compile.wf_with_unif_rewrite_ruleTP_gen Compile.wf_with_unification_resultT pattern.pattern_of_anypattern pattern.type_of_anypattern Compile.wf_maybe_under_lets_expr Compile.wf_maybe_do_again_expr Compile.wf_with_unification_resultT' pattern.type.under_forall_vars_relation Compile.with_unification_resultT' pattern.collect_vars Compile.ident_collect_vars pattern.ident.type_vars pattern.type.collect_vars pattern.base.collect_vars PositiveSet.empty PositiveSet.elements Compile.forall2_type_of_list_cps pattern.ident.arg_types pattern.type.subst_default pattern.base.subst_default PositiveSet.rev PositiveMap.empty];
+        cbn [List.map List.fold_right PositiveSet.union PositiveSet.xelements List.rev List.app projT1 projT2 list_rect PositiveSet.add PositiveSet.rev PositiveSet.rev_append PositiveMap.add PositiveMap.find orb];
+        repeat first [ progress intros
+                     | match goal with
+                       | [ |- { pf : ?x = ?x | _ } ] => (exists eq_refl)
+                       end
+                     | progress cbn [eq_rect] in * ].
 
       Local Ltac good_t_step :=
         first [ progress subst
@@ -414,17 +250,18 @@ Module Compilers.
               | progress destruct_head'_sig
               | progress inversion_option
               | progress destruct_head'_ex
-              | progress cbn [Compile.binding_dataT pattern.ident.arg_types] in *
-              | progress cbn [Compile.wf_binding_dataT Compile.wf_ptype_interp_cps Compile.wf_pbase_type_interp_cps fst snd projT1 projT2] in *
+              | progress cbn [pattern.ident.arg_types] in *
+              | progress cbn [fst snd projT1 projT2] in *
               | progress intros
-              | progress cbv [Compile.ptype_interp Compile.ptype_interp_cps Compile.pbase_type_interp_cps id] in *
-              | progress cbv [Compile.wf_ptype_interp_id] in *
-              | progress cbv [id Compile.binding_dataT pattern.ident.arg_types Compile.ptype_interp Compile.ptype_interp_cps Compile.pbase_type_interp_cps Compile.value Compile.app_binding_data Compile.app_ptype_interp_cps Compile.app_pbase_type_interp_cps Compile.lift_with_bindings Compile.lift_ptype_interp_cps Compile.lift_pbase_type_interp_cps cpsbind cpscall cpsreturn cps_option_bind type_base Compile.wf_binding_dataT Compile.wf_ptype_interp_id Compile.wf_ptype_interp_cps Compile.wf_pbase_type_interp_cps ident.smart_Literal rwhen AnyExpr.unwrap nth_default SubstVarLike.is_var_fst_snd_pair_opp] in *
+              | progress cbv [id pattern.ident.arg_types Compile.value cpsbind cpscall cpsreturn cps_option_bind type_base ident.smart_Literal rwhen rwhenl nth_default SubstVarLike.is_var_fst_snd_pair_opp] in *
               | progress cbv [Compile.option_bind' Compile.castbe Compile.castb Compile.castv] in *
               | progress type_beq_to_eq
               | progress type.inversion_type
               | progress rewrite_type_transport_correct
               | progress specialize_by exact eq_refl
+              | match goal with
+                | [ |- context[invert_expr.reflect_list ?v] ] => destruct (invert_expr.reflect_list v) eqn:?
+                end
               | break_innermost_match_step
               | wf_safe_t_step
               | rewrite !expr.reflect_list_cps_id
@@ -437,6 +274,8 @@ Module Compilers.
                     apply nth_error_value_length in H;
                     exfalso; clear -H0 H H'; lia
                 | [ |- expr.wf _ (reify_list _) (reify_list _) ] => rewrite expr.wf_reify_list
+                | [ |- option_eq _ (rlist_rect _ _ _) (rlist_rect _ _ _) ]
+                  => first [ apply wf_rlist_rect | apply wf_rlist_rectv ]
                 | [ |- context[length ?ls] ] => tryif is_var ls then fail else (progress autorewrite with distr_length)
                 | [ H : context[length ?ls] |- _ ] => tryif is_var ls then fail else (progress autorewrite with distr_length in H)
                 | [ |- @ex (_ = _) _ ] => (exists eq_refl)
@@ -447,20 +286,10 @@ Module Compilers.
                 | [ |- UnderLets.wf _ _ (UnderLets.splice _ _) (UnderLets.splice _ _) ] => eapply UnderLets.wf_splice
                 | [ |- UnderLets.wf _ _ (UnderLets.splice_list _ _) (UnderLets.splice_list _ _) ]
                   => apply @UnderLets.wf_splice_list_no_order with (P:=fun G' => expr.wf G')
-                | [ |- Compile.wf_anyexpr _ _ _ _ ] => constructor
-                | [ |- context[@rlist_rect_cast ?var ?A ?A' ?P ?ivar ?N_case ?C_case ?ls ?T ?k] ]
-                  => (tryif (let __ := constr:(eq_refl : k = (fun x => x)) in idtac)
-                      then fail
-                      else rewrite (@rlist_rect_cast_cps_id var A A' P ivar N_case C_case ls T k))
-                | [ |- context[@rlist_rect ?var ?A ?P ?ivar ?N_case ?C_case ?ls ?T ?k] ]
-                  => (tryif (let __ := constr:(eq_refl : k = (fun x => x)) in idtac)
-                      then fail
-                      else rewrite (@rlist_rect_cps_id var A P ivar N_case C_case ls T k))
                 | [ |- ?x = ?x /\ _ ] => split; [ reflexivity | ]
-                | [ |- context[invert_expr.reflect_list ?v] ] => destruct (invert_expr.reflect_list v) eqn:?
                 | [ H : invert_expr.reflect_list ?v = Some _, H' : invert_expr.reflect_list ?v' = None |- _ ]
                   => first [ erewrite <- expr.wf_reflect_list in H' by eassumption
-                          | erewrite -> expr.wf_reflect_list in H' by eassumption ];
+                           | erewrite -> expr.wf_reflect_list in H' by eassumption ];
                     exfalso; clear -H H'; congruence
                 | [ H : Compile.wf_value _ (reify_list _) (reify_list _) |- _ ]
                   => hnf in H; rewrite expr.wf_reify_list in H
@@ -508,37 +337,11 @@ Module Compilers.
                 | [ H : Compile.wf_value _ ?f ?g |- UnderLets.wf _ _ (?f _ _) (?g _ _) ] => eapply UnderLets.wf_Proper_list; [ | | eapply H; solve [ eauto ] ]; solve [ repeat good_t_step ]
                 | [ H : Compile.wf_value _ ?f ?g |- UnderLets.wf _ _ (?f _ _ _) (?g _ _ _) ] => eapply UnderLets.wf_Proper_list; [ | | eapply H; solve [ eauto ] ]; solve [ repeat good_t_step ]
                 | [ H : Compile.wf_value ?G ?e1 ?e2 |- UnderLets.wf _ ?G (?e1 _) (?e2 _) ] => eapply (H nil)
-                | [ |- Compile.wf_anyexpr _ _ _ _ ] => constructor
-                | [ H : Compile.wf_value ?G ?ls1 ?ls2, H1 : rlist_rect_cast ?N1 ?C1 ?ls1 _ (fun x => x) = _, H2 : rlist_rect_cast ?N2 ?C2 ?ls2 _ (fun y => y) = _ |- _ ]
-                  => let H' := fresh in
-                    pose proof (@wf_rlist_rect_cast _ _ _ N1 N2 C1 C2 ls1 ls2 G H) as H'; cbv [id Compile.value] in H', H1, H2; rewrite H1, H2 in H';
-                    clear H1 H2;
-                    first [ apply H'
-                          | refine ((fun pf : Some _ = None => _) _); [ inversion_option | apply H' ] ]
-                | [ H : Compile.wf_value ?G ?ls1 ?ls2, H1 : rlist_rect_cast ?N1 ?C1 ?ls1 _ (fun x => x) = _, H2 : rlist_rect_cast ?N2 ?C2 ?ls2 _ (fun y => y) = _ |- _ ]
-                  => let H' := fresh in
-                    pose proof (@wf_rlist_rect_castv _ _ _ N1 N2 C1 C2 ls1 ls2 G H) as H'; cbv [id Compile.value] in H', H1, H2; rewrite H1, H2 in H';
-                    clear H1 H2;
-                    first [ apply H'
-                          | refine ((fun pf : Some _ = None => _) _); [ inversion_option | apply H' ] ]
-                | [ H : Compile.wf_value ?G ?ls1 ?ls2, H1 : rlist_rect ?N1 ?C1 ?ls1 _ (fun x => x) = _, H2 : rlist_rect ?N2 ?C2 ?ls2 _ (fun y => y) = _ |- _ ]
-                  => let H' := fresh in
-                    pose proof (@wf_rlist_rect _ _ N1 N2 C1 C2 ls1 ls2 G H) as H'; cbv [id Compile.value] in H', H1, H2; rewrite H1, H2 in H';
-                    clear H1 H2;
-                    first [ apply H'
-                          | refine ((fun pf : Some _ = None => _) _); [ inversion_option | apply H' ] ]
-                | [ H : Compile.wf_value ?G ?ls1 ?ls2, H1 : rlist_rect ?N1 ?C1 ?ls1 _ (fun x => x) = _, H2 : rlist_rect ?N2 ?C2 ?ls2 _ (fun y => y) = _ |- _ ]
-                  => let H' := fresh in
-                    pose proof (@wf_rlist_rectv _ _ N1 N2 C1 C2 ls1 ls2 G H) as H'; cbv [id Compile.value] in H', H1, H2; rewrite H1, H2 in H';
-                    clear H1 H2;
-                    first [ apply H'
-                          | refine ((fun pf : Some _ = None => _) _); [ inversion_option | apply H' ] ]
                 | [ H : ?R ?G ?a ?b |- expr.wf ?G ?a ?b ]
                   => is_evar R; revert H; instantiate (1:=fun G' => expr.wf G'); solve [ auto ]
                 | [ H : expr.wf ?G ?a ?b |- ?R ?G ?a ?b ]
                   => is_evar R; instantiate (1:=fun G' => expr.wf G'); solve [ auto ]
                 | [ |- (forall t v1 v2, In _ _ -> _) /\ expr.wf _ _ _ ] => apply conj; revgoals
-                | [ |- (forall t v1 v2, In _ _ -> _) /\ Compile.wf_anyexpr _ _ _ _ ] => apply conj; revgoals
                 | [ H : expr.wf _ ?x ?y |- Compile.wf_value _ ?x ?y ] => hnf
                 | [ |- Compile.wf_value _ ?x ?y ] => eapply Compile.wf_value'_Proper_list; [ | solve [ cbv [Compile.wf_value] in *; eauto ] ]; solve [ wf_t ]
                 | [ |- In ?x ?ls ] => is_evar ls; refine (or_introl eq_refl : In x (x :: _)); shelve
@@ -553,15 +356,15 @@ Module Compilers.
 
       Lemma nbe_rewrite_rules_good
         : rewrite_rules_goodT nbe_rewrite_rules nbe_rewrite_rules.
-      Proof.
-        Time start_good (@nbe_cps_id) (@nbe_rewrite_rules).
+      Proof using Type.
+        Time start_good.
         Time all: repeat repeat good_t_step.
       Qed.
 
       Lemma arith_rewrite_rules_good max_const
         : rewrite_rules_goodT (arith_rewrite_rules max_const) (arith_rewrite_rules max_const).
-      Proof.
-        Time start_good (@arith_cps_id) (@arith_rewrite_rules).
+      Proof using Type.
+        Time start_good.
         Time all: repeat good_t_step.
       Qed.
 
@@ -570,12 +373,12 @@ Module Compilers.
             (Hlow : forall s v v', invert_low s v = Some v' -> v = Z.land v' (2^(s/2)-1))
             (Hhigh : forall s v v', invert_high s v = Some v' -> v = Z.shiftr v' (s/2))
         : rewrite_rules_goodT (fancy_rewrite_rules invert_low invert_high) (fancy_rewrite_rules invert_low invert_high).
-      Proof.
-        Time start_good (@fancy_cps_id) (@fancy_rewrite_rules).
+      Proof using Type.
+        Time start_good.
         Time all: repeat good_t_step.
         all: cbv [Option.bind].
         Time all: repeat good_t_step.
-      Time Qed.
+      Qed.
     End good.
   End RewriteRules.
 End Compilers.

--- a/src/Experiments/NewPipeline/RewriterWf2.v
+++ b/src/Experiments/NewPipeline/RewriterWf2.v
@@ -45,42 +45,44 @@ Module Compilers.
     Module Compile.
       Import Rewriter.Compilers.RewriteRules.Compile.
       Import RewriterWf1.Compilers.RewriteRules.Compile.
-      Import AnyExpr.
 
       Section with_type.
+        Local Notation type_of_list
+          := (fold_right (fun a b => prod a b) unit).
+        Local Notation type_of_list_cps
+          := (fold_right (fun a K => a -> K)).
         Context {ident : type.type base.type -> Type}
-                {pident : Type}
-                (full_types : pident -> Type)
-                (invert_bind_args : forall t (idc : ident t) (pidc : pident), option (full_types pidc))
-                (type_of_pident : forall (pidc : pident), full_types pidc -> type.type base.type)
-                (pident_to_typed : forall (pidc : pident) (args : full_types pidc), ident (type_of_pident pidc args))
                 (eta_ident_cps : forall {T : type.type base.type -> Type} {t} (idc : ident t)
                                         (f : forall t', ident t' -> T t'),
                     T t)
+                {pident : type.type pattern.base.type -> Type}
+                (pident_arg_types : forall t, pident t -> list Type)
+                (pident_unify pident_unify_unknown : forall t t' (idc : pident t) (idc' : ident t'), option (type_of_list (pident_arg_types t idc)))
+                {raw_pident : Type}
+                (strip_types : forall t, pident t -> raw_pident)
+                (raw_pident_beq : raw_pident -> raw_pident -> bool)
+                (type_vars_of_pident : forall t, pident t -> list (type.type pattern.base.type))
+
+                (full_types : raw_pident -> Type)
+                (invert_bind_args invert_bind_args_unknown : forall t (idc : ident t) (pidc : raw_pident), option (full_types pidc))
+                (type_of_raw_pident : forall (pidc : raw_pident), full_types pidc -> type.type base.type)
+                (raw_pident_to_typed : forall (pidc : raw_pident) (args : full_types pidc), ident (type_of_raw_pident pidc args))
+                (raw_pident_is_simple : raw_pident -> bool)
+                (pident_unify_unknown_correct
+                 : forall t t' idc idc', pident_unify_unknown t t' idc idc' = pident_unify t t' idc idc')
+                (invert_bind_args_unknown_correct
+                 : forall t idc pidc, invert_bind_args_unknown t idc pidc = invert_bind_args t idc pidc)
                 (eta_ident_cps_correct : forall T t idc f, @eta_ident_cps T t idc f = f _ idc)
-                (of_typed_ident : forall {t}, ident t -> pident)
-                (arg_types : pident -> option Type)
-                (bind_args : forall {t} (idc : ident t), match arg_types (of_typed_ident idc) return Type with Some t => t | None => unit end)
-                (pident_beq : pident -> pident -> bool)
-                (try_make_transport_ident_cps : forall (P : pident -> Type) (idc1 idc2 : pident), ~> option (P idc1 -> P idc2))
-                (pident_to_typed_invert_bind_args_type
-                 : forall t idc p f, invert_bind_args t idc p = Some f -> t = type_of_pident p f)
-                (pident_to_typed_invert_bind_args
+                (raw_pident_to_typed_invert_bind_args_type
+                 : forall t idc p f, invert_bind_args t idc p = Some f -> t = type_of_raw_pident p f)
+                (raw_pident_to_typed_invert_bind_args
                  : forall t idc p f (pf : invert_bind_args t idc p = Some f),
-                    pident_to_typed p f = rew [ident] pident_to_typed_invert_bind_args_type t idc p f pf in idc)
-                (pident_bl : forall p q, pident_beq p q = true -> p = q)
-                (pident_lb : forall p q, p = q -> pident_beq p q = true)
-                (try_make_transport_ident_cps_correct
-                 : forall P idc1 idc2 T k,
-                    try_make_transport_ident_cps P idc1 idc2 T k
-                    = k (match Sumbool.sumbool_of_bool (pident_beq idc1 idc2) with
-                         | left pf => Some (fun v => rew [P] pident_bl _ _ pf in v)
-                         | right _ => None
-                         end)).
+                    raw_pident_to_typed p f = rew [ident] raw_pident_to_typed_invert_bind_args_type t idc p f pf in idc)
+        (*(raw_pident_bl : forall p q, raw_pident_beq p q = true -> p = q)
+                (raw_pident_lb : forall p q, p = q -> raw_pident_beq p q = true)*).
         Local Notation type := (type.type base.type).
         Local Notation pattern := (@pattern.pattern pident).
         Local Notation expr := (@expr.expr base.type ident).
-        Local Notation anyexpr := (@anyexpr base.type ident).
         Local Notation UnderLets := (@UnderLets.UnderLets base.type ident).
         Local Notation ptype := (type.type pattern.base.type).
         Local Notation value' := (@value' base.type ident).
@@ -92,12 +94,8 @@ Module Compilers.
         Local Notation reify := (@reify ident).
         Local Notation reflect := (@reflect ident).
         Local Notation rawexpr := (@rawexpr ident).
-        Local Notation eval_decision_tree var := (@eval_decision_tree ident var pident full_types invert_bind_args type_of_pident pident_to_typed).
+        Local Notation eval_decision_tree var := (@eval_decision_tree ident var raw_pident full_types invert_bind_args invert_bind_args_unknown type_of_raw_pident raw_pident_to_typed raw_pident_is_simple).
         Local Notation reveal_rawexpr e := (@reveal_rawexpr_cps ident _ e _ id).
-        Local Notation bind_data_cps var := (@bind_data_cps ident var pident of_typed_ident arg_types bind_args try_make_transport_ident_cps).
-        Local Notation bind_data e p := (@bind_data_cps _ e p _ id).
-        Local Notation ptype_interp := (@ptype_interp ident).
-        Local Notation binding_dataT var := (@binding_dataT ident var pident arg_types).
 
         Section with_var2.
           Context {var1 var2 : type -> Type}.
@@ -116,30 +114,230 @@ Module Compilers.
           Local Notation wf_value_with_lets := (@wf_value_with_lets base.type ident var1 var2).
           Local Notation reify_and_let_binds_cps1 := (@reify_and_let_binds_cps ident var1 reify_and_let_binds_base_cps1).
           Local Notation reify_and_let_binds_cps2 := (@reify_and_let_binds_cps ident var2 reify_and_let_binds_base_cps2).
-          Local Notation rewrite_rulesT1 := (@rewrite_rulesT ident var1 pident arg_types).
-          Local Notation rewrite_rulesT2 := (@rewrite_rulesT ident var2 pident arg_types).
-          Local Notation eval_rewrite_rules1 := (@eval_rewrite_rules ident var1 pident full_types invert_bind_args type_of_pident pident_to_typed of_typed_ident arg_types bind_args try_make_transport_ident_cps).
-          Local Notation eval_rewrite_rules2 := (@eval_rewrite_rules ident var2 pident full_types invert_bind_args type_of_pident pident_to_typed of_typed_ident arg_types bind_args try_make_transport_ident_cps).
+          Local Notation rewrite_rulesT1 := (@rewrite_rulesT ident var1 pident pident_arg_types type_vars_of_pident).
+          Local Notation rewrite_rulesT2 := (@rewrite_rulesT ident var2 pident pident_arg_types type_vars_of_pident).
+          Local Notation eval_rewrite_rules1 := (@eval_rewrite_rules ident var1 pident pident_arg_types pident_unify pident_unify_unknown raw_pident type_vars_of_pident full_types invert_bind_args invert_bind_args_unknown type_of_raw_pident raw_pident_to_typed raw_pident_is_simple).
+          Local Notation eval_rewrite_rules2 := (@eval_rewrite_rules ident var2 pident pident_arg_types pident_unify pident_unify_unknown raw_pident type_vars_of_pident full_types invert_bind_args invert_bind_args_unknown type_of_raw_pident raw_pident_to_typed raw_pident_is_simple).
+          Local Notation with_unification_resultT'1 := (@with_unification_resultT' ident var1 pident pident_arg_types).
+          Local Notation with_unification_resultT'2 := (@with_unification_resultT' ident var2 pident pident_arg_types).
+          Local Notation with_unification_resultT1 := (@with_unification_resultT ident var1 pident pident_arg_types type_vars_of_pident).
+          Local Notation with_unification_resultT2 := (@with_unification_resultT ident var2 pident pident_arg_types type_vars_of_pident).
+          Local Notation rewrite_rule_data1 := (@rewrite_rule_data ident var1 pident pident_arg_types type_vars_of_pident).
+          Local Notation rewrite_rule_data2 := (@rewrite_rule_data ident var2 pident pident_arg_types type_vars_of_pident).
+          Local Notation with_unif_rewrite_ruleTP_gen1 := (@with_unif_rewrite_ruleTP_gen ident var1 pident pident_arg_types type_vars_of_pident).
+          Local Notation with_unif_rewrite_ruleTP_gen2 := (@with_unif_rewrite_ruleTP_gen ident var2 pident pident_arg_types type_vars_of_pident).
           Local Notation wf_rawexpr := (@wf_rawexpr ident var1 var2).
+          (** TODO: Move Me up *)
+          Local Notation unify_pattern'1 := (@unify_pattern' ident var1 pident pident_arg_types pident_unify pident_unify_unknown).
+          Local Notation unify_pattern'2 := (@unify_pattern' ident var2 pident pident_arg_types pident_unify pident_unify_unknown).
+          Local Notation unify_pattern1 := (@unify_pattern ident var1 pident pident_arg_types pident_unify pident_unify_unknown type_vars_of_pident).
+          Local Notation unify_pattern2 := (@unify_pattern ident var2 pident pident_arg_types pident_unify pident_unify_unknown type_vars_of_pident).
+          Local Notation wf_with_unification_resultT' := (@wf_with_unification_resultT' ident pident pident_arg_types var1 var2).
+          Local Notation wf_with_unification_resultT := (@wf_with_unification_resultT ident pident pident_arg_types type_vars_of_pident var1 var2).
+          Local Notation wf_with_unif_rewrite_ruleTP_gen := (@wf_with_unif_rewrite_ruleTP_gen ident pident pident_arg_types type_vars_of_pident var1 var2).
+          Local Notation wf_deep_rewrite_ruleTP_gen := (@wf_deep_rewrite_ruleTP_gen ident var1 var2).
 
           (* Because [proj1] and [proj2] in the stdlib are opaque *)
           Local Notation proj1 x := (let (a, b) := x in a).
           Local Notation proj2 x := (let (a, b) := x in b).
 
-          Lemma swap_list_None_iff {A} (i j : nat) (ls : list A)
-            : swap_list i j ls = None <-> (length ls <= i \/ length ls <= j)%nat.
-          Proof.
-            rewrite <- !nth_error_None.
-            cbv [swap_list]; break_innermost_match; intuition congruence.
+          Lemma wf_unify_pattern'
+                (G : list { t : _ & (var1 t * var2 t)%type })
+                {t1 t2 t'} {p1 : pattern t1} {p2 : pattern t2} {evm1 evm2 : EvarMap} {re1 re2 e1 e2} {K1 K2}
+                (PK : K1 (pattern.type.subst_default t1 evm1) -> K2 (pattern.type.subst_default t2 evm2) -> Prop)
+                {T1 T2}
+                (PT : T1 -> T2 -> Prop)
+                {v1 v2}
+                {cont1 : K1 _ -> option T1}
+                {cont2 : K2 _ -> option T2}
+                (He : @wf_rawexpr G t' re1 e1 re2 e2)
+                (Hv : @wf_with_unification_resultT' G t1 t2 p1 p2 evm1 evm2 _ _ PK v1 v2)
+                (HT : forall v1 v2, PK v1 v2 -> option_eq PT (cont1 v1) (cont2 v2))
+            : option_eq
+                PT
+                (@unify_pattern'1 t1 re1 p1 evm1 K1 v1 T1 cont1)
+                (@unify_pattern'2 t2 re2 p2 evm2 K2 v2 T2 cont2).
+          Proof using pident_unify_unknown_correct.
+            revert dependent p2; intro p2; revert dependent re1; revert dependent re2; revert t' e1 e2; revert dependent evm1; revert dependent evm2; revert dependent K1; revert dependent K2; revert t2 p2.
+            induction p1, p2; intros; cbn [unify_pattern'].
+            all: repeat first [ progress cbn [with_unification_resultT' wf_with_unification_resultT' Option.bind eq_rect eq_sigT eq_sigT_uncurried eq_existT_uncurried] in *
+                              | progress cbv [option_bind'] in *
+                              | assumption
+                              | reflexivity
+                              | exfalso; assumption
+                              | progress subst
+                              | progress destruct_head'_sig
+                              | progress inversion_sigma
+                              | progress rewrite_type_transport_correct
+                              | progress type_beq_to_eq
+                              | match goal with
+                                | [ H : @wf_rawexpr ?G ?t ?re1 ?e1 ?re2 ?e2 |- context[match ?re1 with _ => _ end] ]
+                                  => is_var t; is_var re1; is_var e1; is_var re2; is_var e2; is_var G;
+                                     destruct H
+                                end
+                              | rewrite !pident_unify_unknown_correct
+                              | break_innermost_match_step
+                              | match goal with
+                                | [ |- context[rew ?pf in _] ]
+                                  => is_var pf;
+                                     lazymatch type of pf with
+                                     | type_of_rawexpr _ = ?t
+                                       => let t' := fresh "t" in
+                                          remember t as t' eqn:? in *; destruct pf
+                                     end
+                                | [ H : forall v1 v2, ?PK v1 v2 -> option_eq ?PT (?f1 v1) (?f2 v2) |- option_eq ?PT (?f1 _) (?f2 _) ]
+                                  => is_var PT; is_var PK; apply H; clear dependent PT
+                                | [ H : forall v1 v2, wf_value _ _ _ -> ?PK (?f1 v1) (?f2 v2) |- ?PK (?f1 _) (?f2 _) ]
+                                  => is_var PK; apply H; clear dependent PK
+                                | [ He : wf_rawexpr ?G ?re1 _ ?re2 _
+                                    |- wf_value ?G (rew ?pf in value_of_rawexpr ?re1) (value_of_rawexpr ?re2) ]
+                                  => apply (wf_value_of_wf_rawexpr_gen (pf2:=eq_refl) He)
+                                | [ H : wf_rawexpr _ _ _ _ _ |- _ ]
+                                  => progress (try (unique pose proof (proj1 (eq_type_of_rawexpr_of_wf H)));
+                                               try (unique pose proof (proj2 (eq_type_of_rawexpr_of_wf H))))
+                                | [ H : ?t1 <> ?t2 |- _ ]
+                                  => exfalso; apply H; congruence
+                                end
+                              | solve [ eauto ]
+                              | progress cbv [Option.bind] in *
+                              | apply related_app_type_of_list_of_forall2_type_of_list_cps ].
           Qed.
 
-          Lemma swap_list_Some_length {A} (i j : nat) (ls ls' : list A)
-            : swap_list i j ls = Some ls'
-              -> (i < length ls /\ j < length ls /\ length ls' = length ls)%nat.
-          Proof.
-            cbv [swap_list]; break_innermost_match; intros; inversion_option; subst.
-            repeat match goal with H : _ |- _ => apply nth_error_value_length in H end.
-            autorewrite with distr_length; tauto.
+          Lemma wf_unify_pattern'_id
+                (G : list { t : _ & (var1 t * var2 t)%type })
+                {t1 t2 t'} {p1 : pattern t1} {p2 : pattern t2} {evm1 evm2 : EvarMap} {re1 re2 e1 e2} {K1 K2}
+                (PK : K1 (pattern.type.subst_default t1 evm1) -> K2 (pattern.type.subst_default t2 evm2) -> Prop)
+                {v1 v2}
+                (He : @wf_rawexpr G t' re1 e1 re2 e2)
+                (Hv : @wf_with_unification_resultT' G t1 t2 p1 p2 evm1 evm2 _ _ PK v1 v2)
+            : option_eq
+                PK
+                (@unify_pattern'1 t1 re1 p1 evm1 K1 v1 _ (@Some _))
+                (@unify_pattern'2 t2 re2 p2 evm2 K2 v2 _ (@Some _)).
+          Proof using pident_unify_unknown_correct.
+            eapply wf_unify_pattern'; try eassumption; eauto.
+          Qed.
+
+          Lemma wf_unify_pattern
+                (G : list { t : _ & (var1 t * var2 t)%type })
+                {t t'} {p : pattern t} {re1 re2 e1 e2} {K1 K2}
+                (PK : forall t, K1 t -> K2 t -> Prop)
+                {T1 T2}
+                (PT : T1 -> T2 -> Prop)
+                {v1 v2}
+                {cont1 : K1 _ -> option T1}
+                {cont2 : K2 _ -> option T2}
+                (He : @wf_rawexpr G t' re1 e1 re2 e2)
+                (Hv : @wf_with_unification_resultT G t p _ _ (fun evm => PK _) v1 v2)
+                (HT : forall t v1 v2 pf1 pf2, PK t (rew [K1] pf1 in v1) (rew [K2] pf2 in v2) -> option_eq PT (cont1 v1) (cont2 v2))
+            : option_eq
+                PT
+                (@unify_pattern1 t re1 p K1 v1 T1 cont1)
+                (@unify_pattern2 t re2 p K2 v2 T2 cont2).
+          Proof using pident_unify_unknown_correct.
+            cbv [unify_pattern].
+            erewrite wf_unify_types_cps by eassumption.
+            repeat (rewrite unify_types_cps_id; set (unify_types _ _ _ id)).
+            repeat match goal with v := unify_types _ _ _ id |- _ => subst v end.
+            cbv [Compile.wf_with_unification_resultT] in *.
+            revert dependent cont2; revert dependent cont1.
+            let lem := constr:(eq_type_of_rawexpr_of_wf ltac:(eassumption)) in
+            rewrite (proj1 lem), (proj2 lem).
+            intros; specialize (fun v1 v2 => HT _ v1 v2 eq_refl eq_refl); cbn [eq_rect] in *.
+            repeat first [ progress subst
+                         | progress intros
+                         | progress cbv beta in *
+                         | match goal with
+                           | [ |- ?R ?x ?x ] => reflexivity
+                           | [ |- option_eq ?RB (Option.bind ?a ?b) (Option.bind ?a' ?b') ]
+                             => eapply Option.bind_Proper_option_eq_hetero
+                           | [ |- option_eq _ (pattern.type.app_forall_vars _ _) (pattern.type.app_forall_vars _ _) ]
+                             => refine (pattern.type.app_forall_vars_under_forall_vars_relation _)
+                           | [ |- option_eq _ (@unify_pattern'1 _ _ _ _ _ _ _ _) (@unify_pattern'2 _ _ _ _ _ _ _ _) ]
+                             => eapply wf_unify_pattern'
+                           | [ H1 : forall v1 v2, ?PK _ v1 v2 -> option_eq ?PT (?f1 v1) (?f2 v2),
+                                 H2 : ?RA ?a1 ?a2
+                                 |- option_eq ?PT (?f1 (?a1 _)) (?f2 (?a2 _)) ]
+                             => eapply H1; refine H2
+                           end
+                         | eassumption
+                         | progress rewrite_type_transport_correct ].
+            (* We separate this into two separate [repeat first] statements because we need to unify evars across goals before proceeding here *)
+            repeat first [ reflexivity
+                         | exfalso; assumption
+                         | progress subst
+                         | progress cbn [eq_rect Option.bind option_eq] in *
+                         | progress type_beq_to_eq
+                         | assumption
+                         | progress break_match ].
+          Qed.
+
+          Lemma wf_unify_pattern_id
+                (G : list { t : _ & (var1 t * var2 t)%type })
+                {t t'} {p : pattern t} {re1 re2 e1 e2} {K1 K2}
+                (PK : forall t1 t2, K1 t1 -> K2 t2 -> Prop)
+                {v1 v2}
+                (He : @wf_rawexpr G t' re1 e1 re2 e2)
+                (Hv : @wf_with_unification_resultT G t p _ _ (fun evm => PK _ _) v1 v2)
+            : option_eq
+                (PK _ _)
+                (@unify_pattern1 t re1 p K1 v1 _ (@Some _))
+                (@unify_pattern2 t re2 p K2 v2 _ (@Some _)).
+          Proof using pident_unify_unknown_correct.
+            eapply wf_unify_pattern with (PK:=fun t => PK t t); try eassumption.
+            intros ? ? ? pf1 pf2; destruct pf1, pf2; cbn; trivial.
+          Qed.
+
+          Lemma wf_normalize_deep_rewrite_rule
+                {G}
+                {t}
+                {should_do_again1 with_opt1 under_lets1 is_cps1}
+                {should_do_again2 with_opt2 under_lets2 is_cps2}
+                {r1 r2}
+                (Hwf : @wf_deep_rewrite_ruleTP_gen G t should_do_again1 with_opt1 under_lets1 is_cps1 should_do_again2 with_opt2 under_lets2 is_cps2 r1 r2)
+            : option_eq
+                (UnderLets.wf (fun G' => wf_maybe_do_again_expr G') G)
+                (normalize_deep_rewrite_rule r1 _ id) (normalize_deep_rewrite_rule r2 _ id).
+          Proof using Type.
+            clear -Hwf.
+            all: destruct_head'_bool.
+            all: cbv [normalize_deep_rewrite_rule wf_deep_rewrite_ruleTP_gen deep_rewrite_ruleTP_gen] in *.
+            all: destruct_head'_and.
+            all: repeat first [ assumption
+                              | exfalso; assumption
+                              | progress cbv [Option.bind option_eq wf_maybe_under_lets_expr] in *
+                              | progress inversion_option
+                              | progress subst
+                              | match goal with
+                                | [ |- ?x = ?x ] => reflexivity
+                                | [ H : forall T K, ?f T K = @?v T K, H' : context[?f ?T' ?K'] |- _ ]
+                                  => lazymatch v with
+                                     | context[f]
+                                       => lazymatch K' with
+                                          | id => fail
+                                          | @Some _ => fail
+                                          | _ => idtac
+                                          end
+                                     | _ => idtac
+                                     end;
+                                     rewrite (H T' K') in H'
+                                | [ H : forall T K, ?f T K = @?v T K |- context[?f ?T' ?K'] ]
+                                  => lazymatch v with
+                                     | context[f]
+                                       => lazymatch K' with
+                                          | id => fail
+                                          | @Some _ => fail
+                                          | _ => idtac
+                                          end
+                                     | _ => idtac
+                                     end;
+                                     rewrite (H T' K')
+                                | [ H : context[id ?x] |- _ ] => change (id x) with x in H
+                                | [ |- context[id ?x] ] => change (id x) with x
+                                | [ |- UnderLets.wf _ _ _ _ ] => constructor
+                                end
+                              | break_innermost_match_step
+                              | break_innermost_match_hyps_step ].
           Qed.
 
           Local Ltac fin_handle_list :=
@@ -173,22 +371,85 @@ Module Compilers.
                    end;
             fin_handle_list.
 
-          Lemma nth_error_swap_list {A} {i j : nat} {ls ls' : list A}
-            : swap_list i j ls = Some ls'
-              -> forall k,
-                nth_error ls' k = if Nat.eq_dec k i then nth_error ls j else if Nat.eq_dec k j then nth_error ls i else nth_error ls k.
-          Proof.
-            cbv [swap_list]; break_innermost_match; intros; inversion_option; subst;
-              rewrite ?nth_set_nth; distr_length; break_innermost_match; try congruence; try lia;
-                handle_nth_error.
-          Qed.
-
           Local Ltac handle_swap_list :=
             repeat match goal with
                    | [ H : swap_list _ _ _ = None |- _ ] => rewrite swap_list_None_iff in H
                    | [ H : swap_list _ _ _ = Some _ |- _ ] => unique pose proof (@swap_list_Some_length _ _ _ _ _ H)
                    end;
             fin_handle_list.
+
+          Fixpoint eval_decision_tree_cont_None_ext
+                {var} {T ctx d cont}
+                (Hcont : forall x y, cont x y = None)
+                {struct d}
+            : @eval_decision_tree var T ctx d cont = None.
+          Proof using Type.
+            clear -Hcont eval_decision_tree_cont_None_ext.
+            specialize (fun d ctx => @eval_decision_tree_cont_None_ext var T ctx d).
+            destruct d; cbn [eval_decision_tree]; intros; try (clear eval_decision_tree_cont_None_ext; tauto).
+            { let d := match goal with d : decision_tree |- _ => d end in
+              specialize (eval_decision_tree_cont_None_ext d).
+              rewrite !Hcont, !eval_decision_tree_cont_None_ext by assumption.
+              break_innermost_match; reflexivity. }
+            { let d := match goal with d : decision_tree |- _ => d end in
+              pose proof (eval_decision_tree_cont_None_ext d) as IHd.
+              let d := match goal with d : option decision_tree |- _ => d end in
+              pose proof (match d as d' return match d' with Some _ => _ | None => True end with
+                          | Some d => eval_decision_tree_cont_None_ext d
+                          | None => I
+                          end) as IHapp_case.
+              all: destruct ctx; try (clear eval_decision_tree_cont_None_ext; (tauto || congruence)); [].
+              all: lazymatch goal with
+                   | [ |- match ?d with
+                          | TryLeaf _ _ => (?res ;; ?ev)%option
+                          | _ => _
+                          end = None ]
+                     => cut (res = None /\ ev = None);
+                          [ clear eval_decision_tree_cont_None_ext;
+                            let H1 := fresh in
+                            let H2 := fresh in
+                            intros [H1 H2]; rewrite H1, H2; destruct d; reflexivity
+                          | ]
+                   end.
+              all: split; [ | clear eval_decision_tree_cont_None_ext; eapply IHd; eassumption ].
+              (** We use the trick that [induction] inside [Fixpoint]
+                  gives us nested [fix]es that pass the guarded
+                  checker, as long as we're careful about how we do
+                  things *)
+              let icases := match goal with d : list (_ * decision_tree) |- _ => d end in
+              induction icases as [|icase icases IHicases];
+                [ | pose proof (eval_decision_tree_cont_None_ext (snd icase)) as IHicase ];
+                clear eval_decision_tree_cont_None_ext.
+              (** now we can stop being super-careful about [destruct]
+                  ordering because, if we're [Guarded] here (which we
+                  are), then we cannot break guardedness from this
+                  point on, because we've cleared the bare fixpoint
+                  after specializing it to valid arguments *)
+              2: revert IHicases.
+              all: repeat (rewrite reveal_rawexpr_cps_id; set (reveal_rawexpr _)).
+              all: repeat match goal with H := reveal_rawexpr _ |- _ => subst H end.
+              all: repeat first [ progress cbn [fold_right Option.sequence Option.sequence_return fst snd] in *
+                                | progress subst
+                                | reflexivity
+                                | rewrite IHd
+                                | rewrite IHapp_case
+                                | rewrite IHicase
+                                | break_innermost_match_step
+                                | progress intros
+                                | solve [ auto ]
+                                | progress break_match
+                                | progress cbv [Option.bind option_bind'] in * ]. }
+            { let d := match goal with d : decision_tree |- _ => d end in
+              specialize (eval_decision_tree_cont_None_ext d); rename eval_decision_tree_cont_None_ext into IHd.
+              repeat first [ break_innermost_match_step
+                           | rewrite IHd
+                           | solve [ auto ]
+                           | progress intros ]. }
+          Qed.
+
+          Lemma eval_decision_tree_cont_None {var} {T ctx d}
+            : @eval_decision_tree var T ctx d (fun _ _ => None) = None.
+          Proof using Type. apply eval_decision_tree_cont_None_ext; reflexivity. Qed.
 
           Fixpoint wf_eval_decision_tree' {T1 T2} G d (P : option T1 -> option T2 -> Prop) (HPNone : P None None) {struct d}
             : forall (ctx1 : list (@rawexpr var1))
@@ -210,8 +471,8 @@ Module Compilers.
                             /\ P (cont1 n ls1) (cont2 n ls2)),
               ((@eval_decision_tree var1 T1 ctx1 d cont1) = None <-> (@eval_decision_tree var2 T2 ctx2 d cont2) = None)
               /\ P (@eval_decision_tree var1 T1 ctx1 d cont1) (@eval_decision_tree var2 T2 ctx2 d cont2).
-          Proof using pident_to_typed_invert_bind_args.
-            clear -HPNone pident_to_typed_invert_bind_args wf_eval_decision_tree'.
+          Proof using raw_pident_to_typed_invert_bind_args invert_bind_args_unknown_correct.
+            clear -HPNone raw_pident_to_typed_invert_bind_args invert_bind_args_unknown_correct wf_eval_decision_tree'.
             specialize (fun d => wf_eval_decision_tree' T1 T2 G d P HPNone).
             destruct d; cbn [eval_decision_tree]; intros; try (clear wf_eval_decision_tree'; tauto).
             { let d := match goal with d : decision_tree |- _ => d end in
@@ -281,56 +542,63 @@ Module Compilers.
               2: revert IHicases.
               all: repeat (rewrite reveal_rawexpr_cps_id; set (reveal_rawexpr _)).
               all: repeat match goal with H := reveal_rawexpr _ |- _ => subst H end.
-              all: repeat first [ match goal with
-                                  | [ H : S _ = S _ |- _ ] => inversion H; clear H
-                                  | [ H : S _ = length ?ls |- _ ] => is_var ls; destruct ls; cbn [length] in H; inversion H; clear H
-                                  | [ H : forall t re1 e1 re2 e2, _ = _ \/ _ -> _ |- _ ]
-                                    => pose proof (H _ _ _ _ _ (or_introl eq_refl));
-                                       specialize (fun t re1 e1 re2 e2 pf => H t re1 e1 re2 e2 (or_intror pf))
-                                  | [ H : wf_rawexpr ?G ?r ?e ?r' ?e' |- context[reveal_rawexpr ?r] ]
-                                    => apply wf_reveal_rawexpr in H; revert H;
-                                       generalize (reveal_rawexpr r) (reveal_rawexpr r'); clear r r'; intros r r' H; destruct H
-                                  | [ H1 : length ?ctx1 = length ?ctxe', H2 : length ?ctx2 = length ?ctxe', H1' : wf_rawexpr _ ?f1 ?f1e ?f2 ?f2e, H2' : wf_rawexpr _ ?x1 ?x1e ?x2 ?x2e
-                                      |- _ /\ ?P (@eval_decision_tree _ _ (?f1 :: ?x1 :: ?ctx1) _ _)
-                                               (@eval_decision_tree _ _ (?f2 :: ?x2 :: ?ctx2) _ _) ]
-                                    => apply IHapp_case with (ctxe:=existT _ _ (f1e, f2e) :: existT _ _ (x1e, x2e) :: ctxe'); clear IHapp_case
-                                  | [ H : ?x = ?x -> _ |- _ ] => specialize (H eq_refl)
-                                  | [ H : ?x = ?x |- _ ] => clear H
-                                  | [ |- context [pident_to_typed_invert_bind_args_type ?t ?idc ?p ?f ?pf] ]
-                                    => generalize (type_of_pident p f) (pident_to_typed_invert_bind_args_type t idc p f pf); clear p f pf; intros; subst
-                                  end
-                                | tauto
-                                | progress subst
-                                | progress cbn [length combine List.In fold_right fst snd projT1 projT2 eq_rect Option.sequence Option.sequence_return eq_rect] in *
-                                | progress inversion_sigma
-                                | progress inversion_prod
-                                | progress destruct_head'_sigT
-                                | progress destruct_head'_prod
-                                | progress destruct_head'_and
-                                | progress destruct_head' iff; progress specialize_by (exact eq_refl)
-                                | congruence
-                                | break_innermost_match_step
-                                | progress intros
-                                | progress destruct_head'_or
-                                | solve [ auto ]
-                                | match goal with
-                                  | [ |- wf_rawexpr _ _ _ _ _ ] => constructor
-                                  | [ H : context[(_ = None <-> _ = None) /\ ?P _ _] |- (_ = None <-> _ = None) /\ ?P _ _ ]
-                                    => apply H
-                                  | [ H : fold_right _ None ?ls = None, H' : fold_right _ None ?ls = Some None |- _ ]
-                                    => exfalso; clear -H H'; is_var ls; destruct ls; cbn [fold_right] in H, H'; break_match_hyps; congruence
-                                  end
-                                | progress break_match
-                                | progress cbv [option_bind' Option.bind]
-                                | unshelve erewrite pident_to_typed_invert_bind_args; [ shelve | shelve | eassumption | ]
-                                | match goal with
-                                  | [ |- _ /\ ?P (Option.sequence ?x ?y) (Option.sequence ?x' ?y') ]
-                                    => cut ((x = None <-> x' = None) /\ P x x');
-                                       [ destruct x, x'; cbn [Option.sequence]; solve [ intuition congruence ] | ]
-                                  | [ H1 : length ?ctx1 = length ?ctxe', H2 : length ?ctx2 = length ?ctxe'
-                                      |- _ /\ ?P (@eval_decision_tree _ _ ?ctx1 _ _) (@eval_decision_tree _ _ ?ctx2 _ _) ]
-                                    => apply IHicase with (ctxe := ctxe'); auto
-                                  end ]. }
+              all:repeat first [ match goal with
+                                 | [ H : S _ = S _ |- _ ] => inversion H; clear H
+                                 | [ H : S _ = length ?ls |- _ ] => is_var ls; destruct ls; cbn [length] in H; inversion H; clear H
+                                 | [ H : forall t re1 e1 re2 e2, _ = _ \/ _ -> _ |- _ ]
+                                   => pose proof (H _ _ _ _ _ (or_introl eq_refl));
+                                      specialize (fun t re1 e1 re2 e2 pf => H t re1 e1 re2 e2 (or_intror pf))
+                                 | [ H : wf_rawexpr ?G ?r ?e ?r' ?e' |- context[reveal_rawexpr ?r] ]
+                                   => apply wf_reveal_rawexpr in H; revert H;
+                                      generalize (reveal_rawexpr r) (reveal_rawexpr r'); clear r r'; intros r r' H; destruct H
+                                 | [ H1 : length ?ctx1 = length ?ctxe', H2 : length ?ctx2 = length ?ctxe', H1' : wf_rawexpr _ ?f1 ?f1e ?f2 ?f2e, H2' : wf_rawexpr _ ?x1 ?x1e ?x2 ?x2e
+                                     |- _ /\ ?P (@eval_decision_tree _ _ (?f1 :: ?x1 :: ?ctx1) _ _)
+                                              (@eval_decision_tree _ _ (?f2 :: ?x2 :: ?ctx2) _ _) ]
+                                   => apply IHapp_case with (ctxe:=existT _ _ (f1e, f2e) :: existT _ _ (x1e, x2e) :: ctxe'); clear IHapp_case
+                                 | [ H : ?x = ?x -> _ |- _ ] => specialize (H eq_refl)
+                                 | [ H : ?x = ?x |- _ ] => clear H
+                                 | [ |- context [raw_pident_to_typed_invert_bind_args_type ?t ?idc ?p ?f ?pf] ]
+                                   => generalize (raw_pident_is_simple p) (type_of_raw_pident p f) (raw_pident_to_typed_invert_bind_args_type t idc p f pf); clear p f pf; intros; subst
+                                 end
+                               | tauto
+                               | progress subst
+                               | progress cbn [length combine List.In fold_right fst snd projT1 projT2 eq_rect Option.sequence Option.sequence_return eq_rect] in *
+                               | progress inversion_sigma
+                               | progress inversion_prod
+                               | progress destruct_head'_sigT
+                               | progress destruct_head'_prod
+                               | progress destruct_head'_and
+                               | progress destruct_head' iff; progress specialize_by (exact eq_refl)
+                               | congruence
+                               | match goal with
+                                 | [ |- context[invert_bind_args_unknown] ]
+                                   => rewrite !invert_bind_args_unknown_correct
+                                 | [ H : context[invert_bind_args_unknown] |- _ ]
+                                   => rewrite !invert_bind_args_unknown_correct in H
+                                 end
+                               | rewrite !eval_decision_tree_cont_None
+                               | break_innermost_match_step
+                               | progress intros
+                               | progress destruct_head'_or
+                               | solve [ auto ]
+                               | match goal with
+                                 | [ |- wf_rawexpr _ _ _ _ _ ] => constructor
+                                 | [ H : context[(_ = None <-> _ = None) /\ ?P _ _] |- (_ = None <-> _ = None) /\ ?P _ _ ]
+                                   => apply H
+                                 | [ H : fold_right _ None ?ls = None, H' : fold_right _ None ?ls = Some None |- _ ]
+                                   => exfalso; clear -H H'; is_var ls; destruct ls; cbn [fold_right] in H, H'; break_match_hyps; congruence
+                                 end
+                               | progress break_match
+                               | progress cbv [option_bind' Option.bind]
+                               | unshelve erewrite raw_pident_to_typed_invert_bind_args; [ shelve | shelve | eassumption | ]
+                               | match goal with
+                                 | [ |- _ /\ ?P (Option.sequence ?x ?y) (Option.sequence ?x' ?y') ]
+                                   => cut ((x = None <-> x' = None) /\ P x x');
+                                      [ destruct x, x'; cbn [Option.sequence]; solve [ intuition congruence ] | ]
+                                 | [ H1 : length ?ctx1 = length ?ctxe', H2 : length ?ctx2 = length ?ctxe'
+                                     |- _ /\ ?P (@eval_decision_tree _ _ ?ctx1 _ _) (@eval_decision_tree _ _ ?ctx2 _ _) ]
+                                   => apply IHicase with (ctxe := ctxe'); auto
+                                 end ]. }
             { let d := match goal with d : decision_tree |- _ => d end in
               specialize (wf_eval_decision_tree' d); rename wf_eval_decision_tree' into IHd.
               break_innermost_match; handle_swap_list; try tauto; [].
@@ -385,7 +653,7 @@ Module Compilers.
                          -> (cont1 n ls1 = None <-> cont2 n ls2 = None)
                             /\ P (cont1 n ls1) (cont2 n ls2)),
               P (@eval_decision_tree var1 T1 ctx1 d cont1) (@eval_decision_tree var2 T2 ctx2 d cont2).
-          Proof using pident_to_typed_invert_bind_args. intros; eapply wf_eval_decision_tree'; eassumption. Qed.
+          Proof using raw_pident_to_typed_invert_bind_args invert_bind_args_unknown_correct. intros; eapply wf_eval_decision_tree'; eassumption. Qed.
 
 
           Local Ltac do_eq_type_of_rawexpr_of_wf :=
@@ -417,16 +685,81 @@ Module Compilers.
                                  (fun v => rew [fun t => @UnderLets var (B t)] p in f (rew [A] (eq_sym p) in v)).
           Proof. case p; reflexivity. Defined.
 
-          Local Transparent ERROR_BAD_REWRITE_RULE.
-          Lemma ERROR_BAD_REWRITE_RULE_id {var t p v} : @ERROR_BAD_REWRITE_RULE ident var pident t p v = v.
-          Proof. exact eq_refl. Qed.
-          Local Opaque ERROR_BAD_REWRITE_RULE.
+          Local Lemma ap_transport_Base {var T}
+                (A : T -> Type)
+                (x y : T) (p : x = y)
+                (v : A x)
+            : (rew [fun t => @UnderLets var (A t)] p in UnderLets.Base v)
+              = UnderLets.Base (rew [A] p in v).
+          Proof. case p; reflexivity. Defined.
 
-          Local Notation rewrite_rules_goodT := (@rewrite_rules_goodT ident pident arg_types var1 var2).
-          Local Notation wf_binding_dataT := (@wf_binding_dataT ident pident arg_types var1 var2).
-          Local Notation wf_bind_data := (@wf_bind_data ident pident of_typed_ident arg_types bind_args pident_beq try_make_transport_ident_cps pident_bl try_make_transport_ident_cps_correct var1 var2).
+          Local Notation rewrite_rules_goodT := (@rewrite_rules_goodT ident pident pident_arg_types type_vars_of_pident var1 var2).
+          Local Notation wf_rewrite_rule_data := (@wf_rewrite_rule_data ident pident pident_arg_types type_vars_of_pident var1 var2).
           Local Notation wf_reflect := (@wf_reflect ident var1 var2).
           Local Notation wf_reify := (@wf_reify ident var1 var2).
+
+          Local Ltac fin_t_common_step :=
+            first [ match goal with
+                    | [ |- (Some _ = None <-> Some _ = None) /\ _ ] => split; [ clear; solve [ intuition congruence ] | ]
+                    | [ |- (?x = ?x <-> ?y = ?y) /\ _ ] => split; [ clear; intuition congruence | ]
+                    end ].
+          Local Ltac handle_lists_of_rewrite_rules :=
+            repeat first [ match goal with
+                           | [ Hrew : length _ = length _, H : nth_error _ _ = None, H' : nth_error _ _ = Some _ |- _ ]
+                             => exfalso; rewrite nth_error_None in H;
+                                apply nth_error_value_length in H';
+                                clear -Hrew H H'; try lia
+                           | [ H : O = S _ |- _ ] => exfalso; clear -H; congruence
+                           | [ H : S _ = O |- _ ] => exfalso; clear -H; congruence
+                           end
+                         | progress cbv [rewrite_ruleT] in * (* so the nth_error rewrite lines up *)
+                         | progress cbn [List.length List.combine List.In Option.bind] in *
+                         | match goal with
+                           | [ H : S _ = S _ |- _ ] => inversion H; clear H
+                           | [ H : length ?ls = O |- _ ] => is_var ls; destruct ls; [ | exfalso; clear -H ]
+                           | [ H : length ?ls = S _ |- _ ] => is_var ls; destruct ls; [ exfalso; clear -H | ]
+                           | [ H : ?x = ?x |- _ ] => clear H
+                           | [ H : forall a b c d e, _ = _ \/ False -> _ |- _ ] => specialize (H _ _ _ _ _ (or_introl eq_refl))
+                           | [ |- context[@nth_error ?A ?ls ?n] ] => destruct (@nth_error A ls n) eqn:?
+                           | [ H : forall a b c d, In _ _ -> _, H' : nth_error _ ?n = Some _ |- _ ]
+                             => specialize (fun a b c d pf => H a b c d (@nth_error_In _ _ n _ pf))
+                           | [ H : forall a b, In _ _ -> _, H' : nth_error _ ?n = Some _ |- _ ]
+                             => specialize (fun a b pf => H a b (@nth_error_In _ _ n _ pf))
+                           | [ H : context[nth_error (combine ?l1 ?l2) ?n] |- _ ]
+                             => rewrite (@nth_error_combine _ _ n) in H
+                           | [ H : ?x = Some _, H' : context[?x] |- _ ] => rewrite H in H'
+                           | [ H : forall a b c d, Some _ = Some _ -> _ |- _ ] => specialize (H _ _ _ _ eq_refl)
+                           | [ H : forall a b, Some _ = Some _ -> _ |- _ ] => specialize (H _ _ eq_refl)
+                           end
+                         | progress intros
+                         | progress destruct_head'_sigT
+                         | fin_t_common_step ].
+          Local Ltac cleanup_after_lists_step :=
+            first [ progress subst
+                  | progress destruct_head'_sig
+                  | progress cbn [eq_rect] in * ].
+          Local Ltac clear_lists_of_rewrite_rules :=
+            match goal with
+            | [ H : length ?ls1 = length ?ls2, H' : nth_error ?ls1 ?n = Some _, H'' : nth_error ?ls2 ?n = Some _ |- _ ]
+              => clear ls1 ls2 n H H' H''
+            end;
+            repeat cleanup_after_lists_step.
+
+          Local Ltac try_solve_by_type_of_rawexpr_eqn :=
+            match goal with H : _ <> _ |- _ => idtac end;
+            exfalso;
+            repeat match goal with
+                   | [ H : ?T |- _ ]
+                     => lazymatch T with
+                        | _ = _ :> type.type _ => fail
+                        | _ <> _ => fail
+                        | _ => clear H
+                        end
+                   | [ H : context[type_of_rawexpr ?r] |- _ ]
+                     => generalize dependent (type_of_rawexpr r); clear r; intros
+                   | [ H : ?x = ?y |- _ ] => subst x || subst y
+                   end;
+            try congruence.
 
           Lemma wf_eval_rewrite_rules
                 (do_again1 : forall t : base.type, @expr.expr base.type ident (@value var1) t -> @UnderLets var1 (@expr var1 t))
@@ -434,7 +767,7 @@ Module Compilers.
                 (wf_do_again : forall G (t : base.type) e1 e2,
                     (exists G', (forall t v1 v2, List.In (existT _ t (v1, v2)) G' -> Compile.wf_value G v1 v2) /\ expr.wf G' e1 e2)
                     -> UnderLets.wf (fun G' => expr.wf G') G (@do_again1 t e1) (@do_again2 t e2))
-                (d : @decision_tree pident)
+                (d : @decision_tree raw_pident)
                 (rew1 : rewrite_rulesT1) (rew2 : rewrite_rulesT2)
                 (Hrew : rewrite_rules_goodT rew1 rew2)
                 (re1 : @rawexpr var1) (re2 : @rawexpr var2)
@@ -445,96 +778,157 @@ Module Compilers.
                 G
                 (rew [fun t => @UnderLets var1 (expr t)] (proj1 (eq_type_of_rawexpr_of_wf Hwf)) in (eval_rewrite_rules1 do_again1 d rew1 re1))
                 (rew [fun t => @UnderLets var2 (expr t)] (proj2 (eq_type_of_rawexpr_of_wf Hwf)) in (eval_rewrite_rules2 do_again2 d rew2 re2)).
-          Proof.
+          Proof using invert_bind_args_unknown_correct pident_unify_unknown_correct raw_pident_to_typed_invert_bind_args.
             cbv [eval_rewrite_rules Option.sequence_return rewrite_with_rule].
             cbv [rewrite_rules_goodT] in Hrew.
             eapply wf_eval_decision_tree with (ctxe:=[existT _ t (e1, e2)]);
               cbn [length combine];
               try solve [ reflexivity
                         | cbn [combine In]; wf_t; tauto ].
-            all: repeat first [ progress do_eq_type_of_rawexpr_of_wf
-                              | match goal with
-                                | [ |- (Some _ = None <-> Some _ = None) /\ _ ] => split; [ clear; solve [ intuition congruence ] | ]
-                                | [ Hrew : length _ = length _, H : nth_error _ _ = None, H' : nth_error _ _ = Some _ |- _ ]
-                                  => exfalso; rewrite nth_error_None in H;
-                                     apply nth_error_value_length in H';
-                                     clear -Hrew H H'; try lia
-                                | [ |- context[rew [fun t => @UnderLets ?varp (@?P t)] ?pf in (@UnderLets.splice ?base_type ?ident ?var ?A ?B ?a ?b)] ]
-                                  => rewrite (@ap_transport_splice varp _ (fun _ => _) P _ _ pf a b
-                                              : (rew [fun t => @UnderLets varp (P t)] pf in (@UnderLets.splice base_type ident var A B a b)) = _)
-                                end
-                              | progress intros
-                              | progress subst
-                              | progress destruct_head'_and
-                              | progress destruct_head'_ex
-                              | progress destruct_head' False
-                              | progress split_and
-                              | progress specialize_by (exact eq_refl)
-                              | progress cbn [length combine In Option.bind option_eq fst snd projT1 projT2 UnderLets.splice anyexpr_ty unwrap eq_rect] in *
-                              | progress cbv [rewrite_ruleT id] in *
-                              | progress destruct_head'_sigT
-                              | rewrite Equality.transport_const
-                              | progress cbv [type.try_transport_cps type.try_make_transport_cps]
-                              | progress rewrite_type_transport_correct
-                              | progress type_beq_to_eq
-                              | congruence
-                              | progress destruct_head' (@wf_anyexpr)
-                              | progress destruct_head'_bool
-                              | progress break_match_step ltac:(fun v => let h := head v in constr_eq h (@Sumbool.sumbool_of_bool))
-                              | eapply UnderLets.wf_splice; [ solve [ eauto ] | ]
-                              | match goal with
-                                | [ H : S _ = S _ |- _ ] => inversion H; clear H
-                                | [ H : length ?ls = O |- _ ] => is_var ls; destruct ls
-                                | [ H : length ?ls = S _ |- _ ] => is_var ls; destruct ls
-                                | [ H : ?x = ?x |- _ ] => clear H
-                                | [ H : forall a b c d e, _ = _ \/ False -> _ |- _ ] => specialize (H _ _ _ _ _ (or_introl eq_refl))
-                                | [ |- context[@nth_error ?A ?ls ?n] ] => destruct (@nth_error A ls n) eqn:?
-                                | [ H : forall a b c d, In _ _ -> _, H' : nth_error _ ?n = Some _ |- _ ]
-                                  => specialize (fun a b c d pf => H a b c d (@nth_error_In _ _ n _ pf))
-                                | [ H : forall a b, In _ _ -> _, H' : nth_error _ ?n = Some _ |- _ ]
-                                  => specialize (fun a b pf => H a b (@nth_error_In _ _ n _ pf))
-                                | [ H : context[nth_error (combine ?l1 ?l2) ?n] |- _ ]
-                                  => rewrite (@nth_error_combine _ _ n) in H
-                                | [ H : ?x = Some _, H' : context[?x] |- _ ] => rewrite H in H'
-                                | [ H : forall a b c d, Some _ = Some _ -> _ |- _ ] => specialize (H _ _ _ _ eq_refl)
-                                | [ H : forall a b, Some _ = Some _ -> _ |- _ ] => specialize (H _ _ eq_refl)
-                                | [ H : forall v T k, ?f v T k = k (?f v _ (fun x => x)) |- context[?f ?v' ?T' ?k'] ]
-                                  => (tryif (let __ := constr:(eq_refl : k' = (fun x => x)) in idtac)
-                                       then fail
-                                       else rewrite (H v' T' k'))
-                                | [ H : forall G v1 v2, wf_binding_dataT G ?a ?b v1 v2 -> _, H' : wf_binding_dataT ?G' ?a ?b ?v1' ?v2' |- _ ]
-                                  => specialize (H _ _ _ H')
-                                | [ X := Some _ |- _ ] => subst X
-                                | [ X := None |- _ ] => subst X
-                                | [ X := @bind_data_cps ?var1 ?r1 ?p1 ?T1 (fun x => x), Y := @bind_data_cps ?var2 ?r2 ?p2 ?T2 (fun y => y) |- _ ]
-                                  => pose proof (fun Hp : p1 = p2 => @wf_bind_data _ _ r1 _ r2 _ p1 p2 ltac:(eassumption) Hp);
-                                     cbv [id] in *;
-                                     destruct (@bind_data_cps var1 r1 p1 T1 (fun x => x)), (@bind_data_cps var2 r2 p2 T2 (fun y => y))
-                                end
-                              | erewrite bind_data_cps_id by eassumption; set (bind_data _ _)
-                              | match goal with
-                                | [ H : option_eq _ ?x ?y |- context[?x] ]
-                                  => destruct x eqn:?, y eqn:?; cbn [option_eq] in H
-                                | [ H : wf_value ?G ?v1 ?v2 |- wf_value' (?x0::?seg' ++ ?G) (?v1 _) (?v2 _) ]
-                                  => apply (H (x0::seg')); [ reflexivity | apply wf_reflect ]; solve [ wf_t ]
-                                | [ |- UnderLets.wf
-                                         _ _
-                                         (rew (proj1 (eq_type_of_rawexpr_of_wf ?Hwf)) in match type_of_rawexpr _ with _ => _ end _ _)
-                                         (rew (proj2 (eq_type_of_rawexpr_of_wf ?Hwf)) in match type_of_rawexpr _ with _ => _ end _ _) ]
-                                  => gen_do_eq_type_of_rawexpr_of_wf; break_innermost_match_step
-                                end
-                              | rewrite ERROR_BAD_REWRITE_RULE_id
-                              | wf_safe_t_step
-                              | eapply expr.wf_Proper_list; [ | eapply wf_expr_of_wf_rawexpr; eassumption ]; wf_t
-                              | eapply UnderLets.wf_splice; [ solve [ apply wf_do_again; wf_t ] | ]
-                              | apply wf_reify
-                              | progress destruct_head' (@AnyExpr.anyexpr)
-                              | rewrite app_assoc
-                              | progress fold (@reify var1) (@reify var2) (@reflect var1) (@reflect var2) ].
+            all: split_and.
+            Time all: repeat first [ progress do_eq_type_of_rawexpr_of_wf
+                                   | handle_lists_of_rewrite_rules ].
+            clear_lists_of_rewrite_rules.
+            Time all: repeat first [ fin_t_common_step
+                                   | match goal with
+                                     | [ H : wf_rawexpr ?G _ _ _ _, H' : forall G', wf_rewrite_rule_data G' _ _ |- _ ] => specialize (H' G)
+                                     | [ |- context[rew [fun t => @UnderLets ?varp (@?P t)] ?pf in (@UnderLets.splice ?base_type ?ident ?var ?A ?B ?a ?b)] ]
+                                       => rewrite (@ap_transport_splice varp _ (fun _ => _) P _ _ pf a b
+                                                   : (rew [fun t => @UnderLets varp (P t)] pf in (@UnderLets.splice base_type ident var A B a b)) = _)
+                                     | [ |- context[rew [fun t => @UnderLets ?varp (@?P t)] ?pf in (@UnderLets.Base ?base_type ?ident ?var ?T ?a)] ]
+                                       => rewrite ap_transport_Base
+                                     | [ |- True ] => exact I
+                                     end
+                                   | progress cbv [wf_rewrite_rule_data wf_with_unif_rewrite_ruleTP_gen option_bind'] in *
+                                   | lazymatch goal with
+                                     | [ |- (@unify_pattern1 ?t ?re1 ?p ?K1 ?v1 ?T1 ?cont1 = None
+                                             <-> @unify_pattern2 ?t ?re2 ?p ?K2 ?v2 ?T2 ?cont2 = None)
+                                            /\ _ ]
+                                       => let H := fresh in
+                                          pose proof (fun PK PT => @wf_unify_pattern _ t _ p re1 re2 _ _ K1 K2 PK T1 T2 PT v1 v2 cont1 cont2 ltac:(eassumption)) as H;
+                                            specialize (fun PK pf PT => H PK PT pf);
+                                            cbv beta in *;
+                                            (* grumble grumble dependent type hacking *)
+                                            lazymatch type of H with
+                                            | forall PK, wf_with_unification_resultT ?G (fun evm : ?EVM => PK (?t evm)) ?v1 ?v2 -> _
+                                              => lazymatch goal with
+                                                 | [ H0 : wf_with_unification_resultT G (fun evm : EVM => ?PK') v1 v2 |- _ ]
+                                                   => let PK'' := fresh in
+                                                      let PK'
+                                                          := constr:(
+                                                               fun evm : EVM
+                                                               => match PK' with
+                                                                  | PK''
+                                                                    => ltac:(
+                                                                         let PK' := (eval cbv delta [PK''] in PK'') in
+                                                                         let PK' := match (eval pattern (t evm) in PK') with ?PK' _ => PK' end in
+                                                                         exact PK'
+                                                                       )
+                                                                  end) in
+                                                      let PK' := lazymatch PK' with (fun _ => ?f) => f end in
+                                                      specialize (H PK' H0)
+                                                 end
+                                            end;
+                                            (* end grumbling *)
+                                            (*rewrite unify_pattern_cps_id with (var:=var1), unify_pattern_cps_id with (var:=var2) in H |- *;*)
+                                            (destruct (@unify_pattern1 t re1 p K1 v1 T1 cont1) eqn:?,
+                                                      (@unify_pattern2 t re2 p K2 v2 T2 cont2) eqn:?);
+                                            cbn [Option.bind option_eq pattern.type_of_anypattern pattern.pattern_of_anypattern] in H |- *;
+                                            [ split; [ clear; split | apply H; clear H ]
+                                            | refine ((fun pf => _) _); [ exfalso | eapply (H (fun _ _ => True)) ]; [ (assumption || discriminate) | clear H ]..
+                                            | ]
+                                     | [ H : wf_deep_rewrite_ruleTP_gen _ _ _ |- option_eq ?R (normalize_deep_rewrite_rule _ _ (fun x => x)) (normalize_deep_rewrite_rule _ _ (fun y => y)) ]
+                                       => exact (wf_normalize_deep_rewrite_rule H)
+                                     | [ |- option_eq _ (normalize_deep_rewrite_rule _ _ _) (normalize_deep_rewrite_rule _ _ _) ]
+                                       => rewrite @normalize_deep_rewrite_rule_cps_id with (var:=var1), @normalize_deep_rewrite_rule_cps_id with (var:=var2)
+                                     | [ |- ?x = ?x ] => reflexivity
+                                     end
+                                   | progress intros
+                                   | progress cbn [Option.bind option_eq eq_rect eq_sym eq_trans] in *
+                                   | progress inversion_option
+                                   | progress subst
+                                   | match goal with
+                                     | [ |- UnderLets.wf _ _ _ _ ] => constructor
+                                     | [ |- expr.wf _ (rew _ in expr_of_rawexpr _) (rew _ in expr_of_rawexpr _) ]
+                                       => apply wf_expr_of_wf_rawexpr'
+                                     | [ H : wf_deep_rewrite_ruleTP_gen _ _ _ |- option_eq ?R (normalize_deep_rewrite_rule _ _ (fun x => x)) (normalize_deep_rewrite_rule _ _ (fun y => y)) ]
+                                       => exact (wf_normalize_deep_rewrite_rule H)
+                                     | [ H : wf_deep_rewrite_ruleTP_gen _ _ _ |- (match ?b with true => _ | false => _ end) _ ]
+                                       => clear -H;
+                                            solve [
+                                                destruct_head' (@rewrite_ruleTP);
+                                                  repeat first [ exact I
+                                                               | exfalso; assumption
+                                                               | progress cbn [Compile.rew_should_do_again Compile.rew_under_lets Compile.rew_is_cps Compile.rew_with_opt Compile.rew_replacement] in *
+                                                               | progress destruct_head'_bool
+                                                               | progress cbv [wf_deep_rewrite_ruleTP_gen] in *
+                                                               | progress destruct_head'_and
+                                                               | solve [ auto ]
+                                                               | progress destruct_head' (@eq) ]
+                                              ]
+                                     end
+                                   | progress cbv [type.try_transport_cps(* type.try_make_transport_cps*)]
+                                   | lazymatch goal with
+                                     | [ |- context[type.try_make_transport_cps] ]
+                                       => progress rewrite_type_transport_correct
+                                     | [ |- context[base.try_make_transport_cps] ]
+                                       => progress rewrite_type_transport_correct
+                                     end
+                                   | match goal with
+                                     | [ |- context[match Sumbool.sumbool_of_bool ?b with _ => _ end] ]
+                                       => destruct (Sumbool.sumbool_of_bool b)
+                                     | [ H : wf_rawexpr _ _ _ _ _ |- _ ]
+                                       => let lem1 := constr:(proj1 (eq_type_of_rawexpr_of_wf H)) in
+                                          let lem2 := constr:(proj2 (eq_type_of_rawexpr_of_wf H)) in
+                                          progress (lazymatch type of lem1 with
+                                                    | ?x = ?x => idtac
+                                                    | _ => try (unique pose proof lem1)
+                                                    end;
+                                                      lazymatch type of lem2 with
+                                                      | ?x = ?x => idtac
+                                                      | _ => try (unique pose proof lem2)
+                                                      end)
+                                     | [ |- context[Option.bind _ (fun _ => None)] ] => rewrite !Option.bind_zero_r
+                                     end
+                                   | progress type_beq_to_eq
+                                   | solve [ try_solve_by_type_of_rawexpr_eqn ]
+                                   | match goal with
+                                     | [ H : unify_pattern1 _ _ _ _ _ = _ |- _ ] => clear H
+                                     | [ H : unify_pattern2 _ _ _ _ _ = _ |- _ ] => clear H
+                                     | [ H : ?x = ?x |- _ ] => clear H
+                                     | [ |- option_eq _ (Option.bind _ _) (Option.bind _ _) ]
+                                       => repeat match goal with
+                                                 | [ H : type_of_rawexpr _ = type_of_rawexpr _ |- _ ]
+                                                   => lazymatch goal with
+                                                      | [ |- context[H] ] => destruct H
+                                                      | [ H' : context[H] |- _ ] => destruct H
+                                                      end
+                                                 end;
+                                            eapply Option.bind_Proper_option_eq_hetero
+                                     | [ |- context[rew ?pf in _] ]
+                                       => lazymatch pf with
+                                          | context[eq_type_of_rawexpr_of_wf] => destruct pf
+                                          end
+                                     | [ |- UnderLets.wf _ _ (UnderLets.splice _ _) (UnderLets.splice _ _) ]
+                                       => eapply UnderLets.wf_splice; [ eauto | ]; revgoals
+                                     | [ H : ?T |- _ ] => has_evar T; solve [ unshelve refine H ]
+                                     end ].
+            (* Now we solve the final goal about [maybe_do_again] *)
+            repeat first [ progress destruct_head'_False
+                         | progress type.inversion_type
+                         | progress eliminate_hprop_eq
+                         | break_innermost_match_step
+                         | progress cbv [id] in *
+                         | match goal with
+                           | [ H : wf_maybe_do_again_expr _ ?v _ |- context[?v] ] => clear -H wf_do_again; cbv [wf_maybe_do_again_expr maybe_do_again] in *
+                           | [ |- UnderLets.wf _ _ _ _ ] => constructor
+                           end
+                         | progress destruct_head (@rewrite_ruleTP)
+                         | solve [ eauto ] ].
           Qed.
 
           Section with_do_again.
-            Context (dtree : @decision_tree pident)
+            Context (dtree : @decision_tree raw_pident)
                     (rew1 : rewrite_rulesT1)
                     (rew2 : rewrite_rulesT2)
                     (Hrew : rewrite_rules_goodT rew1 rew2)
@@ -545,8 +939,8 @@ Module Compilers.
                         -> expr.wf G' e1 e2
                         -> UnderLets.wf (fun G' => expr.wf G') G (@do_again1 t e1) (@do_again2 t e2)).
 
-            Local Notation assemble_identifier_rewriters' var := (@assemble_identifier_rewriters' ident var pident full_types invert_bind_args type_of_pident pident_to_typed of_typed_ident arg_types bind_args try_make_transport_ident_cps dtree).
-            Local Notation assemble_identifier_rewriters var := (@assemble_identifier_rewriters ident var pident full_types invert_bind_args type_of_pident pident_to_typed eta_ident_cps of_typed_ident arg_types bind_args try_make_transport_ident_cps dtree).
+            Local Notation assemble_identifier_rewriters' var := (@assemble_identifier_rewriters' ident var pident pident_arg_types pident_unify pident_unify_unknown raw_pident type_vars_of_pident full_types invert_bind_args invert_bind_args_unknown type_of_raw_pident raw_pident_to_typed raw_pident_is_simple dtree).
+            Local Notation assemble_identifier_rewriters var := (@assemble_identifier_rewriters ident var eta_ident_cps pident pident_arg_types pident_unify pident_unify_unknown raw_pident type_vars_of_pident full_types invert_bind_args invert_bind_args_unknown type_of_raw_pident raw_pident_to_typed raw_pident_is_simple dtree).
 
             Lemma wf_assemble_identifier_rewriters' G t re1 e1 re2 e2
                   K1 K2

--- a/src/Experiments/NewPipeline/StandaloneHaskellMain.v
+++ b/src/Experiments/NewPipeline/StandaloneHaskellMain.v
@@ -34,8 +34,6 @@ Extract Inlined Constant _IO_bind => "(Prelude.>>=)".
 Extract Inlined Constant _IO_return => "return".
 Extract Inlined Constant IO_unit => "GHC.Base.IO ()".
 Extract Inlined Constant cast_io => "".
-(** Error messages from deeply nested axioms *)
-Extract Constant Rewriter.Compilers.RewriteRules.Compile.ERROR_BAD_REWRITE_RULE => "\pat e -> Prelude.error ""ERROR BAD REWRITE RULE""".
 
 Local Notation "x <- y ; f" := (_IO_bind _ _ y (fun x => f)).
 

--- a/src/Experiments/NewPipeline/StandaloneOCamlMain.v
+++ b/src/Experiments/NewPipeline/StandaloneOCamlMain.v
@@ -40,8 +40,6 @@ Extract Inlined Constant string_get => "String.get".
 Extract Constant sys_argv => "Array.to_list Sys.argv".
 Extract Inlined Constant string_init => "String.init".
 Extract Constant raise_Failure => "fun x -> raise (Failure x)".
-(** Error messages from deeply nested axioms *)
-Extract Constant Rewriter.Compilers.RewriteRules.Compile.ERROR_BAD_REWRITE_RULE => "fun pat e -> failwith ""ERROR BAD REWRITE RULE""".
 
 Fixpoint nat_of_int (x : int) : nat
   := match x with

--- a/src/Experiments/NewPipeline/Toplevel2.v
+++ b/src/Experiments/NewPipeline/Toplevel2.v
@@ -1955,7 +1955,7 @@ Module Fancy.
     Definition of_prefancy_step
                (of_prefancy : forall (next_name : name) {t} (e : @cexpr var t), @expr name)
                (next_name : name) {t} (e : @cexpr var t) : @expr name
-      := let default _ := (e' <- type.try_transport base.try_make_transport_cps (@cexpr var) t tZ e;
+      := let default _ := (e' <- type.try_transport (@base.try_make_transport_cps) (@cexpr var) t tZ e;
                              Ret (of_prefancy_scalar e')) in
          match e with
          | PreFancy.LetInAppIdentZ s d r eidc x f

--- a/src/Experiments/NewPipeline/arith_rewrite_head.out
+++ b/src/Experiments/NewPipeline/arith_rewrite_head.out
@@ -1,92 +1,43 @@
 arith_rewrite_head = 
-match idc in (ident t) return (Compile.value' true t) with
-| @ident.Literal t v =>
-    match
-      t as t0
-      return
-        (base.base_interp t0 ->
-         UnderLets.UnderLets base.type ident var
-           (defaults.expr (type.base t0)))
-    with
-    | base.type.unit => fun v0 : unit => UnderLets.Base (##v0)%expr
-    | base.type.Z => fun v0 : Z => UnderLets.Base (##v0)%expr
-    | base.type.bool => fun v0 : bool => UnderLets.Base (##v0)%expr
-    | base.type.nat => fun v0 : nat => UnderLets.Base (##v0)%expr
-    end v
-| ident.Nat_succ =>
-    fun x : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_succ)%expr @ x)%expr_pat
-| ident.Nat_pred =>
-    fun x : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_pred)%expr @ x)%expr_pat
-| ident.Nat_max =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_max)%expr @ x @ x0)%expr_pat
-| ident.Nat_mul =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_mul)%expr @ x @ x0)%expr_pat
-| ident.Nat_add =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_add)%expr @ x @ x0)%expr_pat
-| ident.Nat_sub =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_sub)%expr @ x @ x0)%expr_pat
-| @ident.nil t => UnderLets.Base []%expr_pat
-| @ident.cons t =>
-    fun (x : defaults.expr (type.base t))
-      (x0 : defaults.expr (type.base (base.type.list t))) =>
-    UnderLets.Base (x :: x0)%expr_pat
-| @ident.pair A B =>
-    fun (x : defaults.expr (type.base A)) (x0 : defaults.expr (type.base B))
-    => UnderLets.Base (x, x0)%expr_pat
-| @ident.fst A B =>
-    fun x : defaults.expr (type.base (A * B)%etype) =>
+match idc in (Compilers.ident t) return (Compile.value' true t) with
+| @Literal t v => Base (##v)%expr
+| Nat_succ => fun x : expr ℕ => Base (#(Nat_succ)%expr @ x)%expr_pat
+| Nat_pred => fun x : expr ℕ => Base (#(Nat_pred)%expr @ x)%expr_pat
+| Nat_max => fun x x0 : expr ℕ => Base (#(Nat_max)%expr @ x @ x0)%expr_pat
+| Nat_mul => fun x x0 : expr ℕ => Base (#(Nat_mul)%expr @ x @ x0)%expr_pat
+| Nat_add => fun x x0 : expr ℕ => Base (#(Nat_add)%expr @ x @ x0)%expr_pat
+| Nat_sub => fun x x0 : expr ℕ => Base (#(Nat_sub)%expr @ x @ x0)%expr_pat
+| @nil t => Base []%expr_pat
+| @cons t => fun (x : expr t) (x0 : expr (list t)) => Base (x :: x0)%expr_pat
+| @pair A B => fun (x : expr A) (x0 : expr B) => Base (x, x0)%expr_pat
+| @fst A B =>
+    fun x : expr (A * B)%etype =>
     ((match x with
       | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x1) x0 =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x1) _ =>
+          args <- invert_bind_args idc Raw.ident.pair;
           match
-            s0 as t2
-            return
-              (Compile.value' false t2 ->
-               option
-                 (UnderLets.UnderLets base.type ident var
-                    (defaults.expr (type.base A))))
+            pattern.type.unify_extracted_cps
+              ((('1 * '2)%pbtype -> '1%pbtype) ->
+               (('1%pbtype -> '2%pbtype -> ('1 * '2)%pbtype) -> '1%pbtype) ->
+               '2%pbtype)%ptype
+              (((A * B)%etype -> A) ->
+               (((let (x2, _) := args in x2) ->
+                 (let (_, y) := args in y) ->
+                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
+                s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | type.base t2 =>
-              fun v : defaults.expr (type.base t2) =>
-              match
-                s as t3
-                return
-                  (Compile.value' false t3 ->
-                   option
-                     (UnderLets.UnderLets base.type ident var
-                        (defaults.expr (type.base A))))
-              with
-              | type.base t3 =>
-                  fun _ : defaults.expr (type.base t3) =>
-                  Some
-                    (base.try_make_transport_cps t2 A
-                       (fun
-                          a : option
-                                (defaults.expr (type.base t2) ->
-                                 defaults.expr (type.base A)) =>
-                        match a with
-                        | Some x' => UnderLets.Base (x' v)
-                        | None =>
-                            UnderLets.Base
-                              (Compile.ERROR_BAD_REWRITE_RULE
-                                 (#(pattern.ident.fst) @ (??, ??))
-                                 (#(ident.fst)%expr @ x)%expr_pat)
-                        end))
-              | (s1 -> d1)%ptype =>
-                  fun _ : Compile.value' false s1 -> Compile.value' true d1
-                  => None
-              end (Compile.reflect x0)
-          | (s1 -> d1)%ptype =>
-              fun _ : Compile.value' false s1 -> Compile.value' true d1 =>
-              None
-          end (Compile.reflect x1)
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
+              _ <- ident.unify pattern.ident.fst fst;
+              _ <- ident.unify pattern.ident.pair pair;
+              v <- type.try_make_transport_cps s0 b3;
+              _ <- type.try_make_transport_cps s b2;
+              v1 <- base.try_make_transport_cps b3 A;
+              v2 <- base.try_make_transport_cps A A;
+              v3 <- base.try_make_transport_cps A A;
+              Some (Base (v3 (v2 (v1 (v (Compile.reflect x1))))))
+          | None => None
+          end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
@@ -98,55 +49,35 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.fst)%expr @ x)%expr_pat)%option
-| @ident.snd A B =>
-    fun x : defaults.expr (type.base (A * B)%etype) =>
+     Base (#(fst)%expr @ x)%expr_pat)%option
+| @snd A B =>
+    fun x : expr (A * B)%etype =>
     ((match x with
       | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x1) x0 =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) _) x0 =>
+          args <- invert_bind_args idc Raw.ident.pair;
           match
-            s0 as t2
-            return
-              (Compile.value' false t2 ->
-               option
-                 (UnderLets.UnderLets base.type ident var
-                    (defaults.expr (type.base B))))
+            pattern.type.unify_extracted_cps
+              ((('1 * '2)%pbtype -> '2%pbtype) ->
+               (('1%pbtype -> '2%pbtype -> ('1 * '2)%pbtype) -> '1%pbtype) ->
+               '2%pbtype)%ptype
+              (((A * B)%etype -> B) ->
+               (((let (x2, _) := args in x2) ->
+                 (let (_, y) := args in y) ->
+                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
+                s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | type.base t2 =>
-              fun _ : defaults.expr (type.base t2) =>
-              match
-                s as t3
-                return
-                  (Compile.value' false t3 ->
-                   option
-                     (UnderLets.UnderLets base.type ident var
-                        (defaults.expr (type.base B))))
-              with
-              | type.base t3 =>
-                  fun v0 : defaults.expr (type.base t3) =>
-                  Some
-                    (base.try_make_transport_cps t3 B
-                       (fun
-                          a : option
-                                (defaults.expr (type.base t3) ->
-                                 defaults.expr (type.base B)) =>
-                        match a with
-                        | Some x' => UnderLets.Base (x' v0)
-                        | None =>
-                            UnderLets.Base
-                              (Compile.ERROR_BAD_REWRITE_RULE
-                                 (#(pattern.ident.snd) @ (??, ??))
-                                 (#(ident.snd)%expr @ x)%expr_pat)
-                        end))
-              | (s1 -> d1)%ptype =>
-                  fun _ : Compile.value' false s1 -> Compile.value' true d1
-                  => None
-              end (Compile.reflect x0)
-          | (s1 -> d1)%ptype =>
-              fun _ : Compile.value' false s1 -> Compile.value' true d1 =>
-              None
-          end (Compile.reflect x1)
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
+              _ <- ident.unify pattern.ident.snd snd;
+              _ <- ident.unify pattern.ident.pair pair;
+              _ <- type.try_make_transport_cps s0 b3;
+              v0 <- type.try_make_transport_cps s b2;
+              v1 <- base.try_make_transport_cps b2 B;
+              v2 <- base.try_make_transport_cps B B;
+              v3 <- base.try_make_transport_cps B B;
+              Some (Base (v3 (v2 (v1 (v0 (Compile.reflect x0))))))
+          | None => None
+          end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
@@ -158,379 +89,246 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.snd)%expr @ x)%expr_pat)%option
-| @ident.prod_rect A B T =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           defaults.expr (type.base B) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base T)))
-      (x0 : defaults.expr (type.base (A * B)%etype)) =>
-    UnderLets.Base
-      (#(ident.prod_rect)%expr @
-       (λ (x1 : var (type.base A))(x2 : var (type.base B)),
-        UnderLets.to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
-| @ident.bool_rect T =>
-    fun
-      (x
-       x0 : defaults.expr (type.base base.type.unit) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base T)))
-      (x1 : defaults.expr (type.base base.type.bool)) =>
-    UnderLets.Base
-      (#(ident.bool_rect)%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x ($x2)))%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x0 ($x2)))%expr @ x1)%expr_pat
-| @ident.nat_rect P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base base.type.nat) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base base.type.nat)) =>
-    UnderLets.Base
-      (#(ident.nat_rect)%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x ($x2)))%expr @
-       (λ (x2 : var (type.base base.type.nat))(x3 : var (type.base P)),
-        UnderLets.to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
-| @ident.nat_rect_arrow P Q =>
-    fun
-      (x : defaults.expr (type.base P) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base Q)))
-      (x0 : defaults.expr (type.base base.type.nat) ->
-            (defaults.expr (type.base P) ->
-             UnderLets.UnderLets base.type ident var
-               (defaults.expr (type.base Q))) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base Q)))
-      (x1 : defaults.expr (type.base base.type.nat))
-      (x2 : defaults.expr (type.base P)) =>
-    UnderLets.Base
-      (#(ident.nat_rect_arrow)%expr @
-       (λ x3 : var (type.base P),
-        UnderLets.to_expr (x ($x3)))%expr @
-       (λ (x3 : var (type.base base.type.nat))(x4 : var
-                                                      (type.base P ->
-                                                       type.base Q)%ptype)
-        (x5 : var (type.base P)),
-        UnderLets.to_expr
-          (x0 ($x3)
-             (fun x6 : defaults.expr (type.base P) =>
-              UnderLets.Base ($x4 @ x6)%expr_pat) ($x5)))%expr @ x1 @ x2)%expr_pat
-| @ident.list_rect A P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base A) ->
-            defaults.expr (type.base (base.type.list A)) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.list_rect)%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x ($x2)))%expr @
-       (λ (x2 : var (type.base A))(x3 : var (type.base (base.type.list A)))
-        (x4 : var (type.base P)),
-        UnderLets.to_expr (x0 ($x2) ($x3) ($x4)))%expr @ x1)%expr_pat
-| @ident.list_case A P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base A) ->
-            defaults.expr (type.base (base.type.list A)) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.list_case)%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x ($x2)))%expr @
-       (λ (x2 : var (type.base A))(x3 : var (type.base (base.type.list A))),
-        UnderLets.to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
-| @ident.List_length T =>
-    fun x : defaults.expr (type.base (base.type.list T)) =>
-    UnderLets.Base (#(ident.List_length)%expr @ x)%expr_pat
-| ident.List_seq =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.List_seq)%expr @ x @ x0)%expr_pat
-| @ident.List_firstn A =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base (#(ident.List_firstn)%expr @ x @ x0)%expr_pat
-| @ident.List_skipn A =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base (#(ident.List_skipn)%expr @ x @ x0)%expr_pat
-| @ident.List_repeat A =>
-    fun (x : defaults.expr (type.base A))
-      (x0 : defaults.expr (type.base base.type.nat)) =>
-    UnderLets.Base (#(ident.List_repeat)%expr @ x @ x0)%expr_pat
-| @ident.List_combine A B =>
-    fun (x : defaults.expr (type.base (base.type.list A)))
-      (x0 : defaults.expr (type.base (base.type.list B))) =>
-    UnderLets.Base (#(ident.List_combine)%expr @ x @ x0)%expr_pat
-| @ident.List_map A B =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base B)))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.List_map)%expr @
-       (λ x1 : var (type.base A),
-        UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat
-| @ident.List_app A =>
-    fun x x0 : defaults.expr (type.base (base.type.list A)) =>
-    UnderLets.Base (x ++ x0)%expr
-| @ident.List_rev A =>
-    fun x : defaults.expr (type.base (base.type.list A)) =>
-    UnderLets.Base (#(ident.List_rev)%expr @ x)%expr_pat
-| @ident.List_flat_map A B =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base (base.type.list B))))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.List_flat_map)%expr @
-       (λ x1 : var (type.base A),
-        UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat
-| @ident.List_partition A =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base base.type.bool)))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.List_partition)%expr @
-       (λ x1 : var (type.base A),
-        UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat
-| @ident.List_fold_right A B =>
-    fun
-      (x : defaults.expr (type.base B) ->
-           defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base A)))
-      (x0 : defaults.expr (type.base A))
-      (x1 : defaults.expr (type.base (base.type.list B))) =>
-    UnderLets.Base
-      (#(ident.List_fold_right)%expr @
-       (λ (x2 : var (type.base B))(x3 : var (type.base A)),
-        UnderLets.to_expr (x ($x2) ($x3)))%expr @ x0 @ x1)%expr_pat
-| @ident.List_update_nth T =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base T) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base T)))
-      (x1 : defaults.expr (type.base (base.type.list T))) =>
-    UnderLets.Base
-      (#(ident.List_update_nth)%expr @ x @
-       (λ x2 : var (type.base T),
-        UnderLets.to_expr (x0 ($x2)))%expr @ x1)%expr_pat
-| @ident.List_nth_default T =>
-    fun (x : defaults.expr (type.base T))
-      (x0 : defaults.expr (type.base (base.type.list T)))
-      (x1 : defaults.expr (type.base base.type.nat)) =>
-    UnderLets.Base (#(ident.List_nth_default)%expr @ x @ x0 @ x1)%expr_pat
-| ident.Z_add =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (#(snd)%expr @ x)%expr_pat)%option
+| @prod_rect A B T =>
+    fun (x : expr A -> expr B -> UnderLets (expr T))
+      (x0 : expr (A * B)%etype) =>
+    Base
+      (#(prod_rect)%expr @
+       (λ (x1 : var A)(x2 : var B),
+        to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
+| @bool_rect T =>
+    fun (x x0 : expr unit -> UnderLets (expr T)) (x1 : expr bool) =>
+    Base
+      (#(bool_rect)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| @nat_rect P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr ℕ -> expr P -> UnderLets (expr P)) (x1 : expr ℕ) =>
+    Base
+      (#(nat_rect)%expr @ (λ x2 : var unit,
+                           to_expr (x ($x2)))%expr @
+       (λ (x2 : var ℕ)(x3 : var P),
+        to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
+| @nat_rect_arrow P Q =>
+    fun (x : expr P -> UnderLets (expr Q))
+      (x0 : expr ℕ ->
+            (expr P -> UnderLets (expr Q)) -> expr P -> UnderLets (expr Q))
+      (x1 : expr ℕ) (x2 : expr P) =>
+    Base
+      (#(nat_rect_arrow)%expr @ (λ x3 : var P,
+                                 to_expr (x ($x3)))%expr @
+       (λ (x3 : var ℕ)(x4 : var (P -> Q)%ptype)(x5 : var P),
+        to_expr
+          (x0 ($x3) (fun x6 : expr P => Base ($x4 @ x6)%expr_pat) ($x5)))%expr @
+       x1 @ x2)%expr_pat
+| @list_rect A P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr A -> expr (list A) -> expr P -> UnderLets (expr P))
+      (x1 : expr (list A)) =>
+    Base
+      (#(list_rect)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ (x2 : var A)(x3 : var (list A))(x4 : var P),
+        to_expr (x0 ($x2) ($x3) ($x4)))%expr @ x1)%expr_pat
+| @list_case A P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr A -> expr (list A) -> UnderLets (expr P))
+      (x1 : expr (list A)) =>
+    Base
+      (#(list_case)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ (x2 : var A)(x3 : var (list A)),
+        to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
+| @List_length T =>
+    fun x : expr (list T) => Base (#(List_length)%expr @ x)%expr_pat
+| List_seq => fun x x0 : expr ℕ => Base (#(List_seq)%expr @ x @ x0)%expr_pat
+| @List_firstn A =>
+    fun (x : expr ℕ) (x0 : expr (list A)) =>
+    Base (#(List_firstn)%expr @ x @ x0)%expr_pat
+| @List_skipn A =>
+    fun (x : expr ℕ) (x0 : expr (list A)) =>
+    Base (#(List_skipn)%expr @ x @ x0)%expr_pat
+| @List_repeat A =>
+    fun (x : expr A) (x0 : expr ℕ) =>
+    Base (#(List_repeat)%expr @ x @ x0)%expr_pat
+| @List_combine A B =>
+    fun (x : expr (list A)) (x0 : expr (list B)) =>
+    Base (#(List_combine)%expr @ x @ x0)%expr_pat
+| @List_map A B =>
+    fun (x : expr A -> UnderLets (expr B)) (x0 : expr (list A)) =>
+    Base
+      (#(List_map)%expr @ (λ x1 : var A,
+                           to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_app A => fun x x0 : expr (list A) => Base (x ++ x0)%expr
+| @List_rev A =>
+    fun x : expr (list A) => Base (#(List_rev)%expr @ x)%expr_pat
+| @List_flat_map A B =>
+    fun (x : expr A -> UnderLets (expr (list B))) (x0 : expr (list A)) =>
+    Base
+      (#(List_flat_map)%expr @ (λ x1 : var A,
+                                to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_partition A =>
+    fun (x : expr A -> UnderLets (expr bool)) (x0 : expr (list A)) =>
+    Base
+      (#(List_partition)%expr @ (λ x1 : var A,
+                                 to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_fold_right A B =>
+    fun (x : expr B -> expr A -> UnderLets (expr A)) (x0 : expr A)
+      (x1 : expr (list B)) =>
+    Base
+      (#(List_fold_right)%expr @
+       (λ (x2 : var B)(x3 : var A),
+        to_expr (x ($x2) ($x3)))%expr @ x0 @ x1)%expr_pat
+| @List_update_nth T =>
+    fun (x : expr ℕ) (x0 : expr T -> UnderLets (expr T)) (x1 : expr (list T))
+    =>
+    Base
+      (#(List_update_nth)%expr @ x @ (λ x2 : var T,
+                                      to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| @List_nth_default T =>
+    fun (x : expr T) (x0 : expr (list T)) (x1 : expr ℕ) =>
+    Base (#(List_nth_default)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add =>
+    fun x x0 : expr ℤ =>
     (((match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0 then Some (UnderLets.Base x0) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                      then Some x0
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0 then Some (UnderLets.Base x) else None);;
+           (args <- invert_bind_args idc Raw.ident.Literal;
+            match
+              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+            with
+            | Some (_, _) =>
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                       then Some x
+                       else None);
+                Some (Base x1)
+            | None => None
+            end);;
            match x with
            | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x1 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
+                args0 <- invert_bind_args idc Raw.ident.Literal;
+                match
+                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                    (s -> (projT1 args0))%ptype option
+                    (fun x2 : option => x2)
+                with
+                | Some (_, _) =>
+                    v <- type.try_make_transport_cps s ℤ;
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args0);
+                    x2 <- (if (let (x2, _) := idc_args in x2) >? 0
+                           then
+                            Some
+                              (##(let (x2, _) := idc_args in x2) -
+                               v (Compile.reflect x1))%expr
+                           else None);
+                    Some (Base x2)
+                | None => None
+                end);;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   (s -> (projT1 args0))%ptype option (fun x2 : option => x2)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args >? 0
-                          then Some (UnderLets.Base (##args - x' v)%expr)
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1);;
-               match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
-               with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args <? 0
+               | Some (_, _) =>
+                   v <- type.try_make_transport_cps s ℤ;
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   x2 <- (if (let (x2, _) := idc_args in x2) <? 0
                           then
                            Some
-                             (UnderLets.Base (- (x' v + ##(- args)%Z))%expr)
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1)
+                             (-
+                              (v (Compile.reflect x1) +
+                               ##(- (let (x2, _) := idc_args in x2))%Z))%expr
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
              _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
            | _ => None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
            match x with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
+               (args <- invert_bind_args idc0 Raw.ident.Literal;
+                _ <- invert_bind_args idc Raw.ident.Z_opp;
+                match
+                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                    ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
+                with
+                | Some (_, _) =>
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                    v <- type.try_make_transport_cps s ℤ;
+                    x2 <- (if (let (x2, _) := idc_args in x2) >? 0
+                           then
+                            Some
+                              (##(let (x2, _) := idc_args in x2) -
+                               v (Compile.reflect x1))%expr
+                           else None);
+                    Some (Base x2)
+                | None => None
+                end);;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 >? 0
-                          then Some (UnderLets.Base (##args0 - x' v)%expr)
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1);;
-               match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
-               with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 <? 0
+               | Some (_, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   v <- type.try_make_transport_cps s ℤ;
+                   x2 <- (if (let (x2, _) := idc_args in x2) <? 0
                           then
                            Some
-                             (UnderLets.Base (- (##(- args0)%Z + x' v))%expr)
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1)
+                             (-
+                              (##(- (let (x2, _) := idc_args in x2))%Z +
+                               v (Compile.reflect x1)))%expr
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x2 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s0 as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          match
-                            s as t3
-                            return
-                              (Compile.value' false t3 ->
-                               option
-                                 (UnderLets.UnderLets base.type ident var
-                                    (defaults.expr (type.base base.type.Z))))
-                          with
-                          | type.base t3 =>
-                              fun v0 : defaults.expr (type.base t3) =>
-                              base.try_make_transport_cps t3 base.type.Z
-                                (fun
-                                   a0 : option
-                                          (defaults.expr (type.base t3) ->
-                                           defaults.expr
-                                             (type.base base.type.Z)) =>
-                                 match a0 with
-                                 | Some x'0 =>
-                                     Some
-                                       (UnderLets.Base
-                                          (- (x' v + x'0 v0))%expr)
-                                 | None => None
-                                 end)
-                          | (s1 -> d1)%ptype =>
-                              fun
-                                _ : Compile.value' false s1 ->
-                                    Compile.value' true d1 => None
-                          end (Compile.reflect x1)
-                      | None => None
-                      end)
-               | (s1 -> d1)%ptype =>
-                   fun _ : Compile.value' false s1 -> Compile.value' true d1
-                   => None
-               end (Compile.reflect x2)
+               | Some (_, _) =>
+                   v <- type.try_make_transport_cps s0 ℤ;
+                   v0 <- type.try_make_transport_cps s ℤ;
+                   Some
+                     (Base
+                        (- (v (Compile.reflect x2) + v0 (Compile.reflect x1)))%expr)
+               | None => None
+               end
            | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
              (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
@@ -544,30 +342,16 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr (type.base base.type.Z))))
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
+               option (fun x2 : option => x2)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' => Some (UnderLets.Base (x0 - x' v)%expr)
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x1)
+           | Some (_, _) =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some (Base (x0 - v (Compile.reflect x1))%expr)
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
@@ -575,134 +359,155 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x0 with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr (type.base base.type.Z))))
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
+               option (fun x2 : option => x2)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' => Some (UnderLets.Base (x - x' v)%expr)
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x1)
+           | Some (_, _) =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some (Base (x - v (Compile.reflect x1))%expr)
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
        | _ => None
        end);;
       None);;;
-     UnderLets.Base (x + x0)%expr)%option
-| ident.Z_mul =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (x + x0)%expr)%option
+| Z_mul =>
+    fun x x0 : expr ℤ =>
     (((match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
            match x0 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               Some (UnderLets.Base (##(args * args0)%Z)%expr)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   ((projT1 args0) -> (projT1 args))%ptype option
+                   (fun x1 : option => x1)
+               with
+               | Some (_, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   Some
+                     (Base
+                        (##((let (x1, _) := idc_args in x1) *
+                            (let (x1, _) := idc_args0 in x1))%Z)%expr)
+               | None => None
+               end
            | _ => None
            end;;
-           (if args =? 0 then Some (UnderLets.Base (##0)%expr) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                      then Some (##0)%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0 then Some (UnderLets.Base (##0)%expr) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                      then Some (##0)%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 1 then Some (UnderLets.Base x0) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 1
+                      then Some x0
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 1 then Some (UnderLets.Base x) else None);;
+           (args <- invert_bind_args idc Raw.ident.Literal;
+            match
+              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+            with
+            | Some (_, _) =>
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                x1 <- (if (let (x1, _) := idc_args in x1) =? 1
+                       then Some x
+                       else None);
+                Some (Base x1)
+            | None => None
+            end);;
            match x with
            | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x1 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   (s -> (projT1 args0))%ptype option (fun x2 : option => x2)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args =? -1
-                          then Some (UnderLets.Base (x' v))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1)
+               | Some (_, _) =>
+                   v <- type.try_make_transport_cps s ℤ;
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   x2 <- (if (let (x2, _) := idc_args in x2) =? -1
+                          then Some (v (Compile.reflect x1))
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
              _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
            | _ => None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
            match x with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 =? -1
-                          then Some (UnderLets.Base (x' v))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1)
+               | Some (_, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   v <- type.try_make_transport_cps s ℤ;
+                   x2 <- (if (let (x2, _) := idc_args in x2) =? -1
+                          then Some (v (Compile.reflect x1))
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
@@ -712,85 +517,91 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? -1 then Some (UnderLets.Base (- x0)%expr) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? -1
+                      then Some (- x0)%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? -1 then Some (UnderLets.Base (- x)%expr) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? -1
+                      then Some (- x)%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args <? 0
-            then Some (UnderLets.Base (- (##(- args)%Z * x0))%expr)
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) <? 0
+                      then
+                       Some
+                         (- (##(- (let (x1, _) := idc_args in x1))%Z * x0))%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args <? 0
-            then Some (UnderLets.Base (- (x * ##(- args)%Z))%expr)
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) <? 0
+                      then
+                       Some
+                         (- (x * ##(- (let (x1, _) := idc_args in x1))%Z))%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
            match x with
            | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x2 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s0 as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          match
-                            s as t3
-                            return
-                              (Compile.value' false t3 ->
-                               option
-                                 (UnderLets.UnderLets base.type ident var
-                                    (defaults.expr (type.base base.type.Z))))
-                          with
-                          | type.base t3 =>
-                              fun v0 : defaults.expr (type.base t3) =>
-                              base.try_make_transport_cps t3 base.type.Z
-                                (fun
-                                   a0 : option
-                                          (defaults.expr (type.base t3) ->
-                                           defaults.expr
-                                             (type.base base.type.Z)) =>
-                                 match a0 with
-                                 | Some x'0 =>
-                                     Some
-                                       (UnderLets.Base (x' v * x'0 v0)%expr)
-                                 | None => None
-                                 end)
-                          | (s1 -> d1)%ptype =>
-                              fun
-                                _ : Compile.value' false s1 ->
-                                    Compile.value' true d1 => None
-                          end (Compile.reflect x1)
-                      | None => None
-                      end)
-               | (s1 -> d1)%ptype =>
-                   fun _ : Compile.value' false s1 -> Compile.value' true d1
-                   => None
-               end (Compile.reflect x2)
+               | Some (_, _) =>
+                   v <- type.try_make_transport_cps s0 ℤ;
+                   v0 <- type.try_make_transport_cps s ℤ;
+                   Some
+                     (Base
+                        (v (Compile.reflect x2) * v0 (Compile.reflect x1))%expr)
+               | None => None
+               end
            | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
              (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
@@ -804,30 +615,16 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr (type.base base.type.Z))))
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
+               option (fun x2 : option => x2)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' => Some (UnderLets.Base (- (x' v * x0))%expr)
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x1)
+           | Some (_, _) =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some (Base (- (v (Compile.reflect x1) * x0))%expr)
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
@@ -835,35 +632,35 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if (args =? 2 ^ Z.log2 args) && negb (args =? 2)
-            then Some (UnderLets.Base (x << ##(Z.log2 args))%expr)
-            else None)
-       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           args <- invert_bind_args idc Raw.ident.Literal;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr (type.base base.type.Z))))
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' => Some (UnderLets.Base (- (x * x' v))%expr)
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x1)
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if
+                       ((let (x1, _) := idc_args in x1) =?
+                        2 ^ Z.log2 (let (x1, _) := idc_args in x1)) &&
+                       negb ((let (x1, _) := idc_args in x1) =? 2)
+                      then
+                       Some
+                         (x << ##(Z.log2 (let (x1, _) := idc_args in x1)))%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
+       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
+               option (fun x2 : option => x2)
+           with
+           | Some (_, _) =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some (Base (- (x * v (Compile.reflect x1)))%expr)
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
@@ -871,92 +668,65 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if (args =? 2 ^ Z.log2 args) && negb (args =? 2)
-            then Some (UnderLets.Base (x0 << ##(Z.log2 args))%expr)
-            else None);;
+           (args <- invert_bind_args idc Raw.ident.Literal;
+            match
+              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+            with
+            | Some (_, _) =>
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                x1 <- (if
+                        ((let (x1, _) := idc_args in x1) =?
+                         2 ^ Z.log2 (let (x1, _) := idc_args in x1)) &&
+                        negb ((let (x1, _) := idc_args in x1) =? 2)
+                       then
+                        Some
+                          (x0 << ##(Z.log2 (let (x1, _) := idc_args in x1)))%expr
+                       else None);
+                Some (Base x1)
+            | None => None
+            end);;
            match x0 with
            | @expr.App _ _ _ s _
              (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x2) x1 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_mul;
                match x2 with
                | @expr.Ident _ _ _ t1 idc1 =>
-                   args1 <- pattern.ident.invert_bind_args idc1
-                              pattern.ident.LiteralZ;
                    match x1 with
                    | @expr.App _ _ _ s1 _
                      (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t2 idc2) x4)
                      x3 =>
-                       _ <- pattern.ident.invert_bind_args idc2
-                              pattern.ident.Z_mul;
+                       _ <- invert_bind_args idc2 Raw.ident.Z_mul;
+                       args0 <- invert_bind_args idc1 Raw.ident.Literal;
+                       _ <- invert_bind_args idc0 Raw.ident.Z_mul;
+                       args2 <- invert_bind_args idc Raw.ident.Literal;
                        match
-                         s2 as t3
-                         return
-                           (Compile.value' false t3 ->
-                            option
-                              (UnderLets.UnderLets base.type ident var
-                                 (defaults.expr (type.base base.type.Z))))
+                         pattern.type.unify_extracted_cps
+                           (ℤ -> ℤ -> ℤ -> ℤ)%ptype
+                           ((projT1 args2) -> (projT1 args0) -> s2 -> s1)%ptype
+                           option (fun x5 : option => x5)
                        with
-                       | type.base t3 =>
-                           fun v : defaults.expr (type.base t3) =>
-                           base.try_make_transport_cps t3 base.type.Z
-                             (fun
-                                a : option
-                                      (defaults.expr (type.base t3) ->
-                                       defaults.expr (type.base base.type.Z))
-                              =>
-                              match a with
-                              | Some x' =>
-                                  match
-                                    s1 as t4
-                                    return
-                                      (Compile.value' false t4 ->
-                                       option
-                                         (UnderLets.UnderLets base.type ident
-                                            var
-                                            (defaults.expr
-                                               (type.base base.type.Z))))
-                                  with
-                                  | type.base t4 =>
-                                      fun v0 : defaults.expr (type.base t4)
-                                      =>
-                                      base.try_make_transport_cps t4
-                                        base.type.Z
-                                        (fun
-                                           a0 : option
-                                                  (defaults.expr
-                                                     (type.base t4) ->
-                                                   defaults.expr
-                                                     (type.base base.type.Z))
-                                         =>
-                                         match a0 with
-                                         | Some x'0 =>
-                                             if
-                                              (Z.abs args <=?
-                                               Z.abs max_const_val) &&
-                                              (Z.abs args1 <=?
-                                               Z.abs max_const_val)
-                                             then
-                                              Some
-                                                (UnderLets.Base
-                                                   (x' v *
-                                                    (x'0 v0 *
-                                                     (##args * ##args1)))%expr)
-                                             else None
-                                         | None => None
-                                         end)
-                                  | (s3 -> d3)%ptype =>
-                                      fun
-                                        _ : Compile.value' false s3 ->
-                                            Compile.value' true d3 => None
-                                  end (Compile.reflect x3)
-                              | None => None
-                              end)
-                       | (s3 -> d3)%ptype =>
-                           fun
-                             _ : Compile.value' false s3 ->
-                                 Compile.value' true d3 => None
-                       end (Compile.reflect x4)
+                       | Some (_, (_, (_, _))) =>
+                           idc_args <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args2);
+                           idc_args0 <- ident.unify pattern.ident.Literal
+                                          ##(projT2 args0);
+                           v <- type.try_make_transport_cps s2 ℤ;
+                           v0 <- type.try_make_transport_cps s1 ℤ;
+                           x5 <- (if
+                                   (Z.abs (let (x5, _) := idc_args in x5) <=?
+                                    Z.abs max_const_val) &&
+                                   (Z.abs (let (x5, _) := idc_args0 in x5) <=?
+                                    Z.abs max_const_val)
+                                  then
+                                   Some
+                                     (v (Compile.reflect x4) *
+                                      (v0 (Compile.reflect x3) *
+                                       (##(let (x5, _) := idc_args in x5) *
+                                        ##(let (x5, _) := idc_args0 in x5))))%expr
+                                  else None);
+                           Some (Base x5)
+                       | None => None
+                       end
                    | @expr.App _ _ _ s1 _ (@expr.App _ _ _ s2 _ ($_)%expr _)
                      _ | @expr.App _ _ _ s1 _
                      (@expr.App _ _ _ s2 _ (@expr.Abs _ _ _ _ _ _) _) _ |
@@ -974,83 +744,48 @@ match idc in (ident t) return (Compile.value' true t) with
                | _ => None
                end;;
                match x1 with
-               | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @ x3)%expr_pat =>
-                   _ <- pattern.ident.invert_bind_args idc1
-                          pattern.ident.Z_mul;
-                   match x3 with
-                   | @expr.Ident _ _ _ t2 idc2 =>
-                       args2 <- pattern.ident.invert_bind_args idc2
-                                  pattern.ident.LiteralZ;
-                       match
-                         s0 as t3
-                         return
-                           (Compile.value' false t3 ->
-                            option
-                              (UnderLets.UnderLets base.type ident var
-                                 (defaults.expr (type.base base.type.Z))))
-                       with
-                       | type.base t3 =>
-                           fun v : defaults.expr (type.base t3) =>
-                           base.try_make_transport_cps t3 base.type.Z
-                             (fun
-                                a : option
-                                      (defaults.expr (type.base t3) ->
-                                       defaults.expr (type.base base.type.Z))
-                              =>
-                              match a with
-                              | Some x' =>
-                                  match
-                                    s2 as t4
-                                    return
-                                      (Compile.value' false t4 ->
-                                       option
-                                         (UnderLets.UnderLets base.type ident
-                                            var
-                                            (defaults.expr
-                                               (type.base base.type.Z))))
-                                  with
-                                  | type.base t4 =>
-                                      fun v0 : defaults.expr (type.base t4)
-                                      =>
-                                      base.try_make_transport_cps t4
-                                        base.type.Z
-                                        (fun
-                                           a0 : option
-                                                  (defaults.expr
-                                                     (type.base t4) ->
-                                                   defaults.expr
-                                                     (type.base base.type.Z))
-                                         =>
-                                         match a0 with
-                                         | Some x'0 =>
-                                             if
-                                              (Z.abs args <=?
-                                               Z.abs max_const_val) &&
-                                              (Z.abs args2 <=?
-                                               Z.abs max_const_val)
-                                             then
-                                              Some
-                                                (UnderLets.Base
-                                                   (x' v *
-                                                    (x'0 v0 *
-                                                     (##args * ##args2)))%expr)
-                                             else None
-                                         | None => None
-                                         end)
-                                  | (s3 -> d3)%ptype =>
-                                      fun
-                                        _ : Compile.value' false s3 ->
-                                            Compile.value' true d3 => None
-                                  end (Compile.reflect x4)
-                              | None => None
-                              end)
-                       | (s3 -> d3)%ptype =>
-                           fun
-                             _ : Compile.value' false s3 ->
-                                 Compile.value' true d3 => None
-                       end (Compile.reflect x2)
-                   | _ => None
+               | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                  @expr.Ident _ _ _ t2 idc2)%expr_pat =>
+                   args <- invert_bind_args idc2 Raw.ident.Literal;
+                   _ <- invert_bind_args idc1 Raw.ident.Z_mul;
+                   _ <- invert_bind_args idc0 Raw.ident.Z_mul;
+                   args2 <- invert_bind_args idc Raw.ident.Literal;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (ℤ -> ℤ -> ℤ -> ℤ)%ptype
+                       ((projT1 args2) -> s0 -> s2 -> (projT1 args))%ptype
+                       option (fun x5 : option => x5)
+                   with
+                   | Some (_, (_, (_, _))) =>
+                       idc_args <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args2);
+                       v <- type.try_make_transport_cps s0 ℤ;
+                       v0 <- type.try_make_transport_cps s2 ℤ;
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args);
+                       x5 <- (if
+                               (Z.abs (let (x5, _) := idc_args in x5) <=?
+                                Z.abs max_const_val) &&
+                               (Z.abs (let (x5, _) := idc_args0 in x5) <=?
+                                Z.abs max_const_val)
+                              then
+                               Some
+                                 (v (Compile.reflect x2) *
+                                  (v0 (Compile.reflect x4) *
+                                   (##(let (x5, _) := idc_args in x5) *
+                                    ##(let (x5, _) := idc_args0 in x5))))%expr
+                              else None);
+                       Some (Base x5)
+                   | None => None
                    end
+               | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                  ($_)%expr)%expr_pat |
+                 (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                  @expr.Abs _ _ _ _ _ _)%expr_pat |
+                 (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                  (_ @ _))%expr_pat |
+                 (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                  @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
                | (@expr.App _ _ _ s2 _ ($_)%expr _ @ _)%expr_pat |
                  (@expr.App _ _ _ s2 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
                  (@expr.App _ _ _ s2 _ (_ @ _) _ @ _)%expr_pat |
@@ -1058,60 +793,30 @@ match idc in (ident t) return (Compile.value' true t) with
                    None
                | _ => None
                end;;
+               _ <- invert_bind_args idc0 Raw.ident.Z_mul;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
                match
-                 s0 as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ -> ℤ)%ptype
+                   ((projT1 args0) -> s0 -> s)%ptype option
+                   (fun x3 : option => x3)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          match
-                            s as t3
-                            return
-                              (Compile.value' false t3 ->
-                               option
-                                 (UnderLets.UnderLets base.type ident var
-                                    (defaults.expr (type.base base.type.Z))))
-                          with
-                          | type.base t3 =>
-                              fun v0 : defaults.expr (type.base t3) =>
-                              base.try_make_transport_cps t3 base.type.Z
-                                (fun
-                                   a0 : option
-                                          (defaults.expr (type.base t3) ->
-                                           defaults.expr
-                                             (type.base base.type.Z)) =>
-                                 match a0 with
-                                 | Some x'0 =>
-                                     if Z.abs args <=? Z.abs max_const_val
-                                     then
-                                      Some
-                                        (UnderLets.Base
-                                           (x' v * (x'0 v0 * ##args))%expr)
-                                     else None
-                                 | None => None
-                                 end)
-                          | (s1 -> d1)%ptype =>
-                              fun
-                                _ : Compile.value' false s1 ->
-                                    Compile.value' true d1 => None
-                          end (Compile.reflect x1)
-                      | None => None
-                      end)
-               | (s1 -> d1)%ptype =>
-                   fun _ : Compile.value' false s1 -> Compile.value' true d1
-                   => None
-               end (Compile.reflect x2)
+               | Some (_, (_, _)) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   v <- type.try_make_transport_cps s0 ℤ;
+                   v0 <- type.try_make_transport_cps s ℤ;
+                   x3 <- (if
+                           Z.abs (let (x3, _) := idc_args in x3) <=?
+                           Z.abs max_const_val
+                          then
+                           Some
+                             (v (Compile.reflect x2) *
+                              (v0 (Compile.reflect x1) *
+                               ##(let (x3, _) := idc_args in x3)))%expr
+                          else None);
+                   Some (Base x3)
+               | None => None
+               end
            | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ |
              @expr.App _ _ _ s _
              (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ | @expr.App _
@@ -1123,121 +828,124 @@ match idc in (ident t) return (Compile.value' true t) with
              @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
            | _ => None
            end;;
-           (if Z.abs args <=? Z.abs max_const_val
-            then Some (UnderLets.Base (x0 * ##args)%expr)
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if
+                       Z.abs (let (x1, _) := idc_args in x1) <=?
+                       Z.abs max_const_val
+                      then Some (x0 * ##(let (x1, _) := idc_args in x1))%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end);;
       None);;;
-     UnderLets.Base (x * x0)%expr)%option
-| ident.Z_pow =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_pow)%expr @ x @ x0)%expr_pat
-| ident.Z_sub =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (x * x0)%expr)%option
+| Z_pow => fun x x0 : expr ℤ => Base (#(Z_pow)%expr @ x @ x0)%expr_pat
+| Z_sub =>
+    fun x x0 : expr ℤ =>
     (((match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
            match x0 with
            | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x1 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   ((projT1 args0) -> s)%ptype option (fun x2 : option => x2)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args =? 0
-                          then Some (UnderLets.Base (x' v))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1)
+               | Some (_, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   v <- type.try_make_transport_cps s ℤ;
+                   x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                          then Some (v (Compile.reflect x1))
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
              _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
            | _ => None
            end;;
-           (if args =? 0 then Some (UnderLets.Base (- x0)%expr) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                      then Some (- x0)%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0 then Some (UnderLets.Base x) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                      then Some x
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
            match x with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
+               (args <- invert_bind_args idc0 Raw.ident.Literal;
+                _ <- invert_bind_args idc Raw.ident.Z_opp;
+                match
+                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                    ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
+                with
+                | Some (_, _) =>
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                    v <- type.try_make_transport_cps s ℤ;
+                    x2 <- (if (let (x2, _) := idc_args in x2) >? 0
+                           then
+                            Some
+                              (##(let (x2, _) := idc_args in x2) +
+                               v (Compile.reflect x1))%expr
+                           else None);
+                    Some (Base x2)
+                | None => None
+                end);;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 >? 0
-                          then Some (UnderLets.Base (##args0 + x' v)%expr)
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1);;
-               match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
-               with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 <? 0
+               | Some (_, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   v <- type.try_make_transport_cps s ℤ;
+                   x2 <- (if (let (x2, _) := idc_args in x2) <? 0
                           then
-                           Some (UnderLets.Base (x' v - ##(- args0)%Z)%expr)
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1)
+                           Some
+                             (v (Compile.reflect x1) -
+                              ##(- (let (x2, _) := idc_args in x2))%Z)%expr
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
@@ -1247,71 +955,63 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args <? 0
-            then Some (UnderLets.Base (- (##(- args)%Z + x0))%expr)
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) <? 0
+                      then
+                       Some
+                         (- (##(- (let (x1, _) := idc_args in x1))%Z + x0))%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
            match x0 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
+               (args <- invert_bind_args idc0 Raw.ident.Literal;
+                _ <- invert_bind_args idc Raw.ident.Z_opp;
+                match
+                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                    (s -> (projT1 args))%ptype option (fun x2 : option => x2)
+                with
+                | Some (_, _) =>
+                    v <- type.try_make_transport_cps s ℤ;
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                    x2 <- (if (let (x2, _) := idc_args in x2) >? 0
+                           then
+                            Some
+                              (-
+                               (v (Compile.reflect x1) +
+                                ##(- (let (x2, _) := idc_args in x2))%Z))%expr
+                           else None);
+                    Some (Base x2)
+                | None => None
+                end);;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   (s -> (projT1 args))%ptype option (fun x2 : option => x2)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 >? 0
+               | Some (_, _) =>
+                   v <- type.try_make_transport_cps s ℤ;
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   x2 <- (if (let (x2, _) := idc_args in x2) <? 0
                           then
                            Some
-                             (UnderLets.Base (- (x' v + ##(- args0)%Z))%expr)
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1);;
-               match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
-               with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 <? 0
-                          then
-                           Some (UnderLets.Base (##(- args0)%Z - x' v)%expr)
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x1)
+                             (##(- (let (x2, _) := idc_args in x2))%Z -
+                              v (Compile.reflect x1))%expr
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
@@ -1321,65 +1021,38 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args <? 0
-            then Some (UnderLets.Base (x + ##(- args)%Z)%expr)
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) <? 0
+                      then
+                       Some
+                         (x + ##(- (let (x1, _) := idc_args in x1))%Z)%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
            match x with
            | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x2 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s0 as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                   (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          match
-                            s as t3
-                            return
-                              (Compile.value' false t3 ->
-                               option
-                                 (UnderLets.UnderLets base.type ident var
-                                    (defaults.expr (type.base base.type.Z))))
-                          with
-                          | type.base t3 =>
-                              fun v0 : defaults.expr (type.base t3) =>
-                              base.try_make_transport_cps t3 base.type.Z
-                                (fun
-                                   a0 : option
-                                          (defaults.expr (type.base t3) ->
-                                           defaults.expr
-                                             (type.base base.type.Z)) =>
-                                 match a0 with
-                                 | Some x'0 =>
-                                     Some
-                                       (UnderLets.Base (x'0 v0 - x' v)%expr)
-                                 | None => None
-                                 end)
-                          | (s1 -> d1)%ptype =>
-                              fun
-                                _ : Compile.value' false s1 ->
-                                    Compile.value' true d1 => None
-                          end (Compile.reflect x1)
-                      | None => None
-                      end)
-               | (s1 -> d1)%ptype =>
-                   fun _ : Compile.value' false s1 -> Compile.value' true d1
-                   => None
-               end (Compile.reflect x2)
+               | Some (_, _) =>
+                   v <- type.try_make_transport_cps s0 ℤ;
+                   v0 <- type.try_make_transport_cps s ℤ;
+                   Some
+                     (Base
+                        (v0 (Compile.reflect x1) - v (Compile.reflect x2))%expr)
+               | None => None
+               end
            | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
              (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
@@ -1393,30 +1066,16 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr (type.base base.type.Z))))
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
+               option (fun x2 : option => x2)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' => Some (UnderLets.Base (- (x' v + x0))%expr)
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x1)
+           | Some (_, _) =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some (Base (- (v (Compile.reflect x1) + x0))%expr)
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
@@ -1424,264 +1083,355 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x0 with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr (type.base base.type.Z))))
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
+               option (fun x2 : option => x2)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' => Some (UnderLets.Base (x + x' v)%expr)
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x1)
+           | Some (_, _) =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some (Base (x + v (Compile.reflect x1))%expr)
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
        | _ => None
        end);;
       None);;;
-     UnderLets.Base (x - x0)%expr)%option
-| ident.Z_opp =>
-    fun x : defaults.expr (type.base base.type.Z) =>
+     Base (x - x0)%expr)%option
+| Z_opp =>
+    fun x : expr ℤ =>
     (((match x with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x0 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr (type.base base.type.Z))))
+             pattern.type.unify_extracted_cps ℤ s option
+               (fun x1 : option => x1)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' => Some (UnderLets.Base (x' v))
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x0)
+           | Some _ =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some (Base (v (Compile.reflect x0)))
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
        | _ => None
        end;;
-       (if negb (SubstVarLike.is_var_fst_snd_pair_opp x)
-        then
-         Some
-           (UnderLets.UnderLet x
-              (fun v : var (type.base base.type.Z) =>
-               UnderLets.Base (- $v)%expr))
-        else None));;
+       match
+         pattern.type.unify_extracted_cps ℤ ℤ option (fun x0 : option => x0)
+       with
+       | Some _ =>
+           fv <- (if negb (SubstVarLike.is_var_fst_snd_pair_opp x)
+                  then
+                   Some
+                     (UnderLet x
+                        (fun
+                           v : var
+                                 (pattern.base.subst_default ℤ
+                                    (PositiveMap.empty base.type)) =>
+                         Base (- $v)%expr))
+                  else None);
+           Some (fv0 <-- fv;
+                 Base fv0)%under_lets
+       | None => None
+       end);;
       None);;;
-     UnderLets.Base (- x)%expr)%option
-| ident.Z_div =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (- x)%expr)%option
+| Z_div =>
+    fun x x0 : expr ℤ =>
     ((match x0 with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          (if args =? 1 then Some (UnderLets.Base x) else None);;
-          (if args =? 2 ^ Z.log2 args
-           then Some (UnderLets.Base (x >> ##(Z.log2 args))%expr)
-           else None)
+          (args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 1
+                      then Some x
+                      else None);
+               Some (Base x1)
+           | None => None
+           end);;
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+              (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+          with
+          | Some (_, _) =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x1 <- (if
+                      (let (x1, _) := idc_args in x1) =?
+                      2 ^ Z.log2 (let (x1, _) := idc_args in x1)
+                     then
+                      Some
+                        (x >> ##(Z.log2 (let (x1, _) := idc_args in x1)))%expr
+                     else None);
+              Some (Base x1)
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (x / x0)%expr)%option
-| ident.Z_modulo =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (x / x0)%expr)%option
+| Z_modulo =>
+    fun x x0 : expr ℤ =>
     (match x0 with
      | @expr.Ident _ _ _ t idc =>
-         args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-         (if args =? 1 then Some (UnderLets.Base (##0)%expr) else None);;
-         (if args =? 2 ^ Z.log2 args
-          then Some (UnderLets.Base (x &' ##(args - 1)%Z)%expr)
-          else None)
+         (args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+              (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+          with
+          | Some (_, _) =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x1 <- (if (let (x1, _) := idc_args in x1) =? 1
+                     then Some (##0)%expr
+                     else None);
+              Some (Base x1)
+          | None => None
+          end);;
+         args <- invert_bind_args idc Raw.ident.Literal;
+         match
+           pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+             (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+         with
+         | Some (_, _) =>
+             idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+             x1 <- (if
+                     (let (x1, _) := idc_args in x1) =?
+                     2 ^ Z.log2 (let (x1, _) := idc_args in x1)
+                    then
+                     Some
+                       (x &' ##((let (x1, _) := idc_args in x1) - 1)%Z)%expr
+                    else None);
+             Some (Base x1)
+         | None => None
+         end
      | _ => None
      end;;;
-     UnderLets.Base (x mod x0)%expr)%option
-| ident.Z_log2 =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_log2)%expr @ x)%expr_pat
-| ident.Z_log2_up =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_log2_up)%expr @ x)%expr_pat
-| ident.Z_eqb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_eqb)%expr @ x @ x0)%expr_pat
-| ident.Z_leb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_leb)%expr @ x @ x0)%expr_pat
-| ident.Z_geb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_geb)%expr @ x @ x0)%expr_pat
-| ident.Z_of_nat =>
-    fun x : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Z_of_nat)%expr @ x)%expr_pat
-| ident.Z_to_nat =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_to_nat)%expr @ x)%expr_pat
-| ident.Z_shiftr =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x >> x0)%expr
-| ident.Z_shiftl =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x << x0)%expr
-| ident.Z_land =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (x mod x0)%expr)%option
+| Z_log2 => fun x : expr ℤ => Base (#(Z_log2)%expr @ x)%expr_pat
+| Z_log2_up => fun x : expr ℤ => Base (#(Z_log2_up)%expr @ x)%expr_pat
+| Z_eqb => fun x x0 : expr ℤ => Base (#(Z_eqb)%expr @ x @ x0)%expr_pat
+| Z_leb => fun x x0 : expr ℤ => Base (#(Z_leb)%expr @ x @ x0)%expr_pat
+| Z_geb => fun x x0 : expr ℤ => Base (#(Z_geb)%expr @ x @ x0)%expr_pat
+| Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
+| Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
+| Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
+| Z_shiftl => fun x x0 : expr ℤ => Base (x << x0)%expr
+| Z_land =>
+    fun x x0 : expr ℤ =>
     (((match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0 then Some (UnderLets.Base (##0)%expr) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                      then Some (##0)%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0 then Some (UnderLets.Base (##0)%expr) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+           with
+           | Some (_, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                      then Some (##0)%expr
+                      else None);
+               Some (Base x1)
+           | None => None
+           end
        | _ => None
        end);;
       None);;;
-     UnderLets.Base (x &' x0)%expr)%option
-| ident.Z_lor =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x || x0)%expr
-| ident.Z_bneg =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_bneg)%expr @ x)%expr_pat
-| ident.Z_lnot_modulo =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_lnot_modulo)%expr @ x @ x0)%expr_pat
-| ident.Z_mul_split =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (x &' x0)%expr)%option
+| Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
+| Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
+| Z_lnot_modulo =>
+    fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
+| Z_mul_split =>
+    fun x x0 x1 : expr ℤ =>
     (((match x with
        | @expr.Ident _ _ _ t idc =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
            match x0 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if args0 =? 0
-                then Some (UnderLets.Base ((##0)%expr, (##0)%expr)%expr_pat)
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   x2 <- (if (let (x2, _) := idc_args0 in x2) =? 0
+                          then Some ((##0)%expr, (##0)%expr)%expr_pat
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end;;
            match x1 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if args0 =? 0
-                then Some (UnderLets.Base ((##0)%expr, (##0)%expr)%expr_pat)
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   x2 <- (if (let (x2, _) := idc_args0 in x2) =? 0
+                          then Some ((##0)%expr, (##0)%expr)%expr_pat
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end;;
            match x0 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if args0 =? 1
-                then Some (UnderLets.Base (x1, (##0)%expr)%expr_pat)
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   x2 <- (if (let (x2, _) := idc_args0 in x2) =? 1
+                          then Some (x1, (##0)%expr)%expr_pat
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end;;
            match x1 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if args0 =? 1
-                then Some (UnderLets.Base (x0, (##0)%expr)%expr_pat)
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   x2 <- (if (let (x2, _) := idc_args0 in x2) =? 1
+                          then Some (x0, (##0)%expr)%expr_pat
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end;;
            match x0 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if args0 =? -1
-                then Some (UnderLets.Base ((- x1)%expr, (##0)%expr)%expr_pat)
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   x2 <- (if (let (x2, _) := idc_args0 in x2) =? -1
+                          then Some ((- x1)%expr, (##0)%expr)%expr_pat
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end;;
            match x1 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if args0 =? -1
-                then Some (UnderLets.Base ((- x0)%expr, (##0)%expr)%expr_pat)
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   x2 <- (if (let (x2, _) := idc_args0 in x2) =? -1
+                          then Some ((- x0)%expr, (##0)%expr)%expr_pat
+                          else None);
+                   Some (Base x2)
+               | None => None
+               end
            | _ => None
            end
        | _ => None
        end;;
-       Some
-         (UnderLets.UnderLet
-            (#(ident.Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
-            (fun v : var (type.base (base.type.Z * base.type.Z)%etype) =>
-             UnderLets.Base
-               (#(ident.fst)%expr @ ($v)%expr, #(ident.snd)%expr @ ($v)%expr)%expr_pat)));;
+       match
+         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+       with
+       | Some (_, _, _) =>
+           Some
+             (UnderLet (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
+                (fun v : var (ℤ * ℤ)%etype =>
+                 Base
+                   (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+       | None => None
+       end);;
       None);;;
-     UnderLets.Base (#(ident.Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_get_carry =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_get_carry =>
+    fun x x0 x1 : expr ℤ =>
     (((match x0 with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr
-                        (type.base (base.type.Z * base.type.Z)%etype))))
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> s) -> ℤ)%ptype option (fun x3 : option => x3)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' =>
-                      Some
-                        (UnderLets.UnderLet
-                           (#(ident.Z_sub_get_borrow)%expr @ x @ x1 @ x' v)%expr_pat
-                           (fun
-                              v0 : var
-                                     (type.base
-                                        (base.type.Z * base.type.Z)%etype) =>
-                            UnderLets.Base
-                              (#(ident.fst)%expr @ ($v0)%expr,
-                              (- (#(ident.snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x2)
+           | Some (_, _, _) =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some
+                 (UnderLet
+                    (#(Z_sub_get_borrow)%expr @ x @ x1 @
+                     v (Compile.reflect x2))%expr_pat
+                    (fun v0 : var (ℤ * ℤ)%etype =>
+                     Base
+                       (#(fst)%expr @ ($v0)%expr,
+                       (- (#(snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
@@ -1689,41 +1439,23 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x1 with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
-             s as t2
-             return
-               (Compile.value' false t2 ->
-                option
-                  (UnderLets.UnderLets base.type ident var
-                     (defaults.expr
-                        (type.base (base.type.Z * base.type.Z)%etype))))
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> ℤ) -> s)%ptype option (fun x3 : option => x3)
            with
-           | type.base t2 =>
-               fun v : defaults.expr (type.base t2) =>
-               base.try_make_transport_cps t2 base.type.Z
-                 (fun
-                    a : option
-                          (defaults.expr (type.base t2) ->
-                           defaults.expr (type.base base.type.Z)) =>
-                  match a with
-                  | Some x' =>
-                      Some
-                        (UnderLets.UnderLet
-                           (#(ident.Z_sub_get_borrow)%expr @ x @ x0 @ x' v)%expr_pat
-                           (fun
-                              v0 : var
-                                     (type.base
-                                        (base.type.Z * base.type.Z)%etype) =>
-                            UnderLets.Base
-                              (#(ident.fst)%expr @ ($v0)%expr,
-                              (- (#(ident.snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-                  | None => None
-                  end)
-           | (s0 -> d0)%ptype =>
-               fun _ : Compile.value' false s0 -> Compile.value' true d0 =>
-               None
-           end (Compile.reflect x2)
+           | Some (_, _, _) =>
+               v <- type.try_make_transport_cps s ℤ;
+               Some
+                 (UnderLet
+                    (#(Z_sub_get_borrow)%expr @ x @ x0 @
+                     v (Compile.reflect x2))%expr_pat
+                    (fun v0 : var (ℤ * ℤ)%etype =>
+                     Base
+                       (#(fst)%expr @ ($v0)%expr,
+                       (- (#(snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
+           | None => None
+           end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
          @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
@@ -1731,162 +1463,201 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args <? 0
-            then
-             Some
-               (UnderLets.UnderLet
-                  (#(ident.Z_sub_get_borrow)%expr @ x @ x1 @
-                   (##(- args)%Z)%expr)%expr_pat
-                  (fun v : var (type.base (base.type.Z * base.type.Z)%etype)
-                   =>
-                   UnderLets.Base
-                     (#(ident.fst)%expr @ ($v)%expr,
-                     (- (#(ident.snd)%expr @ $v)%expr_pat)%expr)%expr_pat))
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> (projT1 args)) -> ℤ)%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               fv <- (if (let (x2, _) := idc_args in x2) <? 0
+                      then
+                       Some
+                         (UnderLet
+                            (#(Z_sub_get_borrow)%expr @ x @ x1 @
+                             (##(- (let (x2, _) := idc_args in x2))%Z)%expr)%expr_pat
+                            (fun vc : var (ℤ * ℤ)%etype =>
+                             Base
+                               (#(fst)%expr @ ($vc)%expr,
+                               (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                      else None);
+               Some (fv0 <-- fv;
+                     Base fv0)%under_lets
+           | None => None
+           end
        | _ => None
        end;;
        match x1 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args <? 0
-            then
-             Some
-               (UnderLets.UnderLet
-                  (#(ident.Z_sub_get_borrow)%expr @ x @ x0 @
-                   (##(- args)%Z)%expr)%expr_pat
-                  (fun v : var (type.base (base.type.Z * base.type.Z)%etype)
-                   =>
-                   UnderLets.Base
-                     (#(ident.fst)%expr @ ($v)%expr,
-                     (- (#(ident.snd)%expr @ $v)%expr_pat)%expr)%expr_pat))
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> ℤ) -> (projT1 args))%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               fv <- (if (let (x2, _) := idc_args in x2) <? 0
+                      then
+                       Some
+                         (UnderLet
+                            (#(Z_sub_get_borrow)%expr @ x @ x0 @
+                             (##(- (let (x2, _) := idc_args in x2))%Z)%expr)%expr_pat
+                            (fun vc : var (ℤ * ℤ)%etype =>
+                             Base
+                               (#(fst)%expr @ ($vc)%expr,
+                               (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                      else None);
+               Some (fv0 <-- fv;
+                     Base fv0)%under_lets
+           | None => None
+           end
        | _ => None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0
-            then Some (UnderLets.Base (x1, (##0)%expr)%expr_pat)
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> (projT1 args)) -> ℤ)%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                      then Some (x1, (##0)%expr)%expr_pat
+                      else None);
+               Some (Base x2)
+           | None => None
+           end
        | _ => None
        end;;
        match x1 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0
-            then Some (UnderLets.Base (x0, (##0)%expr)%expr_pat)
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> ℤ) -> (projT1 args))%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                      then Some (x0, (##0)%expr)%expr_pat
+                      else None);
+               Some (Base x2)
+           | None => None
+           end
        | _ => None
        end;;
-       Some
-         (UnderLets.UnderLet
-            (#(ident.Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat
-            (fun v : var (type.base (base.type.Z * base.type.Z)%etype) =>
-             UnderLets.Base
-               (#(ident.fst)%expr @ ($v)%expr, #(ident.snd)%expr @ ($v)%expr)%expr_pat)));;
+       match
+         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+       with
+       | Some (_, _, _) =>
+           Some
+             (UnderLet (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat
+                (fun v : var (ℤ * ℤ)%etype =>
+                 Base
+                   (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+       | None => None
+       end);;
       None);;;
-     UnderLets.Base (#(ident.Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_with_carry =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_with_carry =>
+    fun x x0 x1 : expr ℤ =>
     (((match x with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-           (if args =? 0 then Some (UnderLets.Base (x0 + x1)%expr) else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               (((projT1 args) -> ℤ) -> ℤ)%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                      then Some (x0 + x1)%expr
+                      else None);
+               Some (Base x2)
+           | None => None
+           end
        | _ => None
        end;;
-       Some
-         (UnderLets.UnderLet
-            (#(ident.Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
-            (fun v : var (type.base base.type.Z) => UnderLets.Base ($v)%expr)));;
+       match
+         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+       with
+       | Some (_, _, _) =>
+           Some
+             (UnderLet (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
+                (fun v : var ℤ => Base ($v)%expr))
+       | None => None
+       end);;
       None);;;
-     UnderLets.Base (#(ident.Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_with_get_carry =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_with_get_carry =>
+    fun x x0 x1 x2 : expr ℤ =>
     (((match x0 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
            match x1 with
            | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x3 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
+                args0 <- invert_bind_args idc Raw.ident.Literal;
+                match
+                  pattern.type.unify_extracted_cps
+                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                    (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype option
+                    (fun x4 : option => x4)
+                with
+                | Some (_, _, _, _) =>
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args0);
+                    v <- type.try_make_transport_cps s ℤ;
+                    fv <- (if (let (x4, _) := idc_args in x4) =? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_sub_get_borrow)%expr @ x @ x2 @
+                                  v (Compile.reflect x3))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr,
+                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                | None => None
+                end);;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr
-                            (type.base (base.type.Z * base.type.Z)%etype))))
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype option
+                   (fun x4 : option => x4)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args =? 0
+               | Some (_, _, _, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   v <- type.try_make_transport_cps s ℤ;
+                   fv <- (if (let (x4, _) := idc_args in x4) <? 0
                           then
                            Some
-                             (UnderLets.UnderLet
-                                (#(ident.Z_sub_get_borrow)%expr @ x @ x2 @
-                                 x' v)%expr_pat
-                                (fun
-                                   v0 : var
-                                          (type.base
-                                             (base.type.Z * base.type.Z)%etype)
-                                 =>
-                                 UnderLets.Base
-                                   (#(ident.fst)%expr @ ($v0)%expr,
-                                   (- (#(ident.snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x3);;
-               match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr
-                            (type.base (base.type.Z * base.type.Z)%etype))))
-               with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args <? 0
-                          then
-                           Some
-                             (UnderLets.UnderLet
-                                (#(ident.Z_sub_with_get_borrow)%expr @ x @
-                                 (##(- args)%Z)%expr @ x2 @ x' v)%expr_pat
-                                (fun
-                                   v0 : var
-                                          (type.base
-                                             (base.type.Z * base.type.Z)%etype)
-                                 =>
-                                 UnderLets.Base
-                                   (#(ident.fst)%expr @ ($v0)%expr,
-                                   (- (#(ident.snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x3)
+                             (UnderLet
+                                (#(Z_sub_with_get_borrow)%expr @ x @
+                                 (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
+                                 x2 @ v (Compile.reflect x3))%expr_pat
+                                (fun vc : var (ℤ * ℤ)%etype =>
+                                 Base
+                                   (#(fst)%expr @ ($vc)%expr,
+                                   (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                          else None);
+                   Some (fv0 <-- fv;
+                         Base fv0)%under_lets
+               | None => None
+               end
            | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
              _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
@@ -1894,85 +1665,61 @@ match idc in (ident t) return (Compile.value' true t) with
            end;;
            match x2 with
            | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x3 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
+                args0 <- invert_bind_args idc Raw.ident.Literal;
+                match
+                  pattern.type.unify_extracted_cps
+                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                    (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype option
+                    (fun x4 : option => x4)
+                with
+                | Some (_, _, _, _) =>
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args0);
+                    v <- type.try_make_transport_cps s ℤ;
+                    fv <- (if (let (x4, _) := idc_args in x4) =? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_sub_get_borrow)%expr @ x @ x1 @
+                                  v (Compile.reflect x3))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr,
+                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                | None => None
+                end);;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr
-                            (type.base (base.type.Z * base.type.Z)%etype))))
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype option
+                   (fun x4 : option => x4)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args =? 0
+               | Some (_, _, _, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   v <- type.try_make_transport_cps s ℤ;
+                   fv <- (if (let (x4, _) := idc_args in x4) <? 0
                           then
                            Some
-                             (UnderLets.UnderLet
-                                (#(ident.Z_sub_get_borrow)%expr @ x @ x1 @
-                                 x' v)%expr_pat
-                                (fun
-                                   v0 : var
-                                          (type.base
-                                             (base.type.Z * base.type.Z)%etype)
-                                 =>
-                                 UnderLets.Base
-                                   (#(ident.fst)%expr @ ($v0)%expr,
-                                   (- (#(ident.snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x3);;
-               match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr
-                            (type.base (base.type.Z * base.type.Z)%etype))))
-               with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args <? 0
-                          then
-                           Some
-                             (UnderLets.UnderLet
-                                (#(ident.Z_sub_with_get_borrow)%expr @ x @
-                                 (##(- args)%Z)%expr @ x1 @ x' v)%expr_pat
-                                (fun
-                                   v0 : var
-                                          (type.base
-                                             (base.type.Z * base.type.Z)%etype)
-                                 =>
-                                 UnderLets.Base
-                                   (#(ident.fst)%expr @ ($v0)%expr,
-                                   (- (#(ident.snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x3)
+                             (UnderLet
+                                (#(Z_sub_with_get_borrow)%expr @ x @
+                                 (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
+                                 x1 @ v (Compile.reflect x3))%expr_pat
+                                (fun vc : var (ℤ * ℤ)%etype =>
+                                 Base
+                                   (#(fst)%expr @ ($vc)%expr,
+                                   (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                          else None);
+                   Some (fv0 <-- fv;
+                         Base fv0)%under_lets
+               | None => None
+               end
            | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
              _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
@@ -1980,149 +1727,186 @@ match idc in (ident t) return (Compile.value' true t) with
            end;;
            match x1 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if (args0 <=? 0) && (args <=? 0) && (args0 + args <? 0)
-                then
-                 Some
-                   (UnderLets.UnderLet
-                      (#(ident.Z_sub_with_get_borrow)%expr @ x @
-                       (##(- args)%Z)%expr @ x2 @ (##(- args0)%Z)%expr)%expr_pat
-                      (fun
-                         v : var
-                               (type.base (base.type.Z * base.type.Z)%etype)
-                       =>
-                       UnderLets.Base
-                         (#(ident.fst)%expr @ ($v)%expr,
-                         (- (#(ident.snd)%expr @ $v)%expr_pat)%expr)%expr_pat))
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> (projT1 args0)) -> (projT1 args)) -> ℤ)%ptype
+                   option (fun x3 : option => x3)
+               with
+               | Some (_, _, _, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   fv <- (if
+                           ((let (x3, _) := idc_args0 in x3) <=? 0) &&
+                           ((let (x3, _) := idc_args in x3) <=? 0) &&
+                           ((let (x3, _) := idc_args0 in x3) +
+                            (let (x3, _) := idc_args in x3) <? 0)
+                          then
+                           Some
+                             (UnderLet
+                                (#(Z_sub_with_get_borrow)%expr @ x @
+                                 (##(- (let (x3, _) := idc_args in x3))%Z)%expr @
+                                 x2 @
+                                 (##(- (let (x3, _) := idc_args0 in x3))%Z)%expr)%expr_pat
+                                (fun vc : var (ℤ * ℤ)%etype =>
+                                 Base
+                                   (#(fst)%expr @ ($vc)%expr,
+                                   (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                          else None);
+                   Some (fv0 <-- fv;
+                         Base fv0)%under_lets
+               | None => None
+               end
            | _ => None
            end;;
            match x2 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if (args0 <=? 0) && (args <=? 0) && (args0 + args <? 0)
-                then
-                 Some
-                   (UnderLets.UnderLet
-                      (#(ident.Z_sub_with_get_borrow)%expr @ x @
-                       (##(- args)%Z)%expr @ x1 @ (##(- args0)%Z)%expr)%expr_pat
-                      (fun
-                         v : var
-                               (type.base (base.type.Z * base.type.Z)%etype)
-                       =>
-                       UnderLets.Base
-                         (#(ident.fst)%expr @ ($v)%expr,
-                         (- (#(ident.snd)%expr @ $v)%expr_pat)%expr)%expr_pat))
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> (projT1 args0)) -> ℤ) -> (projT1 args))%ptype
+                   option (fun x3 : option => x3)
+               with
+               | Some (_, _, _, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   fv <- (if
+                           ((let (x3, _) := idc_args0 in x3) <=? 0) &&
+                           ((let (x3, _) := idc_args in x3) <=? 0) &&
+                           ((let (x3, _) := idc_args0 in x3) +
+                            (let (x3, _) := idc_args in x3) <? 0)
+                          then
+                           Some
+                             (UnderLet
+                                (#(Z_sub_with_get_borrow)%expr @ x @
+                                 (##(- (let (x3, _) := idc_args in x3))%Z)%expr @
+                                 x1 @
+                                 (##(- (let (x3, _) := idc_args0 in x3))%Z)%expr)%expr_pat
+                                (fun vc : var (ℤ * ℤ)%etype =>
+                                 Base
+                                   (#(fst)%expr @ ($vc)%expr,
+                                   (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                          else None);
+                   Some (fv0 <-- fv;
+                         Base fv0)%under_lets
+               | None => None
+               end
            | _ => None
            end;;
            match x with
            | @expr.Ident _ _ _ t0 idc0 =>
-               _ <- pattern.ident.invert_bind_args idc0
-                      pattern.ident.LiteralZ;
                match x1 with
                | @expr.Ident _ _ _ t1 idc1 =>
-                   args1 <- pattern.ident.invert_bind_args idc1
-                              pattern.ident.LiteralZ;
-                   (if (args =? 0) && (args1 =? 0)
-                    then Some (UnderLets.Base (x2, (##0)%expr)%expr_pat)
-                    else None)
+                   args <- invert_bind_args idc1 Raw.ident.Literal;
+                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                   args1 <- invert_bind_args idc Raw.ident.Literal;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       ((((projT1 args0) -> (projT1 args1)) -> (projT1 args)) ->
+                        ℤ)%ptype option (fun x3 : option => x3)
+                   with
+                   | Some (_, _, _, _) =>
+                       _ <- ident.unify pattern.ident.Literal
+                              ##(projT2 args0);
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args1);
+                       idc_args1 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args);
+                       x3 <- (if
+                               ((let (x3, _) := idc_args0 in x3) =? 0) &&
+                               ((let (x3, _) := idc_args1 in x3) =? 0)
+                              then Some (x2, (##0)%expr)%expr_pat
+                              else None);
+                       Some (Base x3)
+                   | None => None
+                   end
                | _ => None
                end;;
                match x2 with
                | @expr.Ident _ _ _ t1 idc1 =>
-                   args1 <- pattern.ident.invert_bind_args idc1
-                              pattern.ident.LiteralZ;
-                   (if (args =? 0) && (args1 =? 0)
-                    then Some (UnderLets.Base (x1, (##0)%expr)%expr_pat)
-                    else None)
+                   args <- invert_bind_args idc1 Raw.ident.Literal;
+                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                   args1 <- invert_bind_args idc Raw.ident.Literal;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       ((((projT1 args0) -> (projT1 args1)) -> ℤ) ->
+                        (projT1 args))%ptype option (fun x3 : option => x3)
+                   with
+                   | Some (_, _, _, _) =>
+                       _ <- ident.unify pattern.ident.Literal
+                              ##(projT2 args0);
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args1);
+                       idc_args1 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args);
+                       x3 <- (if
+                               ((let (x3, _) := idc_args0 in x3) =? 0) &&
+                               ((let (x3, _) := idc_args1 in x3) =? 0)
+                              then Some (x1, (##0)%expr)%expr_pat
+                              else None);
+                       Some (Base x3)
+                   | None => None
+                   end
                | _ => None
                end
            | _ => None
            end;;
-           (if args =? 0
-            then
-             Some
-               (UnderLets.UnderLet
-                  (#(ident.Z_add_get_carry)%expr @ x @ x1 @ x2)%expr_pat
-                  (fun v : var (type.base (base.type.Z * base.type.Z)%etype)
-                   =>
-                   UnderLets.Base
-                     (#(ident.fst)%expr @ ($v)%expr,
-                     #(ident.snd)%expr @ ($v)%expr)%expr_pat))
-            else None)
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+               (((ℤ -> (projT1 args)) -> ℤ) -> ℤ)%ptype option
+               (fun x3 : option => x3)
+           with
+           | Some (_, _, _, _) =>
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               fv <- (if (let (x3, _) := idc_args in x3) =? 0
+                      then
+                       Some
+                         (UnderLet
+                            (#(Z_add_get_carry)%expr @ x @ x1 @ x2)%expr_pat
+                            (fun vc : var (ℤ * ℤ)%etype =>
+                             Base
+                               (#(fst)%expr @ ($vc)%expr,
+                               #(snd)%expr @ ($vc)%expr)%expr_pat))
+                      else None);
+               Some (fv0 <-- fv;
+                     Base fv0)%under_lets
+           | None => None
+           end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x3 =>
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_opp;
            match x1 with
            | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr
-                            (type.base (base.type.Z * base.type.Z)%etype))))
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> s) -> s0) -> ℤ)%ptype
+                   option (fun x5 : option => x5)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          match
-                            s0 as t3
-                            return
-                              (Compile.value' false t3 ->
-                               option
-                                 (UnderLets.UnderLets base.type ident var
-                                    (defaults.expr
-                                       (type.base
-                                          (base.type.Z * base.type.Z)%etype))))
-                          with
-                          | type.base t3 =>
-                              fun v0 : defaults.expr (type.base t3) =>
-                              base.try_make_transport_cps t3 base.type.Z
-                                (fun
-                                   a0 : option
-                                          (defaults.expr (type.base t3) ->
-                                           defaults.expr
-                                             (type.base base.type.Z)) =>
-                                 match a0 with
-                                 | Some x'0 =>
-                                     Some
-                                       (UnderLets.UnderLet
-                                          (#(ident.Z_sub_with_get_borrow)%expr @
-                                           x @ x' v @ x2 @ x'0 v0)%expr_pat
-                                          (fun
-                                             v1 : var
-                                                    (type.base
-                                                       (base.type.Z *
-                                                        base.type.Z)%etype)
-                                           =>
-                                           UnderLets.Base
-                                             (#(ident.fst)%expr @ ($v1)%expr,
-                                             (-
-                                              (#(ident.snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
-                                 | None => None
-                                 end)
-                          | (s1 -> d1)%ptype =>
-                              fun
-                                _ : Compile.value' false s1 ->
-                                    Compile.value' true d1 => None
-                          end (Compile.reflect x4)
-                      | None => None
-                      end)
-               | (s1 -> d1)%ptype =>
-                   fun _ : Compile.value' false s1 -> Compile.value' true d1
-                   => None
-               end (Compile.reflect x3)
+               | Some (_, _, _, _) =>
+                   v <- type.try_make_transport_cps s ℤ;
+                   v0 <- type.try_make_transport_cps s0 ℤ;
+                   Some
+                     (UnderLet
+                        (#(Z_sub_with_get_borrow)%expr @ x @
+                         v (Compile.reflect x3) @ x2 @
+                         v0 (Compile.reflect x4))%expr_pat
+                        (fun v1 : var (ℤ * ℤ)%etype =>
+                         Base
+                           (#(fst)%expr @ ($v1)%expr,
+                           (- (#(snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
+               | None => None
+               end
            | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
              (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
@@ -2131,72 +1915,27 @@ match idc in (ident t) return (Compile.value' true t) with
            end;;
            match x2 with
            | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
-               _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_opp;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr
-                            (type.base (base.type.Z * base.type.Z)%etype))))
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> s) -> ℤ) -> s0)%ptype
+                   option (fun x5 : option => x5)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          match
-                            s0 as t3
-                            return
-                              (Compile.value' false t3 ->
-                               option
-                                 (UnderLets.UnderLets base.type ident var
-                                    (defaults.expr
-                                       (type.base
-                                          (base.type.Z * base.type.Z)%etype))))
-                          with
-                          | type.base t3 =>
-                              fun v0 : defaults.expr (type.base t3) =>
-                              base.try_make_transport_cps t3 base.type.Z
-                                (fun
-                                   a0 : option
-                                          (defaults.expr (type.base t3) ->
-                                           defaults.expr
-                                             (type.base base.type.Z)) =>
-                                 match a0 with
-                                 | Some x'0 =>
-                                     Some
-                                       (UnderLets.UnderLet
-                                          (#(ident.Z_sub_with_get_borrow)%expr @
-                                           x @ x' v @ x1 @ x'0 v0)%expr_pat
-                                          (fun
-                                             v1 : var
-                                                    (type.base
-                                                       (base.type.Z *
-                                                        base.type.Z)%etype)
-                                           =>
-                                           UnderLets.Base
-                                             (#(ident.fst)%expr @ ($v1)%expr,
-                                             (-
-                                              (#(ident.snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
-                                 | None => None
-                                 end)
-                          | (s1 -> d1)%ptype =>
-                              fun
-                                _ : Compile.value' false s1 ->
-                                    Compile.value' true d1 => None
-                          end (Compile.reflect x4)
-                      | None => None
-                      end)
-               | (s1 -> d1)%ptype =>
-                   fun _ : Compile.value' false s1 -> Compile.value' true d1
-                   => None
-               end (Compile.reflect x3)
+               | Some (_, _, _, _) =>
+                   v <- type.try_make_transport_cps s ℤ;
+                   v0 <- type.try_make_transport_cps s0 ℤ;
+                   Some
+                     (UnderLet
+                        (#(Z_sub_with_get_borrow)%expr @ x @
+                         v (Compile.reflect x3) @ x1 @
+                         v0 (Compile.reflect x4))%expr_pat
+                        (fun v1 : var (ℤ * ℤ)%etype =>
+                         Base
+                           (#(fst)%expr @ ($v1)%expr,
+                           (- (#(snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
+               | None => None
+               end
            | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
              (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
@@ -2205,92 +1944,66 @@ match idc in (ident t) return (Compile.value' true t) with
            end;;
            match x1 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr
-                            (type.base (base.type.Z * base.type.Z)%etype))))
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> s) -> (projT1 args)) -> ℤ)%ptype option
+                   (fun x4 : option => x4)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 <=? 0
+               | Some (_, _, _, _) =>
+                   v <- type.try_make_transport_cps s ℤ;
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   fv <- (if (let (x4, _) := idc_args in x4) <=? 0
                           then
                            Some
-                             (UnderLets.UnderLet
-                                (#(ident.Z_sub_with_get_borrow)%expr @ x @
-                                 x' v @ x2 @ (##(- args0)%Z)%expr)%expr_pat
-                                (fun
-                                   v0 : var
-                                          (type.base
-                                             (base.type.Z * base.type.Z)%etype)
-                                 =>
-                                 UnderLets.Base
-                                   (#(ident.fst)%expr @ ($v0)%expr,
-                                   (- (#(ident.snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x3)
+                             (UnderLet
+                                (#(Z_sub_with_get_borrow)%expr @ x @
+                                 v (Compile.reflect x3) @ x2 @
+                                 (##(- (let (x4, _) := idc_args in x4))%Z)%expr)%expr_pat
+                                (fun vc : var (ℤ * ℤ)%etype =>
+                                 Base
+                                   (#(fst)%expr @ ($vc)%expr,
+                                   (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                          else None);
+                   Some (fv0 <-- fv;
+                         Base fv0)%under_lets
+               | None => None
+               end
            | _ => None
            end;;
            match x2 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr
-                            (type.base (base.type.Z * base.type.Z)%etype))))
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> s) -> ℤ) -> (projT1 args))%ptype option
+                   (fun x4 : option => x4)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 <=? 0
+               | Some (_, _, _, _) =>
+                   v <- type.try_make_transport_cps s ℤ;
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   fv <- (if (let (x4, _) := idc_args in x4) <=? 0
                           then
                            Some
-                             (UnderLets.UnderLet
-                                (#(ident.Z_sub_with_get_borrow)%expr @ x @
-                                 x' v @ x1 @ (##(- args0)%Z)%expr)%expr_pat
-                                (fun
-                                   v0 : var
-                                          (type.base
-                                             (base.type.Z * base.type.Z)%etype)
-                                 =>
-                                 UnderLets.Base
-                                   (#(ident.fst)%expr @ ($v0)%expr,
-                                   (- (#(ident.snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-                          else None
-                      | None => None
-                      end)
-               | (s0 -> d0)%ptype =>
-                   fun _ : Compile.value' false s0 -> Compile.value' true d0
-                   => None
-               end (Compile.reflect x3)
+                             (UnderLet
+                                (#(Z_sub_with_get_borrow)%expr @ x @
+                                 v (Compile.reflect x3) @ x1 @
+                                 (##(- (let (x4, _) := idc_args in x4))%Z)%expr)%expr_pat
+                                (fun vc : var (ℤ * ℤ)%etype =>
+                                 Base
+                                   (#(fst)%expr @ ($vc)%expr,
+                                   (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                          else None);
+                   Some (fv0 <-- fv;
+                         Base fv0)%under_lets
+               | None => None
+               end
            | _ => None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
@@ -2300,129 +2013,125 @@ match idc in (ident t) return (Compile.value' true t) with
        end;;
        match x1 with
        | @expr.Ident _ _ _ t idc =>
-           args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
            match x2 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
-               (if (args =? 0) && (args0 =? 0)
-                then
-                 Some
-                   (UnderLets.UnderLet
-                      (#(ident.Z_add_with_get_carry)%expr @ x @ x0 @
-                       (##args)%expr @ (##args0)%expr)%expr_pat
-                      (fun
-                         v : var
-                               (type.base (base.type.Z * base.type.Z)%etype)
-                       =>
-                       UnderLets.Base
-                         (#(ident.fst)%expr @ ($v)%expr, (##0)%expr)%expr_pat))
-                else None)
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> ℤ) -> (projT1 args0)) -> (projT1 args))%ptype
+                   option (fun x3 : option => x3)
+               with
+               | Some (_, _, _, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   fv <- (if
+                           ((let (x3, _) := idc_args in x3) =? 0) &&
+                           ((let (x3, _) := idc_args0 in x3) =? 0)
+                          then
+                           Some
+                             (UnderLet
+                                (#(Z_add_with_get_carry)%expr @ x @ x0 @
+                                 (##(let (x3, _) := idc_args in x3))%expr @
+                                 (##(let (x3, _) := idc_args0 in x3))%expr)%expr_pat
+                                (fun vc : var (ℤ * ℤ)%etype =>
+                                 Base
+                                   (#(fst)%expr @ ($vc)%expr, (##0)%expr)%expr_pat))
+                          else None);
+                   Some (fv0 <-- fv;
+                         Base fv0)%under_lets
+               | None => None
+               end
            | _ => None
            end
        | _ => None
        end;;
-       Some
-         (UnderLets.UnderLet
-            (#(ident.Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat
-            (fun v : var (type.base (base.type.Z * base.type.Z)%etype) =>
-             UnderLets.Base
-               (#(ident.fst)%expr @ ($v)%expr, #(ident.snd)%expr @ ($v)%expr)%expr_pat)));;
+       match
+         pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype option (fun x3 : option => x3)
+       with
+       | Some (_, _, _, _) =>
+           Some
+             (UnderLet
+                (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+                (fun v : var (ℤ * ℤ)%etype =>
+                 Base
+                   (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+       | None => None
+       end);;
       None);;;
-     UnderLets.Base
-       (#(ident.Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
-| ident.Z_sub_get_borrow =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.UnderLet
-      (#(ident.Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
-      (fun v : var (type.base (base.type.Z * base.type.Z)%etype) =>
-       UnderLets.Base
-         (#(ident.fst)%expr @ ($v)%expr, #(ident.snd)%expr @ ($v)%expr)%expr_pat)
-| ident.Z_sub_with_get_borrow =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.UnderLet
-      (#(ident.Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
-      (fun v : var (type.base (base.type.Z * base.type.Z)%etype) =>
-       UnderLets.Base
-         (#(ident.fst)%expr @ ($v)%expr, #(ident.snd)%expr @ ($v)%expr)%expr_pat)
-| ident.Z_zselect =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_zselect)%expr @ x @ x0 @ x1)%expr_pat
-| ident.Z_add_modulo =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_add_modulo)%expr @ x @ x0 @ x1)%expr_pat
-| ident.Z_rshi =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_rshi)%expr @ x @ x0 @ x1 @ x2)%expr_pat
-| ident.Z_cc_m =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_cc_m)%expr @ x @ x0)%expr_pat
-| ident.Z_cast range =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_cast range)%expr @ x)%expr_pat
-| ident.Z_cast2 range =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
+     Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+| Z_sub_get_borrow =>
+    fun x x0 x1 : expr ℤ =>
+    (match
+       pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+         ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+     with
+     | Some (_, _, _) =>
+         Some
+           (UnderLet (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
+              (fun v : var (ℤ * ℤ)%etype =>
+               Base
+                 (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+     | None => None
+     end;;;
+     Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_sub_with_get_borrow =>
+    fun x x0 x1 x2 : expr ℤ =>
+    (match
+       pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype option (fun x3 : option => x3)
+     with
+     | Some (_, _, _, _) =>
+         Some
+           (UnderLet
+              (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+              (fun v : var (ℤ * ℤ)%etype =>
+               Base
+                 (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+     | None => None
+     end;;;
+     Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+| Z_zselect =>
+    fun x x0 x1 : expr ℤ => Base (#(Z_zselect)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add_modulo =>
+    fun x x0 x1 : expr ℤ =>
+    Base (#(Z_add_modulo)%expr @ x @ x0 @ x1)%expr_pat
+| Z_rshi =>
+    fun x x0 x1 x2 : expr ℤ =>
+    Base (#(Z_rshi)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+| Z_cc_m => fun x x0 : expr ℤ => Base (#(Z_cc_m)%expr @ x @ x0)%expr_pat
+| Z_cast range => fun x : expr ℤ => Base (#(Z_cast range)%expr @ x)%expr_pat
+| Z_cast2 range =>
+    fun x : expr (ℤ * ℤ)%etype =>
     (match x with
      | @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x1) x0 =>
-         _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
+         args <- invert_bind_args idc Raw.ident.pair;
          match
-           s0 as t2
-           return
-             (Compile.value' false t2 ->
-              option
-                (UnderLets.UnderLets base.type ident var
-                   (defaults.expr
-                      (type.base (base.type.Z * base.type.Z)%etype))))
+           pattern.type.unify_extracted_cps
+             (((ℤ -> ℤ -> (ℤ * ℤ)%pbtype) -> ℤ) -> ℤ)%ptype
+             ((((let (x2, _) := args in x2) ->
+                (let (_, y) := args in y) ->
+                ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
+               s0) -> s)%ptype option (fun x2 : option => x2)
          with
-         | type.base t2 =>
-             fun v : defaults.expr (type.base t2) =>
-             base.try_make_transport_cps t2 base.type.Z
-               (fun
-                  a : option
-                        (defaults.expr (type.base t2) ->
-                         defaults.expr (type.base base.type.Z)) =>
-                match a with
-                | Some x' =>
-                    match
-                      s as t3
-                      return
-                        (Compile.value' false t3 ->
-                         option
-                           (UnderLets.UnderLets base.type ident var
-                              (defaults.expr
-                                 (type.base (base.type.Z * base.type.Z)%etype))))
-                    with
-                    | type.base t3 =>
-                        fun v0 : defaults.expr (type.base t3) =>
-                        base.try_make_transport_cps t3 base.type.Z
-                          (fun
-                             a0 : option
-                                    (defaults.expr (type.base t3) ->
-                                     defaults.expr (type.base base.type.Z))
-                           =>
-                           match a0 with
-                           | Some x'0 =>
-                               Some
-                                 (fv <-- do_again (base.type.Z * base.type.Z)
-                                           (#(ident.Z_cast (fst range))%expr @
-                                            ($(x' v))%expr,
-                                           #(ident.Z_cast (snd range))%expr @
-                                           ($(x'0 v0))%expr)%expr_pat;
-                                  UnderLets.Base (id (id fv)))%under_lets
-                           | None => None
-                           end)
-                    | (s1 -> d1)%ptype =>
-                        fun
-                          _ : Compile.value' false s1 ->
-                              Compile.value' true d1 => None
-                    end (Compile.reflect x0)
-                | None => None
-                end)
-         | (s1 -> d1)%ptype =>
-             fun _ : Compile.value' false s1 -> Compile.value' true d1 =>
-             None
-         end (Compile.reflect x1)
+         | Some (_, (_, (_, _)), _, _) =>
+             _ <- ident.unify pattern.ident.pair pair;
+             v <- type.try_make_transport_cps s0 ℤ;
+             v0 <- type.try_make_transport_cps s ℤ;
+             Some
+               (fv <-- do_again (ℤ * ℤ)
+                         (#(Z_cast (Datatypes.fst range))%expr @
+                          ($(v (Compile.reflect x1)))%expr,
+                         #(Z_cast (Datatypes.snd range))%expr @
+                         ($(v0 (Compile.reflect x0)))%expr)%expr_pat;
+                Base fv)%under_lets
+         | None => None
+         end
      | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App _
        _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ | @expr.App
        _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ | @expr.App _ _
@@ -2432,57 +2141,42 @@ match idc in (ident t) return (Compile.value' true t) with
        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
      | _ => None
      end;;;
-     UnderLets.Base (#(ident.Z_cast2 range)%expr @ x)%expr_pat)%option
-| ident.fancy_add log2wordmax imm =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_add log2wordmax imm)%expr @ x)%expr_pat
-| ident.fancy_addc log2wordmax imm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_addc log2wordmax imm)%expr @ x)%expr_pat
-| ident.fancy_sub log2wordmax imm =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_sub log2wordmax imm)%expr @ x)%expr_pat
-| ident.fancy_subb log2wordmax imm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_subb log2wordmax imm)%expr @ x)%expr_pat
-| ident.fancy_mulll log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_mulll log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_mullh log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_mullh log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_mulhl log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_mulhl log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_mulhh log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_mulhh log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_rshi log2wordmax x =>
-    fun x0 : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_rshi log2wordmax x)%expr @ x0)%expr_pat
-| ident.fancy_selc =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_selc)%expr @ x)%expr_pat
-| ident.fancy_selm log2wordmax =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_selm log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_sell =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_sell)%expr @ x)%expr_pat
-| ident.fancy_addm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_addm)%expr @ x)%expr_pat
+     Base (#(Z_cast2 range)%expr @ x)%expr_pat)%option
+| fancy_add log2wordmax imm =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat
+| fancy_addc log2wordmax imm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_addc log2wordmax imm)%expr @ x)%expr_pat
+| fancy_sub log2wordmax imm =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_sub log2wordmax imm)%expr @ x)%expr_pat
+| fancy_subb log2wordmax imm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_subb log2wordmax imm)%expr @ x)%expr_pat
+| fancy_mulll log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulll log2wordmax)%expr @ x)%expr_pat
+| fancy_mullh log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mullh log2wordmax)%expr @ x)%expr_pat
+| fancy_mulhl log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulhl log2wordmax)%expr @ x)%expr_pat
+| fancy_mulhh log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulhh log2wordmax)%expr @ x)%expr_pat
+| fancy_rshi log2wordmax x =>
+    fun x0 : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_rshi log2wordmax x)%expr @ x0)%expr_pat
+| fancy_selc =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_selc)%expr @ x)%expr_pat
+| fancy_selm log2wordmax =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_selm log2wordmax)%expr @ x)%expr_pat
+| fancy_sell =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_sell)%expr @ x)%expr_pat
+| fancy_addm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_addm)%expr @ x)%expr_pat
 end
      : Compile.value' true t

--- a/src/Experiments/NewPipeline/fancy_rewrite_head.out
+++ b/src/Experiments/NewPipeline/fancy_rewrite_head.out
@@ -1,472 +1,332 @@
 fancy_rewrite_head = 
-match idc in (ident t) return (Compile.value' true t) with
-| @ident.Literal t v =>
-    match
-      t as t0
-      return
-        (base.base_interp t0 ->
-         UnderLets.UnderLets base.type ident var
-           (defaults.expr (type.base t0)))
-    with
-    | base.type.unit => fun v0 : unit => UnderLets.Base (##v0)%expr
-    | base.type.Z => fun v0 : Z => UnderLets.Base (##v0)%expr
-    | base.type.bool => fun v0 : bool => UnderLets.Base (##v0)%expr
-    | base.type.nat => fun v0 : nat => UnderLets.Base (##v0)%expr
-    end v
-| ident.Nat_succ =>
-    fun x : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_succ)%expr @ x)%expr_pat
-| ident.Nat_pred =>
-    fun x : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_pred)%expr @ x)%expr_pat
-| ident.Nat_max =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_max)%expr @ x @ x0)%expr_pat
-| ident.Nat_mul =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_mul)%expr @ x @ x0)%expr_pat
-| ident.Nat_add =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_add)%expr @ x @ x0)%expr_pat
-| ident.Nat_sub =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Nat_sub)%expr @ x @ x0)%expr_pat
-| @ident.nil t => UnderLets.Base []%expr_pat
-| @ident.cons t =>
-    fun (x : defaults.expr (type.base t))
-      (x0 : defaults.expr (type.base (base.type.list t))) =>
-    UnderLets.Base (x :: x0)%expr_pat
-| @ident.pair A B =>
-    fun (x : defaults.expr (type.base A)) (x0 : defaults.expr (type.base B))
-    => UnderLets.Base (x, x0)%expr_pat
-| @ident.fst A B =>
-    fun x : defaults.expr (type.base (A * B)%etype) =>
-    UnderLets.Base (#(ident.fst)%expr @ x)%expr_pat
-| @ident.snd A B =>
-    fun x : defaults.expr (type.base (A * B)%etype) =>
-    UnderLets.Base (#(ident.snd)%expr @ x)%expr_pat
-| @ident.prod_rect A B T =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           defaults.expr (type.base B) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base T)))
-      (x0 : defaults.expr (type.base (A * B)%etype)) =>
-    UnderLets.Base
-      (#(ident.prod_rect)%expr @
-       (λ (x1 : var (type.base A))(x2 : var (type.base B)),
-        UnderLets.to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
-| @ident.bool_rect T =>
-    fun
-      (x
-       x0 : defaults.expr (type.base base.type.unit) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base T)))
-      (x1 : defaults.expr (type.base base.type.bool)) =>
-    UnderLets.Base
-      (#(ident.bool_rect)%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x ($x2)))%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x0 ($x2)))%expr @ x1)%expr_pat
-| @ident.nat_rect P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base base.type.nat) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base base.type.nat)) =>
-    UnderLets.Base
-      (#(ident.nat_rect)%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x ($x2)))%expr @
-       (λ (x2 : var (type.base base.type.nat))(x3 : var (type.base P)),
-        UnderLets.to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
-| @ident.nat_rect_arrow P Q =>
-    fun
-      (x : defaults.expr (type.base P) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base Q)))
-      (x0 : defaults.expr (type.base base.type.nat) ->
-            (defaults.expr (type.base P) ->
-             UnderLets.UnderLets base.type ident var
-               (defaults.expr (type.base Q))) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base Q)))
-      (x1 : defaults.expr (type.base base.type.nat))
-      (x2 : defaults.expr (type.base P)) =>
-    UnderLets.Base
-      (#(ident.nat_rect_arrow)%expr @
-       (λ x3 : var (type.base P),
-        UnderLets.to_expr (x ($x3)))%expr @
-       (λ (x3 : var (type.base base.type.nat))(x4 : var
-                                                      (type.base P ->
-                                                       type.base Q)%ptype)
-        (x5 : var (type.base P)),
-        UnderLets.to_expr
-          (x0 ($x3)
-             (fun x6 : defaults.expr (type.base P) =>
-              UnderLets.Base ($x4 @ x6)%expr_pat) ($x5)))%expr @ x1 @ x2)%expr_pat
-| @ident.list_rect A P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base A) ->
-            defaults.expr (type.base (base.type.list A)) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.list_rect)%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x ($x2)))%expr @
-       (λ (x2 : var (type.base A))(x3 : var (type.base (base.type.list A)))
-        (x4 : var (type.base P)),
-        UnderLets.to_expr (x0 ($x2) ($x3) ($x4)))%expr @ x1)%expr_pat
-| @ident.list_case A P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base A) ->
-            defaults.expr (type.base (base.type.list A)) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.list_case)%expr @
-       (λ x2 : var (type.base base.type.unit),
-        UnderLets.to_expr (x ($x2)))%expr @
-       (λ (x2 : var (type.base A))(x3 : var (type.base (base.type.list A))),
-        UnderLets.to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
-| @ident.List_length T =>
-    fun x : defaults.expr (type.base (base.type.list T)) =>
-    UnderLets.Base (#(ident.List_length)%expr @ x)%expr_pat
-| ident.List_seq =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.List_seq)%expr @ x @ x0)%expr_pat
-| @ident.List_firstn A =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base (#(ident.List_firstn)%expr @ x @ x0)%expr_pat
-| @ident.List_skipn A =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base (#(ident.List_skipn)%expr @ x @ x0)%expr_pat
-| @ident.List_repeat A =>
-    fun (x : defaults.expr (type.base A))
-      (x0 : defaults.expr (type.base base.type.nat)) =>
-    UnderLets.Base (#(ident.List_repeat)%expr @ x @ x0)%expr_pat
-| @ident.List_combine A B =>
-    fun (x : defaults.expr (type.base (base.type.list A)))
-      (x0 : defaults.expr (type.base (base.type.list B))) =>
-    UnderLets.Base (#(ident.List_combine)%expr @ x @ x0)%expr_pat
-| @ident.List_map A B =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base B)))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.List_map)%expr @
-       (λ x1 : var (type.base A),
-        UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat
-| @ident.List_app A =>
-    fun x x0 : defaults.expr (type.base (base.type.list A)) =>
-    UnderLets.Base (x ++ x0)%expr
-| @ident.List_rev A =>
-    fun x : defaults.expr (type.base (base.type.list A)) =>
-    UnderLets.Base (#(ident.List_rev)%expr @ x)%expr_pat
-| @ident.List_flat_map A B =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base (base.type.list B))))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.List_flat_map)%expr @
-       (λ x1 : var (type.base A),
-        UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat
-| @ident.List_partition A =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base base.type.bool)))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    UnderLets.Base
-      (#(ident.List_partition)%expr @
-       (λ x1 : var (type.base A),
-        UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat
-| @ident.List_fold_right A B =>
-    fun
-      (x : defaults.expr (type.base B) ->
-           defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base A)))
-      (x0 : defaults.expr (type.base A))
-      (x1 : defaults.expr (type.base (base.type.list B))) =>
-    UnderLets.Base
-      (#(ident.List_fold_right)%expr @
-       (λ (x2 : var (type.base B))(x3 : var (type.base A)),
-        UnderLets.to_expr (x ($x2) ($x3)))%expr @ x0 @ x1)%expr_pat
-| @ident.List_update_nth T =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base T) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base T)))
-      (x1 : defaults.expr (type.base (base.type.list T))) =>
-    UnderLets.Base
-      (#(ident.List_update_nth)%expr @ x @
-       (λ x2 : var (type.base T),
-        UnderLets.to_expr (x0 ($x2)))%expr @ x1)%expr_pat
-| @ident.List_nth_default T =>
-    fun (x : defaults.expr (type.base T))
-      (x0 : defaults.expr (type.base (base.type.list T)))
-      (x1 : defaults.expr (type.base base.type.nat)) =>
-    UnderLets.Base (#(ident.List_nth_default)%expr @ x @ x0 @ x1)%expr_pat
-| ident.Z_add =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x + x0)%expr
-| ident.Z_mul =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+match idc in (Compilers.ident t) return (Compile.value' true t) with
+| @Literal t v => Base (##v)%expr
+| Nat_succ => fun x : expr ℕ => Base (#(Nat_succ)%expr @ x)%expr_pat
+| Nat_pred => fun x : expr ℕ => Base (#(Nat_pred)%expr @ x)%expr_pat
+| Nat_max => fun x x0 : expr ℕ => Base (#(Nat_max)%expr @ x @ x0)%expr_pat
+| Nat_mul => fun x x0 : expr ℕ => Base (#(Nat_mul)%expr @ x @ x0)%expr_pat
+| Nat_add => fun x x0 : expr ℕ => Base (#(Nat_add)%expr @ x @ x0)%expr_pat
+| Nat_sub => fun x x0 : expr ℕ => Base (#(Nat_sub)%expr @ x @ x0)%expr_pat
+| @nil t => Base []%expr_pat
+| @cons t => fun (x : expr t) (x0 : expr (list t)) => Base (x :: x0)%expr_pat
+| @pair A B => fun (x : expr A) (x0 : expr B) => Base (x, x0)%expr_pat
+| @fst A B => fun x : expr (A * B)%etype => Base (#(fst)%expr @ x)%expr_pat
+| @snd A B => fun x : expr (A * B)%etype => Base (#(snd)%expr @ x)%expr_pat
+| @prod_rect A B T =>
+    fun (x : expr A -> expr B -> UnderLets (expr T))
+      (x0 : expr (A * B)%etype) =>
+    Base
+      (#(prod_rect)%expr @
+       (λ (x1 : var A)(x2 : var B),
+        to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
+| @bool_rect T =>
+    fun (x x0 : expr unit -> UnderLets (expr T)) (x1 : expr bool) =>
+    Base
+      (#(bool_rect)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| @nat_rect P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr ℕ -> expr P -> UnderLets (expr P)) (x1 : expr ℕ) =>
+    Base
+      (#(nat_rect)%expr @ (λ x2 : var unit,
+                           to_expr (x ($x2)))%expr @
+       (λ (x2 : var ℕ)(x3 : var P),
+        to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
+| @nat_rect_arrow P Q =>
+    fun (x : expr P -> UnderLets (expr Q))
+      (x0 : expr ℕ ->
+            (expr P -> UnderLets (expr Q)) -> expr P -> UnderLets (expr Q))
+      (x1 : expr ℕ) (x2 : expr P) =>
+    Base
+      (#(nat_rect_arrow)%expr @ (λ x3 : var P,
+                                 to_expr (x ($x3)))%expr @
+       (λ (x3 : var ℕ)(x4 : var (P -> Q)%ptype)(x5 : var P),
+        to_expr
+          (x0 ($x3) (fun x6 : expr P => Base ($x4 @ x6)%expr_pat) ($x5)))%expr @
+       x1 @ x2)%expr_pat
+| @list_rect A P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr A -> expr (list A) -> expr P -> UnderLets (expr P))
+      (x1 : expr (list A)) =>
+    Base
+      (#(list_rect)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ (x2 : var A)(x3 : var (list A))(x4 : var P),
+        to_expr (x0 ($x2) ($x3) ($x4)))%expr @ x1)%expr_pat
+| @list_case A P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr A -> expr (list A) -> UnderLets (expr P))
+      (x1 : expr (list A)) =>
+    Base
+      (#(list_case)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ (x2 : var A)(x3 : var (list A)),
+        to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
+| @List_length T =>
+    fun x : expr (list T) => Base (#(List_length)%expr @ x)%expr_pat
+| List_seq => fun x x0 : expr ℕ => Base (#(List_seq)%expr @ x @ x0)%expr_pat
+| @List_firstn A =>
+    fun (x : expr ℕ) (x0 : expr (list A)) =>
+    Base (#(List_firstn)%expr @ x @ x0)%expr_pat
+| @List_skipn A =>
+    fun (x : expr ℕ) (x0 : expr (list A)) =>
+    Base (#(List_skipn)%expr @ x @ x0)%expr_pat
+| @List_repeat A =>
+    fun (x : expr A) (x0 : expr ℕ) =>
+    Base (#(List_repeat)%expr @ x @ x0)%expr_pat
+| @List_combine A B =>
+    fun (x : expr (list A)) (x0 : expr (list B)) =>
+    Base (#(List_combine)%expr @ x @ x0)%expr_pat
+| @List_map A B =>
+    fun (x : expr A -> UnderLets (expr B)) (x0 : expr (list A)) =>
+    Base
+      (#(List_map)%expr @ (λ x1 : var A,
+                           to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_app A => fun x x0 : expr (list A) => Base (x ++ x0)%expr
+| @List_rev A =>
+    fun x : expr (list A) => Base (#(List_rev)%expr @ x)%expr_pat
+| @List_flat_map A B =>
+    fun (x : expr A -> UnderLets (expr (list B))) (x0 : expr (list A)) =>
+    Base
+      (#(List_flat_map)%expr @ (λ x1 : var A,
+                                to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_partition A =>
+    fun (x : expr A -> UnderLets (expr bool)) (x0 : expr (list A)) =>
+    Base
+      (#(List_partition)%expr @ (λ x1 : var A,
+                                 to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_fold_right A B =>
+    fun (x : expr B -> expr A -> UnderLets (expr A)) (x0 : expr A)
+      (x1 : expr (list B)) =>
+    Base
+      (#(List_fold_right)%expr @
+       (λ (x2 : var B)(x3 : var A),
+        to_expr (x ($x2) ($x3)))%expr @ x0 @ x1)%expr_pat
+| @List_update_nth T =>
+    fun (x : expr ℕ) (x0 : expr T -> UnderLets (expr T)) (x1 : expr (list T))
+    =>
+    Base
+      (#(List_update_nth)%expr @ x @ (λ x2 : var T,
+                                      to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| @List_nth_default T =>
+    fun (x : expr T) (x0 : expr (list T)) (x1 : expr ℕ) =>
+    Base (#(List_nth_default)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add => fun x x0 : expr ℤ => Base (x + x0)%expr
+| Z_mul =>
+    fun x x0 : expr ℤ =>
     (match x with
      | @expr.Ident _ _ _ t idc =>
-         args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
          match x0 with
          | @expr.App _ _ _ s _
            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x2) x1 =>
-             (_ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_land;
-              match x1 with
+             (match x1 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  _ <- invert_bind_args idc0 Raw.ident.Z_land;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
                   match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base base.type.Z))))
+                    pattern.type.unify_extracted_cps (ℤ -> ℤ -> ℤ)%ptype
+                      ((projT1 args1) -> s0 -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args1 =? 2 ^ (2 * Z.log2_up args1 / 2) - 1
+                  | Some (_, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x3 <- (if
+                              (let (x3, _) := idc_args0 in x3) =?
+                              2
+                              ^ (2 *
+                                 Z.log2_up (let (x3, _) := idc_args0 in x3) /
+                                 2) - 1
                              then
-                              (x3 <- invert_low (2 * Z.log2_up args1) args;
-                               Some
-                                 (Some
-                                    (UnderLets.Base
-                                       (#(ident.fancy_mulll
-                                            (2 * Z.log2_up args1))%expr @
-                                        ((##x3)%expr, x' v))%expr_pat)));;;
-                              None
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x2)
+                              x3 <- invert_low
+                                      (2 *
+                                       Z.log2_up
+                                         (let (x3, _) := idc_args0 in x3))
+                                      (let (x3, _) := idc_args in x3);
+                              Some
+                                (#(fancy_mulll
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x4, _) := idc_args0 in x4)))%expr @
+                                 ((##x3)%expr, v (Compile.reflect x2)))%expr_pat
+                             else None);
+                      Some (Base x3)
+                  | None => None
+                  end
               | _ => None
               end;;
               match x2 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match
-                    s as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base base.type.Z))))
-                  with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args1 =? 2 ^ (2 * Z.log2_up args1 / 2) - 1
-                             then
-                              (x3 <- invert_low (2 * Z.log2_up args1) args;
+                  (args <- invert_bind_args idc1 Raw.ident.Literal;
+                   _ <- invert_bind_args idc0 Raw.ident.Z_land;
+                   args1 <- invert_bind_args idc Raw.ident.Literal;
+                   match
+                     pattern.type.unify_extracted_cps (ℤ -> ℤ -> ℤ)%ptype
+                       ((projT1 args1) -> (projT1 args) -> s)%ptype option
+                       (fun x3 : option => x3)
+                   with
+                   | Some (_, (_, _)) =>
+                       idc_args <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args1);
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args);
+                       v <- type.try_make_transport_cps s ℤ;
+                       x3 <- (if
+                               (let (x3, _) := idc_args0 in x3) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x3, _) := idc_args0 in x3) /
+                                  2) - 1
+                              then
+                               x3 <- invert_low
+                                       (2 *
+                                        Z.log2_up
+                                          (let (x3, _) := idc_args0 in x3))
+                                       (let (x3, _) := idc_args in x3);
                                Some
-                                 (Some
-                                    (UnderLets.Base
-                                       (#(ident.fancy_mulll
-                                            (2 * Z.log2_up args1))%expr @
-                                        ((##x3)%expr, x' v))%expr_pat)));;;
-                              None
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x1);;
+                                 (#(fancy_mulll
+                                      (2 *
+                                       Z.log2_up
+                                         (let (x4, _) := idc_args0 in x4)))%expr @
+                                  ((##x3)%expr, v (Compile.reflect x1)))%expr_pat
+                              else None);
+                       Some (Base x3)
+                   | None => None
+                   end);;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  _ <- invert_bind_args idc0 Raw.ident.Z_land;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
                   match
-                    s as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base base.type.Z))))
+                    pattern.type.unify_extracted_cps (ℤ -> ℤ -> ℤ)%ptype
+                      ((projT1 args1) -> (projT1 args) -> s)%ptype option
+                      (fun x3 : option => x3)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args1 =? 2 ^ (2 * Z.log2_up args1 / 2) - 1
+                  | Some (_, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      v <- type.try_make_transport_cps s ℤ;
+                      x3 <- (if
+                              (let (x3, _) := idc_args0 in x3) =?
+                              2
+                              ^ (2 *
+                                 Z.log2_up (let (x3, _) := idc_args0 in x3) /
+                                 2) - 1
                              then
-                              (x3 <- invert_high (2 * Z.log2_up args1) args;
-                               Some
-                                 (Some
-                                    (UnderLets.Base
-                                       (#(ident.fancy_mulhl
-                                            (2 * Z.log2_up args1))%expr @
-                                        ((##x3)%expr, x' v))%expr_pat)));;;
-                              None
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x1)
+                              x3 <- invert_high
+                                      (2 *
+                                       Z.log2_up
+                                         (let (x3, _) := idc_args0 in x3))
+                                      (let (x3, _) := idc_args in x3);
+                              Some
+                                (#(fancy_mulhl
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x4, _) := idc_args0 in x4)))%expr @
+                                 ((##x3)%expr, v (Compile.reflect x1)))%expr_pat
+                             else None);
+                      Some (Base x3)
+                  | None => None
+                  end
               | _ => None
               end;;
               match x1 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  _ <- invert_bind_args idc0 Raw.ident.Z_land;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
                   match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base base.type.Z))))
+                    pattern.type.unify_extracted_cps (ℤ -> ℤ -> ℤ)%ptype
+                      ((projT1 args1) -> s0 -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args1 =? 2 ^ (2 * Z.log2_up args1 / 2) - 1
+                  | Some (_, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x3 <- (if
+                              (let (x3, _) := idc_args0 in x3) =?
+                              2
+                              ^ (2 *
+                                 Z.log2_up (let (x3, _) := idc_args0 in x3) /
+                                 2) - 1
                              then
-                              (x3 <- invert_high (2 * Z.log2_up args1) args;
-                               Some
-                                 (Some
-                                    (UnderLets.Base
-                                       (#(ident.fancy_mulhl
-                                            (2 * Z.log2_up args1))%expr @
-                                        ((##x3)%expr, x' v))%expr_pat)));;;
-                              None
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x2)
+                              x3 <- invert_high
+                                      (2 *
+                                       Z.log2_up
+                                         (let (x3, _) := idc_args0 in x3))
+                                      (let (x3, _) := idc_args in x3);
+                              Some
+                                (#(fancy_mulhl
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x4, _) := idc_args0 in x4)))%expr @
+                                 ((##x3)%expr, v (Compile.reflect x2)))%expr_pat
+                             else None);
+                      Some (Base x3)
+                  | None => None
+                  end
               | _ => None
               end);;
-             _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftr;
              match x1 with
              | @expr.Ident _ _ _ t1 idc1 =>
-                 args1 <- pattern.ident.invert_bind_args idc1
-                            pattern.ident.LiteralZ;
-                 match
-                   s0 as t2
-                   return
-                     (Compile.value' false t2 ->
-                      option
-                        (UnderLets.UnderLets base.type ident var
-                           (defaults.expr (type.base base.type.Z))))
-                 with
-                 | type.base t2 =>
-                     fun v : defaults.expr (type.base t2) =>
-                     base.try_make_transport_cps t2 base.type.Z
-                       (fun
-                          a : option
-                                (defaults.expr (type.base t2) ->
-                                 defaults.expr (type.base base.type.Z)) =>
-                        match a with
-                        | Some x' =>
-                            (x3 <- invert_low (2 * args1) args;
+                 (args <- invert_bind_args idc1 Raw.ident.Literal;
+                  _ <- invert_bind_args idc0 Raw.ident.Z_shiftr;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps (ℤ -> ℤ -> ℤ)%ptype
+                      ((projT1 args1) -> s0 -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
+                  with
+                  | Some (_, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x3 <- (x3 <- invert_low
+                                     (2 * (let (x3, _) := idc_args0 in x3))
+                                     (let (x3, _) := idc_args in x3);
                              Some
-                               (Some
-                                  (UnderLets.Base
-                                     (#(ident.fancy_mullh (2 * args1))%expr @
-                                      ((##x3)%expr, x' v))%expr_pat)));;;
-                            None
-                        | None => None
-                        end)
-                 | (s1 -> d1)%ptype =>
-                     fun
-                       _ : Compile.value' false s1 -> Compile.value' true d1
-                     => None
-                 end (Compile.reflect x2);;
+                               (#(fancy_mullh
+                                    (2 * (let (x4, _) := idc_args0 in x4)))%expr @
+                                ((##x3)%expr, v (Compile.reflect x2)))%expr_pat);
+                      Some (Base x3)
+                  | None => None
+                  end);;
+                 args <- invert_bind_args idc1 Raw.ident.Literal;
+                 _ <- invert_bind_args idc0 Raw.ident.Z_shiftr;
+                 args1 <- invert_bind_args idc Raw.ident.Literal;
                  match
-                   s0 as t2
-                   return
-                     (Compile.value' false t2 ->
-                      option
-                        (UnderLets.UnderLets base.type ident var
-                           (defaults.expr (type.base base.type.Z))))
+                   pattern.type.unify_extracted_cps (ℤ -> ℤ -> ℤ)%ptype
+                     ((projT1 args1) -> s0 -> (projT1 args))%ptype option
+                     (fun x3 : option => x3)
                  with
-                 | type.base t2 =>
-                     fun v : defaults.expr (type.base t2) =>
-                     base.try_make_transport_cps t2 base.type.Z
-                       (fun
-                          a : option
-                                (defaults.expr (type.base t2) ->
-                                 defaults.expr (type.base base.type.Z)) =>
-                        match a with
-                        | Some x' =>
-                            (x3 <- invert_high (2 * args1) args;
-                             Some
-                               (Some
-                                  (UnderLets.Base
-                                     (#(ident.fancy_mulhh (2 * args1))%expr @
-                                      ((##x3)%expr, x' v))%expr_pat)));;;
-                            None
-                        | None => None
-                        end)
-                 | (s1 -> d1)%ptype =>
-                     fun
-                       _ : Compile.value' false s1 -> Compile.value' true d1
-                     => None
-                 end (Compile.reflect x2)
+                 | Some (_, (_, _)) =>
+                     idc_args <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args1);
+                     v <- type.try_make_transport_cps s0 ℤ;
+                     idc_args0 <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args);
+                     x3 <- (x3 <- invert_high
+                                    (2 * (let (x3, _) := idc_args0 in x3))
+                                    (let (x3, _) := idc_args in x3);
+                            Some
+                              (#(fancy_mulhh
+                                   (2 * (let (x4, _) := idc_args0 in x4)))%expr @
+                               ((##x3)%expr, v (Compile.reflect x2)))%expr_pat);
+                     Some (Base x3)
+                 | None => None
+                 end
              | _ => None
              end
          | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ |
@@ -482,279 +342,237 @@ match idc in (ident t) return (Compile.value' true t) with
          end
      | @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x2) x1 =>
-         (_ <- pattern.ident.invert_bind_args idc pattern.ident.Z_land;
-          match x2 with
+         (match x2 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
                   match
-                    s as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base base.type.Z))))
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args0) -> s) -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args0 =? 2 ^ (2 * Z.log2_up args0 / 2) - 1
+                  | Some (_, _, _) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args0);
+                      v <- type.try_make_transport_cps s ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x3 <- (if
+                              (let (x3, _) := idc_args in x3) =?
+                              2
+                              ^ (2 *
+                                 Z.log2_up (let (x3, _) := idc_args in x3) /
+                                 2) - 1
                              then
-                              (y <- invert_low (2 * Z.log2_up args0) args1;
-                               Some
-                                 (Some
-                                    (UnderLets.Base
-                                       (#(ident.fancy_mulll
-                                            (2 * Z.log2_up args0))%expr @
-                                        (x' v, (##y)%expr))%expr_pat)));;;
-                              None
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x1)
+                              y <- invert_low
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x3, _) := idc_args in x3))
+                                     (let (x3, _) := idc_args0 in x3);
+                              Some
+                                (#(fancy_mulll
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x3, _) := idc_args in x3)))%expr @
+                                 (v (Compile.reflect x1), (##y)%expr))%expr_pat
+                             else None);
+                      Some (Base x3)
+                  | None => None
+                  end
               | _ => None
               end
           | _ => None
           end;;
           match x1 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
                   match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base base.type.Z))))
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      ((s0 -> (projT1 args0)) -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args0 =? 2 ^ (2 * Z.log2_up args0 / 2) - 1
+                  | Some (_, _, _) =>
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args0);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x3 <- (if
+                              (let (x3, _) := idc_args in x3) =?
+                              2
+                              ^ (2 *
+                                 Z.log2_up (let (x3, _) := idc_args in x3) /
+                                 2) - 1
                              then
-                              (y <- invert_low (2 * Z.log2_up args0) args1;
-                               Some
-                                 (Some
-                                    (UnderLets.Base
-                                       (#(ident.fancy_mulll
-                                            (2 * Z.log2_up args0))%expr @
-                                        (x' v, (##y)%expr))%expr_pat)));;;
-                              None
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x2)
+                              y <- invert_low
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x3, _) := idc_args in x3))
+                                     (let (x3, _) := idc_args0 in x3);
+                              Some
+                                (#(fancy_mulll
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x3, _) := idc_args in x3)))%expr @
+                                 (v (Compile.reflect x2), (##y)%expr))%expr_pat
+                             else None);
+                      Some (Base x3)
+                  | None => None
+                  end
               | _ => None
               end
           | _ => None
           end;;
           match x2 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
                   match
-                    s as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base base.type.Z))))
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args0) -> s) -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args0 =? 2 ^ (2 * Z.log2_up args0 / 2) - 1
+                  | Some (_, _, _) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args0);
+                      v <- type.try_make_transport_cps s ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x3 <- (if
+                              (let (x3, _) := idc_args in x3) =?
+                              2
+                              ^ (2 *
+                                 Z.log2_up (let (x3, _) := idc_args in x3) /
+                                 2) - 1
                              then
-                              (y <- invert_high (2 * Z.log2_up args0) args1;
-                               Some
-                                 (Some
-                                    (UnderLets.Base
-                                       (#(ident.fancy_mullh
-                                            (2 * Z.log2_up args0))%expr @
-                                        (x' v, (##y)%expr))%expr_pat)));;;
-                              None
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x1)
+                              y <- invert_high
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x3, _) := idc_args in x3))
+                                     (let (x3, _) := idc_args0 in x3);
+                              Some
+                                (#(fancy_mullh
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x3, _) := idc_args in x3)))%expr @
+                                 (v (Compile.reflect x1), (##y)%expr))%expr_pat
+                             else None);
+                      Some (Base x3)
+                  | None => None
+                  end
               | _ => None
               end
           | _ => None
           end;;
           match x1 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
                   match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base base.type.Z))))
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      ((s0 -> (projT1 args0)) -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args0 =? 2 ^ (2 * Z.log2_up args0 / 2) - 1
+                  | Some (_, _, _) =>
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args0);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x3 <- (if
+                              (let (x3, _) := idc_args in x3) =?
+                              2
+                              ^ (2 *
+                                 Z.log2_up (let (x3, _) := idc_args in x3) /
+                                 2) - 1
                              then
-                              (y <- invert_high (2 * Z.log2_up args0) args1;
-                               Some
-                                 (Some
-                                    (UnderLets.Base
-                                       (#(ident.fancy_mullh
-                                            (2 * Z.log2_up args0))%expr @
-                                        (x' v, (##y)%expr))%expr_pat)));;;
-                              None
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x2)
+                              y <- invert_high
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x3, _) := idc_args in x3))
+                                     (let (x3, _) := idc_args0 in x3);
+                              Some
+                                (#(fancy_mullh
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x3, _) := idc_args in x3)))%expr @
+                                 (v (Compile.reflect x2), (##y)%expr))%expr_pat
+                             else None);
+                      Some (Base x3)
+                  | None => None
+                  end
               | _ => None
               end
           | _ => None
           end;;
           match x2 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
               | @expr.App _ _ _ s1 _
-                (@expr.Ident _ _ _ t1 idc1 @ x4)%expr_pat x3 =>
-                  _ <- pattern.ident.invert_bind_args idc1
-                         pattern.ident.Z_land;
-                  match x4 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match
-                        s as t3
-                        return
-                          (Compile.value' false t3 ->
-                           option
-                             (UnderLets.UnderLets base.type ident var
-                                (defaults.expr (type.base base.type.Z))))
-                      with
-                      | type.base t3 =>
-                          fun v : defaults.expr (type.base t3) =>
-                          base.try_make_transport_cps t3 base.type.Z
-                            (fun
-                               a : option
-                                     (defaults.expr (type.base t3) ->
-                                      defaults.expr (type.base base.type.Z))
-                             =>
-                             match a with
-                             | Some x' =>
-                                 match
-                                   s1 as t4
-                                   return
-                                     (Compile.value' false t4 ->
-                                      option
-                                        (UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base base.type.Z))))
-                                 with
-                                 | type.base t4 =>
-                                     fun v0 : defaults.expr (type.base t4) =>
-                                     base.try_make_transport_cps t4
-                                       base.type.Z
-                                       (fun
-                                          a0 : option
-                                                 (defaults.expr
-                                                    (type.base t4) ->
-                                                  defaults.expr
-                                                    (type.base base.type.Z))
-                                        =>
-                                        match a0 with
-                                        | Some x'0 =>
-                                            if
-                                             (args0 =?
-                                              2 ^ (2 * Z.log2_up args0 / 2) -
-                                              1) &&
-                                             (args2 =?
-                                              2 ^ (2 * Z.log2_up args0 / 2) -
-                                              1)
-                                            then
-                                             Some
-                                               (UnderLets.Base
-                                                  (#(ident.fancy_mulll
-                                                       (2 * Z.log2_up args0))%expr @
-                                                   (x' v, x'0 v0))%expr_pat)
-                                            else None
-                                        | None => None
-                                        end)
-                                 | (s3 -> d3)%ptype =>
-                                     fun
-                                       _ : Compile.value' false s3 ->
-                                           Compile.value' true d3 => None
-                                 end (Compile.reflect x3)
-                             | None => None
-                             end)
-                      | (s3 -> d3)%ptype =>
-                          fun
-                            _ : Compile.value' false s3 ->
-                                Compile.value' true d3 => None
-                      end (Compile.reflect x1)
-                  | _ => None
+                (@expr.Ident _ _ _ t1 idc1 @ @expr.Ident _ _ _ t2 idc2)%expr_pat
+                x3 =>
+                  args <- invert_bind_args idc2 Raw.ident.Literal;
+                  _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                  args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
+                  match
+                    pattern.type.unify_extracted_cps
+                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                      (((projT1 args1) -> s) -> (projT1 args) -> s1)%ptype
+                      option (fun x5 : option => x5)
+                  with
+                  | Some (_, _, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      v0 <- type.try_make_transport_cps s1 ℤ;
+                      x5 <- (if
+                              ((let (x5, _) := idc_args in x5) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x5, _) := idc_args in x5) /
+                                  2) - 1) &&
+                              ((let (x5, _) := idc_args0 in x5) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x5, _) := idc_args in x5) /
+                                  2) - 1)
+                             then
+                              Some
+                                (#(fancy_mulll
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x5, _) := idc_args in x5)))%expr @
+                                 (v (Compile.reflect x1),
+                                 v0 (Compile.reflect x3)))%expr_pat
+                             else None);
+                      Some (Base x5)
+                  | None => None
                   end
+              | @expr.App _ _ _ s1 _
+                (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat _ |
+                @expr.App _ _ _ s1 _
+                (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat
+                _ | @expr.App _ _ _ s1 _
+                (@expr.Ident _ _ _ t1 idc1 @ (_ @ _))%expr_pat _ | @expr.App
+                _ _ _ s1 _
+                (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat
+                _ => None
               | @expr.App _ _ _ s1 _ #(_)%expr_pat _ | @expr.App _ _ _ s1 _
                 ($_)%expr _ | @expr.App _ _ _ s1 _ (@expr.Abs _ _ _ _ _ _)
                 _ | @expr.App _ _ _ s1 _ (($_)%expr @ _)%expr_pat _ |
@@ -768,88 +586,59 @@ match idc in (ident t) return (Compile.value' true t) with
           end;;
           match x1 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
               | @expr.App _ _ _ s1 _
-                (@expr.Ident _ _ _ t1 idc1 @ x4)%expr_pat x3 =>
-                  _ <- pattern.ident.invert_bind_args idc1
-                         pattern.ident.Z_land;
-                  match x4 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match
-                        s0 as t3
-                        return
-                          (Compile.value' false t3 ->
-                           option
-                             (UnderLets.UnderLets base.type ident var
-                                (defaults.expr (type.base base.type.Z))))
-                      with
-                      | type.base t3 =>
-                          fun v : defaults.expr (type.base t3) =>
-                          base.try_make_transport_cps t3 base.type.Z
-                            (fun
-                               a : option
-                                     (defaults.expr (type.base t3) ->
-                                      defaults.expr (type.base base.type.Z))
-                             =>
-                             match a with
-                             | Some x' =>
-                                 match
-                                   s1 as t4
-                                   return
-                                     (Compile.value' false t4 ->
-                                      option
-                                        (UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base base.type.Z))))
-                                 with
-                                 | type.base t4 =>
-                                     fun v0 : defaults.expr (type.base t4) =>
-                                     base.try_make_transport_cps t4
-                                       base.type.Z
-                                       (fun
-                                          a0 : option
-                                                 (defaults.expr
-                                                    (type.base t4) ->
-                                                  defaults.expr
-                                                    (type.base base.type.Z))
-                                        =>
-                                        match a0 with
-                                        | Some x'0 =>
-                                            if
-                                             (args0 =?
-                                              2 ^ (2 * Z.log2_up args0 / 2) -
-                                              1) &&
-                                             (args2 =?
-                                              2 ^ (2 * Z.log2_up args0 / 2) -
-                                              1)
-                                            then
-                                             Some
-                                               (UnderLets.Base
-                                                  (#(ident.fancy_mulll
-                                                       (2 * Z.log2_up args0))%expr @
-                                                   (x' v, x'0 v0))%expr_pat)
-                                            else None
-                                        | None => None
-                                        end)
-                                 | (s3 -> d3)%ptype =>
-                                     fun
-                                       _ : Compile.value' false s3 ->
-                                           Compile.value' true d3 => None
-                                 end (Compile.reflect x3)
-                             | None => None
-                             end)
-                      | (s3 -> d3)%ptype =>
-                          fun
-                            _ : Compile.value' false s3 ->
-                                Compile.value' true d3 => None
-                      end (Compile.reflect x2)
-                  | _ => None
+                (@expr.Ident _ _ _ t1 idc1 @ @expr.Ident _ _ _ t2 idc2)%expr_pat
+                x3 =>
+                  args <- invert_bind_args idc2 Raw.ident.Literal;
+                  _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                  args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
+                  match
+                    pattern.type.unify_extracted_cps
+                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                      ((s0 -> (projT1 args1)) -> (projT1 args) -> s1)%ptype
+                      option (fun x5 : option => x5)
+                  with
+                  | Some (_, _, (_, _)) =>
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      v0 <- type.try_make_transport_cps s1 ℤ;
+                      x5 <- (if
+                              ((let (x5, _) := idc_args in x5) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x5, _) := idc_args in x5) /
+                                  2) - 1) &&
+                              ((let (x5, _) := idc_args0 in x5) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x5, _) := idc_args in x5) /
+                                  2) - 1)
+                             then
+                              Some
+                                (#(fancy_mulll
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x5, _) := idc_args in x5)))%expr @
+                                 (v (Compile.reflect x2),
+                                 v0 (Compile.reflect x3)))%expr_pat
+                             else None);
+                      Some (Base x5)
+                  | None => None
                   end
+              | @expr.App _ _ _ s1 _
+                (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat _ |
+                @expr.App _ _ _ s1 _
+                (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat
+                _ | @expr.App _ _ _ s1 _
+                (@expr.Ident _ _ _ t1 idc1 @ (_ @ _))%expr_pat _ | @expr.App
+                _ _ _ s1 _
+                (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat
+                _ => None
               | @expr.App _ _ _ s1 _ #(_)%expr_pat _ | @expr.App _ _ _ s1 _
                 ($_)%expr _ | @expr.App _ _ _ s1 _ (@expr.Abs _ _ _ _ _ _)
                 _ | @expr.App _ _ _ s1 _ (($_)%expr @ _)%expr_pat _ |
@@ -863,87 +652,57 @@ match idc in (ident t) return (Compile.value' true t) with
           end;;
           match x2 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
-              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @ x3)%expr_pat =>
-                  _ <- pattern.ident.invert_bind_args idc1
-                         pattern.ident.Z_land;
-                  match x3 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match
-                        s as t3
-                        return
-                          (Compile.value' false t3 ->
-                           option
-                             (UnderLets.UnderLets base.type ident var
-                                (defaults.expr (type.base base.type.Z))))
-                      with
-                      | type.base t3 =>
-                          fun v : defaults.expr (type.base t3) =>
-                          base.try_make_transport_cps t3 base.type.Z
-                            (fun
-                               a : option
-                                     (defaults.expr (type.base t3) ->
-                                      defaults.expr (type.base base.type.Z))
-                             =>
-                             match a with
-                             | Some x' =>
-                                 match
-                                   s2 as t4
-                                   return
-                                     (Compile.value' false t4 ->
-                                      option
-                                        (UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base base.type.Z))))
-                                 with
-                                 | type.base t4 =>
-                                     fun v0 : defaults.expr (type.base t4) =>
-                                     base.try_make_transport_cps t4
-                                       base.type.Z
-                                       (fun
-                                          a0 : option
-                                                 (defaults.expr
-                                                    (type.base t4) ->
-                                                  defaults.expr
-                                                    (type.base base.type.Z))
-                                        =>
-                                        match a0 with
-                                        | Some x'0 =>
-                                            if
-                                             (args0 =?
-                                              2 ^ (2 * Z.log2_up args0 / 2) -
-                                              1) &&
-                                             (args2 =?
-                                              2 ^ (2 * Z.log2_up args0 / 2) -
-                                              1)
-                                            then
-                                             Some
-                                               (UnderLets.Base
-                                                  (#(ident.fancy_mulll
-                                                       (2 * Z.log2_up args0))%expr @
-                                                   (x' v, x'0 v0))%expr_pat)
-                                            else None
-                                        | None => None
-                                        end)
-                                 | (s3 -> d3)%ptype =>
-                                     fun
-                                       _ : Compile.value' false s3 ->
-                                           Compile.value' true d3 => None
-                                 end (Compile.reflect x4)
-                             | None => None
-                             end)
-                      | (s3 -> d3)%ptype =>
-                          fun
-                            _ : Compile.value' false s3 ->
-                                Compile.value' true d3 => None
-                      end (Compile.reflect x1)
-                  | _ => None
+              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.Ident _ _ _ t2 idc2)%expr_pat =>
+                  args <- invert_bind_args idc2 Raw.ident.Literal;
+                  _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                  args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
+                  match
+                    pattern.type.unify_extracted_cps
+                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                      (((projT1 args1) -> s) -> s2 -> (projT1 args))%ptype
+                      option (fun x5 : option => x5)
+                  with
+                  | Some (_, _, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s ℤ;
+                      v0 <- type.try_make_transport_cps s2 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x5 <- (if
+                              ((let (x5, _) := idc_args in x5) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x5, _) := idc_args in x5) /
+                                  2) - 1) &&
+                              ((let (x5, _) := idc_args0 in x5) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x5, _) := idc_args in x5) /
+                                  2) - 1)
+                             then
+                              Some
+                                (#(fancy_mulll
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x5, _) := idc_args in x5)))%expr @
+                                 (v (Compile.reflect x1),
+                                 v0 (Compile.reflect x4)))%expr_pat
+                             else None);
+                      Some (Base x5)
+                  | None => None
                   end
+              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 ($_)%expr)%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 (_ @ _))%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
               | (@expr.App _ _ _ s2 _ ($_)%expr _ @ _)%expr_pat |
                 (@expr.App _ _ _ s2 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
                 (@expr.App _ _ _ s2 _ (_ @ _) _ @ _)%expr_pat |
@@ -955,87 +714,57 @@ match idc in (ident t) return (Compile.value' true t) with
           end;;
           match x1 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
-              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @ x3)%expr_pat =>
-                  _ <- pattern.ident.invert_bind_args idc1
-                         pattern.ident.Z_land;
-                  match x3 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match
-                        s0 as t3
-                        return
-                          (Compile.value' false t3 ->
-                           option
-                             (UnderLets.UnderLets base.type ident var
-                                (defaults.expr (type.base base.type.Z))))
-                      with
-                      | type.base t3 =>
-                          fun v : defaults.expr (type.base t3) =>
-                          base.try_make_transport_cps t3 base.type.Z
-                            (fun
-                               a : option
-                                     (defaults.expr (type.base t3) ->
-                                      defaults.expr (type.base base.type.Z))
-                             =>
-                             match a with
-                             | Some x' =>
-                                 match
-                                   s2 as t4
-                                   return
-                                     (Compile.value' false t4 ->
-                                      option
-                                        (UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base base.type.Z))))
-                                 with
-                                 | type.base t4 =>
-                                     fun v0 : defaults.expr (type.base t4) =>
-                                     base.try_make_transport_cps t4
-                                       base.type.Z
-                                       (fun
-                                          a0 : option
-                                                 (defaults.expr
-                                                    (type.base t4) ->
-                                                  defaults.expr
-                                                    (type.base base.type.Z))
-                                        =>
-                                        match a0 with
-                                        | Some x'0 =>
-                                            if
-                                             (args0 =?
-                                              2 ^ (2 * Z.log2_up args0 / 2) -
-                                              1) &&
-                                             (args2 =?
-                                              2 ^ (2 * Z.log2_up args0 / 2) -
-                                              1)
-                                            then
-                                             Some
-                                               (UnderLets.Base
-                                                  (#(ident.fancy_mulll
-                                                       (2 * Z.log2_up args0))%expr @
-                                                   (x' v, x'0 v0))%expr_pat)
-                                            else None
-                                        | None => None
-                                        end)
-                                 | (s3 -> d3)%ptype =>
-                                     fun
-                                       _ : Compile.value' false s3 ->
-                                           Compile.value' true d3 => None
-                                 end (Compile.reflect x4)
-                             | None => None
-                             end)
-                      | (s3 -> d3)%ptype =>
-                          fun
-                            _ : Compile.value' false s3 ->
-                                Compile.value' true d3 => None
-                      end (Compile.reflect x2)
-                  | _ => None
+              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.Ident _ _ _ t2 idc2)%expr_pat =>
+                  args <- invert_bind_args idc2 Raw.ident.Literal;
+                  _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                  args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
+                  match
+                    pattern.type.unify_extracted_cps
+                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                      ((s0 -> (projT1 args1)) -> s2 -> (projT1 args))%ptype
+                      option (fun x5 : option => x5)
+                  with
+                  | Some (_, _, (_, _)) =>
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v0 <- type.try_make_transport_cps s2 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x5 <- (if
+                              ((let (x5, _) := idc_args in x5) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x5, _) := idc_args in x5) /
+                                  2) - 1) &&
+                              ((let (x5, _) := idc_args0 in x5) =?
+                               2
+                               ^ (2 *
+                                  Z.log2_up (let (x5, _) := idc_args in x5) /
+                                  2) - 1)
+                             then
+                              Some
+                                (#(fancy_mulll
+                                     (2 *
+                                      Z.log2_up
+                                        (let (x5, _) := idc_args in x5)))%expr @
+                                 (v (Compile.reflect x2),
+                                 v0 (Compile.reflect x4)))%expr_pat
+                             else None);
+                      Some (Base x5)
+                  | None => None
                   end
+              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 ($_)%expr)%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 (_ @ _))%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
               | (@expr.App _ _ _ s2 _ ($_)%expr _ @ _)%expr_pat |
                 (@expr.App _ _ _ s2 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
                 (@expr.App _ _ _ s2 _ (_ @ _) _ @ _)%expr_pat |
@@ -1047,82 +776,48 @@ match idc in (ident t) return (Compile.value' true t) with
           end;;
           match x2 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
-              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @ x3)%expr_pat =>
-                  _ <- pattern.ident.invert_bind_args idc1
-                         pattern.ident.Z_shiftr;
-                  match x3 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match
-                        s as t3
-                        return
-                          (Compile.value' false t3 ->
-                           option
-                             (UnderLets.UnderLets base.type ident var
-                                (defaults.expr (type.base base.type.Z))))
-                      with
-                      | type.base t3 =>
-                          fun v : defaults.expr (type.base t3) =>
-                          base.try_make_transport_cps t3 base.type.Z
-                            (fun
-                               a : option
-                                     (defaults.expr (type.base t3) ->
-                                      defaults.expr (type.base base.type.Z))
-                             =>
-                             match a with
-                             | Some x' =>
-                                 match
-                                   s2 as t4
-                                   return
-                                     (Compile.value' false t4 ->
-                                      option
-                                        (UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base base.type.Z))))
-                                 with
-                                 | type.base t4 =>
-                                     fun v0 : defaults.expr (type.base t4) =>
-                                     base.try_make_transport_cps t4
-                                       base.type.Z
-                                       (fun
-                                          a0 : option
-                                                 (defaults.expr
-                                                    (type.base t4) ->
-                                                  defaults.expr
-                                                    (type.base base.type.Z))
-                                        =>
-                                        match a0 with
-                                        | Some x'0 =>
-                                            if
-                                             args0 =? 2 ^ (2 * args2 / 2) - 1
-                                            then
-                                             Some
-                                               (UnderLets.Base
-                                                  (#(ident.fancy_mullh
-                                                       (2 * args2))%expr @
-                                                   (x' v, x'0 v0))%expr_pat)
-                                            else None
-                                        | None => None
-                                        end)
-                                 | (s3 -> d3)%ptype =>
-                                     fun
-                                       _ : Compile.value' false s3 ->
-                                           Compile.value' true d3 => None
-                                 end (Compile.reflect x4)
-                             | None => None
-                             end)
-                      | (s3 -> d3)%ptype =>
-                          fun
-                            _ : Compile.value' false s3 ->
-                                Compile.value' true d3 => None
-                      end (Compile.reflect x1)
-                  | _ => None
+              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.Ident _ _ _ t2 idc2)%expr_pat =>
+                  args <- invert_bind_args idc2 Raw.ident.Literal;
+                  _ <- invert_bind_args idc1 Raw.ident.Z_shiftr;
+                  args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
+                  match
+                    pattern.type.unify_extracted_cps
+                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                      (((projT1 args1) -> s) -> s2 -> (projT1 args))%ptype
+                      option (fun x5 : option => x5)
+                  with
+                  | Some (_, _, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s ℤ;
+                      v0 <- type.try_make_transport_cps s2 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x5 <- (if
+                              (let (x5, _) := idc_args in x5) =?
+                              2 ^ (2 * (let (x5, _) := idc_args0 in x5) / 2) -
+                              1
+                             then
+                              Some
+                                (#(fancy_mullh
+                                     (2 * (let (x5, _) := idc_args0 in x5)))%expr @
+                                 (v (Compile.reflect x1),
+                                 v0 (Compile.reflect x4)))%expr_pat
+                             else None);
+                      Some (Base x5)
+                  | None => None
                   end
+              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 ($_)%expr)%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 (_ @ _))%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
               | (@expr.App _ _ _ s2 _ ($_)%expr _ @ _)%expr_pat |
                 (@expr.App _ _ _ s2 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
                 (@expr.App _ _ _ s2 _ (_ @ _) _ @ _)%expr_pat |
@@ -1134,82 +829,48 @@ match idc in (ident t) return (Compile.value' true t) with
           end;;
           match x1 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x0 with
-              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @ x3)%expr_pat =>
-                  _ <- pattern.ident.invert_bind_args idc1
-                         pattern.ident.Z_shiftr;
-                  match x3 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match
-                        s0 as t3
-                        return
-                          (Compile.value' false t3 ->
-                           option
-                             (UnderLets.UnderLets base.type ident var
-                                (defaults.expr (type.base base.type.Z))))
-                      with
-                      | type.base t3 =>
-                          fun v : defaults.expr (type.base t3) =>
-                          base.try_make_transport_cps t3 base.type.Z
-                            (fun
-                               a : option
-                                     (defaults.expr (type.base t3) ->
-                                      defaults.expr (type.base base.type.Z))
-                             =>
-                             match a with
-                             | Some x' =>
-                                 match
-                                   s2 as t4
-                                   return
-                                     (Compile.value' false t4 ->
-                                      option
-                                        (UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base base.type.Z))))
-                                 with
-                                 | type.base t4 =>
-                                     fun v0 : defaults.expr (type.base t4) =>
-                                     base.try_make_transport_cps t4
-                                       base.type.Z
-                                       (fun
-                                          a0 : option
-                                                 (defaults.expr
-                                                    (type.base t4) ->
-                                                  defaults.expr
-                                                    (type.base base.type.Z))
-                                        =>
-                                        match a0 with
-                                        | Some x'0 =>
-                                            if
-                                             args0 =? 2 ^ (2 * args2 / 2) - 1
-                                            then
-                                             Some
-                                               (UnderLets.Base
-                                                  (#(ident.fancy_mullh
-                                                       (2 * args2))%expr @
-                                                   (x' v, x'0 v0))%expr_pat)
-                                            else None
-                                        | None => None
-                                        end)
-                                 | (s3 -> d3)%ptype =>
-                                     fun
-                                       _ : Compile.value' false s3 ->
-                                           Compile.value' true d3 => None
-                                 end (Compile.reflect x4)
-                             | None => None
-                             end)
-                      | (s3 -> d3)%ptype =>
-                          fun
-                            _ : Compile.value' false s3 ->
-                                Compile.value' true d3 => None
-                      end (Compile.reflect x2)
-                  | _ => None
+              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.Ident _ _ _ t2 idc2)%expr_pat =>
+                  args <- invert_bind_args idc2 Raw.ident.Literal;
+                  _ <- invert_bind_args idc1 Raw.ident.Z_shiftr;
+                  args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_land;
+                  match
+                    pattern.type.unify_extracted_cps
+                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                      ((s0 -> (projT1 args1)) -> s2 -> (projT1 args))%ptype
+                      option (fun x5 : option => x5)
+                  with
+                  | Some (_, _, (_, _)) =>
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v0 <- type.try_make_transport_cps s2 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x5 <- (if
+                              (let (x5, _) := idc_args in x5) =?
+                              2 ^ (2 * (let (x5, _) := idc_args0 in x5) / 2) -
+                              1
+                             then
+                              Some
+                                (#(fancy_mullh
+                                     (2 * (let (x5, _) := idc_args0 in x5)))%expr @
+                                 (v (Compile.reflect x2),
+                                 v0 (Compile.reflect x4)))%expr_pat
+                             else None);
+                      Some (Base x5)
+                  | None => None
                   end
+              | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 ($_)%expr)%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 (_ @ _))%expr_pat |
+                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
+                 @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
               | (@expr.App _ _ _ s2 _ ($_)%expr _ @ _)%expr_pat |
                 (@expr.App _ _ _ s2 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
                 (@expr.App _ _ _ s2 _ (_ @ _) _ @ _)%expr_pat |
@@ -1219,289 +880,164 @@ match idc in (ident t) return (Compile.value' true t) with
               end
           | _ => None
           end);;
-         _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_shiftr;
          match x1 with
          | @expr.Ident _ _ _ t0 idc0 =>
-             args0 <- pattern.ident.invert_bind_args idc0
-                        pattern.ident.LiteralZ;
              match x0 with
              | @expr.Ident _ _ _ t1 idc1 =>
-                 args1 <- pattern.ident.invert_bind_args idc1
-                            pattern.ident.LiteralZ;
-                 match
-                   s0 as t2
-                   return
-                     (Compile.value' false t2 ->
-                      option
-                        (UnderLets.UnderLets base.type ident var
-                           (defaults.expr (type.base base.type.Z))))
-                 with
-                 | type.base t2 =>
-                     fun v : defaults.expr (type.base t2) =>
-                     base.try_make_transport_cps t2 base.type.Z
-                       (fun
-                          a : option
-                                (defaults.expr (type.base t2) ->
-                                 defaults.expr (type.base base.type.Z)) =>
-                        match a with
-                        | Some x' =>
-                            (y <- invert_low (2 * args0) args1;
+                 (args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  _ <- invert_bind_args idc Raw.ident.Z_shiftr;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      ((s0 -> (projT1 args0)) -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
+                  with
+                  | Some (_, _, _) =>
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args0);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x3 <- (y <- invert_low
+                                    (2 * (let (x3, _) := idc_args in x3))
+                                    (let (x3, _) := idc_args0 in x3);
                              Some
-                               (Some
-                                  (UnderLets.Base
-                                     (#(ident.fancy_mulhl (2 * args0))%expr @
-                                      (x' v, (##y)%expr))%expr_pat)));;;
-                            None
-                        | None => None
-                        end)
-                 | (s1 -> d1)%ptype =>
-                     fun
-                       _ : Compile.value' false s1 -> Compile.value' true d1
-                     => None
-                 end (Compile.reflect x2);;
+                               (#(fancy_mulhl
+                                    (2 * (let (x3, _) := idc_args in x3)))%expr @
+                                (v (Compile.reflect x2), (##y)%expr))%expr_pat);
+                      Some (Base x3)
+                  | None => None
+                  end);;
+                 args <- invert_bind_args idc1 Raw.ident.Literal;
+                 args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                 _ <- invert_bind_args idc Raw.ident.Z_shiftr;
                  match
-                   s0 as t2
-                   return
-                     (Compile.value' false t2 ->
-                      option
-                        (UnderLets.UnderLets base.type ident var
-                           (defaults.expr (type.base base.type.Z))))
+                   pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                     ((s0 -> (projT1 args0)) -> (projT1 args))%ptype option
+                     (fun x3 : option => x3)
                  with
-                 | type.base t2 =>
-                     fun v : defaults.expr (type.base t2) =>
-                     base.try_make_transport_cps t2 base.type.Z
-                       (fun
-                          a : option
-                                (defaults.expr (type.base t2) ->
-                                 defaults.expr (type.base base.type.Z)) =>
-                        match a with
-                        | Some x' =>
-                            (y <- invert_high (2 * args0) args1;
-                             Some
-                               (Some
-                                  (UnderLets.Base
-                                     (#(ident.fancy_mulhh (2 * args0))%expr @
-                                      (x' v, (##y)%expr))%expr_pat)));;;
-                            None
-                        | None => None
-                        end)
-                 | (s1 -> d1)%ptype =>
-                     fun
-                       _ : Compile.value' false s1 -> Compile.value' true d1
-                     => None
-                 end (Compile.reflect x2)
+                 | Some (_, _, _) =>
+                     v <- type.try_make_transport_cps s0 ℤ;
+                     idc_args <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args0);
+                     idc_args0 <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args);
+                     x3 <- (y <- invert_high
+                                   (2 * (let (x3, _) := idc_args in x3))
+                                   (let (x3, _) := idc_args0 in x3);
+                            Some
+                              (#(fancy_mulhh
+                                   (2 * (let (x3, _) := idc_args in x3)))%expr @
+                               (v (Compile.reflect x2), (##y)%expr))%expr_pat);
+                     Some (Base x3)
+                 | None => None
+                 end
              | @expr.App _ _ _ s1 _
                (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4) x3 =>
-                 (_ <- pattern.ident.invert_bind_args idc1
-                         pattern.ident.Z_land;
-                  match x4 with
+                 (match x4 with
                   | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
+                      args <- invert_bind_args idc2 Raw.ident.Literal;
+                      _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                      _ <- invert_bind_args idc Raw.ident.Z_shiftr;
                       match
-                        s0 as t3
-                        return
-                          (Compile.value' false t3 ->
-                           option
-                             (UnderLets.UnderLets base.type ident var
-                                (defaults.expr (type.base base.type.Z))))
+                        pattern.type.unify_extracted_cps
+                          ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                          ((s0 -> (projT1 args1)) -> (projT1 args) -> s1)%ptype
+                          option (fun x5 : option => x5)
                       with
-                      | type.base t3 =>
-                          fun v : defaults.expr (type.base t3) =>
-                          base.try_make_transport_cps t3 base.type.Z
-                            (fun
-                               a : option
-                                     (defaults.expr (type.base t3) ->
-                                      defaults.expr (type.base base.type.Z))
-                             =>
-                             match a with
-                             | Some x' =>
-                                 match
-                                   s1 as t4
-                                   return
-                                     (Compile.value' false t4 ->
-                                      option
-                                        (UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base base.type.Z))))
-                                 with
-                                 | type.base t4 =>
-                                     fun v0 : defaults.expr (type.base t4) =>
-                                     base.try_make_transport_cps t4
-                                       base.type.Z
-                                       (fun
-                                          a0 : option
-                                                 (defaults.expr
-                                                    (type.base t4) ->
-                                                  defaults.expr
-                                                    (type.base base.type.Z))
-                                        =>
-                                        match a0 with
-                                        | Some x'0 =>
-                                            if
-                                             args2 =? 2 ^ (2 * args0 / 2) - 1
-                                            then
-                                             Some
-                                               (UnderLets.Base
-                                                  (#(ident.fancy_mulhl
-                                                       (2 * args0))%expr @
-                                                   (x' v, x'0 v0))%expr_pat)
-                                            else None
-                                        | None => None
-                                        end)
-                                 | (s3 -> d3)%ptype =>
-                                     fun
-                                       _ : Compile.value' false s3 ->
-                                           Compile.value' true d3 => None
-                                 end (Compile.reflect x3)
-                             | None => None
-                             end)
-                      | (s3 -> d3)%ptype =>
-                          fun
-                            _ : Compile.value' false s3 ->
-                                Compile.value' true d3 => None
-                      end (Compile.reflect x2)
+                      | Some (_, _, (_, _)) =>
+                          v <- type.try_make_transport_cps s0 ℤ;
+                          idc_args <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args1);
+                          idc_args0 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args);
+                          v0 <- type.try_make_transport_cps s1 ℤ;
+                          x5 <- (if
+                                  (let (x5, _) := idc_args0 in x5) =?
+                                  2
+                                  ^ (2 * (let (x5, _) := idc_args in x5) / 2) -
+                                  1
+                                 then
+                                  Some
+                                    (#(fancy_mulhl
+                                         (2 * (let (x5, _) := idc_args in x5)))%expr @
+                                     (v (Compile.reflect x2),
+                                     v0 (Compile.reflect x3)))%expr_pat
+                                 else None);
+                          Some (Base x5)
+                      | None => None
+                      end
                   | _ => None
                   end;;
                   match x3 with
                   | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
+                      args <- invert_bind_args idc2 Raw.ident.Literal;
+                      _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                      _ <- invert_bind_args idc Raw.ident.Z_shiftr;
                       match
-                        s0 as t3
-                        return
-                          (Compile.value' false t3 ->
-                           option
-                             (UnderLets.UnderLets base.type ident var
-                                (defaults.expr (type.base base.type.Z))))
+                        pattern.type.unify_extracted_cps
+                          ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                          ((s0 -> (projT1 args1)) -> s2 -> (projT1 args))%ptype
+                          option (fun x5 : option => x5)
                       with
-                      | type.base t3 =>
-                          fun v : defaults.expr (type.base t3) =>
-                          base.try_make_transport_cps t3 base.type.Z
-                            (fun
-                               a : option
-                                     (defaults.expr (type.base t3) ->
-                                      defaults.expr (type.base base.type.Z))
-                             =>
-                             match a with
-                             | Some x' =>
-                                 match
-                                   s2 as t4
-                                   return
-                                     (Compile.value' false t4 ->
-                                      option
-                                        (UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base base.type.Z))))
-                                 with
-                                 | type.base t4 =>
-                                     fun v0 : defaults.expr (type.base t4) =>
-                                     base.try_make_transport_cps t4
-                                       base.type.Z
-                                       (fun
-                                          a0 : option
-                                                 (defaults.expr
-                                                    (type.base t4) ->
-                                                  defaults.expr
-                                                    (type.base base.type.Z))
-                                        =>
-                                        match a0 with
-                                        | Some x'0 =>
-                                            if
-                                             args2 =? 2 ^ (2 * args0 / 2) - 1
-                                            then
-                                             Some
-                                               (UnderLets.Base
-                                                  (#(ident.fancy_mulhl
-                                                       (2 * args0))%expr @
-                                                   (x' v, x'0 v0))%expr_pat)
-                                            else None
-                                        | None => None
-                                        end)
-                                 | (s3 -> d3)%ptype =>
-                                     fun
-                                       _ : Compile.value' false s3 ->
-                                           Compile.value' true d3 => None
-                                 end (Compile.reflect x4)
-                             | None => None
-                             end)
-                      | (s3 -> d3)%ptype =>
-                          fun
-                            _ : Compile.value' false s3 ->
-                                Compile.value' true d3 => None
-                      end (Compile.reflect x2)
+                      | Some (_, _, (_, _)) =>
+                          v <- type.try_make_transport_cps s0 ℤ;
+                          idc_args <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args1);
+                          v0 <- type.try_make_transport_cps s2 ℤ;
+                          idc_args0 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args);
+                          x5 <- (if
+                                  (let (x5, _) := idc_args0 in x5) =?
+                                  2
+                                  ^ (2 * (let (x5, _) := idc_args in x5) / 2) -
+                                  1
+                                 then
+                                  Some
+                                    (#(fancy_mulhl
+                                         (2 * (let (x5, _) := idc_args in x5)))%expr @
+                                     (v (Compile.reflect x2),
+                                     v0 (Compile.reflect x4)))%expr_pat
+                                 else None);
+                          Some (Base x5)
+                      | None => None
+                      end
                   | _ => None
                   end);;
-                 _ <- pattern.ident.invert_bind_args idc1
-                        pattern.ident.Z_shiftr;
                  match x3 with
                  | @expr.Ident _ _ _ t2 idc2 =>
-                     args2 <- pattern.ident.invert_bind_args idc2
-                                pattern.ident.LiteralZ;
+                     args <- invert_bind_args idc2 Raw.ident.Literal;
+                     _ <- invert_bind_args idc1 Raw.ident.Z_shiftr;
+                     args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                     _ <- invert_bind_args idc Raw.ident.Z_shiftr;
                      match
-                       s0 as t3
-                       return
-                         (Compile.value' false t3 ->
-                          option
-                            (UnderLets.UnderLets base.type ident var
-                               (defaults.expr (type.base base.type.Z))))
+                       pattern.type.unify_extracted_cps
+                         ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                         ((s0 -> (projT1 args1)) -> s2 -> (projT1 args))%ptype
+                         option (fun x5 : option => x5)
                      with
-                     | type.base t3 =>
-                         fun v : defaults.expr (type.base t3) =>
-                         base.try_make_transport_cps t3 base.type.Z
-                           (fun
-                              a : option
-                                    (defaults.expr (type.base t3) ->
-                                     defaults.expr (type.base base.type.Z))
-                            =>
-                            match a with
-                            | Some x' =>
-                                match
-                                  s2 as t4
-                                  return
-                                    (Compile.value' false t4 ->
-                                     option
-                                       (UnderLets.UnderLets base.type ident
-                                          var
-                                          (defaults.expr
-                                             (type.base base.type.Z))))
-                                with
-                                | type.base t4 =>
-                                    fun v0 : defaults.expr (type.base t4) =>
-                                    base.try_make_transport_cps t4
-                                      base.type.Z
-                                      (fun
-                                         a0 : option
-                                                (defaults.expr (type.base t4) ->
-                                                 defaults.expr
-                                                   (type.base base.type.Z))
-                                       =>
-                                       match a0 with
-                                       | Some x'0 =>
-                                           if args0 =? args2
-                                           then
-                                            Some
-                                              (UnderLets.Base
-                                                 (#(ident.fancy_mulhh
-                                                      (2 * args0))%expr @
-                                                  (x' v, x'0 v0))%expr_pat)
-                                           else None
-                                       | None => None
-                                       end)
-                                | (s3 -> d3)%ptype =>
-                                    fun
-                                      _ : Compile.value' false s3 ->
-                                          Compile.value' true d3 => None
-                                end (Compile.reflect x4)
-                            | None => None
-                            end)
-                     | (s3 -> d3)%ptype =>
-                         fun
-                           _ : Compile.value' false s3 ->
-                               Compile.value' true d3 => None
-                     end (Compile.reflect x2)
+                     | Some (_, _, (_, _)) =>
+                         v <- type.try_make_transport_cps s0 ℤ;
+                         idc_args <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args1);
+                         v0 <- type.try_make_transport_cps s2 ℤ;
+                         idc_args0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                         x5 <- (if
+                                 (let (x5, _) := idc_args in x5) =?
+                                 (let (x5, _) := idc_args0 in x5)
+                                then
+                                 Some
+                                   (#(fancy_mulhh
+                                        (2 * (let (x5, _) := idc_args in x5)))%expr @
+                                    (v (Compile.reflect x2),
+                                    v0 (Compile.reflect x4)))%expr_pat
+                                else None);
+                         Some (Base x5)
+                     | None => None
+                     end
                  | _ => None
                  end
              | @expr.App _ _ _ s1 _ (@expr.App _ _ _ s2 _ ($_)%expr _) _ |
@@ -1526,110 +1062,68 @@ match idc in (ident t) return (Compile.value' true t) with
        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
      | _ => None
      end;;;
-     UnderLets.Base (x * x0)%expr)%option
-| ident.Z_pow =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_pow)%expr @ x @ x0)%expr_pat
-| ident.Z_sub =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x - x0)%expr
-| ident.Z_opp =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (- x)%expr
-| ident.Z_div =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x / x0)%expr
-| ident.Z_modulo =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x mod x0)%expr
-| ident.Z_log2 =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_log2)%expr @ x)%expr_pat
-| ident.Z_log2_up =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_log2_up)%expr @ x)%expr_pat
-| ident.Z_eqb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_eqb)%expr @ x @ x0)%expr_pat
-| ident.Z_leb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_leb)%expr @ x @ x0)%expr_pat
-| ident.Z_geb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_geb)%expr @ x @ x0)%expr_pat
-| ident.Z_of_nat =>
-    fun x : defaults.expr (type.base base.type.nat) =>
-    UnderLets.Base (#(ident.Z_of_nat)%expr @ x)%expr_pat
-| ident.Z_to_nat =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_to_nat)%expr @ x)%expr_pat
-| ident.Z_shiftr =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x >> x0)%expr
-| ident.Z_shiftl =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x << x0)%expr
-| ident.Z_land =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x &' x0)%expr
-| ident.Z_lor =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (x || x0)%expr
-| ident.Z_bneg =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_bneg)%expr @ x)%expr_pat
-| ident.Z_lnot_modulo =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_lnot_modulo)%expr @ x @ x0)%expr_pat
-| ident.Z_mul_split =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
-| ident.Z_add_get_carry =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (x * x0)%expr)%option
+| Z_pow => fun x x0 : expr ℤ => Base (#(Z_pow)%expr @ x @ x0)%expr_pat
+| Z_sub => fun x x0 : expr ℤ => Base (x - x0)%expr
+| Z_opp => fun x : expr ℤ => Base (- x)%expr
+| Z_div => fun x x0 : expr ℤ => Base (x / x0)%expr
+| Z_modulo => fun x x0 : expr ℤ => Base (x mod x0)%expr
+| Z_log2 => fun x : expr ℤ => Base (#(Z_log2)%expr @ x)%expr_pat
+| Z_log2_up => fun x : expr ℤ => Base (#(Z_log2_up)%expr @ x)%expr_pat
+| Z_eqb => fun x x0 : expr ℤ => Base (#(Z_eqb)%expr @ x @ x0)%expr_pat
+| Z_leb => fun x x0 : expr ℤ => Base (#(Z_leb)%expr @ x @ x0)%expr_pat
+| Z_geb => fun x x0 : expr ℤ => Base (#(Z_geb)%expr @ x @ x0)%expr_pat
+| Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
+| Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
+| Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
+| Z_shiftl => fun x x0 : expr ℤ => Base (x << x0)%expr
+| Z_land => fun x x0 : expr ℤ => Base (x &' x0)%expr
+| Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
+| Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
+| Z_lnot_modulo =>
+    fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
+| Z_mul_split =>
+    fun x x0 x1 : expr ℤ => Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add_get_carry =>
+    fun x x0 x1 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x1 with
-          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftl;
-              match x2 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
-                  with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
-                             then
-                              Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_add (Z.log2 args) args1)%expr @
-                                    (x0, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x3)
-              | _ => None
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @
+             @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              _ <- invert_bind_args idc0 Raw.ident.Z_shiftl;
+              args1 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                  (((projT1 args1) -> ℤ) -> s0 -> (projT1 args))%ptype option
+                  (fun x4 : option => x4)
+              with
+              | Some (_, _, (_, _)) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args1);
+                  v <- type.try_make_transport_cps s0 ℤ;
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  x4 <- (if
+                          (let (x4, _) := idc_args in x4) =?
+                          2 ^ Z.log2 (let (x4, _) := idc_args in x4)
+                         then
+                          Some
+                            (#(fancy_add
+                                 (Z.log2 (let (x4, _) := idc_args in x4))
+                                 (let (x4, _) := idc_args0 in x4))%expr @
+                             (x0, v (Compile.reflect x3)))%expr_pat
+                         else None);
+                  Some (Base x4)
+              | None => None
               end
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ ($_)%expr)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ @expr.Abs
+             _ _ _ _ _ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ (_ @ _))%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @
+             @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
           | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
             (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
             (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
@@ -1638,46 +1132,41 @@ match idc in (ident t) return (Compile.value' true t) with
           | _ => None
           end;;
           match x0 with
-          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftl;
-              match x2 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
-                  with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
-                             then
-                              Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_add (Z.log2 args) args1)%expr @
-                                    (x1, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x3)
-              | _ => None
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @
+             @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              _ <- invert_bind_args idc0 Raw.ident.Z_shiftl;
+              args1 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps ((ℤ -> ℤ -> ℤ) -> ℤ)%ptype
+                  (((projT1 args1) -> s0 -> (projT1 args)) -> ℤ)%ptype option
+                  (fun x4 : option => x4)
+              with
+              | Some (_, (_, _), _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args1);
+                  v <- type.try_make_transport_cps s0 ℤ;
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  x4 <- (if
+                          (let (x4, _) := idc_args in x4) =?
+                          2 ^ Z.log2 (let (x4, _) := idc_args in x4)
+                         then
+                          Some
+                            (#(fancy_add
+                                 (Z.log2 (let (x4, _) := idc_args in x4))
+                                 (let (x4, _) := idc_args0 in x4))%expr @
+                             (x1, v (Compile.reflect x3)))%expr_pat
+                         else None);
+                  Some (Base x4)
+              | None => None
               end
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ ($_)%expr)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ @expr.Abs
+             _ _ _ _ _ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ (_ @ _))%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @
+             @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
           | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
             (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
             (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
@@ -1686,46 +1175,41 @@ match idc in (ident t) return (Compile.value' true t) with
           | _ => None
           end;;
           match x1 with
-          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftr;
-              match x2 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
-                  with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
-                             then
-                              Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_add (Z.log2 args) (- args1))%expr @
-                                    (x0, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x3)
-              | _ => None
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @
+             @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              _ <- invert_bind_args idc0 Raw.ident.Z_shiftr;
+              args1 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                  (((projT1 args1) -> ℤ) -> s0 -> (projT1 args))%ptype option
+                  (fun x4 : option => x4)
+              with
+              | Some (_, _, (_, _)) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args1);
+                  v <- type.try_make_transport_cps s0 ℤ;
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  x4 <- (if
+                          (let (x4, _) := idc_args in x4) =?
+                          2 ^ Z.log2 (let (x4, _) := idc_args in x4)
+                         then
+                          Some
+                            (#(fancy_add
+                                 (Z.log2 (let (x4, _) := idc_args in x4))
+                                 (- (let (x4, _) := idc_args0 in x4)))%expr @
+                             (x0, v (Compile.reflect x3)))%expr_pat
+                         else None);
+                  Some (Base x4)
+              | None => None
               end
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ ($_)%expr)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ @expr.Abs
+             _ _ _ _ _ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ (_ @ _))%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @
+             @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
           | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
             (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
             (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
@@ -1734,358 +1218,346 @@ match idc in (ident t) return (Compile.value' true t) with
           | _ => None
           end;;
           match x0 with
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @
+             @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              _ <- invert_bind_args idc0 Raw.ident.Z_shiftr;
+              args1 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps ((ℤ -> ℤ -> ℤ) -> ℤ)%ptype
+                  (((projT1 args1) -> s0 -> (projT1 args)) -> ℤ)%ptype option
+                  (fun x4 : option => x4)
+              with
+              | Some (_, (_, _), _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args1);
+                  v <- type.try_make_transport_cps s0 ℤ;
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  x4 <- (if
+                          (let (x4, _) := idc_args in x4) =?
+                          2 ^ Z.log2 (let (x4, _) := idc_args in x4)
+                         then
+                          Some
+                            (#(fancy_add
+                                 (Z.log2 (let (x4, _) := idc_args in x4))
+                                 (- (let (x4, _) := idc_args0 in x4)))%expr @
+                             (x1, v (Compile.reflect x3)))%expr_pat
+                         else None);
+                  Some (Base x4)
+              | None => None
+              end
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ ($_)%expr)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ @expr.Abs
+             _ _ _ _ _ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ (_ @ _))%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @
+             @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+              None
+          | _ => None
+          end;;
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+              (((projT1 args) -> ℤ) -> ℤ)%ptype option
+              (fun x2 : option => x2)
+          with
+          | Some (_, _, _) =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x2 <- (if
+                      (let (x2, _) := idc_args in x2) =?
+                      2 ^ Z.log2 (let (x2, _) := idc_args in x2)
+                     then
+                      Some
+                        (#(fancy_add (Z.log2 (let (x2, _) := idc_args in x2))
+                             0)%expr @ (x0, x1))%expr_pat
+                     else None);
+              Some (Base x2)
+          | None => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_with_carry =>
+    fun x x0 x1 : expr ℤ =>
+    Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add_with_get_carry =>
+    fun x x0 x1 x2 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x2 with
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @
+             @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              _ <- invert_bind_args idc0 Raw.ident.Z_shiftl;
+              args1 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps
+                  (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
+                  ((((projT1 args1) -> ℤ) -> ℤ) -> s0 -> (projT1 args))%ptype
+                  option (fun x5 : option => x5)
+              with
+              | Some (_, _, _, (_, _)) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args1);
+                  v <- type.try_make_transport_cps s0 ℤ;
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  x5 <- (if
+                          (let (x5, _) := idc_args in x5) =?
+                          2 ^ Z.log2 (let (x5, _) := idc_args in x5)
+                         then
+                          Some
+                            (#(fancy_addc
+                                 (Z.log2 (let (x5, _) := idc_args in x5))
+                                 (let (x5, _) := idc_args0 in x5))%expr @
+                             (x0, x1, v (Compile.reflect x4)))%expr_pat
+                         else None);
+                  Some (Base x5)
+              | None => None
+              end
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ ($_)%expr)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ @expr.Abs
+             _ _ _ _ _ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ (_ @ _))%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @
+             @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+              None
+          | _ => None
+          end;;
+          match x1 with
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @
+             @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              _ <- invert_bind_args idc0 Raw.ident.Z_shiftl;
+              args1 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps
+                  (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
+                  ((((projT1 args1) -> ℤ) -> s0 -> (projT1 args)) -> ℤ)%ptype
+                  option (fun x5 : option => x5)
+              with
+              | Some (_, _, (_, _), _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args1);
+                  v <- type.try_make_transport_cps s0 ℤ;
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  x5 <- (if
+                          (let (x5, _) := idc_args in x5) =?
+                          2 ^ Z.log2 (let (x5, _) := idc_args in x5)
+                         then
+                          Some
+                            (#(fancy_addc
+                                 (Z.log2 (let (x5, _) := idc_args in x5))
+                                 (let (x5, _) := idc_args0 in x5))%expr @
+                             (x0, x2, v (Compile.reflect x4)))%expr_pat
+                         else None);
+                  Some (Base x5)
+              | None => None
+              end
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ ($_)%expr)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ @expr.Abs
+             _ _ _ _ _ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ (_ @ _))%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @
+             @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+              None
+          | _ => None
+          end;;
+          match x2 with
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @
+             @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              _ <- invert_bind_args idc0 Raw.ident.Z_shiftr;
+              args1 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps
+                  (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
+                  ((((projT1 args1) -> ℤ) -> ℤ) -> s0 -> (projT1 args))%ptype
+                  option (fun x5 : option => x5)
+              with
+              | Some (_, _, _, (_, _)) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args1);
+                  v <- type.try_make_transport_cps s0 ℤ;
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  x5 <- (if
+                          (let (x5, _) := idc_args in x5) =?
+                          2 ^ Z.log2 (let (x5, _) := idc_args in x5)
+                         then
+                          Some
+                            (#(fancy_addc
+                                 (Z.log2 (let (x5, _) := idc_args in x5))
+                                 (- (let (x5, _) := idc_args0 in x5)))%expr @
+                             (x0, x1, v (Compile.reflect x4)))%expr_pat
+                         else None);
+                  Some (Base x5)
+              | None => None
+              end
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ ($_)%expr)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ @expr.Abs
+             _ _ _ _ _ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ (_ @ _))%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @
+             @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+              None
+          | _ => None
+          end;;
+          match x1 with
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @
+             @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              _ <- invert_bind_args idc0 Raw.ident.Z_shiftr;
+              args1 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps
+                  (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
+                  ((((projT1 args1) -> ℤ) -> s0 -> (projT1 args)) -> ℤ)%ptype
+                  option (fun x5 : option => x5)
+              with
+              | Some (_, _, (_, _), _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args1);
+                  v <- type.try_make_transport_cps s0 ℤ;
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  x5 <- (if
+                          (let (x5, _) := idc_args in x5) =?
+                          2 ^ Z.log2 (let (x5, _) := idc_args in x5)
+                         then
+                          Some
+                            (#(fancy_addc
+                                 (Z.log2 (let (x5, _) := idc_args in x5))
+                                 (- (let (x5, _) := idc_args0 in x5)))%expr @
+                             (x0, x2, v (Compile.reflect x4)))%expr_pat
+                         else None);
+                  Some (Base x5)
+              | None => None
+              end
+          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ ($_)%expr)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ @expr.Abs
+             _ _ _ _ _ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ (_ @ _))%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @
+             @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
+            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+              None
+          | _ => None
+          end;;
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+              ((((projT1 args) -> ℤ) -> ℤ) -> ℤ)%ptype option
+              (fun x3 : option => x3)
+          with
+          | Some (_, _, _, _) =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x3 <- (if
+                      (let (x3, _) := idc_args in x3) =?
+                      2 ^ Z.log2 (let (x3, _) := idc_args in x3)
+                     then
+                      Some
+                        (#(fancy_addc
+                             (Z.log2 (let (x3, _) := idc_args in x3)) 0)%expr @
+                         (x0, x1, x2))%expr_pat
+                     else None);
+              Some (Base x3)
+          | None => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+| Z_sub_get_borrow =>
+    fun x x0 x1 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x1 with
           | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftr;
               match x2 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  _ <- invert_bind_args idc0 Raw.ident.Z_shiftl;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
                   match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
+                    pattern.type.unify_extracted_cps
+                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                      (((projT1 args1) -> ℤ) -> s0 -> (projT1 args))%ptype
+                      option (fun x4 : option => x4)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
+                  | Some (_, _, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x4 <- (if
+                              (let (x4, _) := idc_args in x4) =?
+                              2 ^ Z.log2 (let (x4, _) := idc_args in x4)
                              then
                               Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_add (Z.log2 args) (- args1))%expr @
-                                    (x1, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x3)
+                                (#(fancy_sub
+                                     (Z.log2 (let (x4, _) := idc_args in x4))
+                                     (let (x4, _) := idc_args0 in x4))%expr @
+                                 (x0, v (Compile.reflect x3)))%expr_pat
+                             else None);
+                      Some (Base x4)
+                  | None => None
+                  end
               | _ => None
-              end
-          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-              None
-          | _ => None
-          end;;
-          (if args =? 2 ^ Z.log2 args
-           then
-            Some
-              (UnderLets.Base
-                 (#(ident.fancy_add (Z.log2 args) 0)%expr @ (x0, x1))%expr_pat)
-           else None)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_with_carry =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
-| ident.Z_add_with_get_carry =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x2 with
-          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ x3)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftl;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
-                  with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
-                             then
-                              Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_addc (Z.log2 args) args1)%expr @
-                                    (x0, x1, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x4)
-              | _ => None
-              end
-          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-              None
-          | _ => None
-          end;;
-          match x1 with
-          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ x3)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftl;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
-                  with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
-                             then
-                              Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_addc (Z.log2 args) args1)%expr @
-                                    (x0, x2, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x4)
-              | _ => None
-              end
-          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-              None
-          | _ => None
-          end;;
-          match x2 with
-          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ x3)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftr;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
-                  with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
-                             then
-                              Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_addc (Z.log2 args)
-                                        (- args1))%expr @ (x0, x1, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x4)
-              | _ => None
-              end
-          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-              None
-          | _ => None
-          end;;
-          match x1 with
-          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ x3)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftr;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
-                  with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
-                             then
-                              Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_addc (Z.log2 args)
-                                        (- args1))%expr @ (x0, x2, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x4)
-              | _ => None
-              end
-          | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (_ @ _) _ @ _)%expr_pat |
-            (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-              None
-          | _ => None
-          end;;
-          (if args =? 2 ^ Z.log2 args
-           then
-            Some
-              (UnderLets.Base
-                 (#(ident.fancy_addc (Z.log2 args) 0)%expr @ (x0, x1, x2))%expr_pat)
-           else None)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base
-       (#(ident.Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
-| ident.Z_sub_get_borrow =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x1 with
-          | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x3 @ x2)%expr_pat =>
-              (_ <- pattern.ident.invert_bind_args idc0
-                      pattern.ident.Z_shiftl;
-               match x2 with
-               | @expr.Ident _ _ _ t1 idc1 =>
-                   args1 <- pattern.ident.invert_bind_args idc1
-                              pattern.ident.LiteralZ;
-                   match
-                     s0 as t2
-                     return
-                       (Compile.value' false t2 ->
-                        option
-                          (UnderLets.UnderLets base.type ident var
-                             (defaults.expr
-                                (type.base (base.type.Z * base.type.Z)%etype))))
-                   with
-                   | type.base t2 =>
-                       fun v : defaults.expr (type.base t2) =>
-                       base.try_make_transport_cps t2 base.type.Z
-                         (fun
-                            a : option
-                                  (defaults.expr (type.base t2) ->
-                                   defaults.expr (type.base base.type.Z)) =>
-                          match a with
-                          | Some x' =>
-                              if args =? 2 ^ Z.log2 args
-                              then
-                               Some
-                                 (UnderLets.Base
-                                    (#(ident.fancy_sub (Z.log2 args) args1)%expr @
-                                     (x0, x' v))%expr_pat)
-                              else None
-                          | None => None
-                          end)
-                   | (s1 -> d1)%ptype =>
-                       fun
-                         _ : Compile.value' false s1 ->
-                             Compile.value' true d1 => None
-                   end (Compile.reflect x3)
-               | _ => None
-               end);;
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftr;
+              end;;
               match x2 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  _ <- invert_bind_args idc0 Raw.ident.Z_shiftr;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
                   match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
+                    pattern.type.unify_extracted_cps
+                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                      (((projT1 args1) -> ℤ) -> s0 -> (projT1 args))%ptype
+                      option (fun x4 : option => x4)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
+                  | Some (_, _, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x4 <- (if
+                              (let (x4, _) := idc_args in x4) =?
+                              2 ^ Z.log2 (let (x4, _) := idc_args in x4)
                              then
                               Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_sub (Z.log2 args) (- args1))%expr @
-                                    (x0, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x3)
+                                (#(fancy_sub
+                                     (Z.log2 (let (x4, _) := idc_args in x4))
+                                     (- (let (x4, _) := idc_args0 in x4)))%expr @
+                                 (x0, v (Compile.reflect x3)))%expr_pat
+                             else None);
+                      Some (Base x4)
+                  | None => None
+                  end
               | _ => None
               end
           | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
@@ -2095,100 +1567,97 @@ match idc in (ident t) return (Compile.value' true t) with
               None
           | _ => None
           end;;
-          (if args =? 2 ^ Z.log2 args
-           then
-            Some
-              (UnderLets.Base
-                 (#(ident.fancy_sub (Z.log2 args) 0)%expr @ (x0, x1))%expr_pat)
-           else None)
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+              (((projT1 args) -> ℤ) -> ℤ)%ptype option
+              (fun x2 : option => x2)
+          with
+          | Some (_, _, _) =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x2 <- (if
+                      (let (x2, _) := idc_args in x2) =?
+                      2 ^ Z.log2 (let (x2, _) := idc_args in x2)
+                     then
+                      Some
+                        (#(fancy_sub (Z.log2 (let (x2, _) := idc_args in x2))
+                             0)%expr @ (x0, x1))%expr_pat
+                     else None);
+              Some (Base x2)
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_sub_with_get_borrow =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_sub_with_get_borrow =>
+    fun x x0 x1 x2 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x2 with
           | (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 @ x3)%expr_pat =>
-              (_ <- pattern.ident.invert_bind_args idc0
-                      pattern.ident.Z_shiftl;
-               match x3 with
-               | @expr.Ident _ _ _ t1 idc1 =>
-                   args1 <- pattern.ident.invert_bind_args idc1
-                              pattern.ident.LiteralZ;
-                   match
-                     s0 as t2
-                     return
-                       (Compile.value' false t2 ->
-                        option
-                          (UnderLets.UnderLets base.type ident var
-                             (defaults.expr
-                                (type.base (base.type.Z * base.type.Z)%etype))))
-                   with
-                   | type.base t2 =>
-                       fun v : defaults.expr (type.base t2) =>
-                       base.try_make_transport_cps t2 base.type.Z
-                         (fun
-                            a : option
-                                  (defaults.expr (type.base t2) ->
-                                   defaults.expr (type.base base.type.Z)) =>
-                          match a with
-                          | Some x' =>
-                              if args =? 2 ^ Z.log2 args
-                              then
-                               Some
-                                 (UnderLets.Base
-                                    (#(ident.fancy_subb (Z.log2 args) args1)%expr @
-                                     (x0, x1, x' v))%expr_pat)
-                              else None
-                          | None => None
-                          end)
-                   | (s1 -> d1)%ptype =>
-                       fun
-                         _ : Compile.value' false s1 ->
-                             Compile.value' true d1 => None
-                   end (Compile.reflect x4)
-               | _ => None
-               end);;
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.Z_shiftr;
               match x3 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  _ <- invert_bind_args idc0 Raw.ident.Z_shiftl;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
                   match
-                    s0 as t2
-                    return
-                      (Compile.value' false t2 ->
-                       option
-                         (UnderLets.UnderLets base.type ident var
-                            (defaults.expr
-                               (type.base (base.type.Z * base.type.Z)%etype))))
+                    pattern.type.unify_extracted_cps
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
+                      ((((projT1 args1) -> ℤ) -> ℤ) -> s0 -> (projT1 args))%ptype
+                      option (fun x5 : option => x5)
                   with
-                  | type.base t2 =>
-                      fun v : defaults.expr (type.base t2) =>
-                      base.try_make_transport_cps t2 base.type.Z
-                        (fun
-                           a : option
-                                 (defaults.expr (type.base t2) ->
-                                  defaults.expr (type.base base.type.Z)) =>
-                         match a with
-                         | Some x' =>
-                             if args =? 2 ^ Z.log2 args
+                  | Some (_, _, _, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x5 <- (if
+                              (let (x5, _) := idc_args in x5) =?
+                              2 ^ Z.log2 (let (x5, _) := idc_args in x5)
                              then
                               Some
-                                (UnderLets.Base
-                                   (#(ident.fancy_subb (Z.log2 args)
-                                        (- args1))%expr @ (x0, x1, x' v))%expr_pat)
-                             else None
-                         | None => None
-                         end)
-                  | (s1 -> d1)%ptype =>
-                      fun
-                        _ : Compile.value' false s1 -> Compile.value' true d1
-                      => None
-                  end (Compile.reflect x4)
+                                (#(fancy_subb
+                                     (Z.log2 (let (x5, _) := idc_args in x5))
+                                     (let (x5, _) := idc_args0 in x5))%expr @
+                                 (x0, x1, v (Compile.reflect x4)))%expr_pat
+                             else None);
+                      Some (Base x5)
+                  | None => None
+                  end
+              | _ => None
+              end;;
+              match x3 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  _ <- invert_bind_args idc0 Raw.ident.Z_shiftr;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
+                      ((((projT1 args1) -> ℤ) -> ℤ) -> s0 -> (projT1 args))%ptype
+                      option (fun x5 : option => x5)
+                  with
+                  | Some (_, _, _, (_, _)) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      v <- type.try_make_transport_cps s0 ℤ;
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      x5 <- (if
+                              (let (x5, _) := idc_args in x5) =?
+                              2 ^ Z.log2 (let (x5, _) := idc_args in x5)
+                             then
+                              Some
+                                (#(fancy_subb
+                                     (Z.log2 (let (x5, _) := idc_args in x5))
+                                     (- (let (x5, _) := idc_args0 in x5)))%expr @
+                                 (x0, x1, v (Compile.reflect x4)))%expr_pat
+                             else None);
+                      Some (Base x5)
+                  | None => None
+                  end
               | _ => None
               end
           | (@expr.App _ _ _ s0 _ ($_)%expr _ @ _)%expr_pat |
@@ -2198,128 +1667,111 @@ match idc in (ident t) return (Compile.value' true t) with
               None
           | _ => None
           end;;
-          (if args =? 2 ^ Z.log2 args
-           then
-            Some
-              (UnderLets.Base
-                 (#(ident.fancy_subb (Z.log2 args) 0)%expr @ (x0, x1, x2))%expr_pat)
-           else None)
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+              ((((projT1 args) -> ℤ) -> ℤ) -> ℤ)%ptype option
+              (fun x3 : option => x3)
+          with
+          | Some (_, _, _, _) =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x3 <- (if
+                      (let (x3, _) := idc_args in x3) =?
+                      2 ^ Z.log2 (let (x3, _) := idc_args in x3)
+                     then
+                      Some
+                        (#(fancy_subb
+                             (Z.log2 (let (x3, _) := idc_args in x3)) 0)%expr @
+                         (x0, x1, x2))%expr_pat
+                     else None);
+              Some (Base x3)
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base
-       (#(ident.Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
-| ident.Z_zselect =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+| Z_zselect =>
+    fun x x0 x1 : expr ℤ =>
     (((match x with
        | @expr.App _ _ _ s _
          (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x3) x2 =>
-           (_ <- pattern.ident.invert_bind_args idc pattern.ident.Z_cc_m;
-            match x3 with
-            | @expr.Ident _ _ _ t0 idc0 =>
-                args0 <- pattern.ident.invert_bind_args idc0
-                           pattern.ident.LiteralZ;
-                match
-                  s as t2
-                  return
-                    (Compile.value' false t2 ->
-                     option
-                       (UnderLets.UnderLets base.type ident var
-                          (defaults.expr (type.base base.type.Z))))
-                with
-                | type.base t2 =>
-                    fun v : defaults.expr (type.base t2) =>
-                    base.try_make_transport_cps t2 base.type.Z
-                      (fun
-                         a : option
-                               (defaults.expr (type.base t2) ->
-                                defaults.expr (type.base base.type.Z)) =>
-                       match a with
-                       | Some x' =>
-                           if args0 =? 2 ^ Z.log2 args0
-                           then
-                            Some
-                              (UnderLets.Base
-                                 (#(ident.fancy_selm (Z.log2 args0))%expr @
-                                  (x' v, x0, x1))%expr_pat)
-                           else None
-                       | None => None
-                       end)
-                | (s1 -> d1)%ptype =>
-                    fun _ : Compile.value' false s1 -> Compile.value' true d1
-                    => None
-                end (Compile.reflect x2)
-            | _ => None
-            end);;
-           _ <- pattern.ident.invert_bind_args idc pattern.ident.Z_land;
            match x3 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_cc_m;
                match
-                 s as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   ((((projT1 args) -> s) -> ℤ) -> ℤ)%ptype option
+                   (fun x4 : option => x4)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 =? 1
+               | Some (_, _, _, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   v <- type.try_make_transport_cps s ℤ;
+                   x4 <- (if
+                           (let (x4, _) := idc_args in x4) =?
+                           2 ^ Z.log2 (let (x4, _) := idc_args in x4)
                           then
                            Some
-                             (UnderLets.Base
-                                (#(ident.fancy_sell)%expr @ (x' v, x0, x1))%expr_pat)
-                          else None
-                      | None => None
-                      end)
-               | (s1 -> d1)%ptype =>
-                   fun _ : Compile.value' false s1 -> Compile.value' true d1
-                   => None
-               end (Compile.reflect x2)
+                             (#(fancy_selm
+                                  (Z.log2 (let (x4, _) := idc_args in x4)))%expr @
+                              (v (Compile.reflect x2), x0, x1))%expr_pat
+                          else None);
+                   Some (Base x4)
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x3 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_land;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   ((((projT1 args) -> s) -> ℤ) -> ℤ)%ptype option
+                   (fun x4 : option => x4)
+               with
+               | Some (_, _, _, _) =>
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   v <- type.try_make_transport_cps s ℤ;
+                   x4 <- (if (let (x4, _) := idc_args in x4) =? 1
+                          then
+                           Some
+                             (#(fancy_sell)%expr @
+                              (v (Compile.reflect x2), x0, x1))%expr_pat
+                          else None);
+                   Some (Base x4)
+               | None => None
+               end
            | _ => None
            end;;
            match x2 with
            | @expr.Ident _ _ _ t0 idc0 =>
-               args0 <- pattern.ident.invert_bind_args idc0
-                          pattern.ident.LiteralZ;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_land;
                match
-                 s0 as t2
-                 return
-                   (Compile.value' false t2 ->
-                    option
-                      (UnderLets.UnderLets base.type ident var
-                         (defaults.expr (type.base base.type.Z))))
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((s0 -> (projT1 args)) -> ℤ) -> ℤ)%ptype option
+                   (fun x4 : option => x4)
                with
-               | type.base t2 =>
-                   fun v : defaults.expr (type.base t2) =>
-                   base.try_make_transport_cps t2 base.type.Z
-                     (fun
-                        a : option
-                              (defaults.expr (type.base t2) ->
-                               defaults.expr (type.base base.type.Z)) =>
-                      match a with
-                      | Some x' =>
-                          if args0 =? 1
+               | Some (_, _, _, _) =>
+                   v <- type.try_make_transport_cps s0 ℤ;
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                   x4 <- (if (let (x4, _) := idc_args in x4) =? 1
                           then
                            Some
-                             (UnderLets.Base
-                                (#(ident.fancy_sell)%expr @ (x' v, x0, x1))%expr_pat)
-                          else None
-                      | None => None
-                      end)
-               | (s1 -> d1)%ptype =>
-                   fun _ : Compile.value' false s1 -> Compile.value' true d1
-                   => None
-               end (Compile.reflect x3)
+                             (#(fancy_sell)%expr @
+                              (v (Compile.reflect x3), x0, x1))%expr_pat
+                          else None);
+                   Some (Base x4)
+               | None => None
+               end
            | _ => None
            end
        | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
@@ -2332,92 +1784,102 @@ match idc in (ident t) return (Compile.value' true t) with
          s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
        | _ => None
        end;;
-       Some
-         (UnderLets.Base (#(ident.fancy_selc)%expr @ (x, x0, x1))%expr_pat));;
+       match
+         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+       with
+       | Some (_, _, _) =>
+           Some (Base (#(fancy_selc)%expr @ (x, x0, x1))%expr_pat)
+       | None => None
+       end);;
       None);;;
-     UnderLets.Base (#(ident.Z_zselect)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_modulo =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.fancy_addm)%expr @ (x, x0, x1))%expr_pat
-| ident.Z_rshi =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_zselect)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_modulo =>
+    fun x x0 x1 : expr ℤ =>
+    (match
+       pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+         ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+     with
+     | Some (_, _, _) =>
+         Some (Base (#(fancy_addm)%expr @ (x, x0, x1))%expr_pat)
+     | None => None
+     end;;;
+     Base (#(Z_add_modulo)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_rshi =>
+    fun x x0 x1 x2 : expr ℤ =>
     (match x with
      | @expr.Ident _ _ _ t idc =>
-         args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
          match x2 with
          | @expr.Ident _ _ _ t0 idc0 =>
-             args0 <- pattern.ident.invert_bind_args idc0
-                        pattern.ident.LiteralZ;
-             (if args =? 2 ^ Z.log2 args
-              then
-               Some
-                 (UnderLets.Base
-                    (#(ident.fancy_rshi (Z.log2 args) args0)%expr @ (x0, x1))%expr_pat)
-              else None)
+             args <- invert_bind_args idc0 Raw.ident.Literal;
+             args0 <- invert_bind_args idc Raw.ident.Literal;
+             match
+               pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                 ((((projT1 args0) -> ℤ) -> ℤ) -> (projT1 args))%ptype option
+                 (fun x3 : option => x3)
+             with
+             | Some (_, _, _, _) =>
+                 idc_args <- ident.unify pattern.ident.Literal
+                               ##(projT2 args0);
+                 idc_args0 <- ident.unify pattern.ident.Literal
+                                ##(projT2 args);
+                 x3 <- (if
+                         (let (x3, _) := idc_args in x3) =?
+                         2 ^ Z.log2 (let (x3, _) := idc_args in x3)
+                        then
+                         Some
+                           (#(fancy_rshi
+                                (Z.log2 (let (x3, _) := idc_args in x3))
+                                (let (x3, _) := idc_args0 in x3))%expr @
+                            (x0, x1))%expr_pat
+                        else None);
+                 Some (Base x3)
+             | None => None
+             end
          | _ => None
          end
      | _ => None
      end;;;
-     UnderLets.Base (#(ident.Z_rshi)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
-| ident.Z_cc_m =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_cc_m)%expr @ x @ x0)%expr_pat
-| ident.Z_cast range =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    UnderLets.Base (#(ident.Z_cast range)%expr @ x)%expr_pat
-| ident.Z_cast2 range =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.Z_cast2 range)%expr @ x)%expr_pat
-| ident.fancy_add log2wordmax imm =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_add log2wordmax imm)%expr @ x)%expr_pat
-| ident.fancy_addc log2wordmax imm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_addc log2wordmax imm)%expr @ x)%expr_pat
-| ident.fancy_sub log2wordmax imm =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_sub log2wordmax imm)%expr @ x)%expr_pat
-| ident.fancy_subb log2wordmax imm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_subb log2wordmax imm)%expr @ x)%expr_pat
-| ident.fancy_mulll log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_mulll log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_mullh log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_mullh log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_mulhl log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_mulhl log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_mulhh log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_mulhh log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_rshi log2wordmax x =>
-    fun x0 : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_rshi log2wordmax x)%expr @ x0)%expr_pat
-| ident.fancy_selc =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_selc)%expr @ x)%expr_pat
-| ident.fancy_selm log2wordmax =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_selm log2wordmax)%expr @ x)%expr_pat
-| ident.fancy_sell =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_sell)%expr @ x)%expr_pat
-| ident.fancy_addm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    UnderLets.Base (#(ident.fancy_addm)%expr @ x)%expr_pat
+     Base (#(Z_rshi)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+| Z_cc_m => fun x x0 : expr ℤ => Base (#(Z_cc_m)%expr @ x @ x0)%expr_pat
+| Z_cast range => fun x : expr ℤ => Base (#(Z_cast range)%expr @ x)%expr_pat
+| Z_cast2 range =>
+    fun x : expr (ℤ * ℤ)%etype => Base (#(Z_cast2 range)%expr @ x)%expr_pat
+| fancy_add log2wordmax imm =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat
+| fancy_addc log2wordmax imm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_addc log2wordmax imm)%expr @ x)%expr_pat
+| fancy_sub log2wordmax imm =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_sub log2wordmax imm)%expr @ x)%expr_pat
+| fancy_subb log2wordmax imm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_subb log2wordmax imm)%expr @ x)%expr_pat
+| fancy_mulll log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulll log2wordmax)%expr @ x)%expr_pat
+| fancy_mullh log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mullh log2wordmax)%expr @ x)%expr_pat
+| fancy_mulhl log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulhl log2wordmax)%expr @ x)%expr_pat
+| fancy_mulhh log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulhh log2wordmax)%expr @ x)%expr_pat
+| fancy_rshi log2wordmax x =>
+    fun x0 : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_rshi log2wordmax x)%expr @ x0)%expr_pat
+| fancy_selc =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_selc)%expr @ x)%expr_pat
+| fancy_selm log2wordmax =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_selm log2wordmax)%expr @ x)%expr_pat
+| fancy_sell =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_sell)%expr @ x)%expr_pat
+| fancy_addm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_addm)%expr @ x)%expr_pat
 end
      : Compile.value' true t

--- a/src/Experiments/NewPipeline/nbe_rewrite_head.out
+++ b/src/Experiments/NewPipeline/nbe_rewrite_head.out
@@ -1,158 +1,193 @@
 nbe_rewrite_head = 
-match idc in (ident t) return (Compile.value' true t) with
-| @ident.Literal t v =>
-    match
-      t as t0
-      return
-        (base.base_interp t0 ->
-         UnderLets.UnderLets base.type ident var
-           (defaults.expr (type.base t0)))
-    with
-    | base.type.unit => fun v0 : unit => UnderLets.Base (##v0)%expr
-    | base.type.Z => fun v0 : Z => UnderLets.Base (##v0)%expr
-    | base.type.bool => fun v0 : bool => UnderLets.Base (##v0)%expr
-    | base.type.nat => fun v0 : nat => UnderLets.Base (##v0)%expr
-    end v
-| ident.Nat_succ =>
-    fun x : defaults.expr (type.base base.type.nat) =>
+match idc in (Compilers.ident t) return (Compile.value' true t) with
+| @Literal t v => Base (##v)%expr
+| Nat_succ =>
+    fun x : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-          Some (UnderLets.Base (##(Nat.succ args))%expr)
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ℕ (projT1 args) option
+              (fun x0 : option => x0)
+          with
+          | Some _ =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some (Base (##(Nat.succ (let (x0, _) := idc_args in x0)))%expr)
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Nat_succ)%expr @ x)%expr_pat)%option
-| ident.Nat_pred =>
-    fun x : defaults.expr (type.base base.type.nat) =>
+     Base (#(Nat_succ)%expr @ x)%expr_pat)%option
+| Nat_pred =>
+    fun x : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-          Some (UnderLets.Base (##(Nat.pred args))%expr)
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ℕ (projT1 args) option
+              (fun x0 : option => x0)
+          with
+          | Some _ =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some (Base (##(Nat.pred (let (x0, _) := idc_args in x0)))%expr)
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Nat_pred)%expr @ x)%expr_pat)%option
-| ident.Nat_max =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
+     Base (#(Nat_pred)%expr @ x)%expr_pat)%option
+| Nat_max =>
+    fun x x0 : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralNat;
-              Some (UnderLets.Base (##(Nat.max args args0))%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℕ -> ℕ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##(Nat.max (let (x1, _) := idc_args in x1)
+                             (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Nat_max)%expr @ x @ x0)%expr_pat)%option
-| ident.Nat_mul =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
+     Base (#(Nat_max)%expr @ x @ x0)%expr_pat)%option
+| Nat_mul =>
+    fun x x0 : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralNat;
-              Some (UnderLets.Base (##(args * args0)%nat)%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℕ -> ℕ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) *
+                           (let (x1, _) := idc_args0 in x1))%nat)%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Nat_mul)%expr @ x @ x0)%expr_pat)%option
-| ident.Nat_add =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
+     Base (#(Nat_mul)%expr @ x @ x0)%expr_pat)%option
+| Nat_add =>
+    fun x x0 : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralNat;
-              Some (UnderLets.Base (##(args + args0)%nat)%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℕ -> ℕ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) +
+                           (let (x1, _) := idc_args0 in x1))%nat)%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Nat_add)%expr @ x @ x0)%expr_pat)%option
-| ident.Nat_sub =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
+     Base (#(Nat_add)%expr @ x @ x0)%expr_pat)%option
+| Nat_sub =>
+    fun x x0 : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralNat;
-              Some (UnderLets.Base (##(args - args0)%nat)%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℕ -> ℕ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) -
+                           (let (x1, _) := idc_args0 in x1))%nat)%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Nat_sub)%expr @ x @ x0)%expr_pat)%option
-| @ident.nil t => UnderLets.Base []%expr_pat
-| @ident.cons t =>
-    fun (x : defaults.expr (type.base t))
-      (x0 : defaults.expr (type.base (base.type.list t))) =>
-    UnderLets.Base (x :: x0)%expr_pat
-| @ident.pair A B =>
-    fun (x : defaults.expr (type.base A)) (x0 : defaults.expr (type.base B))
-    => UnderLets.Base (x, x0)%expr_pat
-| @ident.fst A B =>
-    fun x : defaults.expr (type.base (A * B)%etype) =>
+     Base (#(Nat_sub)%expr @ x @ x0)%expr_pat)%option
+| @nil t => Base []%expr_pat
+| @cons t => fun (x : expr t) (x0 : expr (list t)) => Base (x :: x0)%expr_pat
+| @pair A B => fun (x : expr A) (x0 : expr B) => Base (x, x0)%expr_pat
+| @fst A B =>
+    fun x : expr (A * B)%etype =>
     ((match x with
       | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x1) x0 =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x1) _ =>
+          args <- invert_bind_args idc Raw.ident.pair;
           match
-            s0 as t2
-            return
-              (Compile.value' false t2 ->
-               option
-                 (UnderLets.UnderLets base.type ident var
-                    (defaults.expr (type.base A))))
+            pattern.type.unify_extracted_cps
+              ((('1 * '2)%pbtype -> '1%pbtype) ->
+               (('1%pbtype -> '2%pbtype -> ('1 * '2)%pbtype) -> '1%pbtype) ->
+               '2%pbtype)%ptype
+              (((A * B)%etype -> A) ->
+               (((let (x2, _) := args in x2) ->
+                 (let (_, y) := args in y) ->
+                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
+                s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | type.base t2 =>
-              fun v : defaults.expr (type.base t2) =>
-              match
-                s as t3
-                return
-                  (Compile.value' false t3 ->
-                   option
-                     (UnderLets.UnderLets base.type ident var
-                        (defaults.expr (type.base A))))
-              with
-              | type.base t3 =>
-                  fun _ : defaults.expr (type.base t3) =>
-                  Some
-                    (base.try_make_transport_cps t2 A
-                       (fun
-                          a : option
-                                (defaults.expr (type.base t2) ->
-                                 defaults.expr (type.base A)) =>
-                        match a with
-                        | Some x' => UnderLets.Base (x' v)
-                        | None =>
-                            UnderLets.Base
-                              (Compile.ERROR_BAD_REWRITE_RULE
-                                 (#(pattern.ident.fst) @ (??, ??))
-                                 (#(ident.fst)%expr @ x)%expr_pat)
-                        end))
-              | (s1 -> d1)%ptype =>
-                  fun _ : Compile.value' false s1 -> Compile.value' true d1
-                  => None
-              end (Compile.reflect x0)
-          | (s1 -> d1)%ptype =>
-              fun _ : Compile.value' false s1 -> Compile.value' true d1 =>
-              None
-          end (Compile.reflect x1)
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
+              _ <- ident.unify pattern.ident.fst fst;
+              _ <- ident.unify pattern.ident.pair pair;
+              v <- type.try_make_transport_cps s0 b3;
+              _ <- type.try_make_transport_cps s b2;
+              v1 <- base.try_make_transport_cps b3 A;
+              v2 <- base.try_make_transport_cps A A;
+              v3 <- base.try_make_transport_cps A A;
+              Some (Base (v3 (v2 (v1 (v (Compile.reflect x1))))))
+          | None => None
+          end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
@@ -164,55 +199,35 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.fst)%expr @ x)%expr_pat)%option
-| @ident.snd A B =>
-    fun x : defaults.expr (type.base (A * B)%etype) =>
+     Base (#(fst)%expr @ x)%expr_pat)%option
+| @snd A B =>
+    fun x : expr (A * B)%etype =>
     ((match x with
       | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x1) x0 =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) _) x0 =>
+          args <- invert_bind_args idc Raw.ident.pair;
           match
-            s0 as t2
-            return
-              (Compile.value' false t2 ->
-               option
-                 (UnderLets.UnderLets base.type ident var
-                    (defaults.expr (type.base B))))
+            pattern.type.unify_extracted_cps
+              ((('1 * '2)%pbtype -> '2%pbtype) ->
+               (('1%pbtype -> '2%pbtype -> ('1 * '2)%pbtype) -> '1%pbtype) ->
+               '2%pbtype)%ptype
+              (((A * B)%etype -> B) ->
+               (((let (x2, _) := args in x2) ->
+                 (let (_, y) := args in y) ->
+                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
+                s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | type.base t2 =>
-              fun _ : defaults.expr (type.base t2) =>
-              match
-                s as t3
-                return
-                  (Compile.value' false t3 ->
-                   option
-                     (UnderLets.UnderLets base.type ident var
-                        (defaults.expr (type.base B))))
-              with
-              | type.base t3 =>
-                  fun v0 : defaults.expr (type.base t3) =>
-                  Some
-                    (base.try_make_transport_cps t3 B
-                       (fun
-                          a : option
-                                (defaults.expr (type.base t3) ->
-                                 defaults.expr (type.base B)) =>
-                        match a with
-                        | Some x' => UnderLets.Base (x' v0)
-                        | None =>
-                            UnderLets.Base
-                              (Compile.ERROR_BAD_REWRITE_RULE
-                                 (#(pattern.ident.snd) @ (??, ??))
-                                 (#(ident.snd)%expr @ x)%expr_pat)
-                        end))
-              | (s1 -> d1)%ptype =>
-                  fun _ : Compile.value' false s1 -> Compile.value' true d1
-                  => None
-              end (Compile.reflect x0)
-          | (s1 -> d1)%ptype =>
-              fun _ : Compile.value' false s1 -> Compile.value' true d1 =>
-              None
-          end (Compile.reflect x1)
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
+              _ <- ident.unify pattern.ident.snd snd;
+              _ <- ident.unify pattern.ident.pair pair;
+              _ <- type.try_make_transport_cps s0 b3;
+              v0 <- type.try_make_transport_cps s b2;
+              v1 <- base.try_make_transport_cps b2 B;
+              v2 <- base.try_make_transport_cps B B;
+              v3 <- base.try_make_transport_cps B B;
+              Some (Base (v3 (v2 (v1 (v0 (Compile.reflect x0))))))
+          | None => None
+          end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
@@ -224,107 +239,95 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.snd)%expr @ x)%expr_pat)%option
-| @ident.prod_rect A B T =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           defaults.expr (type.base B) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base T)))
-      (x0 : defaults.expr (type.base (A * B)%etype)) =>
+     Base (#(snd)%expr @ x)%expr_pat)%option
+| @prod_rect A B T =>
+    fun (x : expr A -> expr B -> UnderLets (expr T))
+      (x0 : expr (A * B)%etype) =>
     ((match x0 with
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x2) x1 =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
+          args <- invert_bind_args idc Raw.ident.pair;
           match
-            s0 as t2
-            return
-              (Compile.value' false t2 ->
-               option
-                 (UnderLets.UnderLets base.type ident var
-                    (defaults.expr (type.base T))))
+            pattern.type.unify_extracted_cps
+              (((('1%pbtype -> '2%pbtype -> '3%pbtype) ->
+                 ('1 * '2)%pbtype -> '3%pbtype) ->
+                '1%pbtype -> '2%pbtype -> '3%pbtype) ->
+               (('1%pbtype -> '2%pbtype -> ('1 * '2)%pbtype) -> '1%pbtype) ->
+               '2%pbtype)%ptype
+              ((((A -> B -> T) -> (A * B)%etype -> T) -> A -> B -> T) ->
+               (((let (x3, _) := args in x3) ->
+                 (let (_, y) := args in y) ->
+                 ((let (x3, _) := args in x3) * (let (_, y) := args in y))%etype) ->
+                s0) -> s)%ptype option (fun x3 : option => x3)
           with
-          | type.base t2 =>
-              fun v : defaults.expr (type.base t2) =>
-              match
-                s as t3
-                return
-                  (Compile.value' false t3 ->
-                   option
-                     (UnderLets.UnderLets base.type ident var
-                        (defaults.expr (type.base T))))
-              with
-              | type.base t3 =>
-                  fun v0 : defaults.expr (type.base t3) =>
-                  Compile.castbe v
-                    (option
-                       (UnderLets.UnderLets base.type ident var
-                          (defaults.expr (type.base T))))
-                    (fun x3 : option (defaults.expr (type.base A)) =>
-                     (x4 <- x3;
-                      Some
-                        (Compile.castbe v0
-                           (option
-                              (UnderLets.UnderLets base.type ident var
-                                 (defaults.expr (type.base T))))
-                           (fun y : option (defaults.expr (type.base B)) =>
-                            (y0 <- y;
-                             Some
-                               (Some
-                                  (fv <-- (e <-- x x4 y0;
-                                           UnderLets.Base
-                                             {|
-                                             anyexpr_ty := T;
-                                             unwrap := e |});
-                                   base.try_make_transport_cps
-                                     (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                                     T
-                                     (fun
-                                        a : option
-                                              (defaults.expr
-                                                 (type.base
-                                                    (let (anyexpr_ty, _) :=
-                                                       fv in
-                                                     anyexpr_ty)) ->
-                                               defaults.expr (type.base T))
-                                      =>
-                                      match a with
-                                      | Some x' =>
-                                          UnderLets.Base
-                                            (x'
-                                               (let
-                                                  (anyexpr_ty, unwrap) as a0
-                                                   return
-                                                     (defaults.expr
-                                                        (type.base
-                                                           (let
-                                                              (anyexpr_ty,
-                                                               _) := a0 in
-                                                            anyexpr_ty))) :=
-                                                  fv in
-                                                unwrap))
-                                      | None =>
-                                          UnderLets.Base
-                                            (Compile.ERROR_BAD_REWRITE_RULE
-                                               (#(pattern.ident.prod_rect) @
-                                                ??{?? -> ?? -> ??} @ 
-                                                (??, ??))
-                                               (#(ident.prod_rect)%expr @
-                                                (λ (x5 : var (type.base A))
-                                                 (x6 : var (type.base B)),
-                                                 UnderLets.to_expr
-                                                   (x ($x5) ($x6)))%expr @ x0)%expr_pat)
-                                      end))%under_lets));;;
-                            None)));;;
-                     None)
-              | (s1 -> d1)%ptype =>
-                  fun _ : Compile.value' false s1 -> Compile.value' true d1
-                  => None
-              end (Compile.reflect x1)
-          | (s1 -> d1)%ptype =>
-              fun _ : Compile.value' false s1 -> Compile.value' true d1 =>
-              None
-          end (Compile.reflect x2)
+          | Some
+            (_, (_, _), (_, _, _), (_, (_, b7)), (_, (_, (_, _)), b9, b8)) =>
+              _ <- ident.unify pattern.ident.prod_rect prod_rect;
+              base.try_make_transport_cps A b9
+                (fun a13 : option =>
+                 (fa <- (fun (T0 : Type) (k : option -> T0) =>
+                         match a13 with
+                         | Some x' =>
+                             base.try_make_transport_cps B b8
+                               (fun a14 : option =>
+                                fa <- (fun (T1 : Type) (k0 : option -> T1) =>
+                                       match a14 with
+                                       | Some x'0 =>
+                                           base.try_make_transport_cps T b7
+                                             (fun a15 : option =>
+                                              fa <- (fun (T2 : Type)
+                                                       (k1 : option -> T2) =>
+                                                     match a15 with
+                                                     | Some x'1 =>
+                                                         (return Some
+                                                                   (fun
+                                                                    v : 
+                                                                    expr b9 ->
+                                                                    expr B ->
+                                                                    UnderLets
+                                                                    (expr T)
+                                                                    =>
+                                                                    x'1
+                                                                    (x'0 v)))
+                                                           T2 k1
+                                                     | None => k1 None
+                                                     end);
+                                              k0 fa)
+                                       | None => k0 None
+                                       end);
+                                fa0 <- (fun (T1 : Type) (k0 : option -> T1)
+                                        =>
+                                        match fa with
+                                        | Some x'0 =>
+                                            (return Some
+                                                      (fun
+                                                         v : expr A ->
+                                                             expr B ->
+                                                             UnderLets
+                                                               (expr T) =>
+                                                       x'0 (x' v))) T1 k0
+                                        | None => k0 None
+                                        end);
+                                k fa0)
+                         | None => k None
+                         end);
+                  match fa with
+                  | Some v =>
+                      (_ <- ident.unify pattern.ident.pair pair;
+                       v0 <- type.try_make_transport_cps s0 b9;
+                       v1 <- type.try_make_transport_cps s b8;
+                       v2 <- base.try_make_transport_cps b7 T;
+                       v3 <- base.try_make_transport_cps T T;
+                       v4 <- base.try_make_transport_cps T T;
+                       Some
+                         (fv <-- v2
+                                   (v x (v0 (Compile.reflect x2))
+                                      (v1 (Compile.reflect x1)));
+                          Base (v4 (v3 fv)))%under_lets)%option
+                  | None => None
+                  end)%cps)
+          | None => None
+          end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
@@ -336,527 +339,884 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base
-       (#(ident.prod_rect)%expr @
-        (λ (x1 : var (type.base A))(x2 : var (type.base B)),
-         UnderLets.to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat)%option
-| @ident.bool_rect T =>
-    fun
-      (x
-       x0 : defaults.expr (type.base base.type.unit) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base T)))
-      (x1 : defaults.expr (type.base base.type.bool)) =>
+     Base
+       (#(prod_rect)%expr @
+        (λ (x1 : var A)(x2 : var B),
+         to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat)%option
+| @bool_rect T =>
+    fun (x x0 : expr unit -> UnderLets (expr T)) (x1 : expr bool) =>
     ((match x1 with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc
-                    pattern.ident.LiteralBool;
-          Some
-            (fv <-- (e <-- (if args as b
-                             return
-                               (UnderLets.UnderLets base.type ident var
-                                  (defaults.expr
-                                     (type.base (if b then T else T))))
-                            then x (##tt)%expr
-                            else x0 (##tt)%expr);
-                     UnderLets.Base
-                       {| anyexpr_ty := if args then T else T; unwrap := e |});
-             base.try_make_transport_cps
-               (let (anyexpr_ty, _) := fv in anyexpr_ty) T
-               (fun
-                  a : option
-                        (defaults.expr
-                           (type.base
-                              (let (anyexpr_ty, _) := fv in anyexpr_ty)) ->
-                         defaults.expr (type.base T)) =>
-                match a with
-                | Some x' =>
-                    UnderLets.Base
-                      (x'
-                         (let
-                            (anyexpr_ty, unwrap) as a0
-                             return
-                               (defaults.expr
-                                  (type.base
-                                     (let (anyexpr_ty, _) := a0 in anyexpr_ty))) :=
-                            fv in
-                          unwrap))
-                | None =>
-                    UnderLets.Base
-                      (Compile.ERROR_BAD_REWRITE_RULE
-                         (#(pattern.ident.bool_rect) @ ??{() -> ??} @
-                          ??{() -> ??} @ #(pattern.ident.LiteralBool))
-                         (#(ident.bool_rect)%expr @
-                          (λ x2 : var (type.base base.type.unit),
-                           UnderLets.to_expr (x ($x2)))%expr @
-                          (λ x2 : var (type.base base.type.unit),
-                           UnderLets.to_expr (x0 ($x2)))%expr @ x1)%expr_pat)
-                end))%under_lets
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps
+              (((((unit -> '1%pbtype) ->
+                  (unit -> '1%pbtype) -> bool -> '1%pbtype) ->
+                 unit -> '1%pbtype) -> unit -> '1%pbtype) -> bool)%ptype
+              (((((unit -> T) -> (unit -> T) -> bool -> T) -> unit -> T) ->
+                unit -> T) -> (projT1 args))%ptype option
+              (fun x2 : option => x2)
+          with
+          | Some (_, _, (_, _, (_, _)), (_, _), (_, b8), _) =>
+              _ <- ident.unify pattern.ident.bool_rect bool_rect;
+              base.try_make_transport_cps T b8
+                (fun a9 : option =>
+                 (fa <- (fun (T0 : Type) (k : option -> T0) =>
+                         match a9 with
+                         | Some x' =>
+                             (return Some
+                                       (fun
+                                          v : expr unit -> UnderLets (expr T)
+                                        => x' v)) T0 k
+                         | None => k None
+                         end);
+                  match fa with
+                  | Some v =>
+                      base.try_make_transport_cps T b8
+                        (fun a10 : option =>
+                         fa0 <- (fun (T0 : Type) (k : option -> T0) =>
+                                 match a10 with
+                                 | Some x' =>
+                                     (return Some
+                                               (fun
+                                                  v0 : expr unit ->
+                                                       UnderLets (expr T) =>
+                                                x' v0)) T0 k
+                                 | None => k None
+                                 end);
+                         match fa0 with
+                         | Some v0 =>
+                             (idc_args0 <- ident.unify pattern.ident.Literal
+                                             ##(projT2 args);
+                              v1 <- base.try_make_transport_cps b8 T;
+                              v2 <- base.try_make_transport_cps T T;
+                              v3 <- base.try_make_transport_cps T T;
+                              Some
+                                (fv <-- v1
+                                          (if let (x2, _) := idc_args0 in x2
+                                           then v x (##tt)%expr
+                                           else v0 x0 (##tt)%expr);
+                                 Base (v3 (v2 fv)))%under_lets)%option
+                         | None => None
+                         end)
+                  | None => None
+                  end)%cps)
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base
-       (#(ident.bool_rect)%expr @
-        (λ x2 : var (type.base base.type.unit),
-         UnderLets.to_expr (x ($x2)))%expr @
-        (λ x2 : var (type.base base.type.unit),
-         UnderLets.to_expr (x0 ($x2)))%expr @ x1)%expr_pat)%option
-| @ident.nat_rect P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base base.type.nat) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base base.type.nat)) =>
+     Base
+       (#(bool_rect)%expr @ (λ x2 : var unit,
+                             to_expr (x ($x2)))%expr @
+        (λ x2 : var unit,
+         to_expr (x0 ($x2)))%expr @ x1)%expr_pat)%option
+| @nat_rect P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr ℕ -> expr P -> UnderLets (expr P)) (x1 : expr ℕ) =>
     ((match x1 with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-          Compile.castv x0
-            (option
-               (UnderLets.UnderLets base.type ident var
-                  (defaults.expr (type.base P))))
-            (fun
-               S_case : option
-                          (defaults.expr (type.base base.type.nat) ->
-                           defaults.expr (type.base P) ->
-                           UnderLets.UnderLets base.type ident var
-                             (defaults.expr (type.base P))) =>
-             (S_case0 <- S_case;
-              Some
-                (Some
-                   (fv <-- (e <-- nat_rect
-                                    (fun _ : nat =>
-                                     UnderLets.UnderLets base.type ident var
-                                       (defaults.expr (type.base P)))
-                                    (x (##tt)%expr)
-                                    (fun (n' : nat)
-                                       (rec : UnderLets.UnderLets base.type
-                                                ident var
-                                                (defaults.expr (type.base P)))
-                                     => rec0 <-- rec;
-                                        S_case0 (##n')%expr rec0) args;
-                            UnderLets.Base {| anyexpr_ty := P; unwrap := e |});
-                    base.try_make_transport_cps
-                      (let (anyexpr_ty, _) := fv in anyexpr_ty) P
-                      (fun
-                         a : option
-                               (defaults.expr
-                                  (type.base
-                                     (let (anyexpr_ty, _) := fv in anyexpr_ty)) ->
-                                defaults.expr (type.base P)) =>
-                       match a with
-                       | Some x' =>
-                           UnderLets.Base
-                             (x'
-                                (let
-                                   (anyexpr_ty, unwrap) as a0
-                                    return
-                                      (defaults.expr
-                                         (type.base
-                                            (let (anyexpr_ty, _) := a0 in
-                                             anyexpr_ty))) := fv in
-                                 unwrap))
-                       | None =>
-                           UnderLets.Base
-                             (Compile.ERROR_BAD_REWRITE_RULE
-                                (#(pattern.ident.nat_rect) @ ??{() -> ??} @
-                                 ??{type.base base.type.nat -> ?? -> ??} @
-                                 #(pattern.ident.LiteralNat))
-                                (#(ident.nat_rect)%expr @
-                                 (λ x2 : var (type.base base.type.unit),
-                                  UnderLets.to_expr (x ($x2)))%expr @
-                                 (λ (x2 : var (type.base base.type.nat))
-                                  (x3 : var (type.base P)),
-                                  UnderLets.to_expr (x0 ($x2) ($x3)))%expr @
-                                 x1)%expr_pat)
-                       end))%under_lets));;;
-             None)
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps
+              (((((unit -> '1%pbtype) ->
+                  (ℕ -> '1%pbtype -> '1%pbtype) -> ℕ -> '1%pbtype) ->
+                 unit -> '1%pbtype) -> ℕ -> '1%pbtype -> '1%pbtype) -> 
+               ℕ)%ptype
+              (((((unit -> P) -> (ℕ -> P -> P) -> ℕ -> P) -> unit -> P) ->
+                ℕ -> P -> P) -> (projT1 args))%ptype option
+              (fun x2 : option => x2)
+          with
+          | Some (_, _, (_, (_, _), (_, _)), (_, _), (_, (_, b10)), _) =>
+              _ <- ident.unify pattern.ident.nat_rect nat_rect;
+              base.try_make_transport_cps P b10
+                (fun a11 : option =>
+                 (fa <- (fun (T : Type) (k : option -> T) =>
+                         match a11 with
+                         | Some x' =>
+                             (return Some
+                                       (fun
+                                          v : expr unit -> UnderLets (expr P)
+                                        => x' v)) T k
+                         | None => k None
+                         end);
+                  match fa with
+                  | Some v =>
+                      base.try_make_transport_cps P b10
+                        (fun a12 : option =>
+                         fa0 <- (fun (T : Type) (k : option -> T) =>
+                                 match a12 with
+                                 | Some x' =>
+                                     base.try_make_transport_cps P b10
+                                       (fun a13 : option =>
+                                        fa0 <- (fun (T0 : Type)
+                                                  (k0 : option -> T0) =>
+                                                match a13 with
+                                                | Some x'0 =>
+                                                    (return Some
+                                                              (fun
+                                                                 v0 : 
+                                                                  expr ℕ ->
+                                                                  expr P ->
+                                                                  UnderLets
+                                                                    (expr P)
+                                                               => x'0 (x' v0)))
+                                                      T0 k0
+                                                | None => k0 None
+                                                end);
+                                        k fa0)
+                                 | None => k None
+                                 end);
+                         fa1 <- (fun (T : Type) (k : option -> T) =>
+                                 match fa0 with
+                                 | Some x' =>
+                                     (return Some
+                                               (fun
+                                                  v0 : expr ℕ ->
+                                                       expr P ->
+                                                       UnderLets (expr P) =>
+                                                x' v0)) T k
+                                 | None => k None
+                                 end);
+                         match fa1 with
+                         | Some v0 =>
+                             (idc_args0 <- ident.unify pattern.ident.Literal
+                                             ##(projT2 args);
+                              v1 <- base.try_make_transport_cps b10 P;
+                              v2 <- base.try_make_transport_cps P P;
+                              v3 <- base.try_make_transport_cps P P;
+                              Some
+                                (fv <-- v1
+                                          (Datatypes.nat_rect
+                                             (fun _ : nat =>
+                                              UnderLets
+                                                (expr
+                                                   (pattern.base.subst_default
+                                                      '1
+                                                      (PositiveMap.add
+                                                         (PositiveSet.rev
+                                                            1%positive) b10
+                                                         (PositiveMap.empty
+                                                            base.type)))))
+                                             (v x (##tt)%expr)
+                                             (fun (n' : nat)
+                                                (rec : UnderLets
+                                                         (expr
+                                                            (pattern.base.subst_default
+                                                               '1
+                                                               (PositiveMap.add
+                                                                  (PositiveSet.rev
+                                                                    1%positive)
+                                                                  b10
+                                                                  (PositiveMap.empty
+                                                                    base.type)))))
+                                              =>
+                                              rec0 <-- rec;
+                                              v0 x0 (##n')%expr rec0)
+                                             (let (x2, _) := idc_args0 in x2));
+                                 Base (v3 (v2 fv)))%under_lets)%option
+                         | None => None
+                         end)
+                  | None => None
+                  end)%cps)
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base
-       (#(ident.nat_rect)%expr @
-        (λ x2 : var (type.base base.type.unit),
-         UnderLets.to_expr (x ($x2)))%expr @
-        (λ (x2 : var (type.base base.type.nat))(x3 : var (type.base P)),
-         UnderLets.to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat)%option
-| @ident.nat_rect_arrow P Q =>
-    fun
-      (x : defaults.expr (type.base P) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base Q)))
-      (x0 : defaults.expr (type.base base.type.nat) ->
-            (defaults.expr (type.base P) ->
-             UnderLets.UnderLets base.type ident var
-               (defaults.expr (type.base Q))) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base Q)))
-      (x1 : defaults.expr (type.base base.type.nat))
-      (x2 : defaults.expr (type.base P)) =>
+     Base
+       (#(nat_rect)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+        (λ (x2 : var ℕ)(x3 : var P),
+         to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat)%option
+| @nat_rect_arrow P Q =>
+    fun (x : expr P -> UnderLets (expr Q))
+      (x0 : expr ℕ ->
+            (expr P -> UnderLets (expr Q)) -> expr P -> UnderLets (expr Q))
+      (x1 : expr ℕ) (x2 : expr P) =>
     (match x1 with
      | @expr.Ident _ _ _ t idc =>
-         args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-         Compile.castv x0
-           (option
-              (UnderLets.UnderLets base.type ident var
-                 (defaults.expr (type.base Q))))
-           (fun
-              S_case : option
-                         (defaults.expr (type.base base.type.nat) ->
-                          (defaults.expr (type.base P) ->
-                           UnderLets.UnderLets base.type ident var
-                             (defaults.expr (type.base Q))) ->
-                          defaults.expr (type.base P) ->
-                          UnderLets.UnderLets base.type ident var
-                            (defaults.expr (type.base Q))) =>
-            (S_case0 <- S_case;
-             Some
-               (Compile.castbe x2
-                  (option
-                     (UnderLets.UnderLets base.type ident var
-                        (defaults.expr (type.base Q))))
-                  (fun v : option (defaults.expr (type.base P)) =>
-                   (v0 <- v;
-                    Some
-                      (Some
-                         (fv <-- (e <-- nat_rect
-                                          (fun _ : nat =>
-                                           defaults.expr (type.base P) ->
-                                           UnderLets.UnderLets base.type
-                                             ident var
-                                             (defaults.expr (type.base Q))) x
-                                          (fun (n' : nat)
-                                             (rec : defaults.expr
-                                                      (type.base P) ->
-                                                    UnderLets.UnderLets
-                                                      base.type ident var
-                                                      (defaults.expr
-                                                         (type.base Q)))
-                                             (v1 : defaults.expr
-                                                     (type.base P)) =>
-                                           S_case0 (##n')%expr rec v1) args
-                                          v0;
-                                  UnderLets.Base
-                                    {| anyexpr_ty := Q; unwrap := e |});
-                          base.try_make_transport_cps
-                            (let (anyexpr_ty, _) := fv in anyexpr_ty) Q
-                            (fun
-                               a : option
-                                     (defaults.expr
-                                        (type.base
-                                           (let (anyexpr_ty, _) := fv in
-                                            anyexpr_ty)) ->
-                                      defaults.expr (type.base Q)) =>
-                             match a with
-                             | Some x' =>
-                                 UnderLets.Base
-                                   (x'
-                                      (let
-                                         (anyexpr_ty, unwrap) as a0
-                                          return
-                                            (defaults.expr
-                                               (type.base
-                                                  (let (anyexpr_ty, _) :=
-                                                     a0 in
-                                                   anyexpr_ty))) := fv in
-                                       unwrap))
-                             | None =>
-                                 UnderLets.Base
-                                   (Compile.ERROR_BAD_REWRITE_RULE
-                                      (#(pattern.ident.nat_rect_arrow) @
-                                       ??{?? -> ??} @
-                                       ??{type.base base.type.nat ->
-                                          (?? -> ??) -> ?? -> ??} @
-                                       #(pattern.ident.LiteralNat) @ 
-                                       ??)
-                                      (#(ident.nat_rect_arrow)%expr @
-                                       (λ x3 : var (type.base P),
-                                        UnderLets.to_expr (x ($x3)))%expr @
-                                       (λ (x3 : var (type.base base.type.nat))
-                                        (x4 : var
-                                                (type.base P -> type.base Q)%ptype)
-                                        (x5 : var (type.base P)),
-                                        UnderLets.to_expr
-                                          (x0 ($x3)
-                                             (fun
-                                                x6 : defaults.expr
-                                                       (type.base P) =>
-                                              UnderLets.Base
-                                                ($x4 @ x6)%expr_pat) 
-                                             ($x5)))%expr @ x1 @ x2)%expr_pat)
-                             end))%under_lets));;;
-                   None)));;;
-            None)
+         args <- invert_bind_args idc Raw.ident.Literal;
+         match
+           pattern.type.unify_extracted_cps
+             (((((('1%pbtype -> '2%pbtype) ->
+                  (ℕ -> ('1%pbtype -> '2%pbtype) -> '1%pbtype -> '2%pbtype) ->
+                  ℕ -> '1%pbtype -> '2%pbtype) -> '1%pbtype -> '2%pbtype) ->
+                ℕ -> ('1%pbtype -> '2%pbtype) -> '1%pbtype -> '2%pbtype) -> 
+               ℕ) -> '1%pbtype)%ptype
+             ((((((P -> Q) -> (ℕ -> (P -> Q) -> P -> Q) -> ℕ -> P -> Q) ->
+                 P -> Q) -> ℕ -> (P -> Q) -> P -> Q) -> (projT1 args)) -> 
+              P)%ptype option (fun x3 : option => x3)
+         with
+         | Some
+           (_, _, (_, (_, _, (_, _)), (_, (_, _))), (_, _),
+           (_, (_, _, (_, b16))), _, b) =>
+             _ <- ident.unify pattern.ident.nat_rect_arrow nat_rect_arrow;
+             base.try_make_transport_cps P b
+               (fun a17 : option =>
+                (fa <- (fun (T : Type) (k : option -> T) =>
+                        match a17 with
+                        | Some x' =>
+                            base.try_make_transport_cps Q b16
+                              (fun a18 : option =>
+                               fa <- (fun (T0 : Type) (k0 : option -> T0) =>
+                                      match a18 with
+                                      | Some x'0 =>
+                                          (return Some
+                                                    (fun
+                                                       v : expr P ->
+                                                           UnderLets (expr Q)
+                                                     => x'0 (x' v))) T0 k0
+                                      | None => k0 None
+                                      end);
+                               k fa)
+                        | None => k None
+                        end);
+                 match fa with
+                 | Some v =>
+                     base.try_make_transport_cps P b
+                       (fun a18 : option =>
+                        fa0 <- (fun (T : Type) (k : option -> T) =>
+                                match a18 with
+                                | Some x' =>
+                                    base.try_make_transport_cps Q b16
+                                      (fun a19 : option =>
+                                       fa0 <- (fun (T0 : Type)
+                                                 (k0 : option -> T0) =>
+                                               match a19 with
+                                               | Some x'0 =>
+                                                   (return Some
+                                                             (fun
+                                                                v0 : 
+                                                                 expr ℕ ->
+                                                                 (expr P ->
+                                                                  UnderLets
+                                                                    (expr Q)) ->
+                                                                 expr P ->
+                                                                 UnderLets
+                                                                   (expr Q)
+                                                              => x'0 (x' v0)))
+                                                     T0 k0
+                                               | None => k0 None
+                                               end);
+                                       k fa0)
+                                | None => k None
+                                end);
+                        fa1 <- (fun (T : Type) (k : option -> T) =>
+                                match fa0 with
+                                | Some x' =>
+                                    base.try_make_transport_cps P b
+                                      (fun a19 : option =>
+                                       fa1 <- (fun (T0 : Type)
+                                                 (k0 : option -> T0) =>
+                                               match a19 with
+                                               | Some x'0 =>
+                                                   base.try_make_transport_cps
+                                                     Q b16
+                                                     (fun a20 : option =>
+                                                      fa1 <- (fun (T1 : Type)
+                                                                (k1 : 
+                                                                 option -> T1)
+                                                              =>
+                                                              match a20 with
+                                                              | Some x'1 =>
+                                                                  (return 
+                                                                   Some
+                                                                    (fun
+                                                                    v0 : 
+                                                                    expr ℕ ->
+                                                                    (expr b ->
+                                                                    UnderLets
+                                                                    (expr b16)) ->
+                                                                    expr P ->
+                                                                    UnderLets
+                                                                    (expr Q)
+                                                                    =>
+                                                                    x'1
+                                                                    (x'0 v0)))
+                                                                    T1 k1
+                                                              | None =>
+                                                                  k1 None
+                                                              end);
+                                                      k0 fa1)
+                                               | None => k0 None
+                                               end);
+                                       fa2 <- (fun (T0 : Type)
+                                                 (k0 : option -> T0) =>
+                                               match fa1 with
+                                               | Some x'0 =>
+                                                   (return Some
+                                                             (fun
+                                                                v0 : 
+                                                                 expr ℕ ->
+                                                                 (expr P ->
+                                                                  UnderLets
+                                                                    (expr Q)) ->
+                                                                 expr P ->
+                                                                 UnderLets
+                                                                   (expr Q)
+                                                              => x'0 (x' v0)))
+                                                     T0 k0
+                                               | None => k0 None
+                                               end);
+                                       k fa2)
+                                | None => k None
+                                end);
+                        fa2 <- (fun (T : Type) (k : option -> T) =>
+                                match fa1 with
+                                | Some x' =>
+                                    (return Some
+                                              (fun
+                                                 v0 : expr ℕ ->
+                                                      (expr P ->
+                                                       UnderLets (expr Q)) ->
+                                                      expr P ->
+                                                      UnderLets (expr Q) =>
+                                               x' v0)) T k
+                                | None => k None
+                                end);
+                        match fa2 with
+                        | Some v0 =>
+                            (idc_args0 <- ident.unify pattern.ident.Literal
+                                            ##(projT2 args);
+                             v1 <- base.try_make_transport_cps P b;
+                             v2 <- base.try_make_transport_cps b16 Q;
+                             v3 <- base.try_make_transport_cps Q Q;
+                             v4 <- base.try_make_transport_cps Q Q;
+                             Some
+                               (fv <-- v2
+                                         (Datatypes.nat_rect
+                                            (fun _ : nat =>
+                                             expr
+                                               (pattern.base.subst_default 
+                                                  '1
+                                                  (PositiveMap.add
+                                                     (PositiveSet.rev
+                                                        2%positive) b16
+                                                     (PositiveMap.add
+                                                        (PositiveSet.rev
+                                                           1%positive) b
+                                                        (PositiveMap.empty
+                                                           base.type)))) ->
+                                             UnderLets
+                                               (expr
+                                                  (pattern.base.subst_default
+                                                     '2
+                                                     (PositiveMap.add
+                                                        (PositiveSet.rev
+                                                           2%positive) b16
+                                                        (PositiveMap.add
+                                                           (PositiveSet.rev
+                                                              1%positive) b
+                                                           (PositiveMap.empty
+                                                              base.type))))))
+                                            (v x)
+                                            (fun (n' : nat)
+                                               (rec : expr
+                                                        (pattern.base.subst_default
+                                                           '1
+                                                           (PositiveMap.add
+                                                              (PositiveSet.rev
+                                                                 2%positive)
+                                                              b16
+                                                              (PositiveMap.add
+                                                                 (PositiveSet.rev
+                                                                    1%positive)
+                                                                 b
+                                                                 (PositiveMap.empty
+                                                                    base.type)))) ->
+                                                      UnderLets
+                                                        (expr
+                                                           (pattern.base.subst_default
+                                                              '2
+                                                              (PositiveMap.add
+                                                                 (PositiveSet.rev
+                                                                    2%positive)
+                                                                 b16
+                                                                 (PositiveMap.add
+                                                                    (PositiveSet.rev
+                                                                    1%positive)
+                                                                    b
+                                                                    (PositiveMap.empty
+                                                                    base.type))))))
+                                               (v5 : expr
+                                                       (pattern.base.subst_default
+                                                          '1
+                                                          (PositiveMap.add
+                                                             (PositiveSet.rev
+                                                                2%positive)
+                                                             b16
+                                                             (PositiveMap.add
+                                                                (PositiveSet.rev
+                                                                   1%positive)
+                                                                b
+                                                                (PositiveMap.empty
+                                                                   base.type)))))
+                                             => v0 x0 (##n')%expr rec v5)
+                                            (let (x3, _) := idc_args0 in x3)
+                                            (v1 x2));
+                                Base (v4 (v3 fv)))%under_lets)%option
+                        | None => None
+                        end)
+                 | None => None
+                 end)%cps)
+         | None => None
+         end
      | _ => None
      end;;;
-     UnderLets.Base
-       (#(ident.nat_rect_arrow)%expr @
-        (λ x3 : var (type.base P),
-         UnderLets.to_expr (x ($x3)))%expr @
-        (λ (x3 : var (type.base base.type.nat))(x4 : var
-                                                       (type.base P ->
-                                                        type.base Q)%ptype)
-         (x5 : var (type.base P)),
-         UnderLets.to_expr
-           (x0 ($x3)
-              (fun x6 : defaults.expr (type.base P) =>
-               UnderLets.Base ($x4 @ x6)%expr_pat) ($x5)))%expr @ x1 @ x2)%expr_pat)%option
-| @ident.list_rect A P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base A) ->
-            defaults.expr (type.base (base.type.list A)) ->
-            defaults.expr (type.base P) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base (base.type.list A))) =>
-    ((Compile.castv x0
-        (option
-           (UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P))))
-        (fun
-           Pcons : option
-                     (defaults.expr (type.base A) ->
-                      defaults.expr (type.base (base.type.list A)) ->
-                      defaults.expr (type.base P) ->
-                      UnderLets.UnderLets base.type ident var
-                        (defaults.expr (type.base P))) =>
-         (Pcons0 <- Pcons;
-          Some
-            (reflect_list_cps x1
-               (fun ls : option (list (defaults.expr (type.base A))) =>
-                (ls0 <- ls;
-                 Some
-                   (Some
-                      (fv <-- (e <-- list_rect
-                                       (fun
-                                          _ : list
-                                                (defaults.expr (type.base A))
-                                        =>
-                                        UnderLets.UnderLets base.type ident
-                                          var (defaults.expr (type.base P)))
-                                       (x (##tt)%expr)
-                                       (fun
-                                          (x2 : defaults.expr (type.base A))
-                                          (xs : list
-                                                  (defaults.expr
-                                                     (type.base A)))
-                                          (rec : UnderLets.UnderLets
-                                                   base.type ident var
-                                                   (defaults.expr
-                                                      (type.base P))) =>
-                                        rec' <-- rec;
-                                        Pcons0 x2 (reify_list xs) rec') ls0;
-                               UnderLets.Base
-                                 {| anyexpr_ty := P; unwrap := e |});
-                       base.try_make_transport_cps
-                         (let (anyexpr_ty, _) := fv in anyexpr_ty) P
-                         (fun
-                            a : option
-                                  (defaults.expr
-                                     (type.base
-                                        (let (anyexpr_ty, _) := fv in
-                                         anyexpr_ty)) ->
-                                   defaults.expr (type.base P)) =>
-                          match a with
-                          | Some x' =>
-                              UnderLets.Base
-                                (x'
-                                   (let
-                                      (anyexpr_ty, unwrap) as a0
-                                       return
-                                         (defaults.expr
-                                            (type.base
-                                               (let (anyexpr_ty, _) := a0 in
-                                                anyexpr_ty))) := fv in
-                                    unwrap))
-                          | None =>
-                              UnderLets.Base
-                                (Compile.ERROR_BAD_REWRITE_RULE
-                                   (#(pattern.ident.list_rect) @ ??{() -> ??} @
-                                    ??{?? -> ?? -> ?? -> ??} @
-                                    ??{type.base (pattern.base.type.list ??)})
-                                   (#(ident.list_rect)%expr @
-                                    (λ x2 : var (type.base base.type.unit),
-                                     UnderLets.to_expr (x ($x2)))%expr @
-                                    (λ (x2 : var (type.base A))(x3 : 
-                                                                var
-                                                                  (type.base
-                                                                    (base.type.list
-                                                                    A)))
-                                     (x4 : var (type.base P)),
-                                     UnderLets.to_expr (x0 ($x2) ($x3) ($x4)))%expr @
-                                    x1)%expr_pat)
-                          end))%under_lets));;;
-                None)));;;
-         None);;
+     Base
+       (#(nat_rect_arrow)%expr @ (λ x3 : var P,
+                                  to_expr (x ($x3)))%expr @
+        (λ (x3 : var ℕ)(x4 : var (P -> Q)%ptype)(x5 : var P),
+         to_expr
+           (x0 ($x3) (fun x6 : expr P => Base ($x4 @ x6)%expr_pat) ($x5)))%expr @
+        x1 @ x2)%expr_pat)%option
+| @list_rect A P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr A -> expr (list A) -> expr P -> UnderLets (expr P))
+      (x1 : expr (list A)) =>
+    ((match
+        pattern.type.unify_extracted_cps
+          (((((unit -> '2%pbtype) ->
+              ('1%pbtype ->
+               (pattern.base.type.list '1) -> '2%pbtype -> '2%pbtype) ->
+              (pattern.base.type.list '1) -> '2%pbtype) -> unit -> '2%pbtype) ->
+            '1%pbtype ->
+            (pattern.base.type.list '1) -> '2%pbtype -> '2%pbtype) ->
+           (pattern.base.type.list '1))%ptype
+          (((((unit -> P) -> (A -> (list A) -> P -> P) -> (list A) -> P) ->
+             unit -> P) -> A -> (list A) -> P -> P) -> (list A))%ptype option
+          (fun x2 : option => x2)
+      with
+      | Some
+        (_, _, (_, (_, (_, _)), (_, _)), (_, _), (_, (_, (_, b12))), b) =>
+          _ <- ident.unify pattern.ident.list_rect list_rect;
+          base.try_make_transport_cps P b12
+            (fun a13 : option =>
+             (fa <- (fun (T : Type) (k : option -> T) =>
+                     match a13 with
+                     | Some x' =>
+                         (return Some
+                                   (fun v : expr unit -> UnderLets (expr P)
+                                    => x' v)) T k
+                     | None => k None
+                     end);
+              match fa with
+              | Some v =>
+                  base.try_make_transport_cps A b
+                    (fun a14 : option =>
+                     fa0 <- (fun (T : Type) (k : option -> T) =>
+                             match a14 with
+                             | Some x' =>
+                                 base.try_make_transport_cps A b
+                                   (fun a15 : option =>
+                                    fa0 <- (fun (T0 : Type)
+                                              (k0 : option -> T0) =>
+                                            match a15 with
+                                            | Some x'0 =>
+                                                base.try_make_transport_cps P
+                                                  b12
+                                                  (fun a16 : option =>
+                                                   fa0 <- (fun (T1 : Type)
+                                                             (k1 : option ->
+                                                                   T1) =>
+                                                           match a16 with
+                                                           | Some x'1 =>
+                                                               base.try_make_transport_cps
+                                                                 P b12
+                                                                 (fun
+                                                                    a17 : option
+                                                                  =>
+                                                                  fa0 <- 
+                                                                  (fun
+                                                                    (T2 : Type)
+                                                                    (k2 : 
+                                                                    option ->
+                                                                    T2) =>
+                                                                   match
+                                                                    a17
+                                                                   with
+                                                                   | Some
+                                                                    x'2 =>
+                                                                    (return 
+                                                                    Some
+                                                                    (fun
+                                                                    v0 : 
+                                                                    expr b ->
+                                                                    expr
+                                                                    (list b) ->
+                                                                    expr P ->
+                                                                    UnderLets
+                                                                    (expr P)
+                                                                    =>
+                                                                    x'2
+                                                                    (x'1 v0)))
+                                                                    T2 k2
+                                                                   | None =>
+                                                                    k2 None
+                                                                   end);
+                                                                  k1 fa0)
+                                                           | None => k1 None
+                                                           end);
+                                                   fa1 <- (fun (T1 : Type)
+                                                             (k1 : option ->
+                                                                   T1) =>
+                                                           match fa0 with
+                                                           | Some x'1 =>
+                                                               (return 
+                                                                Some
+                                                                  (fun
+                                                                    v0 : 
+                                                                    expr b ->
+                                                                    expr
+                                                                    (list A) ->
+                                                                    expr P ->
+                                                                    UnderLets
+                                                                    (expr P)
+                                                                   =>
+                                                                   x'1
+                                                                    (x'0 v0)))
+                                                                 T1 k1
+                                                           | None => k1 None
+                                                           end);
+                                                   k0 fa1)
+                                            | None => k0 None
+                                            end);
+                                    fa1 <- (fun (T0 : Type)
+                                              (k0 : option -> T0) =>
+                                            match fa0 with
+                                            | Some x'0 =>
+                                                (return Some
+                                                          (fun
+                                                             v0 : expr A ->
+                                                                  expr
+                                                                    (list A) ->
+                                                                  expr P ->
+                                                                  UnderLets
+                                                                    (expr P)
+                                                           => x'0 (x' v0)))
+                                                  T0 k0
+                                            | None => k0 None
+                                            end);
+                                    k fa1)
+                             | None => k None
+                             end);
+                     match fa0 with
+                     | Some v0 =>
+                         v1 <- base.try_make_transport_cps A b;
+                         v2 <- base.try_make_transport_cps b12 P;
+                         (fv <- v2
+                                  (ls <- reflect_list (v1 x1);
+                                   Some
+                                     (Datatypes.list_rect
+                                        (fun
+                                           _ : Datatypes.list
+                                                 (expr
+                                                    (pattern.base.subst_default
+                                                       '1
+                                                       (PositiveMap.add
+                                                          (PositiveSet.rev
+                                                             2%positive) b12
+                                                          (PositiveMap.add
+                                                             (PositiveSet.rev
+                                                                1%positive) b
+                                                             (PositiveMap.empty
+                                                                base.type)))))
+                                         =>
+                                         UnderLets
+                                           (expr
+                                              (pattern.base.subst_default 
+                                                 '2
+                                                 (PositiveMap.add
+                                                    (PositiveSet.rev
+                                                       2%positive) b12
+                                                    (PositiveMap.add
+                                                       (PositiveSet.rev
+                                                          1%positive) b
+                                                       (PositiveMap.empty
+                                                          base.type))))))
+                                        (v x (##tt)%expr)
+                                        (fun
+                                           (x2 : expr
+                                                   (pattern.base.subst_default
+                                                      '1
+                                                      (PositiveMap.add
+                                                         (PositiveSet.rev
+                                                            2%positive) b12
+                                                         (PositiveMap.add
+                                                            (PositiveSet.rev
+                                                               1%positive) b
+                                                            (PositiveMap.empty
+                                                               base.type)))))
+                                           (xs : Datatypes.list
+                                                   (expr
+                                                      (pattern.base.subst_default
+                                                         '1
+                                                         (PositiveMap.add
+                                                            (PositiveSet.rev
+                                                               2%positive)
+                                                            b12
+                                                            (PositiveMap.add
+                                                               (PositiveSet.rev
+                                                                  1%positive)
+                                                               b
+                                                               (PositiveMap.empty
+                                                                  base.type))))))
+                                           (rec : UnderLets
+                                                    (expr
+                                                       (pattern.base.subst_default
+                                                          '2
+                                                          (PositiveMap.add
+                                                             (PositiveSet.rev
+                                                                2%positive)
+                                                             b12
+                                                             (PositiveMap.add
+                                                                (PositiveSet.rev
+                                                                   1%positive)
+                                                                b
+                                                                (PositiveMap.empty
+                                                                   base.type))))))
+                                         =>
+                                         (rec' <-- rec;
+                                          v0 x0 x2 (reify_list xs) rec')%under_lets)
+                                        ls));
+                          v3 <- base.try_make_transport_cps P P;
+                          v4 <- base.try_make_transport_cps P P;
+                          Some (fv0 <-- fv;
+                                Base (v4 (v3 fv0)))%under_lets)%option
+                     | None => None
+                     end)
+              | None => None
+              end)%cps)
+      | None => None
+      end;;
       None);;;
-     UnderLets.Base
-       (#(ident.list_rect)%expr @
-        (λ x2 : var (type.base base.type.unit),
-         UnderLets.to_expr (x ($x2)))%expr @
-        (λ (x2 : var (type.base A))(x3 : var (type.base (base.type.list A)))
-         (x4 : var (type.base P)),
-         UnderLets.to_expr (x0 ($x2) ($x3) ($x4)))%expr @ x1)%expr_pat)%option
-| @ident.list_case A P =>
-    fun
-      (x : defaults.expr (type.base base.type.unit) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base P)))
-      (x0 : defaults.expr (type.base A) ->
-            defaults.expr (type.base (base.type.list A)) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base P)))
-      (x1 : defaults.expr (type.base (base.type.list A))) =>
+     Base
+       (#(list_rect)%expr @ (λ x2 : var unit,
+                             to_expr (x ($x2)))%expr @
+        (λ (x2 : var A)(x3 : var (list A))(x4 : var P),
+         to_expr (x0 ($x2) ($x3) ($x4)))%expr @ x1)%expr_pat)%option
+| @list_case A P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr A -> expr (list A) -> UnderLets (expr P))
+      (x1 : expr (list A)) =>
     ((match x1 with
       | @expr.Ident _ _ _ t idc =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.nil;
-          Some
-            (fv <-- (e <-- x (##tt)%expr;
-                     UnderLets.Base {| anyexpr_ty := P; unwrap := e |});
-             base.try_make_transport_cps
-               (let (anyexpr_ty, _) := fv in anyexpr_ty) P
-               (fun
-                  a : option
-                        (defaults.expr
-                           (type.base
-                              (let (anyexpr_ty, _) := fv in anyexpr_ty)) ->
-                         defaults.expr (type.base P)) =>
-                match a with
-                | Some x' =>
-                    UnderLets.Base
-                      (x'
-                         (let
-                            (anyexpr_ty, unwrap) as a0
-                             return
-                               (defaults.expr
-                                  (type.base
-                                     (let (anyexpr_ty, _) := a0 in anyexpr_ty))) :=
-                            fv in
-                          unwrap))
-                | None =>
-                    UnderLets.Base
-                      (Compile.ERROR_BAD_REWRITE_RULE
-                         (#(pattern.ident.list_case) @ ??{() -> ??} @
-                          ??{?? -> ?? -> ??} @ [])
-                         (#(ident.list_case)%expr @
-                          (λ x2 : var (type.base base.type.unit),
-                           UnderLets.to_expr (x ($x2)))%expr @
-                          (λ (x2 : var (type.base A))(x3 : var
-                                                             (type.base
-                                                                (base.type.list
-                                                                   A))),
-                           UnderLets.to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat)
-                end))%under_lets
+          args <- invert_bind_args idc Raw.ident.nil;
+          match
+            pattern.type.unify_extracted_cps
+              (((((unit -> '2%pbtype) ->
+                  ('1%pbtype -> (pattern.base.type.list '1) -> '2%pbtype) ->
+                  (pattern.base.type.list '1) -> '2%pbtype) ->
+                 unit -> '2%pbtype) ->
+                '1%pbtype -> (pattern.base.type.list '1) -> '2%pbtype) ->
+               (pattern.base.type.list '1))%ptype
+              (((((unit -> P) -> (A -> (list A) -> P) -> (list A) -> P) ->
+                 unit -> P) -> A -> (list A) -> P) -> (list args))%ptype
+              option (fun x2 : option => x2)
+          with
+          | Some (_, _, (_, (_, _), (_, _)), (_, _), (_, (_, b10)), b) =>
+              _ <- ident.unify pattern.ident.list_case list_case;
+              base.try_make_transport_cps P b10
+                (fun a11 : option =>
+                 (fa <- (fun (T : Type) (k : option -> T) =>
+                         match a11 with
+                         | Some x' =>
+                             (return Some
+                                       (fun
+                                          v : expr unit -> UnderLets (expr P)
+                                        => x' v)) T k
+                         | None => k None
+                         end);
+                  match fa with
+                  | Some v =>
+                      base.try_make_transport_cps A b
+                        (fun a12 : option =>
+                         fa0 <- (fun (T : Type) (k : option -> T) =>
+                                 match a12 with
+                                 | Some x' =>
+                                     base.try_make_transport_cps A b
+                                       (fun a13 : option =>
+                                        fa0 <- (fun (T0 : Type)
+                                                  (k0 : option -> T0) =>
+                                                match a13 with
+                                                | Some x'0 =>
+                                                    base.try_make_transport_cps
+                                                      P b10
+                                                      (fun a14 : option =>
+                                                       fa0 <- (fun
+                                                                 (T1 : Type)
+                                                                 (k1 : 
+                                                                  option ->
+                                                                  T1) =>
+                                                               match a14 with
+                                                               | Some x'1 =>
+                                                                   (return 
+                                                                    Some
+                                                                    (fun
+                                                                    v0 : 
+                                                                    expr b ->
+                                                                    expr
+                                                                    (list A) ->
+                                                                    UnderLets
+                                                                    (expr P)
+                                                                    =>
+                                                                    x'1
+                                                                    (x'0 v0)))
+                                                                    T1 k1
+                                                               | None =>
+                                                                   k1 None
+                                                               end);
+                                                       k0 fa0)
+                                                | None => k0 None
+                                                end);
+                                        fa1 <- (fun (T0 : Type)
+                                                  (k0 : option -> T0) =>
+                                                match fa0 with
+                                                | Some x'0 =>
+                                                    (return Some
+                                                              (fun
+                                                                 v0 : 
+                                                                  expr A ->
+                                                                  expr
+                                                                    (list A) ->
+                                                                  UnderLets
+                                                                    (expr P)
+                                                               => x'0 (x' v0)))
+                                                      T0 k0
+                                                | None => k0 None
+                                                end);
+                                        k fa1)
+                                 | None => k None
+                                 end);
+                         match fa0 with
+                         | Some _ =>
+                             (_ <- ident.unify pattern.ident.nil nil;
+                              v1 <- base.try_make_transport_cps b10 P;
+                              v2 <- base.try_make_transport_cps P P;
+                              v3 <- base.try_make_transport_cps P P;
+                              Some
+                                (fv <-- v1 (v x (##tt)%expr);
+                                 Base (v3 (v2 fv)))%under_lets)%option
+                         | None => None
+                         end)
+                  | None => None
+                  end)%cps)
+          | None => None
+          end
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x3) x2 =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.cons;
+          args <- invert_bind_args idc Raw.ident.cons;
           match
-            s0 as t2
-            return
-              (Compile.value' false t2 ->
-               option
-                 (UnderLets.UnderLets base.type ident var
-                    (defaults.expr (type.base P))))
+            pattern.type.unify_extracted_cps
+              (((((unit -> '2%pbtype) ->
+                  ('1%pbtype -> (pattern.base.type.list '1) -> '2%pbtype) ->
+                  (pattern.base.type.list '1) -> '2%pbtype) ->
+                 unit -> '2%pbtype) ->
+                '1%pbtype -> (pattern.base.type.list '1) -> '2%pbtype) ->
+               (('1%pbtype ->
+                 (pattern.base.type.list '1) -> (pattern.base.type.list '1)) ->
+                '1%pbtype) -> (pattern.base.type.list '1))%ptype
+              (((((unit -> P) -> (A -> (list A) -> P) -> (list A) -> P) ->
+                 unit -> P) -> A -> (list A) -> P) ->
+               ((args -> (list args) -> (list args)) -> s0) -> s)%ptype
+              option (fun x4 : option => x4)
           with
-          | type.base t2 =>
-              fun v : defaults.expr (type.base t2) =>
-              match
-                s as t3
-                return
-                  (Compile.value' false t3 ->
-                   option
-                     (UnderLets.UnderLets base.type ident var
-                        (defaults.expr (type.base P))))
-              with
-              | type.base t3 =>
-                  fun v0 : defaults.expr (type.base t3) =>
-                  Compile.castbe v
-                    (option
-                       (UnderLets.UnderLets base.type ident var
-                          (defaults.expr (type.base P))))
-                    (fun x4 : option (defaults.expr (type.base A)) =>
-                     (x5 <- x4;
-                      Some
-                        (Compile.castbe v0
-                           (option
-                              (UnderLets.UnderLets base.type ident var
-                                 (defaults.expr (type.base P))))
-                           (fun
-                              xs : option
-                                     (defaults.expr
-                                        (type.base (base.type.list A))) =>
-                            (xs0 <- xs;
-                             Some
-                               (Some
-                                  (fv <-- (e <-- x0 x5 xs0;
-                                           UnderLets.Base
-                                             {|
-                                             anyexpr_ty := P;
-                                             unwrap := e |});
-                                   base.try_make_transport_cps
-                                     (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                                     P
-                                     (fun
-                                        a : option
-                                              (defaults.expr
-                                                 (type.base
-                                                    (let (anyexpr_ty, _) :=
-                                                       fv in
-                                                     anyexpr_ty)) ->
-                                               defaults.expr (type.base P))
-                                      =>
-                                      match a with
-                                      | Some x' =>
-                                          UnderLets.Base
-                                            (x'
-                                               (let
-                                                  (anyexpr_ty, unwrap) as a0
-                                                   return
-                                                     (defaults.expr
-                                                        (type.base
-                                                           (let
-                                                              (anyexpr_ty,
-                                                               _) := a0 in
-                                                            anyexpr_ty))) :=
-                                                  fv in
-                                                unwrap))
-                                      | None =>
-                                          UnderLets.Base
-                                            (Compile.ERROR_BAD_REWRITE_RULE
-                                               (#(pattern.ident.list_case) @
-                                                ??{() -> ??} @
-                                                ??{?? -> ?? -> ??} @
-                                                (?? :: ??))
-                                               (#(ident.list_case)%expr @
-                                                (λ x6 : var
-                                                          (type.base
-                                                             base.type.unit),
-                                                 UnderLets.to_expr (x ($x6)))%expr @
-                                                (λ (x6 : var (type.base A))
-                                                 (x7 : var
-                                                         (type.base
-                                                            (base.type.list A))),
-                                                 UnderLets.to_expr
-                                                   (x0 ($x6) ($x7)))%expr @
-                                                x1)%expr_pat)
-                                      end))%under_lets));;;
-                            None)));;;
-                     None)
-              | (s1 -> d1)%ptype =>
-                  fun _ : Compile.value' false s1 -> Compile.value' true d1
-                  => None
-              end (Compile.reflect x2)
-          | (s1 -> d1)%ptype =>
-              fun _ : Compile.value' false s1 -> Compile.value' true d1 =>
-              None
-          end (Compile.reflect x3)
+          | Some
+            (_, _, (_, (_, _), (_, _)), (_, _), (_, (_, b10)),
+            (_, (_, _), _, b11)) =>
+              _ <- ident.unify pattern.ident.list_case list_case;
+              base.try_make_transport_cps P b10
+                (fun a15 : option =>
+                 (fa <- (fun (T : Type) (k : option -> T) =>
+                         match a15 with
+                         | Some x' =>
+                             (return Some
+                                       (fun
+                                          v : expr unit -> UnderLets (expr P)
+                                        => x' v)) T k
+                         | None => k None
+                         end);
+                  match fa with
+                  | Some _ =>
+                      base.try_make_transport_cps A b11
+                        (fun a16 : option =>
+                         fa0 <- (fun (T : Type) (k : option -> T) =>
+                                 match a16 with
+                                 | Some x' =>
+                                     base.try_make_transport_cps A b11
+                                       (fun a17 : option =>
+                                        fa0 <- (fun (T0 : Type)
+                                                  (k0 : option -> T0) =>
+                                                match a17 with
+                                                | Some x'0 =>
+                                                    base.try_make_transport_cps
+                                                      P b10
+                                                      (fun a18 : option =>
+                                                       fa0 <- (fun
+                                                                 (T1 : Type)
+                                                                 (k1 : 
+                                                                  option ->
+                                                                  T1) =>
+                                                               match a18 with
+                                                               | Some x'1 =>
+                                                                   (return 
+                                                                    Some
+                                                                    (fun
+                                                                    v0 : 
+                                                                    expr b11 ->
+                                                                    expr
+                                                                    (list A) ->
+                                                                    UnderLets
+                                                                    (expr P)
+                                                                    =>
+                                                                    x'1
+                                                                    (x'0 v0)))
+                                                                    T1 k1
+                                                               | None =>
+                                                                   k1 None
+                                                               end);
+                                                       k0 fa0)
+                                                | None => k0 None
+                                                end);
+                                        fa1 <- (fun (T0 : Type)
+                                                  (k0 : option -> T0) =>
+                                                match fa0 with
+                                                | Some x'0 =>
+                                                    (return Some
+                                                              (fun
+                                                                 v0 : 
+                                                                  expr A ->
+                                                                  expr
+                                                                    (list A) ->
+                                                                  UnderLets
+                                                                    (expr P)
+                                                               => x'0 (x' v0)))
+                                                      T0 k0
+                                                | None => k0 None
+                                                end);
+                                        k fa1)
+                                 | None => k None
+                                 end);
+                         match fa0 with
+                         | Some v0 =>
+                             (_ <- ident.unify pattern.ident.cons cons;
+                              v1 <- type.try_make_transport_cps s0 b11;
+                              v2 <- type.try_make_transport_cps s (list b11);
+                              v3 <- base.try_make_transport_cps b10 P;
+                              v4 <- base.try_make_transport_cps P P;
+                              v5 <- base.try_make_transport_cps P P;
+                              Some
+                                (fv <-- v3
+                                          (v0 x0 (v1 (Compile.reflect x3))
+                                             (v2 (Compile.reflect x2)));
+                                 Base (v5 (v4 fv)))%under_lets)%option
+                         | None => None
+                         end)
+                  | None => None
+                  end)%cps)
+          | None => None
+          end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
@@ -868,1177 +1228,1546 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base
-       (#(ident.list_case)%expr @
-        (λ x2 : var (type.base base.type.unit),
-         UnderLets.to_expr (x ($x2)))%expr @
-        (λ (x2 : var (type.base A))(x3 : var (type.base (base.type.list A))),
-         UnderLets.to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat)%option
-| @ident.List_length T =>
-    fun x : defaults.expr (type.base (base.type.list T)) =>
-    (reflect_list_cps x
-       (fun xs : option (list (defaults.expr (type.base T))) =>
-        (xs0 <- xs;
-         Some (Some (UnderLets.Base (##(length xs0))%expr)));;;
-        None);;;
-     UnderLets.Base (#(ident.List_length)%expr @ x)%expr_pat)%option
-| ident.List_seq =>
-    fun x x0 : defaults.expr (type.base base.type.nat) =>
+     Base
+       (#(list_case)%expr @ (λ x2 : var unit,
+                             to_expr (x ($x2)))%expr @
+        (λ (x2 : var A)(x3 : var (list A)),
+         to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat)%option
+| @List_length T =>
+    fun x : expr (list T) =>
+    (match
+       pattern.type.unify_extracted_cps
+         (((pattern.base.type.list '1) -> ℕ) -> (pattern.base.type.list '1))%ptype
+         (((list T) -> ℕ) -> (list T))%ptype option (fun x0 : option => x0)
+     with
+     | Some (_, _, b) =>
+         _ <- ident.unify pattern.ident.List_length List_length;
+         v <- base.try_make_transport_cps T b;
+         x0 <- (xs <- reflect_list (v x);
+                Some (##(length xs))%expr);
+         Some (Base x0)
+     | None => None
+     end;;;
+     Base (#(List_length)%expr @ x)%expr_pat)%option
+| List_seq =>
+    fun x x0 : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralNat;
-              Some
-                (UnderLets.Base
-                   (fold_right
-                      (fun (x1 : defaults.expr (type.base base.type.nat))
-                         (xs : defaults.expr
-                                 (type.base (base.type.list base.type.nat)))
-                       => (x1 :: xs)%expr_pat) []%expr_pat
-                      (map (fun v : nat => (##v)%expr) (seq args args0))))
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℕ -> ℕ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (fold_right
+                          (fun (x1 : expr ℕ) (xs : expr (list ℕ)) =>
+                           (x1 :: xs)%expr_pat) []%expr_pat
+                          (map (fun v : nat => (##v)%expr)
+                             (seq (let (x1, _) := idc_args in x1)
+                                (let (x1, _) := idc_args0 in x1)))))
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.List_seq)%expr @ x @ x0)%expr_pat)%option
-| @ident.List_firstn A =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
+     Base (#(List_seq)%expr @ x @ x0)%expr_pat)%option
+| @List_firstn A =>
+    fun (x : expr ℕ) (x0 : expr (list A)) =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-          reflect_list_cps x0
-            (fun xs : option (list (defaults.expr (type.base A))) =>
-             (xs0 <- xs;
-              Some
-                (Some
-                   (base.try_make_transport_cps A A
-                      (fun
-                         a : option
-                               (defaults.expr (type.base (base.type.list A)) ->
-                                defaults.expr (type.base (base.type.list A)))
-                       =>
-                       match a with
-                       | Some x' =>
-                           UnderLets.Base (x' (reify_list (firstn args xs0)))
-                       | None =>
-                           UnderLets.Base
-                             (Compile.ERROR_BAD_REWRITE_RULE
-                                (#(pattern.ident.List_firstn) @
-                                 #(pattern.ident.LiteralNat) @
-                                 ??{type.base (pattern.base.type.list ??)})
-                                (#(ident.List_firstn)%expr @ x @ x0)%expr_pat)
-                       end))));;;
-             None)
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps
+              (((ℕ ->
+                 (pattern.base.type.list '1) -> (pattern.base.type.list '1)) ->
+                ℕ) -> (pattern.base.type.list '1))%ptype
+              (((ℕ -> (list A) -> (list A)) -> (projT1 args)) -> (list A))%ptype
+              option (fun x1 : option => x1)
+          with
+          | Some (_, (_, _), _, b) =>
+              _ <- ident.unify pattern.ident.List_firstn List_firstn;
+              idc_args0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+              v <- base.try_make_transport_cps A b;
+              v0 <- base.try_make_transport_cps b A;
+              fv <- v0
+                      (xs <- reflect_list (v x0);
+                       Some
+                         (Base
+                            (reify_list
+                               (firstn (let (x1, _) := idc_args0 in x1) xs))));
+              v1 <- base.try_make_transport_cps A A;
+              v2 <- base.try_make_transport_cps A A;
+              Some (fv0 <-- fv;
+                    Base (v2 (v1 fv0)))%under_lets
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.List_firstn)%expr @ x @ x0)%expr_pat)%option
-| @ident.List_skipn A =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
+     Base (#(List_firstn)%expr @ x @ x0)%expr_pat)%option
+| @List_skipn A =>
+    fun (x : expr ℕ) (x0 : expr (list A)) =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-          reflect_list_cps x0
-            (fun xs : option (list (defaults.expr (type.base A))) =>
-             (xs0 <- xs;
-              Some
-                (Some
-                   (base.try_make_transport_cps A A
-                      (fun
-                         a : option
-                               (defaults.expr (type.base (base.type.list A)) ->
-                                defaults.expr (type.base (base.type.list A)))
-                       =>
-                       match a with
-                       | Some x' =>
-                           UnderLets.Base (x' (reify_list (skipn args xs0)))
-                       | None =>
-                           UnderLets.Base
-                             (Compile.ERROR_BAD_REWRITE_RULE
-                                (#(pattern.ident.List_skipn) @
-                                 #(pattern.ident.LiteralNat) @
-                                 ??{type.base (pattern.base.type.list ??)})
-                                (#(ident.List_skipn)%expr @ x @ x0)%expr_pat)
-                       end))));;;
-             None)
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps
+              (((ℕ ->
+                 (pattern.base.type.list '1) -> (pattern.base.type.list '1)) ->
+                ℕ) -> (pattern.base.type.list '1))%ptype
+              (((ℕ -> (list A) -> (list A)) -> (projT1 args)) -> (list A))%ptype
+              option (fun x1 : option => x1)
+          with
+          | Some (_, (_, _), _, b) =>
+              _ <- ident.unify pattern.ident.List_skipn List_skipn;
+              idc_args0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+              v <- base.try_make_transport_cps A b;
+              v0 <- base.try_make_transport_cps b A;
+              fv <- v0
+                      (xs <- reflect_list (v x0);
+                       Some
+                         (Base
+                            (reify_list
+                               (skipn (let (x1, _) := idc_args0 in x1) xs))));
+              v1 <- base.try_make_transport_cps A A;
+              v2 <- base.try_make_transport_cps A A;
+              Some (fv0 <-- fv;
+                    Base (v2 (v1 fv0)))%under_lets
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.List_skipn)%expr @ x @ x0)%expr_pat)%option
-| @ident.List_repeat A =>
-    fun (x : defaults.expr (type.base A))
-      (x0 : defaults.expr (type.base base.type.nat)) =>
+     Base (#(List_skipn)%expr @ x @ x0)%expr_pat)%option
+| @List_repeat A =>
+    fun (x : expr A) (x0 : expr ℕ) =>
     ((match x0 with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-          Some
-            (base.try_make_transport_cps A A
-               (fun
-                  a : option
-                        (defaults.expr (type.base (base.type.list A)) ->
-                         defaults.expr (type.base (base.type.list A))) =>
-                match a with
-                | Some x' => UnderLets.Base (x' (reify_list (repeat x args)))
-                | None =>
-                    UnderLets.Base
-                      (Compile.ERROR_BAD_REWRITE_RULE
-                         (#(pattern.ident.List_repeat) @ ?? @
-                          #(pattern.ident.LiteralNat))
-                         (#(ident.List_repeat)%expr @ x @ x0)%expr_pat)
-                end))
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps
+              ((('1%pbtype -> ℕ -> (pattern.base.type.list '1)) -> '1%pbtype) ->
+               ℕ)%ptype (((A -> ℕ -> (list A)) -> A) -> (projT1 args))%ptype
+              option (fun x1 : option => x1)
+          with
+          | Some (_, (_, _), b0, _) =>
+              _ <- ident.unify pattern.ident.List_repeat List_repeat;
+              v <- base.try_make_transport_cps A b0;
+              idc_args0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+              v0 <- base.try_make_transport_cps b0 A;
+              v1 <- base.try_make_transport_cps A A;
+              v2 <- base.try_make_transport_cps A A;
+              Some
+                (Base
+                   (v2
+                      (v1
+                         (v0
+                            (reify_list
+                               (repeat (v x) (let (x1, _) := idc_args0 in x1)))))))
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.List_repeat)%expr @ x @ x0)%expr_pat)%option
-| @ident.List_combine A B =>
-    fun (x : defaults.expr (type.base (base.type.list A)))
-      (x0 : defaults.expr (type.base (base.type.list B))) =>
-    (reflect_list_cps x
-       (fun xs : option (list (defaults.expr (type.base A))) =>
-        (xs0 <- xs;
-         Some
-           (reflect_list_cps x0
-              (fun ys : option (list (defaults.expr (type.base B))) =>
-               (ys0 <- ys;
-                Some
-                  (Some
-                     ((trA <-- @base.try_make_transport_cps
-                                 (fun A0 : base.type =>
-                                  defaults.expr
-                                    (type.base (base.type.list (A0 * B)))) A
-                                 A;
-                       trB <-- @base.try_make_transport_cps
-                                 (fun B0 : base.type =>
-                                  defaults.expr
-                                    (type.base (base.type.list (A * B0)))) B
-                                 B;
-                       return Some
-                                (fun
-                                   v : defaults.expr
-                                         (type.base (base.type.list (A * B)))
-                                 => trB (trA v)))%cps
-                        (UnderLets.UnderLets base.type ident var
-                           (defaults.expr
-                              (type.base (base.type.list (A * B)))))
-                        (fun
-                           a : option
-                                 (defaults.expr
-                                    (type.base (base.type.list (A * B))) ->
-                                  defaults.expr
-                                    (type.base (base.type.list (A * B)))) =>
-                         match a with
-                         | Some x' =>
-                             UnderLets.Base
-                               (x'
-                                  (reify_list
-                                     (map (fun '(x1, y) => (x1, y)%expr_pat)
-                                        (combine xs0 ys0))))
-                         | None =>
-                             UnderLets.Base
-                               (Compile.ERROR_BAD_REWRITE_RULE
-                                  (#(pattern.ident.List_combine) @
-                                   ??{type.base (pattern.base.type.list ??)} @
-                                   ??{type.base (pattern.base.type.list ??)})
-                                  (#(ident.List_combine)%expr @ x @ x0)%expr_pat)
-                         end))));;;
-               None)));;;
-        None);;;
-     UnderLets.Base (#(ident.List_combine)%expr @ x @ x0)%expr_pat)%option
-| @ident.List_map A B =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base B)))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    ((Compile.castbe x0
-        (option
-           (UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base (base.type.list B)))))
-        (fun e : option (defaults.expr (type.base (base.type.list A))) =>
-         (e0 <- e;
-          Some
-            (reflect_list_cps e0
-               (fun ls : option (list (defaults.expr (type.base A))) =>
-                (ls0 <- ls;
-                 Some
-                   (Some
-                      (fv <-- (e1 <-- list_rect
-                                        (fun
-                                           _ : list
-                                                 (defaults.expr (type.base A))
-                                         =>
-                                         UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base (base.type.list B))))
-                                        (UnderLets.Base []%expr_pat)
-                                        (fun
-                                           (x1 : defaults.expr (type.base A))
-                                           (_ : list
-                                                  (defaults.expr
-                                                     (type.base A)))
-                                           (rec : UnderLets.UnderLets
-                                                    base.type ident var
-                                                    (defaults.expr
-                                                       (type.base
-                                                          (base.type.list B))))
-                                         =>
-                                         rec' <-- rec;
-                                         fx <-- x x1;
-                                         UnderLets.Base (fx :: rec')%expr_pat)
-                                        ls0;
-                               UnderLets.Base
-                                 {|
-                                 anyexpr_ty := base.type.list B;
-                                 unwrap := e1 |});
-                       base.try_make_transport_cps
-                         (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                         (base.type.list B)
-                         (fun
-                            a : option
-                                  (defaults.expr
-                                     (type.base
-                                        (let (anyexpr_ty, _) := fv in
-                                         anyexpr_ty)) ->
-                                   defaults.expr
-                                     (type.base (base.type.list B))) =>
-                          match a with
-                          | Some x' =>
-                              UnderLets.Base
-                                (x'
-                                   (let
-                                      (anyexpr_ty, unwrap) as a0
-                                       return
-                                         (defaults.expr
-                                            (type.base
-                                               (let (anyexpr_ty, _) := a0 in
-                                                anyexpr_ty))) := fv in
-                                    unwrap))
-                          | None =>
-                              UnderLets.Base
-                                (Compile.ERROR_BAD_REWRITE_RULE
-                                   (#(pattern.ident.List_map) @ ??{?? -> ??} @
-                                    ??{type.base (pattern.base.type.list ??)})
-                                   (#(ident.List_map)%expr @
-                                    (λ x1 : var (type.base A),
-                                     UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat)
-                          end))%under_lets));;;
-                None)));;;
-         None);;
+     Base (#(List_repeat)%expr @ x @ x0)%expr_pat)%option
+| @List_combine A B =>
+    fun (x : expr (list A)) (x0 : expr (list B)) =>
+    (match
+       pattern.type.unify_extracted_cps
+         ((((pattern.base.type.list '1) ->
+            (pattern.base.type.list '2) -> (pattern.base.type.list ('1 * '2))) ->
+           (pattern.base.type.list '1)) -> (pattern.base.type.list '2))%ptype
+         ((((list A) -> (list B) -> (list (A * B))) -> (list A)) -> (list B))%ptype
+         option (fun x1 : option => x1)
+     with
+     | Some (_, (_, (_, _)), b0, b) =>
+         _ <- ident.unify pattern.ident.List_combine List_combine;
+         v <- base.try_make_transport_cps A b0;
+         v0 <- base.try_make_transport_cps B b;
+         (trA <-- @base.try_make_transport_cps (fun A0 : base.type => option)
+                    b0 A;
+          trB <-- @base.try_make_transport_cps (fun B0 : base.type => option)
+                    b B;
+          return Some (fun v1 : option => trB (trA v1)))%cps option
+           (fun tr : option =>
+            match tr with
+            | Some v1 =>
+                x1 <- v1
+                        (xs <- reflect_list (v x);
+                         ys <- reflect_list (v0 x0);
+                         Some
+                           (reify_list
+                              (map (fun '(x1, y) => (x1, y)%expr_pat)
+                                 (combine xs ys))));
+                (trA <-- @base.try_make_transport_cps
+                           (fun A0 : base.type => expr (list (A0 * B))) A A;
+                 trB <-- @base.try_make_transport_cps
+                           (fun B0 : base.type => expr (list (A * B0))) B B;
+                 return Some (fun v2 : expr (list (A * B)) => trB (trA v2)))%cps
+                  option
+                  (fun tr0 : option =>
+                   match tr0 with
+                   | Some v2 =>
+                       (trA <-- @base.try_make_transport_cps
+                                  (fun A0 : base.type => expr (list (A0 * B)))
+                                  A A;
+                        trB <-- @base.try_make_transport_cps
+                                  (fun B0 : base.type => expr (list (A * B0)))
+                                  B B;
+                        return Some
+                                 (fun v3 : expr (list (A * B)) =>
+                                  trB (trA v3)))%cps option
+                         (fun tr' : option =>
+                          match tr' with
+                          | Some v3 => Some (Base (v3 (v2 x1)))
+                          | None => None
+                          end)
+                   | None => None
+                   end)
+            | None => None
+            end)
+     | None => None
+     end;;;
+     Base (#(List_combine)%expr @ x @ x0)%expr_pat)%option
+| @List_map A B =>
+    fun (x : expr A -> UnderLets (expr B)) (x0 : expr (list A)) =>
+    ((match
+        pattern.type.unify_extracted_cps
+          (((('1%pbtype -> '2%pbtype) ->
+             (pattern.base.type.list '1) -> (pattern.base.type.list '2)) ->
+            '1%pbtype -> '2%pbtype) -> (pattern.base.type.list '1))%ptype
+          ((((A -> B) -> (list A) -> (list B)) -> A -> B) -> (list A))%ptype
+          option (fun x1 : option => x1)
+      with
+      | Some (_, _, (_, _), (_, b4), b) =>
+          _ <- ident.unify pattern.ident.List_map List_map;
+          base.try_make_transport_cps A b
+            (fun a5 : option =>
+             (fa <- (fun (T : Type) (k : option -> T) =>
+                     match a5 with
+                     | Some x' =>
+                         base.try_make_transport_cps B b4
+                           (fun a6 : option =>
+                            fa <- (fun (T0 : Type) (k0 : option -> T0) =>
+                                   match a6 with
+                                   | Some x'0 =>
+                                       (return Some
+                                                 (fun
+                                                    v : expr A ->
+                                                        UnderLets (expr B) =>
+                                                  x'0 (x' v))) T0 k0
+                                   | None => k0 None
+                                   end);
+                            k fa)
+                     | None => k None
+                     end);
+              match fa with
+              | Some v =>
+                  v0 <- base.try_make_transport_cps A b;
+                  v1 <- base.try_make_transport_cps b4 B;
+                  (fv <- v1
+                           (ls <- reflect_list (v0 x0);
+                            Some
+                              (Datatypes.list_rect
+                                 (fun
+                                    _ : Datatypes.list
+                                          (expr
+                                             (pattern.base.subst_default 
+                                                '1
+                                                (PositiveMap.add
+                                                   (PositiveSet.rev
+                                                      2%positive) b4
+                                                   (PositiveMap.add
+                                                      (PositiveSet.rev
+                                                         1%positive) b
+                                                      (PositiveMap.empty
+                                                         base.type))))) =>
+                                  UnderLets
+                                    (expr
+                                       (list
+                                          (pattern.base.subst_default 
+                                             '2
+                                             (PositiveMap.add
+                                                (PositiveSet.rev 2%positive)
+                                                b4
+                                                (PositiveMap.add
+                                                   (PositiveSet.rev
+                                                      1%positive) b
+                                                   (PositiveMap.empty
+                                                      base.type)))))))
+                                 (Base []%expr_pat)
+                                 (fun
+                                    (x1 : expr
+                                            (pattern.base.subst_default 
+                                               '1
+                                               (PositiveMap.add
+                                                  (PositiveSet.rev 2%positive)
+                                                  b4
+                                                  (PositiveMap.add
+                                                     (PositiveSet.rev
+                                                        1%positive) b
+                                                     (PositiveMap.empty
+                                                        base.type)))))
+                                    (_ : Datatypes.list
+                                           (expr
+                                              (pattern.base.subst_default 
+                                                 '1
+                                                 (PositiveMap.add
+                                                    (PositiveSet.rev
+                                                       2%positive) b4
+                                                    (PositiveMap.add
+                                                       (PositiveSet.rev
+                                                          1%positive) b
+                                                       (PositiveMap.empty
+                                                          base.type))))))
+                                    (rec : UnderLets
+                                             (expr
+                                                (list
+                                                   (pattern.base.subst_default
+                                                      '2
+                                                      (PositiveMap.add
+                                                         (PositiveSet.rev
+                                                            2%positive) b4
+                                                         (PositiveMap.add
+                                                            (PositiveSet.rev
+                                                               1%positive) b
+                                                            (PositiveMap.empty
+                                                               base.type)))))))
+                                  =>
+                                  (rec' <-- rec;
+                                   fx <-- v x x1;
+                                   Base (fx :: rec')%expr_pat)%under_lets) ls));
+                   v2 <- base.try_make_transport_cps B B;
+                   v3 <- base.try_make_transport_cps B B;
+                   Some (fv0 <-- fv;
+                         Base (v3 (v2 fv0)))%under_lets)%option
+              | None => None
+              end)%cps)
+      | None => None
+      end;;
       None);;;
-     UnderLets.Base
-       (#(ident.List_map)%expr @
-        (λ x1 : var (type.base A),
-         UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
-| @ident.List_app A =>
-    fun x x0 : defaults.expr (type.base (base.type.list A)) =>
-    ((Compile.castbe x
-        (option
-           (UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base (base.type.list A)))))
-        (fun e : option (defaults.expr (type.base (base.type.list A))) =>
-         (e0 <- e;
-          Some
-            (reflect_list_cps e0
-               (fun ls : option (list (defaults.expr (type.base A))) =>
-                (ls0 <- ls;
-                 Some
-                   (Some
-                      (fv <-- (e1 <-- list_rect
-                                        (fun
-                                           _ : list
-                                                 (defaults.expr (type.base A))
-                                         =>
-                                         UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base (base.type.list A))))
-                                        (UnderLets.Base x0)
-                                        (fun
-                                           (x1 : defaults.expr (type.base A))
-                                           (_ : list
-                                                  (defaults.expr
-                                                     (type.base A)))
-                                           (rec : UnderLets.UnderLets
-                                                    base.type ident var
-                                                    (defaults.expr
-                                                       (type.base
-                                                          (base.type.list A))))
-                                         =>
-                                         rec' <-- rec;
-                                         UnderLets.Base (x1 :: rec')%expr_pat)
-                                        ls0;
-                               UnderLets.Base
-                                 {|
-                                 anyexpr_ty := base.type.list A;
-                                 unwrap := e1 |});
-                       base.try_make_transport_cps
-                         (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                         (base.type.list A)
-                         (fun
-                            a : option
-                                  (defaults.expr
-                                     (type.base
-                                        (let (anyexpr_ty, _) := fv in
-                                         anyexpr_ty)) ->
-                                   defaults.expr
-                                     (type.base (base.type.list A))) =>
-                          match a with
-                          | Some x' =>
-                              UnderLets.Base
-                                (x'
-                                   (let
-                                      (anyexpr_ty, unwrap) as a0
-                                       return
-                                         (defaults.expr
-                                            (type.base
-                                               (let (anyexpr_ty, _) := a0 in
-                                                anyexpr_ty))) := fv in
-                                    unwrap))
-                          | None =>
-                              UnderLets.Base
-                                (Compile.ERROR_BAD_REWRITE_RULE
-                                   (??{type.base (pattern.base.type.list ??)} ++
-                                    ??{type.base (pattern.base.type.list ??)})
-                                   (x ++ x0))
-                          end))%under_lets));;;
-                None)));;;
-         None);;
+     Base
+       (#(List_map)%expr @ (λ x1 : var A,
+                            to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
+| @List_app A =>
+    fun x x0 : expr (list A) =>
+    ((match
+        pattern.type.unify_extracted_cps
+          ((((pattern.base.type.list '1) ->
+             (pattern.base.type.list '1) -> (pattern.base.type.list '1)) ->
+            (pattern.base.type.list '1)) -> (pattern.base.type.list '1))%ptype
+          ((((list A) -> (list A) -> (list A)) -> (list A)) -> (list A))%ptype
+          option (fun x1 : option => x1)
+      with
+      | Some (_, (_, _), _, b) =>
+          _ <- ident.unify pattern.ident.List_app List_app;
+          v <- base.try_make_transport_cps A b;
+          v0 <- base.try_make_transport_cps A b;
+          v1 <- base.try_make_transport_cps b A;
+          fv <- v1
+                  (ls <- reflect_list (v x);
+                   Some
+                     (Datatypes.list_rect
+                        (fun _ : Datatypes.list (expr b) =>
+                         UnderLets
+                           (expr
+                              (pattern.base.subst_default
+                                 (pattern.base.type.list '1)
+                                 (PositiveMap.add
+                                    (PositiveSet.rev 1%positive) b
+                                    (PositiveMap.empty base.type)))))
+                        (Base (v0 x0))
+                        (fun (x1 : expr b) (_ : Datatypes.list (expr b))
+                           (rec : UnderLets
+                                    (expr
+                                       (pattern.base.subst_default
+                                          (pattern.base.type.list '1)
+                                          (PositiveMap.add
+                                             (PositiveSet.rev 1%positive) b
+                                             (PositiveMap.empty base.type)))))
+                         =>
+                         (rec' <-- rec;
+                          Base (x1 :: rec')%expr_pat)%under_lets) ls));
+          v2 <- base.try_make_transport_cps A A;
+          v3 <- base.try_make_transport_cps A A;
+          Some (fv0 <-- fv;
+                Base (v3 (v2 fv0)))%under_lets
+      | None => None
+      end;;
       None);;;
-     UnderLets.Base (x ++ x0)%expr)%option
-| @ident.List_rev A =>
-    fun x : defaults.expr (type.base (base.type.list A)) =>
-    ((reflect_list_cps x
-        (fun xs : option (list (defaults.expr (type.base A))) =>
-         (xs0 <- xs;
-          Some
-            (Some
-               (base.try_make_transport_cps A A
-                  (fun
-                     a : option
-                           (defaults.expr (type.base (base.type.list A)) ->
-                            defaults.expr (type.base (base.type.list A))) =>
-                   match a with
-                   | Some x' => UnderLets.Base (x' (reify_list (rev xs0)))
-                   | None =>
-                       UnderLets.Base
-                         (Compile.ERROR_BAD_REWRITE_RULE
-                            (#(pattern.ident.List_rev) @
-                             ??{type.base (pattern.base.type.list ??)})
-                            (#(ident.List_rev)%expr @ x)%expr_pat)
-                   end))));;;
-         None);;
+     Base (x ++ x0)%expr)%option
+| @List_rev A =>
+    fun x : expr (list A) =>
+    ((match
+        pattern.type.unify_extracted_cps
+          (((pattern.base.type.list '1) -> (pattern.base.type.list '1)) ->
+           (pattern.base.type.list '1))%ptype
+          (((list A) -> (list A)) -> (list A))%ptype option
+          (fun x0 : option => x0)
+      with
+      | Some (_, _, b) =>
+          _ <- ident.unify pattern.ident.List_rev List_rev;
+          v <- base.try_make_transport_cps A b;
+          v0 <- base.try_make_transport_cps b A;
+          fv <- v0
+                  (xs <- reflect_list (v x);
+                   Some (Base (reify_list (rev xs))));
+          v1 <- base.try_make_transport_cps A A;
+          v2 <- base.try_make_transport_cps A A;
+          Some (fv0 <-- fv;
+                Base (v2 (v1 fv0)))%under_lets
+      | None => None
+      end;;
       None);;;
-     UnderLets.Base (#(ident.List_rev)%expr @ x)%expr_pat)%option
-| @ident.List_flat_map A B =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base (base.type.list B))))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    ((Compile.castbe x0
-        (option
-           (UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base (base.type.list B)))))
-        (fun e : option (defaults.expr (type.base (base.type.list A))) =>
-         (e0 <- e;
-          Some
-            (reflect_list_cps e0
-               (fun ls : option (list (defaults.expr (type.base A))) =>
-                (ls0 <- ls;
-                 Some
-                   (Some
-                      (fv <-- (e1 <-- list_rect
-                                        (fun
-                                           _ : list
-                                                 (defaults.expr (type.base A))
-                                         =>
-                                         UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base (base.type.list B))))
-                                        (UnderLets.Base []%expr_pat)
-                                        (fun
-                                           (x1 : defaults.expr (type.base A))
-                                           (_ : list
-                                                  (defaults.expr
-                                                     (type.base A)))
-                                           (rec : UnderLets.UnderLets
-                                                    base.type ident var
-                                                    (defaults.expr
-                                                       (type.base
-                                                          (base.type.list B))))
-                                         =>
-                                         rec' <-- rec;
-                                         fx <-- x x1;
-                                         UnderLets.Base ($fx ++ rec')%expr)
-                                        ls0;
-                               UnderLets.Base
-                                 {|
-                                 anyexpr_ty := base.type.list B;
-                                 unwrap := e1 |});
-                       fv0 <-- do_again
-                                 (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                                 (let
-                                    (anyexpr_ty, unwrap) as a
-                                     return
-                                       (defaults.expr
-                                          (type.base
-                                             (let (anyexpr_ty, _) := a in
-                                              anyexpr_ty))) := fv in
-                                  unwrap);
-                       base.try_make_transport_cps
-                         (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                         (base.type.list B)
-                         (fun
-                            a : option
-                                  (defaults.expr
-                                     (type.base
-                                        (let (anyexpr_ty, _) := fv in
-                                         anyexpr_ty)) ->
-                                   defaults.expr
-                                     (type.base (base.type.list B))) =>
-                          match a with
-                          | Some x' => UnderLets.Base (x' fv0)
-                          | None =>
-                              UnderLets.Base
-                                (Compile.ERROR_BAD_REWRITE_RULE
-                                   (#(pattern.ident.List_flat_map) @
-                                    ??{?? ->
-                                       type.base (pattern.base.type.list ??)} @
-                                    ??{type.base (pattern.base.type.list ??)})
-                                   (#(ident.List_flat_map)%expr @
-                                    (λ x1 : var (type.base A),
-                                     UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat)
-                          end))%under_lets));;;
-                None)));;;
-         None);;
+     Base (#(List_rev)%expr @ x)%expr_pat)%option
+| @List_flat_map A B =>
+    fun (x : expr A -> UnderLets (expr (list B))) (x0 : expr (list A)) =>
+    ((match
+        pattern.type.unify_extracted_cps
+          (((('1%pbtype -> (pattern.base.type.list '2)) ->
+             (pattern.base.type.list '1) -> (pattern.base.type.list '2)) ->
+            '1%pbtype -> (pattern.base.type.list '2)) ->
+           (pattern.base.type.list '1))%ptype
+          ((((A -> (list B)) -> (list A) -> (list B)) -> A -> (list B)) ->
+           (list A))%ptype option (fun x1 : option => x1)
+      with
+      | Some (_, _, (_, _), (_, b4), b) =>
+          _ <- ident.unify pattern.ident.List_flat_map List_flat_map;
+          base.try_make_transport_cps A b
+            (fun a5 : option =>
+             (fa <- (fun (T : Type) (k : option -> T) =>
+                     match a5 with
+                     | Some x' =>
+                         base.try_make_transport_cps B b4
+                           (fun a6 : option =>
+                            fa <- (fun (T0 : Type) (k0 : option -> T0) =>
+                                   match a6 with
+                                   | Some x'0 =>
+                                       (return Some
+                                                 (fun
+                                                    v : expr A ->
+                                                        UnderLets
+                                                          (expr (list B)) =>
+                                                  x'0 (x' v))) T0 k0
+                                   | None => k0 None
+                                   end);
+                            k fa)
+                     | None => k None
+                     end);
+              match fa with
+              | Some v =>
+                  v0 <- base.try_make_transport_cps A b;
+                  v1 <- base.try_make_transport_cps b4 B;
+                  (fv <- v1
+                           (ls <- reflect_list (v0 x0);
+                            Some
+                              (Datatypes.list_rect
+                                 (fun
+                                    _ : Datatypes.list
+                                          (expr
+                                             (pattern.base.subst_default 
+                                                '1
+                                                (PositiveMap.add
+                                                   (PositiveSet.rev
+                                                      2%positive) b4
+                                                   (PositiveMap.add
+                                                      (PositiveSet.rev
+                                                         1%positive) b
+                                                      (PositiveMap.empty
+                                                         base.type))))) =>
+                                  UnderLets (expr (list b4)))
+                                 (Base []%expr_pat)
+                                 (fun
+                                    (x1 : expr
+                                            (pattern.base.subst_default 
+                                               '1
+                                               (PositiveMap.add
+                                                  (PositiveSet.rev 2%positive)
+                                                  b4
+                                                  (PositiveMap.add
+                                                     (PositiveSet.rev
+                                                        1%positive) b
+                                                     (PositiveMap.empty
+                                                        base.type)))))
+                                    (_ : Datatypes.list
+                                           (expr
+                                              (pattern.base.subst_default 
+                                                 '1
+                                                 (PositiveMap.add
+                                                    (PositiveSet.rev
+                                                       2%positive) b4
+                                                    (PositiveMap.add
+                                                       (PositiveSet.rev
+                                                          1%positive) b
+                                                       (PositiveMap.empty
+                                                          base.type))))))
+                                    (rec : UnderLets (expr (list b4))) =>
+                                  (rec' <-- rec;
+                                   fx <-- v x x1;
+                                   Base ($fx ++ rec')%expr)%under_lets) ls));
+                   v2 <- base.try_make_transport_cps B B;
+                   v3 <- base.try_make_transport_cps B B;
+                   Some
+                     (fv0 <-- fv;
+                      fv1 <-- do_again (list B) (v2 fv0);
+                      Base (v3 fv1))%under_lets)%option
+              | None => None
+              end)%cps)
+      | None => None
+      end;;
       None);;;
-     UnderLets.Base
-       (#(ident.List_flat_map)%expr @
-        (λ x1 : var (type.base A),
-         UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
-| @ident.List_partition A =>
-    fun
-      (x : defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base base.type.bool)))
-      (x0 : defaults.expr (type.base (base.type.list A))) =>
-    ((Compile.castbe x0
-        (option
-           (UnderLets.UnderLets base.type ident var
-              (defaults.expr
-                 (type.base (base.type.list A * base.type.list A)%etype))))
-        (fun e : option (defaults.expr (type.base (base.type.list A))) =>
-         (e0 <- e;
-          Some
-            (reflect_list_cps e0
-               (fun ls : option (list (defaults.expr (type.base A))) =>
-                (ls0 <- ls;
-                 Some
-                   (Some
-                      (fv <-- (e1 <-- list_rect
+     Base
+       (#(List_flat_map)%expr @ (λ x1 : var A,
+                                 to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
+| @List_partition A =>
+    fun (x : expr A -> UnderLets (expr bool)) (x0 : expr (list A)) =>
+    ((match
+        pattern.type.unify_extracted_cps
+          (((('1%pbtype -> bool) ->
+             (pattern.base.type.list '1) ->
+             (pattern.base.type.list '1 * pattern.base.type.list '1)%pbtype) ->
+            '1%pbtype -> bool) -> (pattern.base.type.list '1))%ptype
+          ((((A -> bool) -> (list A) -> (list A * list A)%etype) -> A -> bool) ->
+           (list A))%ptype option (fun x1 : option => x1)
+      with
+      | Some (_, _, (_, (_, _)), (_, _), b) =>
+          _ <- ident.unify pattern.ident.List_partition List_partition;
+          base.try_make_transport_cps A b
+            (fun a6 : option =>
+             (fa <- (fun (T : Type) (k : option -> T) =>
+                     match a6 with
+                     | Some x' =>
+                         (return Some
+                                   (fun v : expr A -> UnderLets (expr bool)
+                                    => x' v)) T (fun fa : option => k fa)
+                     | None => k None
+                     end);
+              match fa with
+              | Some v =>
+                  v0 <- base.try_make_transport_cps A b;
+                  base.try_make_transport_cps b A
+                    (fun a7 : option =>
+                     fa0 <- (fun (T : Type) (k : option -> T) =>
+                             match a7 with
+                             | Some x' =>
+                                 base.try_make_transport_cps b A
+                                   (fun a8 : option =>
+                                    fa0 <- (fun (T0 : Type)
+                                              (k0 : option -> T0) =>
+                                            match a8 with
+                                            | Some x'0 =>
+                                                (return Some
+                                                          (fun v1 : option =>
+                                                           x'0 (x' v1))) T0
+                                                  k0
+                                            | None => k0 None
+                                            end);
+                                    k fa0)
+                             | None => k None
+                             end);
+                     match fa0 with
+                     | Some v1 =>
+                         (fv <- v1
+                                  (ls <- reflect_list (v0 x0);
+                                   Some
+                                     (Datatypes.list_rect
                                         (fun
-                                           _ : list
-                                                 (defaults.expr (type.base A))
-                                         =>
-                                         UnderLets.UnderLets base.type ident
-                                           var
-                                           (defaults.expr
-                                              (type.base
-                                                 (base.type.list A *
-                                                  base.type.list A)%etype)))
-                                        (UnderLets.Base ([], [])%expr_pat)
+                                           _ : Datatypes.list
+                                                 (expr
+                                                    (pattern.base.subst_default
+                                                       '1
+                                                       (PositiveMap.add
+                                                          (PositiveSet.rev
+                                                             1%positive) b
+                                                          (PositiveMap.empty
+                                                             base.type)))) =>
+                                         UnderLets
+                                           (expr
+                                              (list
+                                                 (pattern.base.subst_default
+                                                    '1
+                                                    (PositiveMap.add
+                                                       (PositiveSet.rev
+                                                          1%positive) b
+                                                       (PositiveMap.empty
+                                                          base.type))) *
+                                               list
+                                                 (pattern.base.subst_default
+                                                    '1
+                                                    (PositiveMap.add
+                                                       (PositiveSet.rev
+                                                          1%positive) b
+                                                       (PositiveMap.empty
+                                                          base.type))))%etype))
+                                        (Base ([], [])%expr_pat)
                                         (fun
-                                           (x1 : defaults.expr (type.base A))
-                                           (_ : list
-                                                  (defaults.expr
-                                                     (type.base A)))
-                                           (rec : UnderLets.UnderLets
-                                                    base.type ident var
-                                                    (defaults.expr
-                                                       (type.base
-                                                          (base.type.list A *
-                                                           base.type.list A)%etype)))
+                                           (x1 : expr
+                                                   (pattern.base.subst_default
+                                                      '1
+                                                      (PositiveMap.add
+                                                         (PositiveSet.rev
+                                                            1%positive) b
+                                                         (PositiveMap.empty
+                                                            base.type))))
+                                           (_ : Datatypes.list
+                                                  (expr
+                                                     (pattern.base.subst_default
+                                                        '1
+                                                        (PositiveMap.add
+                                                           (PositiveSet.rev
+                                                              1%positive) b
+                                                           (PositiveMap.empty
+                                                              base.type)))))
+                                           (rec : UnderLets
+                                                    (expr
+                                                       (list
+                                                          (pattern.base.subst_default
+                                                             '1
+                                                             (PositiveMap.add
+                                                                (PositiveSet.rev
+                                                                   1%positive)
+                                                                b
+                                                                (PositiveMap.empty
+                                                                   base.type))) *
+                                                        list
+                                                          (pattern.base.subst_default
+                                                             '1
+                                                             (PositiveMap.add
+                                                                (PositiveSet.rev
+                                                                   1%positive)
+                                                                b
+                                                                (PositiveMap.empty
+                                                                   base.type))))%etype))
                                          =>
-                                         rec' <-- rec;
-                                         fx <-- id x x1;
-                                         UnderLets.Base
-                                           (#(ident.prod_rect)%expr @
-                                            (λ g
-                                                d : defaults.expr
-                                                      (type.base
-                                                         (base.type.list A)),
-                                             (#(ident.bool_rect)%expr @
-                                              (λ _ : defaults.expr
-                                                       (type.base
-                                                          base.type.unit),
-                                               ($x1 :: $g, $d)%expr_pat) @
-                                              (λ _ : defaults.expr
-                                                       (type.base
-                                                          base.type.unit),
-                                               ($g, $x1 :: $d)%expr_pat) @
-                                              $fx)%expr_pat)%expr @ rec')%expr_pat)
-                                        ls0;
-                               UnderLets.Base
-                                 {|
-                                 anyexpr_ty := (base.type.list A *
-                                                base.type.list A)%etype;
-                                 unwrap := e1 |});
-                       fv0 <-- do_again
-                                 (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                                 (let
-                                    (anyexpr_ty, unwrap) as a
-                                     return
-                                       (defaults.expr
-                                          (type.base
-                                             (let (anyexpr_ty, _) := a in
-                                              anyexpr_ty))) := fv in
-                                  unwrap);
-                       base.try_make_transport_cps
-                         (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                         (base.type.list A * base.type.list A)
-                         (fun
-                            a : option
-                                  (defaults.expr
-                                     (type.base
-                                        (let (anyexpr_ty, _) := fv in
-                                         anyexpr_ty)) ->
-                                   defaults.expr
-                                     (type.base
-                                        (base.type.list A * base.type.list A)%etype))
-                          =>
-                          match a with
-                          | Some x' => UnderLets.Base (x' fv0)
-                          | None =>
-                              UnderLets.Base
-                                (Compile.ERROR_BAD_REWRITE_RULE
-                                   (#(pattern.ident.List_partition) @
-                                    ??{?? -> type.base base.type.bool} @
-                                    ??{type.base (pattern.base.type.list ??)})
-                                   (#(ident.List_partition)%expr @
-                                    (λ x1 : var (type.base A),
-                                     UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat)
-                          end))%under_lets));;;
-                None)));;;
-         None);;
+                                         (rec' <-- rec;
+                                          fx <-- v x x1;
+                                          Base
+                                            (#(prod_rect)%expr @
+                                             (λ g
+                                                 d : expr
+                                                       (list
+                                                          (pattern.base.subst_default
+                                                             '1
+                                                             (PositiveMap.add
+                                                                (PositiveSet.rev
+                                                                   1%positive)
+                                                                b
+                                                                (PositiveMap.empty
+                                                                   base.type)))),
+                                              (#(bool_rect)%expr @
+                                               (λ _ : expr unit,
+                                                ($x1 :: $g, $d)%expr_pat) @
+                                               (λ _ : expr unit,
+                                                ($g, $x1 :: $d)%expr_pat) @
+                                               $fx)%expr_pat)%expr @ rec')%expr_pat)%under_lets)
+                                        ls));
+                          base.try_make_transport_cps A A
+                            (fun a8 : option =>
+                             (fa1 <- (fun (T : Type) (k : option -> T) =>
+                                      match a8 with
+                                      | Some x' =>
+                                          base.try_make_transport_cps A A
+                                            (fun a9 : option =>
+                                             fa1 <- (fun (T0 : Type)
+                                                       (k0 : option -> T0) =>
+                                                     match a9 with
+                                                     | Some x'0 =>
+                                                         (return Some
+                                                                   (fun
+                                                                    v2 : 
+                                                                    expr
+                                                                    (list A *
+                                                                    list A)%etype
+                                                                    =>
+                                                                    x'0
+                                                                    (x' v2)))
+                                                           T0 k0
+                                                     | None => k0 None
+                                                     end);
+                                             k fa1)
+                                      | None => k None
+                                      end);
+                              match fa1 with
+                              | Some v2 =>
+                                  base.try_make_transport_cps A A
+                                    (fun a9 : option =>
+                                     fa2 <- (fun (T : Type) (k : option -> T)
+                                             =>
+                                             match a9 with
+                                             | Some x' =>
+                                                 base.try_make_transport_cps
+                                                   A A
+                                                   (fun a10 : option =>
+                                                    fa2 <- (fun (T0 : Type)
+                                                              (k0 : option ->
+                                                                    T0) =>
+                                                            match a10 with
+                                                            | Some x'0 =>
+                                                                (return 
+                                                                 Some
+                                                                   (fun
+                                                                    v3 : 
+                                                                    expr
+                                                                    (list A *
+                                                                    list A)%etype
+                                                                    =>
+                                                                    x'0
+                                                                    (x' v3)))
+                                                                  T0 k0
+                                                            | None => k0 None
+                                                            end);
+                                                    k fa2)
+                                             | None => k None
+                                             end);
+                                     match fa2 with
+                                     | Some v3 =>
+                                         Some
+                                           (fv0 <-- fv;
+                                            fv1 <-- do_again
+                                                      (list A * list A)
+                                                      (v2 fv0);
+                                            Base (v3 fv1))%under_lets
+                                     | None => None
+                                     end)
+                              | None => None
+                              end)%cps))%option
+                     | None => None
+                     end)
+              | None => None
+              end)%cps)
+      | None => None
+      end;;
       None);;;
-     UnderLets.Base
-       (#(ident.List_partition)%expr @
-        (λ x1 : var (type.base A),
-         UnderLets.to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
-| @ident.List_fold_right A B =>
-    fun
-      (x : defaults.expr (type.base B) ->
-           defaults.expr (type.base A) ->
-           UnderLets.UnderLets base.type ident var
-             (defaults.expr (type.base A)))
-      (x0 : defaults.expr (type.base A))
-      (x1 : defaults.expr (type.base (base.type.list B))) =>
-    ((Compile.castv x
-        (option
-           (UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base A))))
-        (fun
-           f : option
-                 (defaults.expr (type.base B) ->
-                  defaults.expr (type.base A) ->
-                  UnderLets.UnderLets base.type ident var
-                    (defaults.expr (type.base A))) =>
-         (f0 <- f;
-          Some
-            (reflect_list_cps x1
-               (fun ls : option (list (defaults.expr (type.base B))) =>
-                (ls0 <- ls;
-                 Some
-                   (Some
-                      (fv <-- (e <-- list_rect
-                                       (fun
-                                          _ : list
-                                                (defaults.expr (type.base B))
-                                        =>
-                                        UnderLets.UnderLets base.type ident
-                                          var (defaults.expr (type.base A)))
-                                       (UnderLets.Base x0)
-                                       (fun
-                                          (x2 : defaults.expr (type.base B))
-                                          (_ : list
-                                                 (defaults.expr (type.base B)))
-                                          (rec : UnderLets.UnderLets
-                                                   base.type ident var
-                                                   (defaults.expr
-                                                      (type.base A))) =>
-                                        rec' <-- rec;
-                                        f0 x2 rec') ls0;
-                               UnderLets.Base
-                                 {| anyexpr_ty := A; unwrap := e |});
-                       base.try_make_transport_cps
-                         (let (anyexpr_ty, _) := fv in anyexpr_ty) A
-                         (fun
-                            a : option
-                                  (defaults.expr
-                                     (type.base
-                                        (let (anyexpr_ty, _) := fv in
-                                         anyexpr_ty)) ->
-                                   defaults.expr (type.base A)) =>
-                          match a with
-                          | Some x' =>
-                              UnderLets.Base
-                                (x'
-                                   (let
-                                      (anyexpr_ty, unwrap) as a0
-                                       return
-                                         (defaults.expr
-                                            (type.base
-                                               (let (anyexpr_ty, _) := a0 in
-                                                anyexpr_ty))) := fv in
-                                    unwrap))
-                          | None =>
-                              UnderLets.Base
-                                (Compile.ERROR_BAD_REWRITE_RULE
-                                   (#(pattern.ident.List_fold_right) @
-                                    ??{?? -> ?? -> ??} @ ?? @
-                                    ??{type.base (pattern.base.type.list ??)})
-                                   (#(ident.List_fold_right)%expr @
-                                    (λ (x2 : var (type.base B))(x3 : 
-                                                                var
-                                                                  (type.base
-                                                                    A)),
-                                     UnderLets.to_expr (x ($x2) ($x3)))%expr @
-                                    x0 @ x1)%expr_pat)
-                          end))%under_lets));;;
-                None)));;;
-         None);;
+     Base
+       (#(List_partition)%expr @ (λ x1 : var A,
+                                  to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
+| @List_fold_right A B =>
+    fun (x : expr B -> expr A -> UnderLets (expr A)) (x0 : expr A)
+      (x1 : expr (list B)) =>
+    ((match
+        pattern.type.unify_extracted_cps
+          ((((('2%pbtype -> '1%pbtype -> '1%pbtype) ->
+              '1%pbtype -> (pattern.base.type.list '2) -> '1%pbtype) ->
+             '2%pbtype -> '1%pbtype -> '1%pbtype) -> '1%pbtype) ->
+           (pattern.base.type.list '2))%ptype
+          (((((B -> A -> A) -> A -> (list B) -> A) -> B -> A -> A) -> A) ->
+           (list B))%ptype option (fun x2 : option => x2)
+      with
+      | Some (_, (_, _), (_, (_, _)), (_, (_, _)), b0, b) =>
+          _ <- ident.unify pattern.ident.List_fold_right List_fold_right;
+          base.try_make_transport_cps B b
+            (fun a9 : option =>
+             (fa <- (fun (T : Type) (k : option -> T) =>
+                     match a9 with
+                     | Some x' =>
+                         base.try_make_transport_cps A b0
+                           (fun a10 : option =>
+                            fa <- (fun (T0 : Type) (k0 : option -> T0) =>
+                                   match a10 with
+                                   | Some x'0 =>
+                                       base.try_make_transport_cps A b0
+                                         (fun a11 : option =>
+                                          fa <- (fun (T1 : Type)
+                                                   (k1 : option -> T1) =>
+                                                 match a11 with
+                                                 | Some x'1 =>
+                                                     (return Some
+                                                               (fun
+                                                                  v : 
+                                                                   expr b ->
+                                                                   expr A ->
+                                                                   UnderLets
+                                                                    (expr A)
+                                                                =>
+                                                                x'1 (x'0 v)))
+                                                       T1 k1
+                                                 | None => k1 None
+                                                 end);
+                                          k0 fa)
+                                   | None => k0 None
+                                   end);
+                            fa0 <- (fun (T0 : Type) (k0 : option -> T0) =>
+                                    match fa with
+                                    | Some x'0 =>
+                                        (return Some
+                                                  (fun
+                                                     v : expr B ->
+                                                         expr A ->
+                                                         UnderLets (expr A)
+                                                   => x'0 (x' v))) T0 k0
+                                    | None => k0 None
+                                    end);
+                            k fa0)
+                     | None => k None
+                     end);
+              match fa with
+              | Some v =>
+                  v0 <- base.try_make_transport_cps A b0;
+                  v1 <- base.try_make_transport_cps B b;
+                  v2 <- base.try_make_transport_cps b0 A;
+                  (fv <- v2
+                           (ls <- reflect_list (v1 x1);
+                            Some
+                              (Datatypes.list_rect
+                                 (fun
+                                    _ : Datatypes.list
+                                          (expr
+                                             (pattern.base.subst_default 
+                                                '2
+                                                (PositiveMap.add
+                                                   (PositiveSet.rev
+                                                      2%positive) b
+                                                   (PositiveMap.add
+                                                      (PositiveSet.rev
+                                                         1%positive) b0
+                                                      (PositiveMap.empty
+                                                         base.type))))) =>
+                                  UnderLets
+                                    (expr
+                                       (pattern.base.subst_default '1
+                                          (PositiveMap.add
+                                             (PositiveSet.rev 2%positive) b
+                                             (PositiveMap.add
+                                                (PositiveSet.rev 1%positive)
+                                                b0
+                                                (PositiveMap.empty base.type))))))
+                                 (Base (v0 x0))
+                                 (fun
+                                    (x2 : expr
+                                            (pattern.base.subst_default 
+                                               '2
+                                               (PositiveMap.add
+                                                  (PositiveSet.rev 2%positive)
+                                                  b
+                                                  (PositiveMap.add
+                                                     (PositiveSet.rev
+                                                        1%positive) b0
+                                                     (PositiveMap.empty
+                                                        base.type)))))
+                                    (_ : Datatypes.list
+                                           (expr
+                                              (pattern.base.subst_default 
+                                                 '2
+                                                 (PositiveMap.add
+                                                    (PositiveSet.rev
+                                                       2%positive) b
+                                                    (PositiveMap.add
+                                                       (PositiveSet.rev
+                                                          1%positive) b0
+                                                       (PositiveMap.empty
+                                                          base.type))))))
+                                    (rec : UnderLets
+                                             (expr
+                                                (pattern.base.subst_default
+                                                   '1
+                                                   (PositiveMap.add
+                                                      (PositiveSet.rev
+                                                         2%positive) b
+                                                      (PositiveMap.add
+                                                         (PositiveSet.rev
+                                                            1%positive) b0
+                                                         (PositiveMap.empty
+                                                            base.type))))))
+                                  => (rec' <-- rec;
+                                      v x x2 rec')%under_lets) ls));
+                   v3 <- base.try_make_transport_cps A A;
+                   v4 <- base.try_make_transport_cps A A;
+                   Some (fv0 <-- fv;
+                         Base (v4 (v3 fv0)))%under_lets)%option
+              | None => None
+              end)%cps)
+      | None => None
+      end;;
       None);;;
-     UnderLets.Base
-       (#(ident.List_fold_right)%expr @
-        (λ (x2 : var (type.base B))(x3 : var (type.base A)),
-         UnderLets.to_expr (x ($x2) ($x3)))%expr @ x0 @ x1)%expr_pat)%option
-| @ident.List_update_nth T =>
-    fun (x : defaults.expr (type.base base.type.nat))
-      (x0 : defaults.expr (type.base T) ->
-            UnderLets.UnderLets base.type ident var
-              (defaults.expr (type.base T)))
-      (x1 : defaults.expr (type.base (base.type.list T))) =>
+     Base
+       (#(List_fold_right)%expr @
+        (λ (x2 : var B)(x3 : var A),
+         to_expr (x ($x2) ($x3)))%expr @ x0 @ x1)%expr_pat)%option
+| @List_update_nth T =>
+    fun (x : expr ℕ) (x0 : expr T -> UnderLets (expr T)) (x1 : expr (list T))
+    =>
     (match x with
      | @expr.Ident _ _ _ t idc =>
-         args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-         Compile.castv x0
-           (option
-              (UnderLets.UnderLets base.type ident var
-                 (defaults.expr (type.base (base.type.list T)))))
-           (fun
-              f : option
-                    (defaults.expr (type.base T) ->
-                     UnderLets.UnderLets base.type ident var
-                       (defaults.expr (type.base T))) =>
-            (f0 <- f;
-             Some
-               (reflect_list_cps x1
-                  (fun ls : option (list (defaults.expr (type.base T))) =>
-                   (ls0 <- ls;
-                    Some
-                      (Some
-                         (fv <-- (e <-- (retv <---- update_nth args
-                                                      (fun
-                                                         x2 : UnderLets.UnderLets
-                                                                base.type
-                                                                ident var
-                                                                (defaults.expr
-                                                                   (type.base
-                                                                    T)) =>
-                                                       x3 <-- x2;
-                                                       f0 x3)
-                                                      (map UnderLets.Base ls0);
-                                         UnderLets.Base (reify_list retv));
-                                  UnderLets.Base
-                                    {|
-                                    anyexpr_ty := base.type.list T;
-                                    unwrap := e |});
-                          base.try_make_transport_cps
-                            (let (anyexpr_ty, _) := fv in anyexpr_ty)
-                            (base.type.list T)
-                            (fun
-                               a : option
-                                     (defaults.expr
-                                        (type.base
-                                           (let (anyexpr_ty, _) := fv in
-                                            anyexpr_ty)) ->
-                                      defaults.expr
-                                        (type.base (base.type.list T))) =>
-                             match a with
-                             | Some x' =>
-                                 UnderLets.Base
-                                   (x'
-                                      (let
-                                         (anyexpr_ty, unwrap) as a0
-                                          return
-                                            (defaults.expr
-                                               (type.base
-                                                  (let (anyexpr_ty, _) :=
-                                                     a0 in
-                                                   anyexpr_ty))) := fv in
-                                       unwrap))
-                             | None =>
-                                 UnderLets.Base
-                                   (Compile.ERROR_BAD_REWRITE_RULE
-                                      (#(pattern.ident.List_update_nth) @
-                                       #(pattern.ident.LiteralNat) @
-                                       ??{?? -> ??} @
-                                       ??{type.base
-                                            (pattern.base.type.list ??)})
-                                      (#(ident.List_update_nth)%expr @ x @
-                                       (λ x2 : var (type.base T),
-                                        UnderLets.to_expr (x0 ($x2)))%expr @
-                                       x1)%expr_pat)
-                             end))%under_lets));;;
-                   None)));;;
-            None)
+         args <- invert_bind_args idc Raw.ident.Literal;
+         match
+           pattern.type.unify_extracted_cps
+             ((((ℕ ->
+                 ('1%pbtype -> '1%pbtype) ->
+                 (pattern.base.type.list '1) -> (pattern.base.type.list '1)) ->
+                ℕ) -> '1%pbtype -> '1%pbtype) -> (pattern.base.type.list '1))%ptype
+             ((((ℕ -> (T -> T) -> (list T) -> (list T)) -> (projT1 args)) ->
+               T -> T) -> (list T))%ptype option (fun x2 : option => x2)
+         with
+         | Some (_, (_, _, (_, _)), _, (_, _), b) =>
+             _ <- ident.unify pattern.ident.List_update_nth List_update_nth;
+             idc_args0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+             base.try_make_transport_cps T b
+               (fun a7 : option =>
+                (fa <- (fun (T0 : Type) (k : option -> T0) =>
+                        match a7 with
+                        | Some x' =>
+                            base.try_make_transport_cps T b
+                              (fun a8 : option =>
+                               fa <- (fun (T1 : Type) (k0 : option -> T1) =>
+                                      match a8 with
+                                      | Some x'0 =>
+                                          (return Some
+                                                    (fun
+                                                       v : expr T ->
+                                                           UnderLets (expr T)
+                                                     => x'0 (x' v))) T1 k0
+                                      | None => k0 None
+                                      end);
+                               k fa)
+                        | None => k None
+                        end);
+                 match fa with
+                 | Some v =>
+                     v0 <- base.try_make_transport_cps T b;
+                     v1 <- base.try_make_transport_cps b T;
+                     (fv <- v1
+                              (ls <- reflect_list (v0 x1);
+                               Some
+                                 (retv <---- update_nth
+                                               (let (x2, _) := idc_args0 in
+                                                x2)
+                                               (fun
+                                                  x2 : UnderLets
+                                                         (expr
+                                                            (pattern.base.subst_default
+                                                               '1
+                                                               (PositiveMap.add
+                                                                  (PositiveSet.rev
+                                                                    1%positive)
+                                                                  b
+                                                                  (PositiveMap.empty
+                                                                    base.type))))
+                                                => x3 <-- x2;
+                                                   v x0 x3) (map Base ls);
+                                  Base (reify_list retv))%under_lets);
+                      v2 <- base.try_make_transport_cps T T;
+                      v3 <- base.try_make_transport_cps T T;
+                      Some (fv0 <-- fv;
+                            Base (v3 (v2 fv0)))%under_lets)%option
+                 | None => None
+                 end)%cps)
+         | None => None
+         end
      | _ => None
      end;;;
-     UnderLets.Base
-       (#(ident.List_update_nth)%expr @ x @
-        (λ x2 : var (type.base T),
-         UnderLets.to_expr (x0 ($x2)))%expr @ x1)%expr_pat)%option
-| @ident.List_nth_default T =>
-    fun (x : defaults.expr (type.base T))
-      (x0 : defaults.expr (type.base (base.type.list T)))
-      (x1 : defaults.expr (type.base base.type.nat)) =>
+     Base
+       (#(List_update_nth)%expr @ x @ (λ x2 : var T,
+                                       to_expr (x0 ($x2)))%expr @ x1)%expr_pat)%option
+| @List_nth_default T =>
+    fun (x : expr T) (x0 : expr (list T)) (x1 : expr ℕ) =>
     ((match x1 with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-          Compile.castbe x
-            (option
-               (UnderLets.UnderLets base.type ident var
-                  (defaults.expr (type.base T))))
-            (fun default : option (defaults.expr (type.base T)) =>
-             (default0 <- default;
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps
+              (((('1%pbtype -> (pattern.base.type.list '1) -> ℕ -> '1%pbtype) ->
+                 '1%pbtype) -> (pattern.base.type.list '1)) -> ℕ)%ptype
+              ((((T -> (list T) -> ℕ -> T) -> T) -> (list T)) ->
+               (projT1 args))%ptype option (fun x2 : option => x2)
+          with
+          | Some (_, (_, (_, _)), _, b0, _) =>
+              _ <- ident.unify pattern.ident.List_nth_default
+                     List_nth_default;
+              v <- base.try_make_transport_cps T b0;
+              v0 <- base.try_make_transport_cps T b0;
+              idc_args0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+              v1 <- base.try_make_transport_cps b0 T;
+              x2 <- v1
+                      (ls <- reflect_list (v0 x0);
+                       Some
+                         (nth_default (v x) ls
+                            (let (x2, _) := idc_args0 in x2)));
+              v2 <- base.try_make_transport_cps T T;
+              v3 <- base.try_make_transport_cps T T;
+              Some (Base (v3 (v2 x2)))
+          | None => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(List_nth_default)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) +
+                           (let (x1, _) := idc_args0 in x1))%Z)%expr)
+              | None => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (x + x0)%expr)%option
+| Z_mul =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) *
+                           (let (x1, _) := idc_args0 in x1))%Z)%expr)
+              | None => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (x * x0)%expr)%option
+| Z_pow =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1)
+                           ^ (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_pow)%expr @ x @ x0)%expr_pat)%option
+| Z_sub =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) -
+                           (let (x1, _) := idc_args0 in x1))%Z)%expr)
+              | None => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (x - x0)%expr)%option
+| Z_opp =>
+    fun x : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ℤ (projT1 args) option
+              (fun x0 : option => x0)
+          with
+          | Some _ =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some (Base (##(- (let (x0, _) := idc_args in x0))%Z)%expr)
+          | None => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (- x)%expr)%option
+| Z_div =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) /
+                           (let (x1, _) := idc_args0 in x1))%Z)%expr)
+              | None => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (x / x0)%expr)%option
+| Z_modulo =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1)
+                           mod (let (x1, _) := idc_args0 in x1))%Z)%expr)
+              | None => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (x mod x0)%expr)%option
+| Z_log2 =>
+    fun x : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ℤ (projT1 args) option
+              (fun x0 : option => x0)
+          with
+          | Some _ =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some (Base (##(Z.log2 (let (x0, _) := idc_args in x0)))%expr)
+          | None => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_log2)%expr @ x)%expr_pat)%option
+| Z_log2_up =>
+    fun x : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ℤ (projT1 args) option
+              (fun x0 : option => x0)
+          with
+          | Some _ =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
               Some
-                (reflect_list_cps x0
-                   (fun ls : option (list (defaults.expr (type.base T))) =>
-                    (ls0 <- ls;
-                     Some
-                       (Some
-                          (base.try_make_transport_cps T T
-                             (fun
-                                a : option
-                                      (defaults.expr (type.base T) ->
-                                       defaults.expr (type.base T)) =>
-                              match a with
-                              | Some x' =>
-                                  UnderLets.Base
-                                    (x' (nth_default default0 ls0 args))
-                              | None =>
-                                  UnderLets.Base
-                                    (Compile.ERROR_BAD_REWRITE_RULE
-                                       (#(pattern.ident.List_nth_default) @
-                                        ?? @
-                                        ??{type.base
-                                             (pattern.base.type.list ??)} @
-                                        #(pattern.ident.LiteralNat))
-                                       (#(ident.List_nth_default)%expr @ x @
-                                        x0 @ x1)%expr_pat)
-                              end))));;;
-                    None)));;;
-             None)
+                (Base (##(Z.log2_up (let (x0, _) := idc_args in x0)))%expr)
+          | None => None
+          end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.List_nth_default)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_log2_up)%expr @ x)%expr_pat)%option
+| Z_eqb =>
+    fun x x0 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args + args0)%Z)%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) =?
+                           (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (x + x0)%expr)%option
-| ident.Z_mul =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_eqb)%expr @ x @ x0)%expr_pat)%option
+| Z_leb =>
+    fun x x0 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args * args0)%Z)%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) <=?
+                           (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (x * x0)%expr)%option
-| ident.Z_pow =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_leb)%expr @ x @ x0)%expr_pat)%option
+| Z_geb =>
+    fun x x0 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args ^ args0))%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##((let (x1, _) := idc_args in x1) >=?
+                           (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Z_pow)%expr @ x @ x0)%expr_pat)%option
-| ident.Z_sub =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_geb)%expr @ x @ x0)%expr_pat)%option
+| Z_of_nat =>
+    fun x : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ℕ (projT1 args) option
+              (fun x0 : option => x0)
+          with
+          | Some _ =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some (Base (##(Z.of_nat (let (x0, _) := idc_args in x0)))%expr)
+          | None => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_of_nat)%expr @ x)%expr_pat)%option
+| Z_to_nat =>
+    fun x : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ℤ (projT1 args) option
+              (fun x0 : option => x0)
+          with
+          | Some _ =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some (Base (##(Z.to_nat (let (x0, _) := idc_args in x0)))%expr)
+          | None => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_to_nat)%expr @ x)%expr_pat)%option
+| Z_shiftr =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args - args0)%Z)%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##(Z.shiftr (let (x1, _) := idc_args in x1)
+                             (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (x - x0)%expr)%option
-| ident.Z_opp =>
-    fun x : defaults.expr (type.base base.type.Z) =>
+     Base (x >> x0)%expr)%option
+| Z_shiftl =>
+    fun x x0 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          Some (UnderLets.Base (##(- args)%Z)%expr)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (- x)%expr)%option
-| ident.Z_div =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args / args0)%Z)%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##(Z.shiftl (let (x1, _) := idc_args in x1)
+                             (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (x / x0)%expr)%option
-| ident.Z_modulo =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (x << x0)%expr)%option
+| Z_land =>
+    fun x x0 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args mod args0)%Z)%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##(Z.land (let (x1, _) := idc_args in x1)
+                             (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (x mod x0)%expr)%option
-| ident.Z_log2 =>
-    fun x : defaults.expr (type.base base.type.Z) =>
+     Base (x &' x0)%expr)%option
+| Z_lor =>
+    fun x x0 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          Some (UnderLets.Base (##(Z.log2 args))%expr)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_log2)%expr @ x)%expr_pat)%option
-| ident.Z_log2_up =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          Some (UnderLets.Base (##(Z.log2_up args))%expr)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_log2_up)%expr @ x)%expr_pat)%option
-| ident.Z_eqb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args =? args0))%expr)
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
+                  Some
+                    (Base
+                       (##(Z.lor (let (x1, _) := idc_args in x1)
+                             (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
+              end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Z_eqb)%expr @ x @ x0)%expr_pat)%option
-| ident.Z_leb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (x || x0)%expr)%option
+| Z_bneg =>
+    fun x : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args <=? args0))%expr)
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_leb)%expr @ x @ x0)%expr_pat)%option
-| ident.Z_geb =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(args >=? args0))%expr)
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_geb)%expr @ x @ x0)%expr_pat)%option
-| ident.Z_of_nat =>
-    fun x : defaults.expr (type.base base.type.nat) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralNat;
-          Some (UnderLets.Base (##(Z.of_nat args))%expr)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_of_nat)%expr @ x)%expr_pat)%option
-| ident.Z_to_nat =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          Some (UnderLets.Base (##(Z.to_nat args))%expr)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_to_nat)%expr @ x)%expr_pat)%option
-| ident.Z_shiftr =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(Z.shiftr args args0))%expr)
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (x >> x0)%expr)%option
-| ident.Z_shiftl =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(Z.shiftl args args0))%expr)
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (x << x0)%expr)%option
-| ident.Z_land =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(Z.land args args0))%expr)
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (x &' x0)%expr)%option
-| ident.Z_lor =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(Z.lor args args0))%expr)
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (x || x0)%expr)%option
-| ident.Z_bneg =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          Some (UnderLets.Base (##(Definitions.Z.bneg args))%expr)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_bneg)%expr @ x)%expr_pat)%option
-| ident.Z_lnot_modulo =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps ℤ (projT1 args) option
+              (fun x0 : option => x0)
+          with
+          | Some _ =>
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
               Some
-                (UnderLets.Base
-                   (##(Definitions.Z.lnot_modulo args args0))%expr)
-          | _ => None
+                (Base
+                   (##(Definitions.Z.bneg (let (x0, _) := idc_args in x0)))%expr)
+          | None => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Z_lnot_modulo)%expr @ x @ x0)%expr_pat)%option
-| ident.Z_mul_split =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_bneg)%expr @ x)%expr_pat)%option
+| Z_lnot_modulo =>
+    fun x x0 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
                   Some
-                    (UnderLets.Base
-                       (let
-                        '(a, b) := Definitions.Z.mul_split args args0 args1
-                         in ((##a)%expr, (##b)%expr)%expr_pat))
-              | _ => None
+                    (Base
+                       (##(Definitions.Z.lnot_modulo
+                             (let (x1, _) := idc_args in x1)
+                             (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
               end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_get_carry =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat)%option
+| Z_mul_split =>
+    fun x x0 x1 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x1 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (let
-                        '(a, b) :=
-                         Definitions.Z.add_get_carry_full args args0 args1 in
-                         ((##a)%expr, (##b)%expr)%expr_pat))
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_with_carry =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (##(Definitions.Z.add_with_carry args args0 args1))%expr)
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_with_get_carry =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
+                      option (fun x2 : option => x2)
+                  with
+                  | Some (_, _, _) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args0);
+                      idc_args1 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
                       Some
-                        (UnderLets.Base
+                        (Base
                            (let
-                            '(a, b) :=
-                             Definitions.Z.add_with_get_carry_full args args0
-                               args1 args2 in
-                             ((##a)%expr, (##b)%expr)%expr_pat))
-                  | _ => None
+                            '(a1, b1) :=
+                             Definitions.Z.mul_split
+                               (let (x2, _) := idc_args in x2)
+                               (let (x2, _) := idc_args0 in x2)
+                               (let (x2, _) := idc_args1 in x2) in
+                             ((##a1)%expr, (##b1)%expr)%expr_pat))
+                  | None => None
                   end
               | _ => None
               end
@@ -2047,60 +2776,40 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base
-       (#(ident.Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
-| ident.Z_sub_get_borrow =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_get_carry =>
+    fun x x0 x1 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x1 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (let
-                        '(a, b) :=
-                         Definitions.Z.sub_get_borrow_full args args0 args1
-                         in ((##a)%expr, (##b)%expr)%expr_pat))
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_sub_with_get_borrow =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
+                      option (fun x2 : option => x2)
+                  with
+                  | Some (_, _, _) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args0);
+                      idc_args1 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
                       Some
-                        (UnderLets.Base
+                        (Base
                            (let
-                            '(a, b) :=
-                             Definitions.Z.sub_with_get_borrow_full args
-                               args0 args1 args2 in
-                             ((##a)%expr, (##b)%expr)%expr_pat))
-                  | _ => None
+                            '(a1, b1) :=
+                             Definitions.Z.add_get_carry_full
+                               (let (x2, _) := idc_args in x2)
+                               (let (x2, _) := idc_args0 in x2)
+                               (let (x2, _) := idc_args1 in x2) in
+                             ((##a1)%expr, (##b1)%expr)%expr_pat))
+                  | None => None
                   end
               | _ => None
               end
@@ -2109,77 +2818,37 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base
-       (#(ident.Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
-| ident.Z_zselect =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_with_carry =>
+    fun x x0 x1 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x1 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (##(Definitions.Z.zselect args args0 args1))%expr)
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_zselect)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_add_modulo =>
-    fun x x0 x1 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (##(Definitions.Z.add_modulo args args0 args1))%expr)
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_add_modulo)%expr @ x @ x0 @ x1)%expr_pat)%option
-| ident.Z_rshi =>
-    fun x x0 x1 x2 : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
+                      option (fun x2 : option => x2)
+                  with
+                  | Some (_, _, _) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args0);
+                      idc_args1 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
                       Some
-                        (UnderLets.Base
-                           (##(Definitions.Z.rshi args args0 args1 args2))%expr)
-                  | _ => None
+                        (Base
+                           (##(Definitions.Z.add_with_carry
+                                 (let (x2, _) := idc_args in x2)
+                                 (let (x2, _) := idc_args0 in x2)
+                                 (let (x2, _) := idc_args1 in x2)))%expr)
+                  | None => None
                   end
               | _ => None
               end
@@ -2188,516 +2857,606 @@ match idc in (ident t) return (Compile.value' true t) with
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.Z_rshi)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
-| ident.Z_cc_m =>
-    fun x x0 : defaults.expr (type.base base.type.Z) =>
+     Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_with_get_carry =>
+    fun x x0 x1 x2 : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
           match x0 with
           | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              Some (UnderLets.Base (##(Definitions.Z.cc_m args args0))%expr)
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_cc_m)%expr @ x @ x0)%expr_pat)%option
-| ident.Z_cast range =>
-    fun x : defaults.expr (type.base base.type.Z) =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          args <- pattern.ident.invert_bind_args idc pattern.ident.LiteralZ;
-          Some
-            (UnderLets.Base
-               (##(ident.cast ident.cast_outside_of_range range args))%expr)
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_cast range)%expr @ x)%expr_pat)%option
-| ident.Z_cast2 range =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (let
-                        '(a, b) :=
-                         (let (r1, r2) := range in
-                          fun '(x2, x3) =>
-                          (ident.cast ident.cast_outside_of_range r1 x2,
-                          ident.cast ident.cast_outside_of_range r2 x3))
-                           (args0, args1) in
-                         ((##a)%expr, (##b)%expr)%expr_pat))
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.Z_cast2 range)%expr @ x)%expr_pat)%option
-| ident.fancy_add log2wordmax imm =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (let
-                        '(a, b) :=
-                         ident.fancy.interp
-                           (invert_Some
-                              (ident.to_fancy
-                                 (ident.fancy_add log2wordmax imm)))
-                           (args0, args1) in
-                         ((##a)%expr, (##b)%expr)%expr_pat))
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_add log2wordmax imm)%expr @ x)%expr_pat)%option
-| ident.fancy_addc log2wordmax imm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | (@expr.Ident _ _ _ t0 idc0 @ x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.pair;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args3 <- pattern.ident.invert_bind_args idc3
-                                     pattern.ident.LiteralZ;
-                          Some
-                            (UnderLets.Base
-                               (let
-                                '(a, b) :=
-                                 ident.fancy.interp
-                                   (invert_Some
-                                      (ident.to_fancy
-                                         (ident.fancy_addc log2wordmax imm)))
-                                   (args1, args2, args3) in
-                                 ((##a)%expr, (##b)%expr)%expr_pat))
-                      | _ => None
-                      end
-                  | _ => None
-                  end
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_addc log2wordmax imm)%expr @ x)%expr_pat)%option
-| ident.fancy_sub log2wordmax imm =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (let
-                        '(a, b) :=
-                         ident.fancy.interp
-                           (invert_Some
-                              (ident.to_fancy
-                                 (ident.fancy_sub log2wordmax imm)))
-                           (args0, args1) in
-                         ((##a)%expr, (##b)%expr)%expr_pat))
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_sub log2wordmax imm)%expr @ x)%expr_pat)%option
-| ident.fancy_subb log2wordmax imm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | (@expr.Ident _ _ _ t0 idc0 @ x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.pair;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args3 <- pattern.ident.invert_bind_args idc3
-                                     pattern.ident.LiteralZ;
-                          Some
-                            (UnderLets.Base
-                               (let
-                                '(a, b) :=
-                                 ident.fancy.interp
-                                   (invert_Some
-                                      (ident.to_fancy
-                                         (ident.fancy_subb log2wordmax imm)))
-                                   (args1, args2, args3) in
-                                 ((##a)%expr, (##b)%expr)%expr_pat))
-                      | _ => None
-                      end
-                  | _ => None
-                  end
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_subb log2wordmax imm)%expr @ x)%expr_pat)%option
-| ident.fancy_mulll log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (##(ident.fancy.interp
-                             (invert_Some
-                                (ident.to_fancy
-                                   (ident.fancy_mulll log2wordmax)))
-                             (args0, args1)%core))%expr)
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_mulll log2wordmax)%expr @ x)%expr_pat)%option
-| ident.fancy_mullh log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (##(ident.fancy.interp
-                             (invert_Some
-                                (ident.to_fancy
-                                   (ident.fancy_mullh log2wordmax)))
-                             (args0, args1)%core))%expr)
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_mullh log2wordmax)%expr @ x)%expr_pat)%option
-| ident.fancy_mulhl log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (##(ident.fancy.interp
-                             (invert_Some
-                                (ident.to_fancy
-                                   (ident.fancy_mulhl log2wordmax)))
-                             (args0, args1)%core))%expr)
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_mulhl log2wordmax)%expr @ x)%expr_pat)%option
-| ident.fancy_mulhh log2wordmax =>
-    fun x : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  Some
-                    (UnderLets.Base
-                       (##(ident.fancy.interp
-                             (invert_Some
-                                (ident.to_fancy
-                                   (ident.fancy_mulhh log2wordmax)))
-                             (args0, args1)%core))%expr)
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_mulhh log2wordmax)%expr @ x)%expr_pat)%option
-| ident.fancy_rshi log2wordmax x =>
-    fun x0 : defaults.expr (type.base (base.type.Z * base.type.Z)%etype) =>
-    ((match x0 with
-      | (@expr.Ident _ _ _ t idc @ x2 @ x1)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x2 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args0 <- pattern.ident.invert_bind_args idc0
-                         pattern.ident.LiteralZ;
               match x1 with
               | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
+                  match x2 with
+                  | @expr.Ident _ _ _ t2 idc2 =>
+                      args <- invert_bind_args idc2 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                      args2 <- invert_bind_args idc Raw.ident.Literal;
+                      match
+                        pattern.type.unify_extracted_cps
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          ((((projT1 args2) -> (projT1 args1)) ->
+                            (projT1 args0)) -> (projT1 args))%ptype option
+                          (fun x3 : option => x3)
+                      with
+                      | Some (_, _, _, _) =>
+                          idc_args <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args2);
+                          idc_args0 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args1);
+                          idc_args1 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args0);
+                          idc_args2 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args);
+                          Some
+                            (Base
+                               (let
+                                '(a2, b2) :=
+                                 Definitions.Z.add_with_get_carry_full
+                                   (let (x3, _) := idc_args in x3)
+                                   (let (x3, _) := idc_args0 in x3)
+                                   (let (x3, _) := idc_args1 in x3)
+                                   (let (x3, _) := idc_args2 in x3) in
+                                 ((##a2)%expr, (##b2)%expr)%expr_pat))
+                      | None => None
+                      end
+                  | _ => None
+                  end
+              | _ => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+| Z_sub_get_borrow =>
+    fun x x0 x1 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              match x1 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
+                      option (fun x2 : option => x2)
+                  with
+                  | Some (_, _, _) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args0);
+                      idc_args1 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      Some
+                        (Base
+                           (let
+                            '(a1, b1) :=
+                             Definitions.Z.sub_get_borrow_full
+                               (let (x2, _) := idc_args in x2)
+                               (let (x2, _) := idc_args0 in x2)
+                               (let (x2, _) := idc_args1 in x2) in
+                             ((##a1)%expr, (##b1)%expr)%expr_pat))
+                  | None => None
+                  end
+              | _ => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_sub_with_get_borrow =>
+    fun x x0 x1 x2 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              match x1 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  match x2 with
+                  | @expr.Ident _ _ _ t2 idc2 =>
+                      args <- invert_bind_args idc2 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                      args2 <- invert_bind_args idc Raw.ident.Literal;
+                      match
+                        pattern.type.unify_extracted_cps
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          ((((projT1 args2) -> (projT1 args1)) ->
+                            (projT1 args0)) -> (projT1 args))%ptype option
+                          (fun x3 : option => x3)
+                      with
+                      | Some (_, _, _, _) =>
+                          idc_args <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args2);
+                          idc_args0 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args1);
+                          idc_args1 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args0);
+                          idc_args2 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args);
+                          Some
+                            (Base
+                               (let
+                                '(a2, b2) :=
+                                 Definitions.Z.sub_with_get_borrow_full
+                                   (let (x3, _) := idc_args in x3)
+                                   (let (x3, _) := idc_args0 in x3)
+                                   (let (x3, _) := idc_args1 in x3)
+                                   (let (x3, _) := idc_args2 in x3) in
+                                 ((##a2)%expr, (##b2)%expr)%expr_pat))
+                      | None => None
+                      end
+                  | _ => None
+                  end
+              | _ => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+| Z_zselect =>
+    fun x x0 x1 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              match x1 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
+                      option (fun x2 : option => x2)
+                  with
+                  | Some (_, _, _) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args0);
+                      idc_args1 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      Some
+                        (Base
+                           (##(Definitions.Z.zselect
+                                 (let (x2, _) := idc_args in x2)
+                                 (let (x2, _) := idc_args0 in x2)
+                                 (let (x2, _) := idc_args1 in x2)))%expr)
+                  | None => None
+                  end
+              | _ => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_zselect)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_add_modulo =>
+    fun x x0 x1 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              match x1 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
+                      option (fun x2 : option => x2)
+                  with
+                  | Some (_, _, _) =>
+                      idc_args <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                      idc_args0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args0);
+                      idc_args1 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                      Some
+                        (Base
+                           (##(Definitions.Z.add_modulo
+                                 (let (x2, _) := idc_args in x2)
+                                 (let (x2, _) := idc_args0 in x2)
+                                 (let (x2, _) := idc_args1 in x2)))%expr)
+                  | None => None
+                  end
+              | _ => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_add_modulo)%expr @ x @ x0 @ x1)%expr_pat)%option
+| Z_rshi =>
+    fun x x0 x1 x2 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              match x1 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  match x2 with
+                  | @expr.Ident _ _ _ t2 idc2 =>
+                      args <- invert_bind_args idc2 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                      args2 <- invert_bind_args idc Raw.ident.Literal;
+                      match
+                        pattern.type.unify_extracted_cps
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          ((((projT1 args2) -> (projT1 args1)) ->
+                            (projT1 args0)) -> (projT1 args))%ptype option
+                          (fun x3 : option => x3)
+                      with
+                      | Some (_, _, _, _) =>
+                          idc_args <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args2);
+                          idc_args0 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args1);
+                          idc_args1 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args0);
+                          idc_args2 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args);
+                          Some
+                            (Base
+                               (##(Definitions.Z.rshi
+                                     (let (x3, _) := idc_args in x3)
+                                     (let (x3, _) := idc_args0 in x3)
+                                     (let (x3, _) := idc_args1 in x3)
+                                     (let (x3, _) := idc_args2 in x3)))%expr)
+                      | None => None
+                      end
+                  | _ => None
+                  end
+              | _ => None
+              end
+          | _ => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_rshi)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+| Z_cc_m =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype option
+                  (fun x1 : option => x1)
+              with
+              | Some (_, _) =>
+                  idc_args <- ident.unify pattern.ident.Literal
+                                ##(projT2 args0);
+                  idc_args0 <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args);
                   Some
-                    (UnderLets.Base
-                       (##(ident.fancy.interp
-                             (invert_Some
-                                (ident.to_fancy
-                                   (ident.fancy_rshi log2wordmax x)))
-                             (args0, args1)%core))%expr)
-              | _ => None
+                    (Base
+                       (##(Definitions.Z.cc_m (let (x1, _) := idc_args in x1)
+                             (let (x1, _) := idc_args0 in x1)))%expr)
+              | None => None
               end
           | _ => None
           end
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.fancy_rshi log2wordmax x)%expr @ x0)%expr_pat)%option
-| ident.fancy_selc =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
+     Base (#(Z_cc_m)%expr @ x @ x0)%expr_pat)%option
+| Z_cast range => fun x : expr ℤ => Base (#(Z_cast range)%expr @ x)%expr_pat
+| Z_cast2 range =>
+    fun x : expr (ℤ * ℤ)%etype => Base (#(Z_cast2 range)%expr @ x)%expr_pat
+| fancy_add log2wordmax imm =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat
+| fancy_addc log2wordmax imm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_addc log2wordmax imm)%expr @ x)%expr_pat
+| fancy_sub log2wordmax imm =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_sub log2wordmax imm)%expr @ x)%expr_pat
+| fancy_subb log2wordmax imm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_subb log2wordmax imm)%expr @ x)%expr_pat
+| fancy_mulll log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulll log2wordmax)%expr @ x)%expr_pat
+| fancy_mullh log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mullh log2wordmax)%expr @ x)%expr_pat
+| fancy_mulhl log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulhl log2wordmax)%expr @ x)%expr_pat
+| fancy_mulhh log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulhh log2wordmax)%expr @ x)%expr_pat
+| fancy_rshi log2wordmax x =>
+    fun x0 : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_rshi log2wordmax x)%expr @ x0)%expr_pat
+| fancy_selc =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
     ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | (@expr.Ident _ _ _ t0 idc0 @ x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.pair;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args3 <- pattern.ident.invert_bind_args idc3
-                                     pattern.ident.LiteralZ;
-                          Some
-                            (UnderLets.Base
-                               (##(ident.fancy.interp
-                                     (invert_Some
-                                        (ident.to_fancy ident.fancy_selc))
-                                     (args1, args2, args3)%core))%expr)
-                      | _ => None
-                      end
-                  | _ => None
-                  end
-              | _ => None
-              end
-          | _ => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
+          args <- invert_bind_args idc3 Raw.ident.Literal;
+          args0 <- invert_bind_args idc2 Raw.ident.Literal;
+          args1 <- invert_bind_args idc1 Raw.ident.Literal;
+          args2 <- invert_bind_args idc0 Raw.ident.pair;
+          args3 <- invert_bind_args idc Raw.ident.pair;
+          match
+            pattern.type.unify_extracted_cps
+              ((((ℤ * ℤ)%pbtype -> ℤ -> (ℤ * ℤ * ℤ)%pbtype) ->
+                ((ℤ -> ℤ -> (ℤ * ℤ)%pbtype) -> ℤ) -> ℤ) -> ℤ)%ptype
+              ((((let (x4, _) := args3 in x4) ->
+                 (let (_, y) := args3 in y) ->
+                 ((let (x4, _) := args3 in x4) * (let (_, y) := args3 in y))%etype) ->
+                (((let (x4, _) := args2 in x4) ->
+                  (let (_, y) := args2 in y) ->
+                  ((let (x4, _) := args2 in x4) * (let (_, y) := args2 in y))%etype) ->
+                 (projT1 args1)) -> (projT1 args0)) -> (projT1 args))%ptype
+              option (fun x4 : option => x4)
+          with
+          | Some (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _) =>
+              _ <- ident.unify pattern.ident.pair pair;
+              _ <- ident.unify pattern.ident.pair pair;
+              idc_args1 <- ident.unify pattern.ident.Literal ##(projT2 args1);
+              idc_args2 <- ident.unify pattern.ident.Literal ##(projT2 args0);
+              idc_args3 <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some
+                (Base
+                   (##(fancy.interp (invert_Some (to_fancy fancy_selc))
+                         (let (x4, _) := idc_args1 in x4,
+                         let (x4, _) := idc_args2 in x4,
+                         let (x4, _) := idc_args3 in x4)%core))%expr)
+          | None => None
           end
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ ($_)%expr)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ (_ @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ ($_)%expr) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Abs _
+          _ _ _ _ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ (_ @ _)) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.LetIn
+          _ _ _ _ _ _ _) @ _)%expr_pat => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ (_ @ _) @ _) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat =>
+          None
+      | (@expr.Ident _ _ _ t idc @ #(_) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ ($_)%expr @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _ @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (#(_) @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (($_)%expr @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (($_)%expr @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Abs _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (_ @ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat =>
+          None
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.fancy_selc)%expr @ x)%expr_pat)%option
-| ident.fancy_selm log2wordmax =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
+     Base (#(fancy_selc)%expr @ x)%expr_pat)%option
+| fancy_selm log2wordmax =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_selm log2wordmax)%expr @ x)%expr_pat
+| fancy_sell =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
     ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | (@expr.Ident _ _ _ t0 idc0 @ x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.pair;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args3 <- pattern.ident.invert_bind_args idc3
-                                     pattern.ident.LiteralZ;
-                          Some
-                            (UnderLets.Base
-                               (##(ident.fancy.interp
-                                     (invert_Some
-                                        (ident.to_fancy
-                                           (ident.fancy_selm log2wordmax)))
-                                     (args1, args2, args3)%core))%expr)
-                      | _ => None
-                      end
-                  | _ => None
-                  end
-              | _ => None
-              end
-          | _ => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
+          args <- invert_bind_args idc3 Raw.ident.Literal;
+          args0 <- invert_bind_args idc2 Raw.ident.Literal;
+          args1 <- invert_bind_args idc1 Raw.ident.Literal;
+          args2 <- invert_bind_args idc0 Raw.ident.pair;
+          args3 <- invert_bind_args idc Raw.ident.pair;
+          match
+            pattern.type.unify_extracted_cps
+              ((((ℤ * ℤ)%pbtype -> ℤ -> (ℤ * ℤ * ℤ)%pbtype) ->
+                ((ℤ -> ℤ -> (ℤ * ℤ)%pbtype) -> ℤ) -> ℤ) -> ℤ)%ptype
+              ((((let (x4, _) := args3 in x4) ->
+                 (let (_, y) := args3 in y) ->
+                 ((let (x4, _) := args3 in x4) * (let (_, y) := args3 in y))%etype) ->
+                (((let (x4, _) := args2 in x4) ->
+                  (let (_, y) := args2 in y) ->
+                  ((let (x4, _) := args2 in x4) * (let (_, y) := args2 in y))%etype) ->
+                 (projT1 args1)) -> (projT1 args0)) -> (projT1 args))%ptype
+              option (fun x4 : option => x4)
+          with
+          | Some (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _) =>
+              _ <- ident.unify pattern.ident.pair pair;
+              _ <- ident.unify pattern.ident.pair pair;
+              idc_args1 <- ident.unify pattern.ident.Literal ##(projT2 args1);
+              idc_args2 <- ident.unify pattern.ident.Literal ##(projT2 args0);
+              idc_args3 <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some
+                (Base
+                   (##(fancy.interp (invert_Some (to_fancy fancy_sell))
+                         (let (x4, _) := idc_args1 in x4,
+                         let (x4, _) := idc_args2 in x4,
+                         let (x4, _) := idc_args3 in x4)%core))%expr)
+          | None => None
           end
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ ($_)%expr)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ (_ @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ ($_)%expr) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Abs _
+          _ _ _ _ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ (_ @ _)) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.LetIn
+          _ _ _ _ _ _ _) @ _)%expr_pat => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ (_ @ _) @ _) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat =>
+          None
+      | (@expr.Ident _ _ _ t idc @ #(_) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ ($_)%expr @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _ @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (#(_) @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (($_)%expr @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (($_)%expr @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Abs _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (_ @ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat =>
+          None
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.fancy_selm log2wordmax)%expr @ x)%expr_pat)%option
-| ident.fancy_sell =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
+     Base (#(fancy_sell)%expr @ x)%expr_pat)%option
+| fancy_addm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
     ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | (@expr.Ident _ _ _ t0 idc0 @ x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.pair;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args3 <- pattern.ident.invert_bind_args idc3
-                                     pattern.ident.LiteralZ;
-                          Some
-                            (UnderLets.Base
-                               (##(ident.fancy.interp
-                                     (invert_Some
-                                        (ident.to_fancy ident.fancy_sell))
-                                     (args1, args2, args3)%core))%expr)
-                      | _ => None
-                      end
-                  | _ => None
-                  end
-              | _ => None
-              end
-          | _ => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
+          args <- invert_bind_args idc3 Raw.ident.Literal;
+          args0 <- invert_bind_args idc2 Raw.ident.Literal;
+          args1 <- invert_bind_args idc1 Raw.ident.Literal;
+          args2 <- invert_bind_args idc0 Raw.ident.pair;
+          args3 <- invert_bind_args idc Raw.ident.pair;
+          match
+            pattern.type.unify_extracted_cps
+              ((((ℤ * ℤ)%pbtype -> ℤ -> (ℤ * ℤ * ℤ)%pbtype) ->
+                ((ℤ -> ℤ -> (ℤ * ℤ)%pbtype) -> ℤ) -> ℤ) -> ℤ)%ptype
+              ((((let (x4, _) := args3 in x4) ->
+                 (let (_, y) := args3 in y) ->
+                 ((let (x4, _) := args3 in x4) * (let (_, y) := args3 in y))%etype) ->
+                (((let (x4, _) := args2 in x4) ->
+                  (let (_, y) := args2 in y) ->
+                  ((let (x4, _) := args2 in x4) * (let (_, y) := args2 in y))%etype) ->
+                 (projT1 args1)) -> (projT1 args0)) -> (projT1 args))%ptype
+              option (fun x4 : option => x4)
+          with
+          | Some (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _) =>
+              _ <- ident.unify pattern.ident.pair pair;
+              _ <- ident.unify pattern.ident.pair pair;
+              idc_args1 <- ident.unify pattern.ident.Literal ##(projT2 args1);
+              idc_args2 <- ident.unify pattern.ident.Literal ##(projT2 args0);
+              idc_args3 <- ident.unify pattern.ident.Literal ##(projT2 args);
+              Some
+                (Base
+                   (##(fancy.interp (invert_Some (to_fancy fancy_addm))
+                         (let (x4, _) := idc_args1 in x4,
+                         let (x4, _) := idc_args2 in x4,
+                         let (x4, _) := idc_args3 in x4)%core))%expr)
+          | None => None
           end
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ ($_)%expr)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ (_ @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
+          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ ($_)%expr) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Abs _
+          _ _ _ _ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ (_ @ _)) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.LetIn
+          _ _ _ _ _ _ _) @ _)%expr_pat => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ (_ @ _) @ _) @
+         _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat =>
+          None
+      | (@expr.Ident _ _ _ t idc @ #(_) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ ($_)%expr @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _ @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (#(_) @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (($_)%expr @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (($_)%expr @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Abs _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (_ @ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat =>
+          None
       | _ => None
       end;;
       None);;;
-     UnderLets.Base (#(ident.fancy_sell)%expr @ x)%expr_pat)%option
-| ident.fancy_addm =>
-    fun
-      x : defaults.expr
-            (type.base (base.type.Z * base.type.Z * base.type.Z)%etype) =>
-    ((match x with
-      | (@expr.Ident _ _ _ t idc @ x1 @ x0)%expr_pat =>
-          _ <- pattern.ident.invert_bind_args idc pattern.ident.pair;
-          match x1 with
-          | (@expr.Ident _ _ _ t0 idc0 @ x3 @ x2)%expr_pat =>
-              _ <- pattern.ident.invert_bind_args idc0 pattern.ident.pair;
-              match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args1 <- pattern.ident.invert_bind_args idc1
-                             pattern.ident.LiteralZ;
-                  match x2 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args2 <- pattern.ident.invert_bind_args idc2
-                                 pattern.ident.LiteralZ;
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args3 <- pattern.ident.invert_bind_args idc3
-                                     pattern.ident.LiteralZ;
-                          Some
-                            (UnderLets.Base
-                               (##(ident.fancy.interp
-                                     (invert_Some
-                                        (ident.to_fancy ident.fancy_addm))
-                                     (args1, args2, args3)%core))%expr)
-                      | _ => None
-                      end
-                  | _ => None
-                  end
-              | _ => None
-              end
-          | _ => None
-          end
-      | _ => None
-      end;;
-      None);;;
-     UnderLets.Base (#(ident.fancy_addm)%expr @ x)%expr_pat)%option
+     Base (#(fancy_addm)%expr @ x)%expr_pat)%option
 end
      : Compile.value' true t


### PR DESCRIPTION
This paves the way for writing down interpretation proofs for the
rewriter by writing down "default interpretations".  Otherwise, e.g.,
there was not enough type information to write down any good
interpretation for [map fst nil] (which would bind no type variables in
the previous veresion).

Unfortunately the rewriter itself got a bit slower (though the proof of
rewrite-rule-correctness got a bit faster).

```
After     | File Name                                                            | Before    || Change    | % Change
--------------------------------------------------------------------------------------------------------------------
24m05.07s | Total                                                                | 24m08.92s || -0m03.85s | -0.26%
--------------------------------------------------------------------------------------------------------------------
1m13.28s  | Experiments/NewPipeline/RewriterRulesGood.vo                         | 3m58.20s  || -2m44.91s | -69.23%
2m50.62s  | Experiments/NewPipeline/Rewriter.vo                                  | 1m12.64s  || +1m37.98s | +134.88%
1m45.22s  | Experiments/NewPipeline/RewriterWf2.vo                               | 1m13.64s  || +0m31.57s | +42.88%
0m16.82s  | Experiments/NewPipeline/GENERATEDIdentifiersWithoutTypesProofs.vo    | 0m11.46s  || +0m05.35s | +46.77%
0m08.04s  | Experiments/NewPipeline/RewriterWf1.vo                               | 0m04.52s  || +0m03.51s | +77.87%
6m07.90s  | Experiments/NewPipeline/SlowPrimeSynthesisExamples.vo                | 6m05.01s  || +0m02.88s | +0.79%
0m39.74s  | Experiments/NewPipeline/ExtractionOCaml/word_by_word_montgomery      | 0m37.09s  || +0m02.64s | +7.14%
0m37.83s  | Experiments/NewPipeline/ExtractionHaskell/word_by_word_montgomery    | 0m34.94s  || +0m02.89s | +8.27%
0m26.05s  | p384_32.c                                                            | 0m23.72s  || +0m02.33s | +9.82%
0m23.37s  | Experiments/NewPipeline/ExtractionHaskell/unsaturated_solinas        | 0m21.01s  || +0m02.35s | +11.23%
0m21.30s  | Experiments/NewPipeline/ExtractionOCaml/unsaturated_solinas          | 0m19.02s  || +0m02.28s | +11.98%
0m16.22s  | Experiments/NewPipeline/ExtractionHaskell/saturated_solinas          | 0m14.01s  || +0m02.20s | +15.77%
4m34.84s  | Experiments/NewPipeline/Toplevel1.vo                                 | 4m36.15s  || -0m01.30s | -0.47%
1m42.79s  | Experiments/NewPipeline/Toplevel2.vo                                 | 1m44.07s  || -0m01.28s | -1.22%
0m40.07s  | p521_32.c                                                            | 0m38.58s  || +0m01.49s | +3.86%
0m33.52s  | p521_64.c                                                            | 0m32.04s  || +0m01.48s | +4.61%
0m12.80s  | Experiments/NewPipeline/ExtractionOCaml/saturated_solinas            | 0m11.12s  || +0m01.68s | +15.10%
0m09.01s  | Experiments/NewPipeline/ExtractionOCaml/word_by_word_montgomery.ml   | 0m08.76s  || +0m00.25s | +2.85%
0m08.80s  | p384_64.c                                                            | 0m08.49s  || +0m00.31s | +3.65%
0m07.65s  | Experiments/NewPipeline/GENERATEDIdentifiersWithoutTypes.vo          | 0m07.83s  || -0m00.17s | -2.29%
0m05.92s  | Experiments/NewPipeline/ExtractionOCaml/unsaturated_solinas.ml       | 0m05.40s  || +0m00.51s | +9.62%
0m05.59s  | Experiments/NewPipeline/ExtractionHaskell/word_by_word_montgomery.hs | 0m05.61s  || -0m00.02s | -0.35%
0m04.40s  | secp256k1_32.c                                                       | 0m03.95s  || +0m00.45s | +11.39%
0m04.27s  | Experiments/NewPipeline/ExtractionOCaml/saturated_solinas.ml         | 0m03.98s  || +0m00.28s | +7.28%
0m04.27s  | p256_32.c                                                            | 0m03.76s  || +0m00.50s | +13.56%
0m04.23s  | Experiments/NewPipeline/ExtractionHaskell/unsaturated_solinas.hs     | 0m04.14s  || +0m00.09s | +2.17%
0m03.39s  | Experiments/NewPipeline/ExtractionHaskell/saturated_solinas.hs       | 0m03.35s  || +0m00.04s | +1.19%
0m02.56s  | p224_32.c                                                            | 0m02.24s  || +0m00.31s | +14.28%
0m02.37s  | curve25519_32.c                                                      | 0m02.18s  || +0m00.18s | +8.71%
0m01.66s  | p224_64.c                                                            | 0m01.66s  || +0m00.00s | +0.00%
0m01.64s  | p256_64.c                                                            | 0m01.53s  || +0m00.10s | +7.18%
0m01.60s  | secp256k1_64.c                                                       | 0m01.50s  || +0m00.10s | +6.66%
0m01.52s  | curve25519_64.c                                                      | 0m01.51s  || +0m00.01s | +0.66%
0m01.38s  | Experiments/NewPipeline/CLI.vo                                       | 0m01.37s  || +0m00.00s | +0.72%
0m01.27s  | Experiments/NewPipeline/StandaloneHaskellMain.vo                     | 0m01.16s  || +0m00.11s | +9.48%
0m01.19s  | Experiments/NewPipeline/StandaloneOCamlMain.vo                       | 0m01.29s  || -0m00.10s | -7.75%
0m01.05s  | Experiments/NewPipeline/CompilersTestCases.vo                        | 0m01.06s  || -0m00.01s | -0.94%
0m00.90s  | Experiments/NewPipeline/RewriterProofs.vo                            | 0m00.94s  || -0m00.03s | -4.25%
```