### PR TITLE
Tactic-in-term: ensuring same scope for all occurrences of a notation variable (continued)

### DIFF
--- a/src/Util/SideConditions/ReductionPackages.v
+++ b/src/Util/SideConditions/ReductionPackages.v
@@ -57,7 +57,7 @@ Notation optional_evar_rel_package pkg_type x
         x
         _
         (fun a b
-         => ltac:(lazymatch eval hnf in (pkg_type b) with
+         => ltac:(lazymatch eval hnf in (pkg_type%function b) with
                   | evar_Prop_package ?P
                     => let P := (eval cbv beta in (P a)) in
                        exact P


### PR DESCRIPTION
Hi, this is another backward-compatible change in relation with coq/coq#8745 (I missed it initially).

Follow-up of PR #450.