### PR TITLE
Tactic-in-term: ensuring same scope for all occurrences of a notation variable

### DIFF
--- a/src/Util/SideConditions/ReductionPackages.v
+++ b/src/Util/SideConditions/ReductionPackages.v
@@ -39,7 +39,7 @@ Notation None_evar_Prop_package := (@None_evar_Prop_package' unit).
 
 Notation optional_evar_package pkg_type
   := (optional_evar_Prop_package
-        (ltac:(lazymatch eval hnf in pkg_type with evar_Prop_package ?P => exact P end))
+        (ltac:(lazymatch eval hnf in pkg_type%type with evar_Prop_package ?P => exact P end))
         pkg_type)
        (only parsing).
 


### PR DESCRIPTION
Hi, this is a backward-compatible change in relation with coq/coq#8745
as [suggested](https://github.com/coq/coq/pull/8745#issuecomment-432335811) by @jasongross.