### PR TITLE
Guarantee that casting always returns inrange

### DIFF
--- a/src/Experiments/NewPipeline/AbstractInterpretationZRangeProofs.v
+++ b/src/Experiments/NewPipeline/AbstractInterpretationZRangeProofs.v
@@ -35,9 +35,11 @@ Require Import Crypto.Util.Tactics.UniquePose.
 Require Import Crypto.Util.Tactics.SpecializeBy.
 Require Import Crypto.Util.Tactics.SpecializeAllWays.
 Require Import Crypto.Util.Tactics.Head.
+Require Import Crypto.Experiments.NewPipeline.LanguageWf.
 Require Import Crypto.Experiments.NewPipeline.AbstractInterpretation.
 
 Module Compilers.
+  Import LanguageWf.Compilers.
   Import AbstractInterpretation.Compilers.
 
   Module ZRange.
@@ -72,10 +74,11 @@ Module Compilers.
 
           Local Ltac z_cast_t :=
             cbn [type.related_hetero ZRange.ident.option.interp ident.interp ident.gen_interp respectful_hetero type.interp ZRange.type.base.option.interp ZRange.type.base.interp base.interp base.base_interp ZRange.type.base.option.Some];
-            cbv [ZRange.ident.option.interp_Z_cast ident.cast ZRange.type.base.option.is_bounded_by ZRange.type.base.is_bounded_by is_tighter_than_bool respectful_hetero is_bounded_by_bool];
+            cbv [ZRange.ident.option.interp_Z_cast ZRange.type.base.option.is_bounded_by ZRange.type.base.is_bounded_by respectful_hetero];
             intros; break_innermost_match; trivial;
             rewrite ?Bool.andb_true_iff, ?Bool.andb_false_iff in *; destruct_head'_and; destruct_head'_or; repeat apply conj; Z.ltb_to_lt;
-            try reflexivity; try lia.
+            rewrite ?ident.cast_in_bounds by (eapply ZRange.is_bounded_by_iff_is_tighter_than; eauto);
+            try reflexivity; try lia; try assumption.
 
           Lemma interp_related_Z_cast r : interp_is_related (@ident.Z_cast r).
           Proof. z_cast_t. Qed.

--- a/src/Experiments/NewPipeline/CompilersTestCases.v
+++ b/src/Experiments/NewPipeline/CompilersTestCases.v
@@ -57,7 +57,8 @@ Module testrewrite.
                              @ (##1, ##7))%expr).
 
 
-  Eval cbv in partial.eval_with_bound (RewriteRules.RewriteNBE (fun var =>
+  Eval cbv in partial.eval_with_bound partial.default_relax_zrange
+                                      (RewriteRules.RewriteNBE (fun var =>
                 (\z , ((\ x , expr_let y := ##5 in $y + ($z + (#ident.fst @ $x + #ident.snd @ $x)))
                          @ (##1, ##7)))%expr) _)
                 (Some r[0~>100]%zrange, tt).
@@ -81,6 +82,7 @@ Module testpartial.
 
 
   Eval cbv in partial.eval_with_bound
+                partial.default_relax_zrange
                 (\z , ((\ x , expr_let y := ##5 in $y + ($z + (#ident.fst @ $x + #ident.snd @ $x)))
                          @ (##1, ##7)))%expr
                 (Some r[0~>100]%zrange, tt).
@@ -106,7 +108,7 @@ Module test2.
               expr_let x1 := ($x0 * $x0) in
               ($x1, $x1))%expr) => idtac
     end.
-    pose (partial.EvalWithBound E' (Some r[0~>10]%zrange, tt)) as E''.
+    pose (partial.EvalWithBound partial.default_relax_zrange E' (Some r[0~>10]%zrange, tt)) as E''.
     lazy in E''.
      lazymatch (eval cbv delta [E''] in E'') with
      | (fun var : type -> Type =>
@@ -142,7 +144,7 @@ Module test3.
               $x3 * $x3)%expr)
       => idtac
     end.
-    pose (partial.EvalWithBound E' (Some r[0~>10]%zrange, tt)) as E'''.
+    pose (partial.EvalWithBound partial.default_relax_zrange E' (Some r[0~>10]%zrange, tt)) as E'''.
     lazy in E'''.
     lazymatch (eval cbv delta [E'''] in E''') with
     | (fun var : type -> Type =>
@@ -163,7 +165,7 @@ Module test3point5.
     let v := Reify (fun y : (list Z) => List.nth_default (-1) y 0) in
     pose v as E.
     vm_compute in E.
-    pose (partial.EvalWithBound E (Some [Some r[0~>10]%zrange], tt)) as E'.
+    pose (partial.EvalWithBound partial.default_relax_zrange E (Some [Some r[0~>10]%zrange], tt)) as E'.
     lazy in E'.
     clear E.
     lazymatch (eval cbv delta [E'] in E') with
@@ -194,7 +196,7 @@ Module test4.
     clear E'.
     pose (PartialEvaluate E'') as E'''.
     lazy in E'''.
-    pose (partial.EvalWithBound E''' bound) as E''''.
+    pose (partial.EvalWithBound partial.default_relax_zrange E''' bound) as E''''.
     lazy in E''''.
     clear E'' E'''.
     lazymatch (eval cbv delta [E''''] in E'''') with

--- a/src/Experiments/NewPipeline/Language.v
+++ b/src/Experiments/NewPipeline/Language.v
@@ -8,6 +8,7 @@ Require Import Crypto.Util.ListUtil Coq.Lists.List Crypto.Util.NatUtil.
 Require Import Crypto.Util.Option.
 Require Import Crypto.Util.Prod.
 Require Import Crypto.Util.ZRange.
+Require Import Crypto.Util.ZRange.Operations.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Notations.
 Require Import Crypto.Util.CPSNotations.
@@ -912,9 +913,10 @@ Module Compilers.
         Context (cast_outside_of_range : zrange -> BinInt.Z -> BinInt.Z).
 
         Definition cast (r : zrange) (x : BinInt.Z)
-          := if (lower r <=? x) && (x <=? upper r)
+          := let r := ZRange.normalize r in
+             if (lower r <=? x) && (x <=? upper r)
              then x
-             else cast_outside_of_range r x.
+             else ((cast_outside_of_range r x - lower r) mod (upper r - lower r + 1)) + lower r.
 
         Local Notation wordmax log2wordmax := (2 ^ log2wordmax).
         Local Notation half_bits log2wordmax := (log2wordmax / 2).
@@ -1737,3 +1739,4 @@ Module Compilers.
       := FromFlat (to_flat e).
   End GeneralizeVar.
 End Compilers.
+Global Opaque Compilers.ident.cast. (* This should never be unfolded except in [LanguageWf] *)


### PR DESCRIPTION
We fuse the bounds relaxation pass with the abstract interpretation pass
by folding bounds relaxation into the annotation method.  This allows us
to not need any particular assumptions about what happens when you cast
outside the range.

We can therefore now guarantee that the output of casting is always
bounded by the given range (rather, by the normalized version of the
range), which will be required to take advantage of bounds information
in the rewriter (because otherwise we're not guaranteed that casting
something to within a range actually outputs something within that
range).