### PR TITLE
 Split off all of the arithmetic rules that need bounds info

### DIFF
--- a/src/Experiments/NewPipeline/RewriterRulesGood.v
+++ b/src/Experiments/NewPipeline/RewriterRulesGood.v
@@ -59,7 +59,7 @@ Module Compilers.
         = (fun var => @fancy_with_casts_rewrite_head0 var (*invert_low invert_high*)).
     Proof. reflexivity. Qed.
 
-    Lemma arith_with_casts_rewrite_head_eq : (fun var _ => @arith_with_casts_rewrite_head var) = @arith_with_casts_rewrite_head0.
+    Lemma arith_with_casts_rewrite_head_eq : @arith_with_casts_rewrite_head = @arith_with_casts_rewrite_head0.
     Proof. reflexivity. Qed.
 
     Lemma nbe_all_rewrite_rules_eq : @nbe_all_rewrite_rules = @nbe_rewrite_rules.

--- a/src/Experiments/NewPipeline/RewriterRulesInterpGood.v
+++ b/src/Experiments/NewPipeline/RewriterRulesInterpGood.v
@@ -345,6 +345,13 @@ Module Compilers.
       Proof using Type.
         Time start_interp_good.
         Time all: try solve [ repeat interp_good_t_step; (lia + nia) ].
+      Qed.
+
+      Lemma arith_with_casts_rewrite_rules_interp_good
+        : rewrite_rules_interp_goodT arith_with_casts_rewrite_rules.
+      Proof using Type.
+        Time start_interp_good.
+        Time all: try solve [ repeat interp_good_t_step; (lia + nia) ].
         (* This is mainly for display *)
         all: repeat first [ progress cbn [Compile.value' Compile.reify] in *
                           | progress subst
@@ -457,13 +464,6 @@ subgoal 9 (ID 33473) is:
  end
          *)
         1-9: exact admit.
-      Qed.
-
-      Lemma arith_with_casts_rewrite_rules_interp_good
-        : rewrite_rules_interp_goodT arith_with_casts_rewrite_rules.
-      Proof using Type.
-        Time start_interp_good.
-        Time all: try solve [ repeat interp_good_t_step; (lia + nia) ].
       Qed.
 
       Local Ltac fancy_local_t :=

--- a/src/Experiments/NewPipeline/Toplevel1.v
+++ b/src/Experiments/NewPipeline/Toplevel1.v
@@ -714,6 +714,7 @@ Module Pipeline.
       let E := PartialEvaluate E in
       let E := RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArith 0) with_dead_code_elimination with_subst01 E in
       let E := RewriteRules.RewriteArith (2^8) E in (* reassociate small consts *)
+      let E := RewriteAndEliminateDeadAndInline RewriteRules.RewriteArithWithCasts with_dead_code_elimination with_subst01 E in
       let E := match translate_to_fancy with
                | Some {| invert_low := invert_low ; invert_high := invert_high |} => RewriteRules.RewriteToFancy invert_low invert_high E
                | None => E
@@ -723,7 +724,7 @@ Module Pipeline.
       let E' := CheckedPartialEvaluateWithBounds relax_zrange E arg_bounds out_bounds in
       match E' with
       | inl E
-        => let E := RewriteRules.RewriteArithWithCasts E in
+        => (*let E := RewriteAndEliminateDeadAndInline RewriteRules.RewriteArithWithCasts with_dead_code_elimination with_subst01 E in*)
            let E := match translate_to_fancy with
                     | Some {| invert_low := invert_low ; invert_high := invert_high |} => RewriteRules.RewriteToFancyWithCasts invert_low invert_high E
                     | None => E

--- a/src/Experiments/NewPipeline/Toplevel1.v
+++ b/src/Experiments/NewPipeline/Toplevel1.v
@@ -714,7 +714,6 @@ Module Pipeline.
       let E := PartialEvaluate E in
       let E := RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArith 0) with_dead_code_elimination with_subst01 E in
       let E := RewriteRules.RewriteArith (2^8) E in (* reassociate small consts *)
-      let E := RewriteAndEliminateDeadAndInline RewriteRules.RewriteArithWithCasts with_dead_code_elimination with_subst01 E in
       let E := match translate_to_fancy with
                | Some {| invert_low := invert_low ; invert_high := invert_high |} => RewriteRules.RewriteToFancy invert_low invert_high E
                | None => E
@@ -724,7 +723,7 @@ Module Pipeline.
       let E' := CheckedPartialEvaluateWithBounds relax_zrange E arg_bounds out_bounds in
       match E' with
       | inl E
-        => (*let E := RewriteAndEliminateDeadAndInline RewriteRules.RewriteArithWithCasts with_dead_code_elimination with_subst01 E in*)
+        => let E := RewriteAndEliminateDeadAndInline RewriteRules.RewriteArithWithCasts with_dead_code_elimination with_subst01 E in
            let E := match translate_to_fancy with
                     | Some {| invert_low := invert_low ; invert_high := invert_high |} => RewriteRules.RewriteToFancyWithCasts invert_low invert_high E
                     | None => E

--- a/src/Experiments/NewPipeline/arith_rewrite_head.out
+++ b/src/Experiments/NewPipeline/arith_rewrite_head.out
@@ -27,7 +27,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b3) ->
@@ -78,7 +78,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b2) ->
@@ -222,7 +222,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -244,7 +244,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
             with
-            | Some (_, _)%zrange =>
+            | Some (_, _) =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    (ℤ -> (projT1 args))%ptype
@@ -267,7 +267,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     (s -> (projT1 args0))%ptype option
                     (fun x2 : option => x2)
                 with
-                | Some (_, _)%zrange =>
+                | Some (_, _) =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype (s -> (projT1 args0))%ptype
@@ -291,7 +291,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s -> (projT1 args0))%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args0))%ptype
@@ -324,7 +324,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                     ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                 with
-                | Some (_, _)%zrange =>
+                | Some (_, _) =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype ((projT1 args) -> s)%ptype
@@ -348,7 +348,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -374,7 +374,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
@@ -406,7 +406,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
@@ -428,7 +428,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
@@ -458,7 +458,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                    ((projT1 args0) -> (projT1 args))%ptype option
                    (fun x1 : option => x1)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args0) -> (projT1 args))%ptype
@@ -481,7 +481,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -503,7 +503,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -525,7 +525,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -547,7 +547,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
             with
-            | Some (_, _)%zrange =>
+            | Some (_, _) =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    (ℤ -> (projT1 args))%ptype
@@ -569,7 +569,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s -> (projT1 args0))%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args0))%ptype
@@ -598,7 +598,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -627,7 +627,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -649,7 +649,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -671,7 +671,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -695,7 +695,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -719,7 +719,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
@@ -750,7 +750,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
@@ -772,7 +772,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -796,7 +796,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
@@ -818,7 +818,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                 ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
             with
-            | Some (_, _)%zrange =>
+            | Some (_, _) =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    ((projT1 args) -> ℤ)%ptype
@@ -856,7 +856,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            ((projT1 args2) -> (projT1 args0) -> s2 -> s1)%ptype
                            option (fun x5 : option => x5)
                        with
-                       | Some (_, (_, (_, _)))%zrange =>
+                       | Some (_, (_, (_, _))) =>
                            if
                             type.type_beq base.type base.type.type_beq
                               (ℤ -> ℤ -> ℤ -> ℤ)%ptype
@@ -913,7 +913,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                        ((projT1 args2) -> s0 -> s2 -> (projT1 args))%ptype
                        option (fun x5 : option => x5)
                    with
-                   | Some (_, (_, (_, _)))%zrange =>
+                   | Some (_, (_, (_, _))) =>
                        if
                         type.type_beq base.type base.type.type_beq
                           (ℤ -> ℤ -> ℤ -> ℤ)%ptype
@@ -963,7 +963,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                    ((projT1 args0) -> s0 -> s)%ptype option
                    (fun x3 : option => x3)
                with
-               | Some (_, (_, _))%zrange =>
+               | Some (_, (_, _)) =>
                    if
                     type.type_beq base.type base.type.type_beq
                       (ℤ -> ℤ -> ℤ)%ptype ((projT1 args0) -> s0 -> s)%ptype
@@ -1001,7 +1001,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1034,7 +1034,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    ((projT1 args0) -> s)%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args0) -> s)%ptype
@@ -1059,7 +1059,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1081,7 +1081,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1103,7 +1103,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                     ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                 with
-                | Some (_, _)%zrange =>
+                | Some (_, _) =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype ((projT1 args) -> s)%ptype
@@ -1127,7 +1127,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -1159,7 +1159,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1183,7 +1183,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                     (s -> (projT1 args))%ptype option (fun x2 : option => x2)
                 with
-                | Some (_, _)%zrange =>
+                | Some (_, _) =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype (s -> (projT1 args))%ptype
@@ -1208,7 +1208,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s -> (projT1 args))%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args))%ptype
@@ -1240,7 +1240,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1264,7 +1264,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | Some (_, _)%zrange =>
+               | Some (_, _) =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
@@ -1295,7 +1295,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
@@ -1317,7 +1317,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
@@ -1362,7 +1362,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
        | Some _ =>
            if type.type_beq base.type base.type.type_beq ℤ ℤ
            then
-            fv <- (if negb (SubstVarLike.is_var_fst_snd_pair_opp_cast x)
+            fv <- (if negb (SubstVarLike.is_var_fst_snd_pair_opp x)
                    then
                     Some
                       (UnderLet x
@@ -1388,7 +1388,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1406,7 +1406,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
           with
-          | Some (_, _)%zrange =>
+          | Some (_, _) =>
               if
                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                  (ℤ -> (projT1 args))%ptype
@@ -1436,7 +1436,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
           with
-          | Some (_, _)%zrange =>
+          | Some (_, _) =>
               if
                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                  (ℤ -> (projT1 args))%ptype
@@ -1454,7 +1454,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
              (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
          with
-         | Some (_, _)%zrange =>
+         | Some (_, _) =>
              if
               type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype
@@ -1492,7 +1492,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1514,7 +1514,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _)%zrange =>
+           | Some (_, _) =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1536,1022 +1536,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_lnot_modulo =>
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
 | Z_mul_split =>
-    fun x x0 x1 : expr ℤ =>
-    (((match x with
-       | @expr.Ident _ _ _ t idc =>
-           match x0 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 0
-                           then Some ((##0)%expr, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 0
-                           then Some ((##0)%expr, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x0 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 1
-                           then Some (x1, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 1
-                           then Some (x0, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x0 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? -1
-                           then Some ((- x1)%expr, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? -1
-                           then Some ((- x0)%expr, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end
-       | _ => None
-       end;;
-       match
-         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
-       with
-       | Some (_, _, _)%zrange =>
-           if
-            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
-              ((ℤ -> ℤ) -> ℤ)%ptype
-           then
-            Some
-              (UnderLet (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
-                 (fun v : var (ℤ * ℤ)%etype =>
-                  Base
-                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-           else None
-       | None => None
-       end);;
-      None);;;
-     Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
+    fun x x0 x1 : expr ℤ => Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
 | Z_add_get_carry =>
     fun x x0 x1 : expr ℤ =>
-    (((match x0 with
-       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
-           _ <- invert_bind_args idc Raw.ident.Z_opp;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> s) -> ℤ)%ptype option (fun x3 : option => x3)
-           with
-           | Some (_, _, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> s) -> ℤ)%ptype
-               then
-                v <- type.try_make_transport_cps s ℤ;
-                Some
-                  (UnderLet
-                     (#(Z_sub_get_borrow)%expr @ x @ x1 @
-                      v (Compile.reflect x2))%expr_pat
-                     (fun v0 : var (ℤ * ℤ)%etype =>
-                      Base
-                        (#(fst)%expr @ ($v0)%expr,
-                        (- (#(snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-               else None
-           | None => None
-           end
-       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
-       end;;
-       match x1 with
-       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
-           _ <- invert_bind_args idc Raw.ident.Z_opp;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> ℤ) -> s)%ptype option (fun x3 : option => x3)
-           with
-           | Some (_, _, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> s)%ptype
-               then
-                v <- type.try_make_transport_cps s ℤ;
-                Some
-                  (UnderLet
-                     (#(Z_sub_get_borrow)%expr @ x @ x0 @
-                      v (Compile.reflect x2))%expr_pat
-                     (fun v0 : var (ℤ * ℤ)%etype =>
-                      Base
-                        (#(fst)%expr @ ($v0)%expr,
-                        (- (#(snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-               else None
-           | None => None
-           end
-       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
-       end;;
-       match x0 with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> (projT1 args)) -> ℤ)%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> (projT1 args)) -> ℤ)%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                fv <- (if (let (x2, _) := idc_args in x2) <? 0
-                       then
-                        Some
-                          (UnderLet
-                             (#(Z_sub_get_borrow)%expr @ x @ x1 @
-                              (##(- (let (x2, _) := idc_args in x2))%Z)%expr)%expr_pat
-                             (fun vc : var (ℤ * ℤ)%etype =>
-                              Base
-                                (#(fst)%expr @ ($vc)%expr,
-                                (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                       else None);
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match x1 with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> ℤ) -> (projT1 args))%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> (projT1 args))%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                fv <- (if (let (x2, _) := idc_args in x2) <? 0
-                       then
-                        Some
-                          (UnderLet
-                             (#(Z_sub_get_borrow)%expr @ x @ x0 @
-                              (##(- (let (x2, _) := idc_args in x2))%Z)%expr)%expr_pat
-                             (fun vc : var (ℤ * ℤ)%etype =>
-                              Base
-                                (#(fst)%expr @ ($vc)%expr,
-                                (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                       else None);
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match x0 with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> (projT1 args)) -> ℤ)%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> (projT1 args)) -> ℤ)%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
-                       then Some (x1, (##0)%expr)%expr_pat
-                       else None);
-                Some (Base x2)
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match x1 with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> ℤ) -> (projT1 args))%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> (projT1 args))%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
-                       then Some (x0, (##0)%expr)%expr_pat
-                       else None);
-                Some (Base x2)
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match
-         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
-       with
-       | Some (_, _, _)%zrange =>
-           if
-            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
-              ((ℤ -> ℤ) -> ℤ)%ptype
-           then
-            Some
-              (UnderLet (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat
-                 (fun v : var (ℤ * ℤ)%etype =>
-                  Base
-                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-           else None
-       | None => None
-       end);;
-      None);;;
-     Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
+    Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat
 | Z_add_with_carry =>
     fun x x0 x1 : expr ℤ =>
-    (((match x with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               (((projT1 args) -> ℤ) -> ℤ)%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype (((projT1 args) -> ℤ) -> ℤ)%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
-                       then Some (x0 + x1)%expr
-                       else None);
-                Some (Base x2)
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match
-         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
-       with
-       | Some (_, _, _)%zrange =>
-           if
-            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
-              ((ℤ -> ℤ) -> ℤ)%ptype
-           then
-            Some
-              (UnderLet (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
-                 (fun v : var ℤ => Base ($v)%expr))
-           else None
-       | None => None
-       end);;
-      None);;;
-     Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
+    Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
 | Z_add_with_get_carry =>
     fun x x0 x1 x2 : expr ℤ =>
-    (((match x0 with
-       | @expr.Ident _ _ _ t idc =>
-           match x1 with
-           | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x3 =>
-               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
-                args0 <- invert_bind_args idc Raw.ident.Literal;
-                match
-                  pattern.type.unify_extracted_cps
-                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                    (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype option
-                    (fun x4 : option => x4)
-                with
-                | Some (_, _, _, _)%zrange =>
-                    if
-                     type.type_beq base.type base.type.type_beq
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype
-                    then
-                     idc_args <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args0);
-                     v <- type.try_make_transport_cps s ℤ;
-                     fv <- (if (let (x4, _) := idc_args in x4) =? 0
-                            then
-                             Some
-                               (UnderLet
-                                  (#(Z_sub_get_borrow)%expr @ x @ x2 @
-                                   v (Compile.reflect x3))%expr_pat
-                                  (fun vc : var (ℤ * ℤ)%etype =>
-                                   Base
-                                     (#(fst)%expr @ ($vc)%expr,
-                                     (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                            else None);
-                     Some (fv0 <-- fv;
-                           Base fv0)%under_lets
-                    else None
-                | None => None
-                end);;
-               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype option
-                   (fun x4 : option => x4)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    v <- type.try_make_transport_cps s ℤ;
-                    fv <- (if (let (x4, _) := idc_args in x4) <? 0
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
-                                  x2 @ v (Compile.reflect x3))%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
-           end;;
-           match x2 with
-           | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x3 =>
-               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
-                args0 <- invert_bind_args idc Raw.ident.Literal;
-                match
-                  pattern.type.unify_extracted_cps
-                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                    (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype option
-                    (fun x4 : option => x4)
-                with
-                | Some (_, _, _, _)%zrange =>
-                    if
-                     type.type_beq base.type base.type.type_beq
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype
-                    then
-                     idc_args <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args0);
-                     v <- type.try_make_transport_cps s ℤ;
-                     fv <- (if (let (x4, _) := idc_args in x4) =? 0
-                            then
-                             Some
-                               (UnderLet
-                                  (#(Z_sub_get_borrow)%expr @ x @ x1 @
-                                   v (Compile.reflect x3))%expr_pat
-                                  (fun vc : var (ℤ * ℤ)%etype =>
-                                   Base
-                                     (#(fst)%expr @ ($vc)%expr,
-                                     (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                            else None);
-                     Some (fv0 <-- fv;
-                           Base fv0)%under_lets
-                    else None
-                | None => None
-                end);;
-               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype option
-                   (fun x4 : option => x4)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    v <- type.try_make_transport_cps s ℤ;
-                    fv <- (if (let (x4, _) := idc_args in x4) <? 0
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
-                                  x1 @ v (Compile.reflect x3))%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> (projT1 args0)) -> (projT1 args)) -> ℤ)%ptype
-                   option (fun x3 : option => x3)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> (projT1 args0)) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    fv <- (if
-                            ((let (x3, _) := idc_args0 in x3) <=? 0) &&
-                            ((let (x3, _) := idc_args in x3) <=? 0) &&
-                            ((let (x3, _) := idc_args0 in x3) +
-                             (let (x3, _) := idc_args in x3) <? 0)
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  (##(- (let (x3, _) := idc_args in x3))%Z)%expr @
-                                  x2 @
-                                  (##(- (let (x3, _) := idc_args0 in x3))%Z)%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x2 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> (projT1 args0)) -> ℤ) -> (projT1 args))%ptype
-                   option (fun x3 : option => x3)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> (projT1 args0)) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    fv <- (if
-                            ((let (x3, _) := idc_args0 in x3) <=? 0) &&
-                            ((let (x3, _) := idc_args in x3) <=? 0) &&
-                            ((let (x3, _) := idc_args0 in x3) +
-                             (let (x3, _) := idc_args in x3) <? 0)
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  (##(- (let (x3, _) := idc_args in x3))%Z)%expr @
-                                  x1 @
-                                  (##(- (let (x3, _) := idc_args0 in x3))%Z)%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               match x1 with
-               | @expr.Ident _ _ _ t1 idc1 =>
-                   args <- invert_bind_args idc1 Raw.ident.Literal;
-                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                   args1 <- invert_bind_args idc Raw.ident.Literal;
-                   match
-                     pattern.type.unify_extracted_cps
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       ((((projT1 args0) -> (projT1 args1)) -> (projT1 args)) ->
-                        ℤ)%ptype option (fun x3 : option => x3)
-                   with
-                   | Some (_, _, _, _)%zrange =>
-                       if
-                        type.type_beq base.type base.type.type_beq
-                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                          ((((projT1 args0) -> (projT1 args1)) ->
-                            (projT1 args)) -> ℤ)%ptype
-                       then
-                        _ <- ident.unify pattern.ident.Literal
-                               ##(projT2 args0);
-                        idc_args0 <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args1);
-                        idc_args1 <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args);
-                        x3 <- (if
-                                ((let (x3, _) := idc_args0 in x3) =? 0) &&
-                                ((let (x3, _) := idc_args1 in x3) =? 0)
-                               then Some (x2, (##0)%expr)%expr_pat
-                               else None);
-                        Some (Base x3)
-                       else None
-                   | None => None
-                   end
-               | _ => None
-               end;;
-               match x2 with
-               | @expr.Ident _ _ _ t1 idc1 =>
-                   args <- invert_bind_args idc1 Raw.ident.Literal;
-                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                   args1 <- invert_bind_args idc Raw.ident.Literal;
-                   match
-                     pattern.type.unify_extracted_cps
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       ((((projT1 args0) -> (projT1 args1)) -> ℤ) ->
-                        (projT1 args))%ptype option (fun x3 : option => x3)
-                   with
-                   | Some (_, _, _, _)%zrange =>
-                       if
-                        type.type_beq base.type base.type.type_beq
-                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                          ((((projT1 args0) -> (projT1 args1)) -> ℤ) ->
-                           (projT1 args))%ptype
-                       then
-                        _ <- ident.unify pattern.ident.Literal
-                               ##(projT2 args0);
-                        idc_args0 <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args1);
-                        idc_args1 <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args);
-                        x3 <- (if
-                                ((let (x3, _) := idc_args0 in x3) =? 0) &&
-                                ((let (x3, _) := idc_args1 in x3) =? 0)
-                               then Some (x1, (##0)%expr)%expr_pat
-                               else None);
-                        Some (Base x3)
-                       else None
-                   | None => None
-                   end
-               | _ => None
-               end
-           | _ => None
-           end;;
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-               (((ℤ -> (projT1 args)) -> ℤ) -> ℤ)%ptype option
-               (fun x3 : option => x3)
-           with
-           | Some (_, _, _, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                  (((ℤ -> (projT1 args)) -> ℤ) -> ℤ)%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                fv <- (if (let (x3, _) := idc_args in x3) =? 0
-                       then
-                        Some
-                          (UnderLet
-                             (#(Z_add_get_carry)%expr @ x @ x1 @ x2)%expr_pat
-                             (fun vc : var (ℤ * ℤ)%etype =>
-                              Base
-                                (#(fst)%expr @ ($vc)%expr,
-                                #(snd)%expr @ ($vc)%expr)%expr_pat))
-                       else None);
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
-       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x3 =>
-           match x1 with
-           | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
-               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-               _ <- invert_bind_args idc Raw.ident.Z_opp;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> s) -> s0) -> ℤ)%ptype
-                   option (fun x5 : option => x5)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> s) -> s0) -> ℤ)%ptype
-                   then
-                    v <- type.try_make_transport_cps s ℤ;
-                    v0 <- type.try_make_transport_cps s0 ℤ;
-                    Some
-                      (UnderLet
-                         (#(Z_sub_with_get_borrow)%expr @ x @
-                          v (Compile.reflect x3) @ x2 @
-                          v0 (Compile.reflect x4))%expr_pat
-                         (fun v1 : var (ℤ * ℤ)%etype =>
-                          Base
-                            (#(fst)%expr @ ($v1)%expr,
-                            (- (#(snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
-                   else None
-               | None => None
-               end
-           | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
-             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
-             (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
-             (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
-           end;;
-           match x2 with
-           | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
-               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-               _ <- invert_bind_args idc Raw.ident.Z_opp;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> s) -> ℤ) -> s0)%ptype
-                   option (fun x5 : option => x5)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> s) -> ℤ) -> s0)%ptype
-                   then
-                    v <- type.try_make_transport_cps s ℤ;
-                    v0 <- type.try_make_transport_cps s0 ℤ;
-                    Some
-                      (UnderLet
-                         (#(Z_sub_with_get_borrow)%expr @ x @
-                          v (Compile.reflect x3) @ x1 @
-                          v0 (Compile.reflect x4))%expr_pat
-                         (fun v1 : var (ℤ * ℤ)%etype =>
-                          Base
-                            (#(fst)%expr @ ($v1)%expr,
-                            (- (#(snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
-                   else None
-               | None => None
-               end
-           | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
-             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
-             (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
-             (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               _ <- invert_bind_args idc Raw.ident.Z_opp;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> s) -> (projT1 args)) -> ℤ)%ptype option
-                   (fun x4 : option => x4)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> s) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    v <- type.try_make_transport_cps s ℤ;
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args);
-                    fv <- (if (let (x4, _) := idc_args in x4) <=? 0
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  v (Compile.reflect x3) @ x2 @
-                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x2 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               _ <- invert_bind_args idc Raw.ident.Z_opp;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> s) -> ℤ) -> (projT1 args))%ptype option
-                   (fun x4 : option => x4)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> s) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    v <- type.try_make_transport_cps s ℤ;
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args);
-                    fv <- (if (let (x4, _) := idc_args in x4) <=? 0
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  v (Compile.reflect x3) @ x1 @
-                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end
-       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
-       end;;
-       match x1 with
-       | @expr.Ident _ _ _ t idc =>
-           match x2 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> ℤ) -> (projT1 args0)) -> (projT1 args))%ptype
-                   option (fun x3 : option => x3)
-               with
-               | Some (_, _, _, _)%zrange =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> ℤ) -> (projT1 args0)) -> (projT1 args))%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    fv <- (if
-                            ((let (x3, _) := idc_args in x3) =? 0) &&
-                            ((let (x3, _) := idc_args0 in x3) =? 0)
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_add_with_get_carry)%expr @ x @ x0 @
-                                  (##(let (x3, _) := idc_args in x3))%expr @
-                                  (##(let (x3, _) := idc_args0 in x3))%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr, (##0)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end
-       | _ => None
-       end;;
-       match
-         pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype option (fun x3 : option => x3)
-       with
-       | Some (_, _, _, _)%zrange =>
-           if
-            type.type_beq base.type base.type.type_beq
-              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-           then
-            Some
-              (UnderLet
-                 (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat
-                 (fun v : var (ℤ * ℤ)%etype =>
-                  Base
-                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-           else None
-       | None => None
-       end);;
-      None);;;
-     Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+    Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat
 | Z_sub_get_borrow =>
     fun x x0 x1 : expr ℤ =>
-    (match
-       pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-         ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
-     with
-     | Some (_, _, _)%zrange =>
-         if
-          type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
-            ((ℤ -> ℤ) -> ℤ)%ptype
-         then
-          Some
-            (UnderLet (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
-               (fun v : var (ℤ * ℤ)%etype =>
-                Base
-                  (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-         else None
-     | None => None
-     end;;;
-     Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
+    Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
 | Z_sub_with_get_borrow =>
     fun x x0 x1 x2 : expr ℤ =>
-    (match
-       pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype option (fun x3 : option => x3)
-     with
-     | Some (_, _, _, _)%zrange =>
-         if
-          type.type_beq base.type base.type.type_beq
-            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-         then
-          Some
-            (UnderLet
-               (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
-               (fun v : var (ℤ * ℤ)%etype =>
-                Base
-                  (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-         else None
-     | None => None
-     end;;;
-     Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+    Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
 | Z_zselect =>
     fun x x0 x1 : expr ℤ => Base (#(Z_zselect)%expr @ x @ x0 @ x1)%expr_pat
 | Z_add_modulo =>
@@ -2576,7 +1576,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                s0) -> s)%ptype option (fun x2 : option => x2)
          with
-         | Some (_, (_, (_, _)), _, _)%zrange =>
+         | Some (_, (_, (_, _)), _, _) =>
              if
               type.type_beq base.type base.type.type_beq
                 (((ℤ -> ℤ -> (ℤ * ℤ)%etype) -> ℤ) -> ℤ)%ptype

--- a/src/Experiments/NewPipeline/arith_rewrite_head.out
+++ b/src/Experiments/NewPipeline/arith_rewrite_head.out
@@ -27,7 +27,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b3) ->
@@ -78,7 +78,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b2) ->
@@ -222,7 +222,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -244,7 +244,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
             with
-            | Some (_, _) =>
+            | Some (_, _)%zrange =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    (ℤ -> (projT1 args))%ptype
@@ -267,7 +267,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     (s -> (projT1 args0))%ptype option
                     (fun x2 : option => x2)
                 with
-                | Some (_, _) =>
+                | Some (_, _)%zrange =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype (s -> (projT1 args0))%ptype
@@ -291,7 +291,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s -> (projT1 args0))%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args0))%ptype
@@ -324,7 +324,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                     ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                 with
-                | Some (_, _) =>
+                | Some (_, _)%zrange =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype ((projT1 args) -> s)%ptype
@@ -348,7 +348,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -374,7 +374,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
@@ -406,7 +406,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
@@ -428,7 +428,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
@@ -458,7 +458,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                    ((projT1 args0) -> (projT1 args))%ptype option
                    (fun x1 : option => x1)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args0) -> (projT1 args))%ptype
@@ -481,7 +481,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -503,7 +503,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -525,7 +525,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -547,7 +547,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
             with
-            | Some (_, _) =>
+            | Some (_, _)%zrange =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    (ℤ -> (projT1 args))%ptype
@@ -569,7 +569,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s -> (projT1 args0))%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args0))%ptype
@@ -598,7 +598,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -627,7 +627,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -649,7 +649,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -671,7 +671,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -695,7 +695,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -719,7 +719,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
@@ -750,7 +750,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
@@ -772,7 +772,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -796,7 +796,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
@@ -818,7 +818,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                 ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
             with
-            | Some (_, _) =>
+            | Some (_, _)%zrange =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    ((projT1 args) -> ℤ)%ptype
@@ -856,7 +856,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            ((projT1 args2) -> (projT1 args0) -> s2 -> s1)%ptype
                            option (fun x5 : option => x5)
                        with
-                       | Some (_, (_, (_, _))) =>
+                       | Some (_, (_, (_, _)))%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               (ℤ -> ℤ -> ℤ -> ℤ)%ptype
@@ -913,7 +913,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                        ((projT1 args2) -> s0 -> s2 -> (projT1 args))%ptype
                        option (fun x5 : option => x5)
                    with
-                   | Some (_, (_, (_, _))) =>
+                   | Some (_, (_, (_, _)))%zrange =>
                        if
                         type.type_beq base.type base.type.type_beq
                           (ℤ -> ℤ -> ℤ -> ℤ)%ptype
@@ -963,7 +963,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                    ((projT1 args0) -> s0 -> s)%ptype option
                    (fun x3 : option => x3)
                with
-               | Some (_, (_, _)) =>
+               | Some (_, (_, _))%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq
                       (ℤ -> ℤ -> ℤ)%ptype ((projT1 args0) -> s0 -> s)%ptype
@@ -1001,7 +1001,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1034,7 +1034,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    ((projT1 args0) -> s)%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args0) -> s)%ptype
@@ -1059,7 +1059,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1081,7 +1081,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1103,7 +1103,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                     ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                 with
-                | Some (_, _) =>
+                | Some (_, _)%zrange =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype ((projT1 args) -> s)%ptype
@@ -1127,7 +1127,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -1159,7 +1159,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1183,7 +1183,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                     (s -> (projT1 args))%ptype option (fun x2 : option => x2)
                 with
-                | Some (_, _) =>
+                | Some (_, _)%zrange =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype (s -> (projT1 args))%ptype
@@ -1208,7 +1208,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s -> (projT1 args))%ptype option (fun x2 : option => x2)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args))%ptype
@@ -1240,7 +1240,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1264,7 +1264,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                    (s0 -> s)%ptype option (fun x3 : option => x3)
                with
-               | Some (_, _) =>
+               | Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
@@ -1295,7 +1295,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
@@ -1317,7 +1317,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
                option (fun x2 : option => x2)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
@@ -1362,7 +1362,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
        | Some _ =>
            if type.type_beq base.type base.type.type_beq ℤ ℤ
            then
-            fv <- (if negb (SubstVarLike.is_var_fst_snd_pair_opp x)
+            fv <- (if negb (SubstVarLike.is_var_fst_snd_pair_opp_cast x)
                    then
                     Some
                       (UnderLet x
@@ -1388,7 +1388,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1406,7 +1406,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
           with
-          | Some (_, _) =>
+          | Some (_, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                  (ℤ -> (projT1 args))%ptype
@@ -1436,7 +1436,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
               (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
           with
-          | Some (_, _) =>
+          | Some (_, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                  (ℤ -> (projT1 args))%ptype
@@ -1454,7 +1454,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
              (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
          with
-         | Some (_, _) =>
+         | Some (_, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype
@@ -1492,7 +1492,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1514,7 +1514,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
            with
-           | Some (_, _) =>
+           | Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1576,7 +1576,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                s0) -> s)%ptype option (fun x2 : option => x2)
          with
-         | Some (_, (_, (_, _)), _, _) =>
+         | Some (_, (_, (_, _)), _, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq
                 (((ℤ -> ℤ -> (ℤ * ℤ)%etype) -> ℤ) -> ℤ)%ptype

--- a/src/Experiments/NewPipeline/arith_with_casts_rewrite_head.out
+++ b/src/Experiments/NewPipeline/arith_with_casts_rewrite_head.out
@@ -27,7 +27,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b3) ->
@@ -78,7 +78,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b2) ->
@@ -216,8 +216,84 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_add => fun x x0 : expr ℤ => Base (x + x0)%expr
 | Z_mul => fun x x0 : expr ℤ => Base (x * x0)%expr
 | Z_pow => fun x x0 : expr ℤ => Base (#(Z_pow)%expr @ x @ x0)%expr_pat
-| Z_sub => fun x x0 : expr ℤ => Base (x - x0)%expr
-| Z_opp => fun x : expr ℤ => Base (- x)%expr
+| Z_sub =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x1 =>
+              _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> s)%ptype option (fun x2 : option => x2)
+              with
+              | Some (_, _) =>
+                  if
+                   type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                     ((projT1 args0) -> s)%ptype
+                  then
+                   idc_args <- ident.unify pattern.ident.Literal
+                                 ##(projT2 args0);
+                   v <- type.try_make_transport_cps s ℤ;
+                   x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                          then Some (v (Compile.reflect x1))
+                          else None);
+                   Some (Base x2)
+                  else None
+              | None => None
+              end
+          | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
+            _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+          | _ => None
+          end;;
+          args <- invert_bind_args idc Raw.ident.Literal;
+          match
+            pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+              ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+          with
+          | Some (_, _) =>
+              if
+               type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                 ((projT1 args) -> ℤ)%ptype
+              then
+               idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+               x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                      then Some (- x0)%expr
+                      else None);
+               Some (Base x1)
+              else None
+          | None => None
+          end
+      | _ => None
+      end;;
+      None);;;
+     Base (x - x0)%expr)%option
+| Z_opp =>
+    fun x : expr ℤ =>
+    ((match x with
+      | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x0 =>
+          _ <- invert_bind_args idc Raw.ident.Z_opp;
+          match
+            pattern.type.unify_extracted_cps ℤ s option
+              (fun x1 : option => x1)
+          with
+          | Some _ =>
+              if type.type_beq base.type base.type.type_beq ℤ s
+              then
+               v <- type.try_make_transport_cps s ℤ;
+               Some (Base (v (Compile.reflect x0)))
+              else None
+          | None => None
+          end
+      | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+        (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
+        @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+      | _ => None
+      end;;
+      None);;;
+     Base (- x)%expr)%option
 | Z_div => fun x x0 : expr ℤ => Base (x / x0)%expr
 | Z_modulo => fun x x0 : expr ℤ => Base (x mod x0)%expr
 | Z_log2 => fun x : expr ℤ => Base (#(Z_log2)%expr @ x)%expr_pat
@@ -228,29 +304,1053 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
 | Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
 | Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
-| Z_shiftl => fun x x0 : expr ℤ => Base (x << x0)%expr
+| Z_shiftl =>
+    fun x x0 : expr ℤ =>
+    (match x with
+     | @expr.Ident _ _ _ t idc =>
+         args <- invert_bind_args idc Raw.ident.Literal;
+         match
+           pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
+             ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
+         with
+         | Some (_, _) =>
+             if
+              type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                ((projT1 args) -> ℤ)%ptype
+             then
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x1 <- (if (let (x1, _) := idc_args in x1) =? 0
+                     then Some (##0)%expr
+                     else None);
+              Some (Base x1)
+             else None
+         | None => None
+         end
+     | _ => None
+     end;;;
+     Base (x << x0)%expr)%option
 | Z_land => fun x x0 : expr ℤ => Base (x &' x0)%expr
 | Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
 | Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
 | Z_lnot_modulo =>
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
 | Z_mul_split =>
-    fun x x0 x1 : expr ℤ => Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
+    fun x x0 x1 : expr ℤ =>
+    (((match x with
+       | @expr.Ident _ _ _ t idc =>
+           match x0 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
+                   then
+                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 0
+                           then Some ((##0)%expr, (##0)%expr)%expr_pat
+                           else None);
+                    Some (Base x2)
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x1 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
+                   then
+                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 0
+                           then Some ((##0)%expr, (##0)%expr)%expr_pat
+                           else None);
+                    Some (Base x2)
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x0 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
+                   then
+                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 1
+                           then Some (x1, (##0)%expr)%expr_pat
+                           else None);
+                    Some (Base x2)
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x1 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
+                   then
+                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 1
+                           then Some (x0, (##0)%expr)%expr_pat
+                           else None);
+                    Some (Base x2)
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x0 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
+                   then
+                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? -1
+                           then Some ((- x1)%expr, (##0)%expr)%expr_pat
+                           else None);
+                    Some (Base x2)
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x1 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
+                   (fun x2 : option => x2)
+               with
+               | Some (_, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
+                   then
+                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? -1
+                           then Some ((- x0)%expr, (##0)%expr)%expr_pat
+                           else None);
+                    Some (Base x2)
+                   else None
+               | None => None
+               end
+           | _ => None
+           end
+       | _ => None
+       end;;
+       match
+         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+       with
+       | Some (_, _, _) =>
+           if
+            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
+              ((ℤ -> ℤ) -> ℤ)%ptype
+           then
+            Some
+              (UnderLet (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
+                 (fun v : var (ℤ * ℤ)%etype =>
+                  Base
+                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+           else None
+       | None => None
+       end);;
+      None);;;
+     Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_get_carry =>
     fun x x0 x1 : expr ℤ =>
-    Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat
+    (((match x0 with
+       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> s) -> ℤ)%ptype option (fun x3 : option => x3)
+           with
+           | Some (_, _, _) =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> s) -> ℤ)%ptype
+               then
+                v <- type.try_make_transport_cps s ℤ;
+                Some
+                  (UnderLet
+                     (#(Z_sub_get_borrow)%expr @ x @ x1 @
+                      v (Compile.reflect x2))%expr_pat
+                     (fun v0 : var (ℤ * ℤ)%etype =>
+                      Base
+                        (#(fst)%expr @ ($v0)%expr,
+                        (- (#(snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
+               else None
+           | None => None
+           end
+       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+       | _ => None
+       end;;
+       match x1 with
+       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
+           _ <- invert_bind_args idc Raw.ident.Z_opp;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> ℤ) -> s)%ptype option (fun x3 : option => x3)
+           with
+           | Some (_, _, _) =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> s)%ptype
+               then
+                v <- type.try_make_transport_cps s ℤ;
+                Some
+                  (UnderLet
+                     (#(Z_sub_get_borrow)%expr @ x @ x0 @
+                      v (Compile.reflect x2))%expr_pat
+                     (fun v0 : var (ℤ * ℤ)%etype =>
+                      Base
+                        (#(fst)%expr @ ($v0)%expr,
+                        (- (#(snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
+               else None
+           | None => None
+           end
+       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+       | _ => None
+       end;;
+       match x0 with
+       | @expr.Ident _ _ _ t idc =>
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> (projT1 args)) -> ℤ)%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> (projT1 args)) -> ℤ)%ptype
+               then
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                fv <- (if (let (x2, _) := idc_args in x2) <? 0
+                       then
+                        Some
+                          (UnderLet
+                             (#(Z_sub_get_borrow)%expr @ x @ x1 @
+                              (##(- (let (x2, _) := idc_args in x2))%Z)%expr)%expr_pat
+                             (fun vc : var (ℤ * ℤ)%etype =>
+                              Base
+                                (#(fst)%expr @ ($vc)%expr,
+                                (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                       else None);
+                Some (fv0 <-- fv;
+                      Base fv0)%under_lets
+               else None
+           | None => None
+           end
+       | _ => None
+       end;;
+       match x1 with
+       | @expr.Ident _ _ _ t idc =>
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> ℤ) -> (projT1 args))%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> (projT1 args))%ptype
+               then
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                fv <- (if (let (x2, _) := idc_args in x2) <? 0
+                       then
+                        Some
+                          (UnderLet
+                             (#(Z_sub_get_borrow)%expr @ x @ x0 @
+                              (##(- (let (x2, _) := idc_args in x2))%Z)%expr)%expr_pat
+                             (fun vc : var (ℤ * ℤ)%etype =>
+                              Base
+                                (#(fst)%expr @ ($vc)%expr,
+                                (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                       else None);
+                Some (fv0 <-- fv;
+                      Base fv0)%under_lets
+               else None
+           | None => None
+           end
+       | _ => None
+       end;;
+       match x0 with
+       | @expr.Ident _ _ _ t idc =>
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> (projT1 args)) -> ℤ)%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> (projT1 args)) -> ℤ)%ptype
+               then
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                       then Some (x1, (##0)%expr)%expr_pat
+                       else None);
+                Some (Base x2)
+               else None
+           | None => None
+           end
+       | _ => None
+       end;;
+       match x1 with
+       | @expr.Ident _ _ _ t idc =>
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> ℤ) -> (projT1 args))%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> (projT1 args))%ptype
+               then
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                       then Some (x0, (##0)%expr)%expr_pat
+                       else None);
+                Some (Base x2)
+               else None
+           | None => None
+           end
+       | _ => None
+       end;;
+       match
+         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+       with
+       | Some (_, _, _) =>
+           if
+            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
+              ((ℤ -> ℤ) -> ℤ)%ptype
+           then
+            Some
+              (UnderLet (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat
+                 (fun v : var (ℤ * ℤ)%etype =>
+                  Base
+                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+           else None
+       | None => None
+       end);;
+      None);;;
+     Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_carry =>
     fun x x0 x1 : expr ℤ =>
-    Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
+    (((match x with
+       | @expr.Ident _ _ _ t idc =>
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               (((projT1 args) -> ℤ) -> ℤ)%ptype option
+               (fun x2 : option => x2)
+           with
+           | Some (_, _, _) =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype (((projT1 args) -> ℤ) -> ℤ)%ptype
+               then
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                       then Some (x0 + x1)%expr
+                       else None);
+                Some (Base x2)
+               else None
+           | None => None
+           end
+       | _ => None
+       end;;
+       match
+         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+       with
+       | Some (_, _, _) =>
+           if
+            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
+              ((ℤ -> ℤ) -> ℤ)%ptype
+           then
+            Some
+              (UnderLet (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
+                 (fun v : var ℤ => Base ($v)%expr))
+           else None
+       | None => None
+       end);;
+      None);;;
+     Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_get_carry =>
     fun x x0 x1 x2 : expr ℤ =>
-    Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+    (((match x0 with
+       | @expr.Ident _ _ _ t idc =>
+           match x1 with
+           | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x3 =>
+               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
+                args0 <- invert_bind_args idc Raw.ident.Literal;
+                match
+                  pattern.type.unify_extracted_cps
+                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                    (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype option
+                    (fun x4 : option => x4)
+                with
+                | Some (_, _, _, _) =>
+                    if
+                     type.type_beq base.type base.type.type_beq
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype
+                    then
+                     idc_args <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args0);
+                     v <- type.try_make_transport_cps s ℤ;
+                     fv <- (if (let (x4, _) := idc_args in x4) =? 0
+                            then
+                             Some
+                               (UnderLet
+                                  (#(Z_sub_get_borrow)%expr @ x @ x2 @
+                                   v (Compile.reflect x3))%expr_pat
+                                  (fun vc : var (ℤ * ℤ)%etype =>
+                                   Base
+                                     (#(fst)%expr @ ($vc)%expr,
+                                     (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                            else None);
+                     Some (fv0 <-- fv;
+                           Base fv0)%under_lets
+                    else None
+                | None => None
+                end);;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype option
+                   (fun x4 : option => x4)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype
+                   then
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args0);
+                    v <- type.try_make_transport_cps s ℤ;
+                    fv <- (if (let (x4, _) := idc_args in x4) <? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_sub_with_get_borrow)%expr @ x @
+                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
+                                  x2 @ v (Compile.reflect x3))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr,
+                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
+             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+           | _ => None
+           end;;
+           match x2 with
+           | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x3 =>
+               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
+                args0 <- invert_bind_args idc Raw.ident.Literal;
+                match
+                  pattern.type.unify_extracted_cps
+                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                    (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype option
+                    (fun x4 : option => x4)
+                with
+                | Some (_, _, _, _) =>
+                    if
+                     type.type_beq base.type base.type.type_beq
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype
+                    then
+                     idc_args <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args0);
+                     v <- type.try_make_transport_cps s ℤ;
+                     fv <- (if (let (x4, _) := idc_args in x4) =? 0
+                            then
+                             Some
+                               (UnderLet
+                                  (#(Z_sub_get_borrow)%expr @ x @ x1 @
+                                   v (Compile.reflect x3))%expr_pat
+                                  (fun vc : var (ℤ * ℤ)%etype =>
+                                   Base
+                                     (#(fst)%expr @ ($vc)%expr,
+                                     (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                            else None);
+                     Some (fv0 <-- fv;
+                           Base fv0)%under_lets
+                    else None
+                | None => None
+                end);;
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype option
+                   (fun x4 : option => x4)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype
+                   then
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args0);
+                    v <- type.try_make_transport_cps s ℤ;
+                    fv <- (if (let (x4, _) := idc_args in x4) <? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_sub_with_get_borrow)%expr @ x @
+                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
+                                  x1 @ v (Compile.reflect x3))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr,
+                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
+             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+           | _ => None
+           end;;
+           match x1 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> (projT1 args0)) -> (projT1 args)) -> ℤ)%ptype
+                   option (fun x3 : option => x3)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> (projT1 args0)) -> (projT1 args)) -> ℤ)%ptype
+                   then
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    fv <- (if
+                            ((let (x3, _) := idc_args0 in x3) <=? 0) &&
+                            ((let (x3, _) := idc_args in x3) <=? 0) &&
+                            ((let (x3, _) := idc_args0 in x3) +
+                             (let (x3, _) := idc_args in x3) <? 0)
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_sub_with_get_borrow)%expr @ x @
+                                  (##(- (let (x3, _) := idc_args in x3))%Z)%expr @
+                                  x2 @
+                                  (##(- (let (x3, _) := idc_args0 in x3))%Z)%expr)%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr,
+                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x2 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> (projT1 args0)) -> ℤ) -> (projT1 args))%ptype
+                   option (fun x3 : option => x3)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> (projT1 args0)) -> ℤ) -> (projT1 args))%ptype
+                   then
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    fv <- (if
+                            ((let (x3, _) := idc_args0 in x3) <=? 0) &&
+                            ((let (x3, _) := idc_args in x3) <=? 0) &&
+                            ((let (x3, _) := idc_args0 in x3) +
+                             (let (x3, _) := idc_args in x3) <? 0)
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_sub_with_get_borrow)%expr @ x @
+                                  (##(- (let (x3, _) := idc_args in x3))%Z)%expr @
+                                  x1 @
+                                  (##(- (let (x3, _) := idc_args0 in x3))%Z)%expr)%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr,
+                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               match x1 with
+               | @expr.Ident _ _ _ t1 idc1 =>
+                   args <- invert_bind_args idc1 Raw.ident.Literal;
+                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                   args1 <- invert_bind_args idc Raw.ident.Literal;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       ((((projT1 args0) -> (projT1 args1)) -> (projT1 args)) ->
+                        ℤ)%ptype option (fun x3 : option => x3)
+                   with
+                   | Some (_, _, _, _) =>
+                       if
+                        type.type_beq base.type base.type.type_beq
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          ((((projT1 args0) -> (projT1 args1)) ->
+                            (projT1 args)) -> ℤ)%ptype
+                       then
+                        _ <- ident.unify pattern.ident.Literal
+                               ##(projT2 args0);
+                        idc_args0 <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args1);
+                        idc_args1 <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args);
+                        x3 <- (if
+                                ((let (x3, _) := idc_args0 in x3) =? 0) &&
+                                ((let (x3, _) := idc_args1 in x3) =? 0)
+                               then Some (x2, (##0)%expr)%expr_pat
+                               else None);
+                        Some (Base x3)
+                       else None
+                   | None => None
+                   end
+               | _ => None
+               end;;
+               match x2 with
+               | @expr.Ident _ _ _ t1 idc1 =>
+                   args <- invert_bind_args idc1 Raw.ident.Literal;
+                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                   args1 <- invert_bind_args idc Raw.ident.Literal;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       ((((projT1 args0) -> (projT1 args1)) -> ℤ) ->
+                        (projT1 args))%ptype option (fun x3 : option => x3)
+                   with
+                   | Some (_, _, _, _) =>
+                       if
+                        type.type_beq base.type base.type.type_beq
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          ((((projT1 args0) -> (projT1 args1)) -> ℤ) ->
+                           (projT1 args))%ptype
+                       then
+                        _ <- ident.unify pattern.ident.Literal
+                               ##(projT2 args0);
+                        idc_args0 <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args1);
+                        idc_args1 <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args);
+                        x3 <- (if
+                                ((let (x3, _) := idc_args0 in x3) =? 0) &&
+                                ((let (x3, _) := idc_args1 in x3) =? 0)
+                               then Some (x1, (##0)%expr)%expr_pat
+                               else None);
+                        Some (Base x3)
+                       else None
+                   | None => None
+                   end
+               | _ => None
+               end
+           | _ => None
+           end;;
+           args <- invert_bind_args idc Raw.ident.Literal;
+           match
+             pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+               (((ℤ -> (projT1 args)) -> ℤ) -> ℤ)%ptype option
+               (fun x3 : option => x3)
+           with
+           | Some (_, _, _, _) =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                  (((ℤ -> (projT1 args)) -> ℤ) -> ℤ)%ptype
+               then
+                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+                fv <- (if (let (x3, _) := idc_args in x3) =? 0
+                       then
+                        Some
+                          (UnderLet
+                             (#(Z_add_get_carry)%expr @ x @ x1 @ x2)%expr_pat
+                             (fun vc : var (ℤ * ℤ)%etype =>
+                              Base
+                                (#(fst)%expr @ ($vc)%expr,
+                                #(snd)%expr @ ($vc)%expr)%expr_pat))
+                       else None);
+                Some (fv0 <-- fv;
+                      Base fv0)%under_lets
+               else None
+           | None => None
+           end
+       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x3 =>
+           match x1 with
+           | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> s) -> s0) -> ℤ)%ptype
+                   option (fun x5 : option => x5)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> s) -> s0) -> ℤ)%ptype
+                   then
+                    v <- type.try_make_transport_cps s ℤ;
+                    v0 <- type.try_make_transport_cps s0 ℤ;
+                    Some
+                      (UnderLet
+                         (#(Z_sub_with_get_borrow)%expr @ x @
+                          v (Compile.reflect x3) @ x2 @
+                          v0 (Compile.reflect x4))%expr_pat
+                         (fun v1 : var (ℤ * ℤ)%etype =>
+                          Base
+                            (#(fst)%expr @ ($v1)%expr,
+                            (- (#(snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
+                   else None
+               | None => None
+               end
+           | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
+             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
+             (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
+             (@expr.LetIn _ _ _ _ _ _ _) _ => None
+           | _ => None
+           end;;
+           match x2 with
+           | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
+               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> s) -> ℤ) -> s0)%ptype
+                   option (fun x5 : option => x5)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> s) -> ℤ) -> s0)%ptype
+                   then
+                    v <- type.try_make_transport_cps s ℤ;
+                    v0 <- type.try_make_transport_cps s0 ℤ;
+                    Some
+                      (UnderLet
+                         (#(Z_sub_with_get_borrow)%expr @ x @
+                          v (Compile.reflect x3) @ x1 @
+                          v0 (Compile.reflect x4))%expr_pat
+                         (fun v1 : var (ℤ * ℤ)%etype =>
+                          Base
+                            (#(fst)%expr @ ($v1)%expr,
+                            (- (#(snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
+                   else None
+               | None => None
+               end
+           | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
+             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
+             (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
+             (@expr.LetIn _ _ _ _ _ _ _) _ => None
+           | _ => None
+           end;;
+           match x1 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> s) -> (projT1 args)) -> ℤ)%ptype option
+                   (fun x4 : option => x4)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> s) -> (projT1 args)) -> ℤ)%ptype
+                   then
+                    v <- type.try_make_transport_cps s ℤ;
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                    fv <- (if (let (x4, _) := idc_args in x4) <=? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_sub_with_get_borrow)%expr @ x @
+                                  v (Compile.reflect x3) @ x2 @
+                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr)%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr,
+                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x2 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_opp;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> s) -> ℤ) -> (projT1 args))%ptype option
+                   (fun x4 : option => x4)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> s) -> ℤ) -> (projT1 args))%ptype
+                   then
+                    v <- type.try_make_transport_cps s ℤ;
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                    fv <- (if (let (x4, _) := idc_args in x4) <=? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_sub_with_get_borrow)%expr @ x @
+                                  v (Compile.reflect x3) @ x1 @
+                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr)%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr,
+                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | _ => None
+           end
+       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+       | _ => None
+       end;;
+       match x1 with
+       | @expr.Ident _ _ _ t idc =>
+           match x2 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Literal;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((ℤ -> ℤ) -> (projT1 args0)) -> (projT1 args))%ptype
+                   option (fun x3 : option => x3)
+               with
+               | Some (_, _, _, _) =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((ℤ -> ℤ) -> (projT1 args0)) -> (projT1 args))%ptype
+                   then
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args0);
+                    idc_args0 <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args);
+                    fv <- (if
+                            ((let (x3, _) := idc_args in x3) =? 0) &&
+                            ((let (x3, _) := idc_args0 in x3) =? 0)
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_add_with_get_carry)%expr @ x @ x0 @
+                                  (##(let (x3, _) := idc_args in x3))%expr @
+                                  (##(let (x3, _) := idc_args0 in x3))%expr)%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(fst)%expr @ ($vc)%expr, (##0)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | _ => None
+           end
+       | _ => None
+       end;;
+       match
+         pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype option (fun x3 : option => x3)
+       with
+       | Some (_, _, _, _) =>
+           if
+            type.type_beq base.type base.type.type_beq
+              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+           then
+            Some
+              (UnderLet
+                 (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+                 (fun v : var (ℤ * ℤ)%etype =>
+                  Base
+                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+           else None
+       | None => None
+       end);;
+      None);;;
+     Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
 | Z_sub_get_borrow =>
     fun x x0 x1 : expr ℤ =>
-    Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
+    (match
+       pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+         ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+     with
+     | Some (_, _, _) =>
+         if
+          type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
+            ((ℤ -> ℤ) -> ℤ)%ptype
+         then
+          Some
+            (UnderLet (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
+               (fun v : var (ℤ * ℤ)%etype =>
+                Base
+                  (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+         else None
+     | None => None
+     end;;;
+     Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_sub_with_get_borrow =>
     fun x x0 x1 x2 : expr ℤ =>
-    Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+    (match
+       pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype option (fun x3 : option => x3)
+     with
+     | Some (_, _, _, _) =>
+         if
+          type.type_beq base.type base.type.type_beq
+            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+         then
+          Some
+            (UnderLet
+               (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+               (fun v : var (ℤ * ℤ)%etype =>
+                Base
+                  (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
+         else None
+     | None => None
+     end;;;
+     Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
 | Z_zselect =>
     fun x x0 x1 : expr ℤ => Base (#(Z_zselect)%expr @ x @ x0 @ x1)%expr_pat
 | Z_add_modulo =>

--- a/src/Experiments/NewPipeline/arith_with_casts_rewrite_head.out
+++ b/src/Experiments/NewPipeline/arith_with_casts_rewrite_head.out
@@ -27,7 +27,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b3) ->
@@ -78,7 +78,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype option (fun x2 : option => x2)
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2)) =>
+          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b2) ->
@@ -221,31 +221,64 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
     ((match x with
       | @expr.Ident _ _ _ t idc =>
           match x0 with
-          | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x1 =>
-              _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-              args0 <- invert_bind_args idc Raw.ident.Literal;
+          | (@expr.Ident _ _ _ t0 idc0 @
+             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _
+              (@expr.Ident _ _ _ t2 idc2) x3))%expr_pat =>
+              args <- invert_bind_args idc2 Raw.ident.Z_cast;
+              _ <- invert_bind_args idc1 Raw.ident.Z_opp;
+              args1 <- invert_bind_args idc0 Raw.ident.Z_cast;
+              args2 <- invert_bind_args idc Raw.ident.Literal;
               match
                 pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
-                  ((projT1 args0) -> s)%ptype option (fun x2 : option => x2)
+                  ((projT1 args2) -> s1)%ptype option (fun x4 : option => x4)
               with
-              | Some (_, _) =>
+              | Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
-                     ((projT1 args0) -> s)%ptype
+                     ((projT1 args2) -> s1)%ptype
                   then
                    idc_args <- ident.unify pattern.ident.Literal
-                                 ##(projT2 args0);
-                   v <- type.try_make_transport_cps s ℤ;
-                   x2 <- (if (let (x2, _) := idc_args in x2) =? 0
-                          then Some (v (Compile.reflect x1))
+                                 ##(projT2 args2);
+                   v <- type.try_make_transport_cps s1 ℤ;
+                   x4 <- (if
+                           ((let (x4, _) := idc_args in x4) =? 0) &&
+                           (ZRange.normalize args <=?
+                            - ZRange.normalize args1)%zrange
+                          then
+                           Some
+                             (#(Z_cast args)%expr @ v (Compile.reflect x3))%expr_pat
                           else None);
-                   Some (Base x2)
+                   Some (Base x4)
                   else None
               | None => None
               end
-          | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+          | (@expr.Ident _ _ _ t0 idc0 @
+             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _ ($_)%expr _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @
+             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _
+              (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @
+             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _ (_ @ _) _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @
+             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _
+              (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+          | (@expr.Ident _ _ _ t0 idc0 @ (@expr.Ident _ _ _ t1 idc1 @ #(_)))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @
+             (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @
+             (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @
+             (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+              None
+          | (@expr.Ident _ _ _ t0 idc0 @ #(_))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (($_)%expr @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (_ @ _ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+              None
           | _ => None
           end;;
           args <- invert_bind_args idc Raw.ident.Literal;
@@ -253,7 +286,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
               ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
           with
-          | Some (_, _) =>
+          | Some (_, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                  ((projT1 args) -> ℤ)%ptype
@@ -273,23 +306,56 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_opp =>
     fun x : expr ℤ =>
     ((match x with
-      | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x0 =>
-          _ <- invert_bind_args idc Raw.ident.Z_opp;
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t1 idc1) x2))%expr_pat =>
+          args <- invert_bind_args idc1 Raw.ident.Z_cast;
+          _ <- invert_bind_args idc0 Raw.ident.Z_opp;
+          args1 <- invert_bind_args idc Raw.ident.Z_cast;
           match
-            pattern.type.unify_extracted_cps ℤ s option
-              (fun x1 : option => x1)
+            pattern.type.unify_extracted_cps ℤ s1 option
+              (fun x3 : option => x3)
           with
           | Some _ =>
-              if type.type_beq base.type base.type.type_beq ℤ s
+              if type.type_beq base.type base.type.type_beq ℤ s1
               then
-               v <- type.try_make_transport_cps s ℤ;
-               Some (Base (v (Compile.reflect x0)))
+               v <- type.try_make_transport_cps s1 ℤ;
+               x3 <- (if
+                       (ZRange.normalize args <=? - ZRange.normalize args1)%zrange
+                      then
+                       Some
+                         (#(Z_cast args)%expr @ v (Compile.reflect x2))%expr_pat
+                      else None);
+               Some (Base x3)
               else None
           | None => None
           end
-      | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-        (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-        @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+      | (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.App _ _ _ s1 _ ($_)%expr _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.App _ _ _ s1 _
+          (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.App _ _ _ s1 _ (_ @ _) _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.App _ _ _ s1 _
+          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+      | (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ #(_)))%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr))%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+          None
+      | (@expr.Ident _ _ _ t idc @ #(_))%expr_pat |
+        (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (($_)%expr @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (_ @ _ @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+          None
       | _ => None
       end;;
       None);;;
@@ -313,7 +379,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            pattern.type.unify_extracted_cps (ℤ -> ℤ)%ptype
              ((projT1 args) -> ℤ)%ptype option (fun x1 : option => x1)
          with
-         | Some (_, _) =>
+         | Some (_, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                 ((projT1 args) -> ℤ)%ptype
@@ -336,45 +402,45 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
 | Z_mul_split =>
     fun x x0 x1 : expr ℤ =>
-    (((match x with
-       | @expr.Ident _ _ _ t idc =>
-           match x0 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 0
-                           then Some ((##0)%expr, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                  (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
+                  (fun x2 : option => x2)
+              with
+              | Some (_, _, _)%zrange =>
+                  if
+                   type.type_beq base.type base.type.type_beq
+                     ((ℤ -> ℤ) -> ℤ)%ptype
+                     (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
+                  then
+                   _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   idc_args0 <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                   x2 <- (if (let (x2, _) := idc_args0 in x2) =? 0
+                          then Some ((##0)%expr, (##0)%expr)%expr_pat
+                          else None);
+                   Some (Base x2)
+                  else None
+              | None => None
+              end
+          | _ => None
+          end;;
+          match x1 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              (args <- invert_bind_args idc0 Raw.ident.Literal;
                args0 <- invert_bind_args idc Raw.ident.Literal;
                match
                  pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
                    (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
                    (fun x2 : option => x2)
                with
-               | Some (_, _, _) =>
+               | Some (_, _, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq
                       ((ℤ -> ℤ) -> ℤ)%ptype
@@ -389,968 +455,398 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     Some (Base x2)
                    else None
                | None => None
-               end
-           | _ => None
-           end;;
-           match x0 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 1
-                           then Some (x1, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? 1
-                           then Some (x0, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x0 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? -1
-                           then Some ((- x1)%expr, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype option
-                   (fun x2 : option => x2)
-               with
-               | Some (_, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    x2 <- (if (let (x2, _) := idc_args0 in x2) =? -1
-                           then Some ((- x0)%expr, (##0)%expr)%expr_pat
-                           else None);
-                    Some (Base x2)
-                   else None
-               | None => None
-               end
-           | _ => None
-           end
-       | _ => None
-       end;;
-       match
-         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
-       with
-       | Some (_, _, _) =>
-           if
-            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
-              ((ℤ -> ℤ) -> ℤ)%ptype
-           then
-            Some
-              (UnderLet (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
-                 (fun v : var (ℤ * ℤ)%etype =>
-                  Base
-                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-           else None
-       | None => None
-       end);;
+               end);;
+              match x0 with
+              | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t1 idc1) x2 =>
+                  args <- invert_bind_args idc1 Raw.ident.Z_cast;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> s) -> (projT1 args0))%ptype option
+                      (fun x3 : option => x3)
+                  with
+                  | Some (_, _, _)%zrange =>
+                      if
+                       type.type_beq base.type base.type.type_beq
+                         ((ℤ -> ℤ) -> ℤ)%ptype
+                         (((projT1 args1) -> s) -> (projT1 args0))%ptype
+                      then
+                       idc_args <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args1);
+                       v <- type.try_make_transport_cps s ℤ;
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args0);
+                       x3 <- (if
+                               ((let (x3, _) := idc_args0 in x3) =? 1) &&
+                               (ZRange.normalize args <=?
+                                r[0 ~> (let (x3, _) := idc_args in x3) - 1])%zrange
+                              then
+                               Some
+                                 (#(Z_cast args)%expr @
+                                  v (Compile.reflect x2), (##0)%expr)%expr_pat
+                              else None);
+                       Some (Base x3)
+                      else None
+                  | None => None
+                  end
+              | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
+                (_ @ _)%expr_pat _ | @expr.App _ _ _ s _
+                (@expr.LetIn _ _ _ _ _ _ _) _ => None
+              | _ => None
+              end
+          | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x2 =>
+              match x0 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args)) -> s)%ptype option
+                      (fun x3 : option => x3)
+                  with
+                  | Some (_, _, _)%zrange =>
+                      if
+                       type.type_beq base.type base.type.type_beq
+                         ((ℤ -> ℤ) -> ℤ)%ptype
+                         (((projT1 args1) -> (projT1 args)) -> s)%ptype
+                      then
+                       idc_args <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args1);
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args);
+                       v <- type.try_make_transport_cps s ℤ;
+                       x3 <- (if
+                               ((let (x3, _) := idc_args0 in x3) =? 1) &&
+                               (ZRange.normalize args0 <=?
+                                r[0 ~> (let (x3, _) := idc_args in x3) - 1])%zrange
+                              then
+                               Some
+                                 (#(Z_cast args0)%expr @
+                                  v (Compile.reflect x2), (##0)%expr)%expr_pat
+                              else None);
+                       Some (Base x3)
+                      else None
+                  | None => None
+                  end
+              | _ => None
+              end
+          | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
+            _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+          | _ => None
+          end
+      | _ => None
+      end;;
       None);;;
      Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_get_carry =>
     fun x x0 x1 : expr ℤ =>
-    (((match x0 with
-       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
-           _ <- invert_bind_args idc Raw.ident.Z_opp;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> s) -> ℤ)%ptype option (fun x3 : option => x3)
-           with
-           | Some (_, _, _) =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> s) -> ℤ)%ptype
-               then
-                v <- type.try_make_transport_cps s ℤ;
-                Some
-                  (UnderLet
-                     (#(Z_sub_get_borrow)%expr @ x @ x1 @
-                      v (Compile.reflect x2))%expr_pat
-                     (fun v0 : var (ℤ * ℤ)%etype =>
-                      Base
-                        (#(fst)%expr @ ($v0)%expr,
-                        (- (#(snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-               else None
-           | None => None
-           end
-       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
-       end;;
-       match x1 with
-       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
-           _ <- invert_bind_args idc Raw.ident.Z_opp;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> ℤ) -> s)%ptype option (fun x3 : option => x3)
-           with
-           | Some (_, _, _) =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> s)%ptype
-               then
-                v <- type.try_make_transport_cps s ℤ;
-                Some
-                  (UnderLet
-                     (#(Z_sub_get_borrow)%expr @ x @ x0 @
-                      v (Compile.reflect x2))%expr_pat
-                     (fun v0 : var (ℤ * ℤ)%etype =>
-                      Base
-                        (#(fst)%expr @ ($v0)%expr,
-                        (- (#(snd)%expr @ $v0)%expr_pat)%expr)%expr_pat))
-               else None
-           | None => None
-           end
-       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
-       end;;
-       match x0 with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> (projT1 args)) -> ℤ)%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _) =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> (projT1 args)) -> ℤ)%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                fv <- (if (let (x2, _) := idc_args in x2) <? 0
-                       then
-                        Some
-                          (UnderLet
-                             (#(Z_sub_get_borrow)%expr @ x @ x1 @
-                              (##(- (let (x2, _) := idc_args in x2))%Z)%expr)%expr_pat
-                             (fun vc : var (ℤ * ℤ)%etype =>
-                              Base
-                                (#(fst)%expr @ ($vc)%expr,
-                                (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                       else None);
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match x1 with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> ℤ) -> (projT1 args))%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _) =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> (projT1 args))%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                fv <- (if (let (x2, _) := idc_args in x2) <? 0
-                       then
-                        Some
-                          (UnderLet
-                             (#(Z_sub_get_borrow)%expr @ x @ x0 @
-                              (##(- (let (x2, _) := idc_args in x2))%Z)%expr)%expr_pat
-                             (fun vc : var (ℤ * ℤ)%etype =>
-                              Base
-                                (#(fst)%expr @ ($vc)%expr,
-                                (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                       else None);
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match x0 with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> (projT1 args)) -> ℤ)%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _) =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> (projT1 args)) -> ℤ)%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
-                       then Some (x1, (##0)%expr)%expr_pat
-                       else None);
-                Some (Base x2)
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match x1 with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               ((ℤ -> ℤ) -> (projT1 args))%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _) =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> (projT1 args))%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
-                       then Some (x0, (##0)%expr)%expr_pat
-                       else None);
-                Some (Base x2)
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match
-         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
-       with
-       | Some (_, _, _) =>
-           if
-            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
-              ((ℤ -> ℤ) -> ℤ)%ptype
-           then
-            Some
-              (UnderLet (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat
-                 (fun v : var (ℤ * ℤ)%etype =>
-                  Base
-                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-           else None
-       | None => None
-       end);;
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              match x1 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
+                      option (fun x2 : option => x2)
+                  with
+                  | Some (_, _, _)%zrange =>
+                      if
+                       type.type_beq base.type base.type.type_beq
+                         ((ℤ -> ℤ) -> ℤ)%ptype
+                         (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
+                      then
+                       idc_args <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args1);
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args0);
+                       idc_args1 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args);
+                       Some
+                         (Base
+                            (let
+                             '(a1, b1)%zrange :=
+                              Z.add_get_carry_full
+                                (let (x2, _) := idc_args in x2)
+                                (let (x2, _) := idc_args0 in x2)
+                                (let (x2, _) := idc_args1 in x2) in
+                              ((##a1)%expr, (##b1)%expr)%expr_pat))
+                      else None
+                  | None => None
+                  end
+              | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t1 idc1) x2 =>
+                  args <- invert_bind_args idc1 Raw.ident.Z_cast;
+                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> (projT1 args0)) -> s)%ptype option
+                      (fun x3 : option => x3)
+                  with
+                  | Some (_, _, _)%zrange =>
+                      if
+                       type.type_beq base.type base.type.type_beq
+                         ((ℤ -> ℤ) -> ℤ)%ptype
+                         (((projT1 args1) -> (projT1 args0)) -> s)%ptype
+                      then
+                       idc_args <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args1);
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args0);
+                       v <- type.try_make_transport_cps s ℤ;
+                       x3 <- (if
+                               ((let (x3, _) := idc_args0 in x3) =? 0) &&
+                               (ZRange.normalize args <=?
+                                r[0 ~> (let (x3, _) := idc_args in x3) - 1])%zrange
+                              then
+                               Some
+                                 (#(Z_cast args)%expr @
+                                  v (Compile.reflect x2), (##0)%expr)%expr_pat
+                              else None);
+                       Some (Base x3)
+                      else None
+                  | None => None
+                  end
+              | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
+                (_ @ _)%expr_pat _ | @expr.App _ _ _ s _
+                (@expr.LetIn _ _ _ _ _ _ _) _ => None
+              | _ => None
+              end
+          | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x2 =>
+              match x1 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                  args1 <- invert_bind_args idc Raw.ident.Literal;
+                  match
+                    pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                      (((projT1 args1) -> s) -> (projT1 args))%ptype option
+                      (fun x3 : option => x3)
+                  with
+                  | Some (_, _, _)%zrange =>
+                      if
+                       type.type_beq base.type base.type.type_beq
+                         ((ℤ -> ℤ) -> ℤ)%ptype
+                         (((projT1 args1) -> s) -> (projT1 args))%ptype
+                      then
+                       idc_args <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args1);
+                       v <- type.try_make_transport_cps s ℤ;
+                       idc_args0 <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args);
+                       x3 <- (if
+                               ((let (x3, _) := idc_args0 in x3) =? 0) &&
+                               (ZRange.normalize args0 <=?
+                                r[0 ~> (let (x3, _) := idc_args in x3) - 1])%zrange
+                              then
+                               Some
+                                 (#(Z_cast args0)%expr @
+                                  v (Compile.reflect x2), (##0)%expr)%expr_pat
+                              else None);
+                       Some (Base x3)
+                      else None
+                  | None => None
+                  end
+              | _ => None
+              end
+          | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
+            _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+          | _ => None
+          end
+      | _ => None
+      end;;
       None);;;
      Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_carry =>
     fun x x0 x1 : expr ℤ =>
-    (((match x with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-               (((projT1 args) -> ℤ) -> ℤ)%ptype option
-               (fun x2 : option => x2)
-           with
-           | Some (_, _, _) =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  ((ℤ -> ℤ) -> ℤ)%ptype (((projT1 args) -> ℤ) -> ℤ)%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                x2 <- (if (let (x2, _) := idc_args in x2) =? 0
-                       then Some (x0 + x1)%expr
-                       else None);
-                Some (Base x2)
-               else None
-           | None => None
-           end
-       | _ => None
-       end;;
-       match
-         pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-           ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
-       with
-       | Some (_, _, _) =>
-           if
-            type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
-              ((ℤ -> ℤ) -> ℤ)%ptype
-           then
-            Some
-              (UnderLet (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
-                 (fun v : var ℤ => Base ($v)%expr))
-           else None
-       | None => None
-       end);;
-      None);;;
+    (match x with
+     | @expr.Ident _ _ _ t idc =>
+         args <- invert_bind_args idc Raw.ident.Literal;
+         match
+           pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+             (((projT1 args) -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
+         with
+         | Some (_, _, _)%zrange =>
+             if
+              type.type_beq base.type base.type.type_beq
+                ((ℤ -> ℤ) -> ℤ)%ptype (((projT1 args) -> ℤ) -> ℤ)%ptype
+             then
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x2 <- (if (let (x2, _) := idc_args in x2) =? 0
+                     then Some (x0 + x1)%expr
+                     else None);
+              Some (Base x2)
+             else None
+         | None => None
+         end
+     | _ => None
+     end;;;
      Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_get_carry =>
     fun x x0 x1 x2 : expr ℤ =>
-    (((match x0 with
-       | @expr.Ident _ _ _ t idc =>
-           match x1 with
-           | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x3 =>
-               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
-                args0 <- invert_bind_args idc Raw.ident.Literal;
-                match
-                  pattern.type.unify_extracted_cps
-                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                    (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype option
-                    (fun x4 : option => x4)
-                with
-                | Some (_, _, _, _) =>
-                    if
-                     type.type_beq base.type base.type.type_beq
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype
-                    then
-                     idc_args <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args0);
-                     v <- type.try_make_transport_cps s ℤ;
-                     fv <- (if (let (x4, _) := idc_args in x4) =? 0
-                            then
-                             Some
-                               (UnderLet
-                                  (#(Z_sub_get_borrow)%expr @ x @ x2 @
-                                   v (Compile.reflect x3))%expr_pat
-                                  (fun vc : var (ℤ * ℤ)%etype =>
-                                   Base
-                                     (#(fst)%expr @ ($vc)%expr,
-                                     (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                            else None);
-                     Some (fv0 <-- fv;
-                           Base fv0)%under_lets
-                    else None
-                | None => None
-                end);;
-               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype option
-                   (fun x4 : option => x4)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> (projT1 args0)) -> s) -> ℤ)%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    v <- type.try_make_transport_cps s ℤ;
-                    fv <- (if (let (x4, _) := idc_args in x4) <? 0
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
-                                  x2 @ v (Compile.reflect x3))%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
-           end;;
-           match x2 with
-           | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x3 =>
-               (_ <- invert_bind_args idc0 Raw.ident.Z_opp;
-                args0 <- invert_bind_args idc Raw.ident.Literal;
-                match
-                  pattern.type.unify_extracted_cps
-                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                    (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype option
-                    (fun x4 : option => x4)
-                with
-                | Some (_, _, _, _) =>
-                    if
-                     type.type_beq base.type base.type.type_beq
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype
-                    then
-                     idc_args <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args0);
-                     v <- type.try_make_transport_cps s ℤ;
-                     fv <- (if (let (x4, _) := idc_args in x4) =? 0
-                            then
-                             Some
-                               (UnderLet
-                                  (#(Z_sub_get_borrow)%expr @ x @ x1 @
-                                   v (Compile.reflect x3))%expr_pat
-                                  (fun vc : var (ℤ * ℤ)%etype =>
-                                   Base
-                                     (#(fst)%expr @ ($vc)%expr,
-                                     (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                            else None);
-                     Some (fv0 <-- fv;
-                           Base fv0)%under_lets
-                    else None
-                | None => None
-                end);;
-               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype option
-                   (fun x4 : option => x4)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> (projT1 args0)) -> ℤ) -> s)%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    v <- type.try_make_transport_cps s ℤ;
-                    fv <- (if (let (x4, _) := idc_args in x4) <? 0
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
-                                  x1 @ v (Compile.reflect x3))%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> (projT1 args0)) -> (projT1 args)) -> ℤ)%ptype
-                   option (fun x3 : option => x3)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> (projT1 args0)) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    fv <- (if
-                            ((let (x3, _) := idc_args0 in x3) <=? 0) &&
-                            ((let (x3, _) := idc_args in x3) <=? 0) &&
-                            ((let (x3, _) := idc_args0 in x3) +
-                             (let (x3, _) := idc_args in x3) <? 0)
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  (##(- (let (x3, _) := idc_args in x3))%Z)%expr @
-                                  x2 @
-                                  (##(- (let (x3, _) := idc_args0 in x3))%Z)%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x2 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> (projT1 args0)) -> ℤ) -> (projT1 args))%ptype
-                   option (fun x3 : option => x3)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> (projT1 args0)) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    fv <- (if
-                            ((let (x3, _) := idc_args0 in x3) <=? 0) &&
-                            ((let (x3, _) := idc_args in x3) <=? 0) &&
-                            ((let (x3, _) := idc_args0 in x3) +
-                             (let (x3, _) := idc_args in x3) <? 0)
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  (##(- (let (x3, _) := idc_args in x3))%Z)%expr @
-                                  x1 @
-                                  (##(- (let (x3, _) := idc_args0 in x3))%Z)%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               match x1 with
-               | @expr.Ident _ _ _ t1 idc1 =>
-                   args <- invert_bind_args idc1 Raw.ident.Literal;
-                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                   args1 <- invert_bind_args idc Raw.ident.Literal;
-                   match
-                     pattern.type.unify_extracted_cps
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       ((((projT1 args0) -> (projT1 args1)) -> (projT1 args)) ->
-                        ℤ)%ptype option (fun x3 : option => x3)
-                   with
-                   | Some (_, _, _, _) =>
-                       if
-                        type.type_beq base.type base.type.type_beq
-                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                          ((((projT1 args0) -> (projT1 args1)) ->
-                            (projT1 args)) -> ℤ)%ptype
-                       then
-                        _ <- ident.unify pattern.ident.Literal
-                               ##(projT2 args0);
-                        idc_args0 <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args1);
-                        idc_args1 <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args);
-                        x3 <- (if
-                                ((let (x3, _) := idc_args0 in x3) =? 0) &&
-                                ((let (x3, _) := idc_args1 in x3) =? 0)
-                               then Some (x2, (##0)%expr)%expr_pat
-                               else None);
-                        Some (Base x3)
-                       else None
-                   | None => None
-                   end
-               | _ => None
-               end;;
-               match x2 with
-               | @expr.Ident _ _ _ t1 idc1 =>
-                   args <- invert_bind_args idc1 Raw.ident.Literal;
-                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                   args1 <- invert_bind_args idc Raw.ident.Literal;
-                   match
-                     pattern.type.unify_extracted_cps
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       ((((projT1 args0) -> (projT1 args1)) -> ℤ) ->
-                        (projT1 args))%ptype option (fun x3 : option => x3)
-                   with
-                   | Some (_, _, _, _) =>
-                       if
-                        type.type_beq base.type base.type.type_beq
-                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                          ((((projT1 args0) -> (projT1 args1)) -> ℤ) ->
-                           (projT1 args))%ptype
-                       then
-                        _ <- ident.unify pattern.ident.Literal
-                               ##(projT2 args0);
-                        idc_args0 <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args1);
-                        idc_args1 <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args);
-                        x3 <- (if
-                                ((let (x3, _) := idc_args0 in x3) =? 0) &&
-                                ((let (x3, _) := idc_args1 in x3) =? 0)
-                               then Some (x1, (##0)%expr)%expr_pat
-                               else None);
-                        Some (Base x3)
-                       else None
-                   | None => None
-                   end
-               | _ => None
-               end
-           | _ => None
-           end;;
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match
-             pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-               (((ℤ -> (projT1 args)) -> ℤ) -> ℤ)%ptype option
-               (fun x3 : option => x3)
-           with
-           | Some (_, _, _, _) =>
-               if
-                type.type_beq base.type base.type.type_beq
-                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                  (((ℤ -> (projT1 args)) -> ℤ) -> ℤ)%ptype
-               then
-                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-                fv <- (if (let (x3, _) := idc_args in x3) =? 0
-                       then
-                        Some
-                          (UnderLet
-                             (#(Z_add_get_carry)%expr @ x @ x1 @ x2)%expr_pat
-                             (fun vc : var (ℤ * ℤ)%etype =>
-                              Base
-                                (#(fst)%expr @ ($vc)%expr,
-                                #(snd)%expr @ ($vc)%expr)%expr_pat))
-                       else None);
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
-       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x3 =>
-           match x1 with
-           | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
-               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-               _ <- invert_bind_args idc Raw.ident.Z_opp;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> s) -> s0) -> ℤ)%ptype
-                   option (fun x5 : option => x5)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> s) -> s0) -> ℤ)%ptype
-                   then
-                    v <- type.try_make_transport_cps s ℤ;
-                    v0 <- type.try_make_transport_cps s0 ℤ;
-                    Some
-                      (UnderLet
-                         (#(Z_sub_with_get_borrow)%expr @ x @
-                          v (Compile.reflect x3) @ x2 @
-                          v0 (Compile.reflect x4))%expr_pat
-                         (fun v1 : var (ℤ * ℤ)%etype =>
-                          Base
-                            (#(fst)%expr @ ($v1)%expr,
-                            (- (#(snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
-                   else None
-               | None => None
-               end
-           | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
-             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
-             (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
-             (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
-           end;;
-           match x2 with
-           | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
-               _ <- invert_bind_args idc0 Raw.ident.Z_opp;
-               _ <- invert_bind_args idc Raw.ident.Z_opp;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> s) -> ℤ) -> s0)%ptype
-                   option (fun x5 : option => x5)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> s) -> ℤ) -> s0)%ptype
-                   then
-                    v <- type.try_make_transport_cps s ℤ;
-                    v0 <- type.try_make_transport_cps s0 ℤ;
-                    Some
-                      (UnderLet
-                         (#(Z_sub_with_get_borrow)%expr @ x @
-                          v (Compile.reflect x3) @ x1 @
-                          v0 (Compile.reflect x4))%expr_pat
-                         (fun v1 : var (ℤ * ℤ)%etype =>
-                          Base
-                            (#(fst)%expr @ ($v1)%expr,
-                            (- (#(snd)%expr @ $v1)%expr_pat)%expr)%expr_pat))
-                   else None
-               | None => None
-               end
-           | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
-             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
-             (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
-             (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
-           end;;
-           match x1 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               _ <- invert_bind_args idc Raw.ident.Z_opp;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> s) -> (projT1 args)) -> ℤ)%ptype option
-                   (fun x4 : option => x4)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> s) -> (projT1 args)) -> ℤ)%ptype
-                   then
-                    v <- type.try_make_transport_cps s ℤ;
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args);
-                    fv <- (if (let (x4, _) := idc_args in x4) <=? 0
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  v (Compile.reflect x3) @ x2 @
-                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end;;
-           match x2 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               _ <- invert_bind_args idc Raw.ident.Z_opp;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> s) -> ℤ) -> (projT1 args))%ptype option
-                   (fun x4 : option => x4)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> s) -> ℤ) -> (projT1 args))%ptype
-                   then
-                    v <- type.try_make_transport_cps s ℤ;
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args);
-                    fv <- (if (let (x4, _) := idc_args in x4) <=? 0
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_sub_with_get_borrow)%expr @ x @
-                                  v (Compile.reflect x3) @ x1 @
-                                  (##(- (let (x4, _) := idc_args in x4))%Z)%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr,
-                                    (- (#(snd)%expr @ $vc)%expr_pat)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end
-       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
-       end;;
-       match x1 with
-       | @expr.Ident _ _ _ t idc =>
-           match x2 with
-           | @expr.Ident _ _ _ t0 idc0 =>
-               args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
-               match
-                 pattern.type.unify_extracted_cps
-                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                   (((ℤ -> ℤ) -> (projT1 args0)) -> (projT1 args))%ptype
-                   option (fun x3 : option => x3)
-               with
-               | Some (_, _, _, _) =>
-                   if
-                    type.type_beq base.type base.type.type_beq
-                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((ℤ -> ℤ) -> (projT1 args0)) -> (projT1 args))%ptype
-                   then
-                    idc_args <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args0);
-                    idc_args0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                    fv <- (if
-                            ((let (x3, _) := idc_args in x3) =? 0) &&
-                            ((let (x3, _) := idc_args0 in x3) =? 0)
-                           then
-                            Some
-                              (UnderLet
-                                 (#(Z_add_with_get_carry)%expr @ x @ x0 @
-                                  (##(let (x3, _) := idc_args in x3))%expr @
-                                  (##(let (x3, _) := idc_args0 in x3))%expr)%expr_pat
-                                 (fun vc : var (ℤ * ℤ)%etype =>
-                                  Base
-                                    (#(fst)%expr @ ($vc)%expr, (##0)%expr)%expr_pat))
-                           else None);
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
-               end
-           | _ => None
-           end
-       | _ => None
-       end;;
-       match
-         pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype option (fun x3 : option => x3)
-       with
-       | Some (_, _, _, _) =>
-           if
-            type.type_beq base.type base.type.type_beq
-              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-           then
-            Some
-              (UnderLet
-                 (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat
-                 (fun v : var (ℤ * ℤ)%etype =>
-                  Base
-                    (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-           else None
-       | None => None
-       end);;
-      None);;;
+    (match x with
+     | @expr.Ident _ _ _ t idc =>
+         match x0 with
+         | @expr.Ident _ _ _ t0 idc0 =>
+             match x1 with
+             | @expr.Ident _ _ _ t1 idc1 =>
+                 match x2 with
+                 | @expr.Ident _ _ _ t2 idc2 =>
+                     args <- invert_bind_args idc2 Raw.ident.Literal;
+                     args0 <- invert_bind_args idc1 Raw.ident.Literal;
+                     args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                     args2 <- invert_bind_args idc Raw.ident.Literal;
+                     match
+                       pattern.type.unify_extracted_cps
+                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                         ((((projT1 args2) -> (projT1 args1)) ->
+                           (projT1 args0)) -> (projT1 args))%ptype option
+                         (fun x3 : option => x3)
+                     with
+                     | Some (_, _, _, _)%zrange =>
+                         if
+                          type.type_beq base.type base.type.type_beq
+                            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                            ((((projT1 args2) -> (projT1 args1)) ->
+                              (projT1 args0)) -> (projT1 args))%ptype
+                         then
+                          idc_args <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args2);
+                          idc_args0 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args1);
+                          idc_args1 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args0);
+                          idc_args2 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args);
+                          Some
+                            (Base
+                               (let
+                                '(a2, b2)%zrange :=
+                                 Z.add_with_get_carry_full
+                                   (let (x3, _) := idc_args in x3)
+                                   (let (x3, _) := idc_args0 in x3)
+                                   (let (x3, _) := idc_args1 in x3)
+                                   (let (x3, _) := idc_args2 in x3) in
+                                 ((##a2)%expr, (##b2)%expr)%expr_pat))
+                         else None
+                     | None => None
+                     end
+                 | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t2 idc2) x3 =>
+                     args <- invert_bind_args idc2 Raw.ident.Z_cast;
+                     args0 <- invert_bind_args idc1 Raw.ident.Literal;
+                     args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                     args2 <- invert_bind_args idc Raw.ident.Literal;
+                     match
+                       pattern.type.unify_extracted_cps
+                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                         ((((projT1 args2) -> (projT1 args1)) ->
+                           (projT1 args0)) -> s)%ptype option
+                         (fun x4 : option => x4)
+                     with
+                     | Some (_, _, _, _)%zrange =>
+                         if
+                          type.type_beq base.type base.type.type_beq
+                            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                            ((((projT1 args2) -> (projT1 args1)) ->
+                              (projT1 args0)) -> s)%ptype
+                         then
+                          idc_args <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args2);
+                          idc_args0 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args1);
+                          idc_args1 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args0);
+                          v <- type.try_make_transport_cps s ℤ;
+                          x4 <- (if
+                                  ((let (x4, _) := idc_args0 in x4) =? 0) &&
+                                  ((let (x4, _) := idc_args1 in x4) =? 0) &&
+                                  (ZRange.normalize args <=?
+                                   r[0 ~> (let (x4, _) := idc_args in x4) - 1])%zrange
+                                 then
+                                  Some
+                                    (#(Z_cast args)%expr @
+                                     v (Compile.reflect x3), (##0)%expr)%expr_pat
+                                 else None);
+                          Some (Base x4)
+                         else None
+                     | None => None
+                     end
+                 | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+                   (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
+                   (_ @ _)%expr_pat _ | @expr.App _ _ _ s _
+                   (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                 | _ => None
+                 end
+             | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t1 idc1) x3 =>
+                 match x2 with
+                 | @expr.Ident _ _ _ t2 idc2 =>
+                     args <- invert_bind_args idc2 Raw.ident.Literal;
+                     args0 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                     args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                     args2 <- invert_bind_args idc Raw.ident.Literal;
+                     match
+                       pattern.type.unify_extracted_cps
+                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                         ((((projT1 args2) -> (projT1 args1)) -> s) ->
+                          (projT1 args))%ptype option (fun x4 : option => x4)
+                     with
+                     | Some (_, _, _, _)%zrange =>
+                         if
+                          type.type_beq base.type base.type.type_beq
+                            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                            ((((projT1 args2) -> (projT1 args1)) -> s) ->
+                             (projT1 args))%ptype
+                         then
+                          idc_args <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args2);
+                          idc_args0 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args1);
+                          v <- type.try_make_transport_cps s ℤ;
+                          idc_args1 <- ident.unify pattern.ident.Literal
+                                         ##(projT2 args);
+                          x4 <- (if
+                                  ((let (x4, _) := idc_args0 in x4) =? 0) &&
+                                  ((let (x4, _) := idc_args1 in x4) =? 0) &&
+                                  (ZRange.normalize args0 <=?
+                                   r[0 ~> (let (x4, _) := idc_args in x4) - 1])%zrange
+                                 then
+                                  Some
+                                    (#(Z_cast args0)%expr @
+                                     v (Compile.reflect x3), (##0)%expr)%expr_pat
+                                 else None);
+                          Some (Base x4)
+                         else None
+                     | None => None
+                     end
+                 | _ => None
+                 end
+             | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+               (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
+               (_ @ _)%expr_pat _ | @expr.App _ _ _ s _
+               (@expr.LetIn _ _ _ _ _ _ _) _ => None
+             | _ => None
+             end
+         | _ => None
+         end
+     | _ => None
+     end;;;
      Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
 | Z_sub_get_borrow =>
     fun x x0 x1 : expr ℤ =>
-    (match
-       pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
-         ((ℤ -> ℤ) -> ℤ)%ptype option (fun x2 : option => x2)
-     with
-     | Some (_, _, _) =>
-         if
-          type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
-            ((ℤ -> ℤ) -> ℤ)%ptype
-         then
-          Some
-            (UnderLet (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
-               (fun v : var (ℤ * ℤ)%etype =>
-                Base
-                  (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-         else None
-     | None => None
-     end;;;
-     Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
+    Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
 | Z_sub_with_get_borrow =>
     fun x x0 x1 x2 : expr ℤ =>
-    (match
-       pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype option (fun x3 : option => x3)
-     with
-     | Some (_, _, _, _) =>
-         if
-          type.type_beq base.type base.type.type_beq
-            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-         then
-          Some
-            (UnderLet
-               (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
-               (fun v : var (ℤ * ℤ)%etype =>
-                Base
-                  (#(fst)%expr @ ($v)%expr, #(snd)%expr @ ($v)%expr)%expr_pat))
-         else None
-     | None => None
-     end;;;
-     Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
+    Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
 | Z_zselect =>
     fun x x0 x1 : expr ℤ => Base (#(Z_zselect)%expr @ x @ x0 @ x1)%expr_pat
 | Z_add_modulo =>
@@ -1363,6 +859,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_cast range =>
     fun x : expr ℤ =>
     (match x with
+     | @expr.Ident _ _ _ t idc =>
+         args <- invert_bind_args idc Raw.ident.Literal;
+         match
+           pattern.type.unify_extracted_cps ℤ (projT1 args) option
+             (fun x0 : option => x0)
+         with
+         | Some _ =>
+             if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
+             then
+              idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
+              x0 <- (if
+                      is_bounded_by_bool (let (x0, _) := idc_args in x0)
+                        range
+                     then Some (##(let (x0, _) := idc_args in x0))%expr
+                     else None);
+              Some (Base x0)
+             else None
+         | None => None
+         end
      | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x0 =>
          args <- invert_bind_args idc Raw.ident.Z_cast;
          match
@@ -1383,14 +898,1466 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              else None
          | None => None
          end
+     | @expr.App _ _ _ s _
+       (@expr.App _ _ _ s0 _
+        (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t idc) x2) x1) x0 =>
+         _ <- invert_bind_args idc Raw.ident.Z_add_with_carry;
+         match
+           pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+             ((s1 -> s0) -> s)%ptype option (fun x3 : option => x3)
+         with
+         | Some (_, _, _)%zrange =>
+             if
+              type.type_beq base.type base.type.type_beq
+                ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
+             then
+              v <- type.try_make_transport_cps s1 ℤ;
+              v0 <- type.try_make_transport_cps s0 ℤ;
+              v1 <- type.try_make_transport_cps s ℤ;
+              Some
+                (UnderLet
+                   (#(Z_cast range)%expr @
+                    (#(Z_add_with_carry)%expr @ v (Compile.reflect x2) @
+                     v0 (Compile.reflect x1) @ v1 (Compile.reflect x0)))%expr_pat
+                   (fun v2 : var ℤ =>
+                    Base (#(Z_cast range)%expr @ ($v2)%expr)%expr_pat))
+             else None
+         | None => None
+         end
+     | @expr.App _ _ _ s _
+       (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ ($_)%expr _) _) _ |
+       @expr.App _ _ _ s _
+       (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ (@expr.Abs _ _ _ _ _ _) _)
+        _) _ | @expr.App _ _ _ s _
+       (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ (_ @ _)%expr_pat _) _) _ |
+       @expr.App _ _ _ s _
+       (@expr.App _ _ _ s0 _
+        (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ => None
+     | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ #(_)%expr_pat _) _ |
+       @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App _
+       _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ | @expr.App
+       _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+         None
      | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-       (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-       @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+       (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
+       (@expr.LetIn _ _ _ _ _ _ _) _ => None
      | _ => None
      end;;;
      Base (#(Z_cast range)%expr @ x)%expr_pat)%option
 | Z_cast2 range =>
-    fun x : expr (ℤ * ℤ)%etype => Base (#(Z_cast2 range)%expr @ x)%expr_pat
+    fun x : expr (ℤ * ℤ)%etype =>
+    ((match x with
+      | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x1) x0 =>
+          args <- invert_bind_args idc Raw.ident.pair;
+          match
+            pattern.type.unify_extracted_cps
+              (((ℤ -> ℤ -> (ℤ * ℤ)%pbtype) -> ℤ) -> ℤ)%ptype
+              ((((let (x2, _) := args in x2) ->
+                 (let (_, y) := args in y) ->
+                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
+                s0) -> s)%ptype option (fun x2 : option => x2)
+          with
+          | Some (_, (_, (_, _)), _, _)%zrange =>
+              if
+               type.type_beq base.type base.type.type_beq
+                 (((ℤ -> ℤ -> (ℤ * ℤ)%etype) -> ℤ) -> ℤ)%ptype
+                 ((((let (x2, _) := args in x2) ->
+                    (let (_, y) := args in y) ->
+                    ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
+                   s0) -> s)%ptype
+              then
+               _ <- ident.unify pattern.ident.pair pair;
+               v <- type.try_make_transport_cps s0 ℤ;
+               v0 <- type.try_make_transport_cps s ℤ;
+               Some
+                 (fv <-- do_again (ℤ * ℤ)
+                           (#(Z_cast (Datatypes.fst range))%expr @
+                            ($(v (Compile.reflect x1)))%expr,
+                           #(Z_cast (Datatypes.snd range))%expr @
+                           ($(v0 (Compile.reflect x0)))%expr)%expr_pat;
+                  Base fv)%under_lets
+              else None
+          | None => None
+          end
+      | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t idc) x2) x1) x0 =>
+          (match x1 with
+           | (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _
+               (@expr.Ident _ _ _ t2 idc2) x5))%expr_pat =>
+               args <- invert_bind_args idc2 Raw.ident.Z_cast;
+               _ <- invert_bind_args idc1 Raw.ident.Z_opp;
+               args1 <- invert_bind_args idc0 Raw.ident.Z_cast;
+               _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   ((s1 -> s4) -> s)%ptype option (fun x6 : option => x6)
+               with
+               | Some (_, _, _)%zrange =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s4) -> s)%ptype
+                   then
+                    v <- type.try_make_transport_cps s1 ℤ;
+                    v0 <- type.try_make_transport_cps s4 ℤ;
+                    v1 <- type.try_make_transport_cps s ℤ;
+                    fv <- (if
+                            (ZRange.normalize args <=?
+                             - ZRange.normalize args1)%zrange
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_cast2
+                                      (Datatypes.fst range,
+                                      - Datatypes.snd range))%expr @
+                                  (#(Z_sub_get_borrow)%expr @
+                                   v (Compile.reflect x2) @
+                                   v1 (Compile.reflect x0) @
+                                   (#(Z_cast args)%expr @
+                                    v0 (Compile.reflect x5))))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(Z_cast (Datatypes.fst range))%expr @
+                                     (#(fst)%expr @
+                                      (#(Z_cast2
+                                           (Datatypes.fst range,
+                                           - Datatypes.snd range))%expr @
+                                       ($vc)%expr)),
+                                    #(Z_cast (Datatypes.snd range))%expr @
+                                    (-
+                                     (#(Z_cast (- Datatypes.snd range))%expr @
+                                      (#(snd)%expr @
+                                       (#(Z_cast2
+                                            (Datatypes.fst range,
+                                            - Datatypes.snd range))%expr @
+                                        $vc)))%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _ ($_)%expr _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _
+               (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _ (_ @ _) _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _
+               (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+           | (@expr.Ident _ _ _ t0 idc0 @ (@expr.Ident _ _ _ t1 idc1 @ #(_)))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+               None
+           | (@expr.Ident _ _ _ t0 idc0 @ #(_))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (($_)%expr @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _ @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+               None
+           | _ => None
+           end;;
+           match x0 with
+           | (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _
+               (@expr.Ident _ _ _ t2 idc2) x5))%expr_pat =>
+               args <- invert_bind_args idc2 Raw.ident.Z_cast;
+               _ <- invert_bind_args idc1 Raw.ident.Z_opp;
+               args1 <- invert_bind_args idc0 Raw.ident.Z_cast;
+               _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   ((s1 -> s0) -> s4)%ptype option (fun x6 : option => x6)
+               with
+               | Some (_, _, _)%zrange =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s4)%ptype
+                   then
+                    v <- type.try_make_transport_cps s1 ℤ;
+                    v0 <- type.try_make_transport_cps s0 ℤ;
+                    v1 <- type.try_make_transport_cps s4 ℤ;
+                    fv <- (if
+                            (ZRange.normalize args <=?
+                             - ZRange.normalize args1)%zrange
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_cast2
+                                      (Datatypes.fst range,
+                                      - Datatypes.snd range))%expr @
+                                  (#(Z_sub_get_borrow)%expr @
+                                   v (Compile.reflect x2) @
+                                   v0 (Compile.reflect x1) @
+                                   (#(Z_cast args)%expr @
+                                    v1 (Compile.reflect x5))))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(Z_cast (Datatypes.fst range))%expr @
+                                     (#(fst)%expr @
+                                      (#(Z_cast2
+                                           (Datatypes.fst range,
+                                           - Datatypes.snd range))%expr @
+                                       ($vc)%expr)),
+                                    #(Z_cast (Datatypes.snd range))%expr @
+                                    (-
+                                     (#(Z_cast (- Datatypes.snd range))%expr @
+                                      (#(snd)%expr @
+                                       (#(Z_cast2
+                                            (Datatypes.fst range,
+                                            - Datatypes.snd range))%expr @
+                                        $vc)))%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _ ($_)%expr _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _
+               (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _ (_ @ _) _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _
+               (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+           | (@expr.Ident _ _ _ t0 idc0 @ (@expr.Ident _ _ _ t1 idc1 @ #(_)))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @
+              (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+               None
+           | (@expr.Ident _ _ _ t0 idc0 @ #(_))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (($_)%expr @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _ @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+               None
+           | _ => None
+           end;;
+           match x1 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   ((s1 -> (projT1 args)) -> s)%ptype option
+                   (fun x3 : option => x3)
+               with
+               | Some (_, _, _)%zrange =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype
+                      ((s1 -> (projT1 args)) -> s)%ptype
+                   then
+                    v <- type.try_make_transport_cps s1 ℤ;
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                    v0 <- type.try_make_transport_cps s ℤ;
+                    fv <- (if (let (x3, _) := idc_args in x3) <? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_cast2
+                                      (Datatypes.fst range,
+                                      - Datatypes.snd range))%expr @
+                                  (#(Z_sub_get_borrow)%expr @
+                                   v (Compile.reflect x2) @
+                                   v0 (Compile.reflect x0) @
+                                   (##(- (let (x3, _) := idc_args in x3))%Z)%expr))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(Z_cast (Datatypes.fst range))%expr @
+                                     (#(fst)%expr @
+                                      (#(Z_cast2
+                                           (Datatypes.fst range,
+                                           - Datatypes.snd range))%expr @
+                                       ($vc)%expr)),
+                                    #(Z_cast (Datatypes.snd range))%expr @
+                                    (-
+                                     (#(Z_cast (- Datatypes.snd range))%expr @
+                                      (#(snd)%expr @
+                                       (#(Z_cast2
+                                            (Datatypes.fst range,
+                                            - Datatypes.snd range))%expr @
+                                        $vc)))%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           match x0 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
+               match
+                 pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+                   ((s1 -> s0) -> (projT1 args))%ptype option
+                   (fun x3 : option => x3)
+               with
+               | Some (_, _, _)%zrange =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      ((ℤ -> ℤ) -> ℤ)%ptype
+                      ((s1 -> s0) -> (projT1 args))%ptype
+                   then
+                    v <- type.try_make_transport_cps s1 ℤ;
+                    v0 <- type.try_make_transport_cps s0 ℤ;
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                    fv <- (if (let (x3, _) := idc_args in x3) <? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_cast2
+                                      (Datatypes.fst range,
+                                      - Datatypes.snd range))%expr @
+                                  (#(Z_sub_get_borrow)%expr @
+                                   v (Compile.reflect x2) @
+                                   v0 (Compile.reflect x1) @
+                                   (##(- (let (x3, _) := idc_args in x3))%Z)%expr))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(Z_cast (Datatypes.fst range))%expr @
+                                     (#(fst)%expr @
+                                      (#(Z_cast2
+                                           (Datatypes.fst range,
+                                           - Datatypes.snd range))%expr @
+                                       ($vc)%expr)),
+                                    #(Z_cast (Datatypes.snd range))%expr @
+                                    (-
+                                     (#(Z_cast (- Datatypes.snd range))%expr @
+                                      (#(snd)%expr @
+                                       (#(Z_cast2
+                                            (Datatypes.fst range,
+                                            - Datatypes.snd range))%expr @
+                                        $vc)))%expr_pat)%expr)%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | _ => None
+           end;;
+           _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((s1 -> s0) -> s)%ptype option (fun x3 : option => x3)
+           with
+           | Some (_, _, _)%zrange =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
+               then
+                v <- type.try_make_transport_cps s1 ℤ;
+                v0 <- type.try_make_transport_cps s0 ℤ;
+                v1 <- type.try_make_transport_cps s ℤ;
+                Some
+                  (UnderLet
+                     (#(Z_cast2 range)%expr @
+                      (#(Z_add_get_carry)%expr @ v (Compile.reflect x2) @
+                       v0 (Compile.reflect x1) @ v1 (Compile.reflect x0)))%expr_pat
+                     (fun v2 : var (ℤ * ℤ)%etype =>
+                      Base
+                        (#(Z_cast (Datatypes.fst range))%expr @
+                         (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)),
+                        #(Z_cast (Datatypes.snd range))%expr @
+                        (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)))%expr_pat))
+               else None
+           | None => None
+           end);;
+          (_ <- invert_bind_args idc Raw.ident.Z_sub_get_borrow;
+           match
+             pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+               ((s1 -> s0) -> s)%ptype option (fun x3 : option => x3)
+           with
+           | Some (_, _, _)%zrange =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
+               then
+                v <- type.try_make_transport_cps s1 ℤ;
+                v0 <- type.try_make_transport_cps s0 ℤ;
+                v1 <- type.try_make_transport_cps s ℤ;
+                Some
+                  (UnderLet
+                     (#(Z_cast2 range)%expr @
+                      (#(Z_sub_get_borrow)%expr @ v (Compile.reflect x2) @
+                       v0 (Compile.reflect x1) @ v1 (Compile.reflect x0)))%expr_pat
+                     (fun v2 : var (ℤ * ℤ)%etype =>
+                      Base
+                        (#(Z_cast (Datatypes.fst range))%expr @
+                         (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)),
+                        #(Z_cast (Datatypes.snd range))%expr @
+                        (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)))%expr_pat))
+               else None
+           | None => None
+           end);;
+          _ <- invert_bind_args idc Raw.ident.Z_mul_split;
+          match
+            pattern.type.unify_extracted_cps ((ℤ -> ℤ) -> ℤ)%ptype
+              ((s1 -> s0) -> s)%ptype option (fun x3 : option => x3)
+          with
+          | Some (_, _, _)%zrange =>
+              if
+               type.type_beq base.type base.type.type_beq
+                 ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
+              then
+               v <- type.try_make_transport_cps s1 ℤ;
+               v0 <- type.try_make_transport_cps s0 ℤ;
+               v1 <- type.try_make_transport_cps s ℤ;
+               Some
+                 (UnderLet
+                    (#(Z_cast2 range)%expr @
+                     (#(Z_mul_split)%expr @ v (Compile.reflect x2) @
+                      v0 (Compile.reflect x1) @ v1 (Compile.reflect x0)))%expr_pat
+                    (fun v2 : var (ℤ * ℤ)%etype =>
+                     Base
+                       (#(Z_cast (Datatypes.fst range))%expr @
+                        (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)),
+                       #(Z_cast (Datatypes.snd range))%expr @
+                       (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)))%expr_pat))
+              else None
+          | None => None
+          end
+      | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t idc) x3) x2) x1) x0 =>
+          (match x2 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               match x1 with
+               | (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
+                   (@expr.Ident _ _ _ t3 idc3) x6))%expr_pat =>
+                   (args <- invert_bind_args idc3 Raw.ident.Z_cast;
+                    _ <- invert_bind_args idc2 Raw.ident.Z_opp;
+                    args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                    args2 <- invert_bind_args idc0 Raw.ident.Literal;
+                    _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+                    match
+                      pattern.type.unify_extracted_cps
+                        (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                        (((s2 -> (projT1 args2)) -> s5) -> s)%ptype option
+                        (fun x7 : option => x7)
+                    with
+                    | Some (_, _, _, _)%zrange =>
+                        if
+                         type.type_beq base.type base.type.type_beq
+                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                           (((s2 -> (projT1 args2)) -> s5) -> s)%ptype
+                        then
+                         v <- type.try_make_transport_cps s2 ℤ;
+                         idc_args <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args2);
+                         v0 <- type.try_make_transport_cps s5 ℤ;
+                         v1 <- type.try_make_transport_cps s ℤ;
+                         fv <- (if
+                                 ((let (x7, _) := idc_args in x7) =? 0) &&
+                                 (ZRange.normalize args <=?
+                                  - ZRange.normalize args1)%zrange
+                                then
+                                 Some
+                                   (UnderLet
+                                      (#(Z_cast2
+                                           (Datatypes.fst range,
+                                           - Datatypes.snd range))%expr @
+                                       (#(Z_sub_get_borrow)%expr @
+                                        v (Compile.reflect x3) @
+                                        v1 (Compile.reflect x0) @
+                                        (#(Z_cast args)%expr @
+                                         v0 (Compile.reflect x6))))%expr_pat
+                                      (fun vc : var (ℤ * ℤ)%etype =>
+                                       Base
+                                         (#(Z_cast (Datatypes.fst range))%expr @
+                                          (#(fst)%expr @
+                                           (#(Z_cast2
+                                                (Datatypes.fst range,
+                                                - Datatypes.snd range))%expr @
+                                            ($vc)%expr)),
+                                         #(Z_cast (Datatypes.snd range))%expr @
+                                         (-
+                                          (#(Z_cast (- Datatypes.snd range))%expr @
+                                           (#(snd)%expr @
+                                            (#(Z_cast2
+                                                 (Datatypes.fst range,
+                                                 - Datatypes.snd range))%expr @
+                                             $vc)))%expr_pat)%expr)%expr_pat))
+                                else None);
+                         Some (fv0 <-- fv;
+                               Base fv0)%under_lets
+                        else None
+                    | None => None
+                    end);;
+                   args <- invert_bind_args idc3 Raw.ident.Z_cast;
+                   _ <- invert_bind_args idc2 Raw.ident.Z_opp;
+                   args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                   args2 <- invert_bind_args idc0 Raw.ident.Literal;
+                   _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       (((s2 -> (projT1 args2)) -> s5) -> s)%ptype option
+                       (fun x7 : option => x7)
+                   with
+                   | Some (_, _, _, _)%zrange =>
+                       if
+                        type.type_beq base.type base.type.type_beq
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          (((s2 -> (projT1 args2)) -> s5) -> s)%ptype
+                       then
+                        v <- type.try_make_transport_cps s2 ℤ;
+                        idc_args <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args2);
+                        v0 <- type.try_make_transport_cps s5 ℤ;
+                        v1 <- type.try_make_transport_cps s ℤ;
+                        fv <- (if
+                                ((let (x7, _) := idc_args in x7) <? 0) &&
+                                (ZRange.normalize args <=?
+                                 - ZRange.normalize args1)%zrange
+                               then
+                                Some
+                                  (UnderLet
+                                     (#(Z_cast2
+                                          (Datatypes.fst range,
+                                          - Datatypes.snd range))%expr @
+                                      (#(Z_sub_with_get_borrow)%expr @
+                                       v (Compile.reflect x3) @
+                                       (##(- (let (x7, _) := idc_args in x7))%Z)%expr @
+                                       v1 (Compile.reflect x0) @
+                                       (#(Z_cast args)%expr @
+                                        v0 (Compile.reflect x6))))%expr_pat
+                                     (fun vc : var (ℤ * ℤ)%etype =>
+                                      Base
+                                        (#(Z_cast (Datatypes.fst range))%expr @
+                                         (#(fst)%expr @
+                                          (#(Z_cast2
+                                               (Datatypes.fst range,
+                                               - Datatypes.snd range))%expr @
+                                           ($vc)%expr)),
+                                        #(Z_cast (Datatypes.snd range))%expr @
+                                        (-
+                                         (#(Z_cast (- Datatypes.snd range))%expr @
+                                          (#(snd)%expr @
+                                           (#(Z_cast2
+                                                (Datatypes.fst range,
+                                                - Datatypes.snd range))%expr @
+                                            $vc)))%expr_pat)%expr)%expr_pat))
+                               else None);
+                        Some (fv0 <-- fv;
+                              Base fv0)%under_lets
+                       else None
+                   | None => None
+                   end
+               | (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _ ($_)%expr
+                   _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
+                   (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _ (_ @ _) _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
+                   (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+               | (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ #(_)))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                   None
+               | (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ (($_)%expr @ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ (_ @ _ @ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                   None
+               | _ => None
+               end;;
+               match x0 with
+               | (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
+                   (@expr.Ident _ _ _ t3 idc3) x6))%expr_pat =>
+                   (args <- invert_bind_args idc3 Raw.ident.Z_cast;
+                    _ <- invert_bind_args idc2 Raw.ident.Z_opp;
+                    args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                    args2 <- invert_bind_args idc0 Raw.ident.Literal;
+                    _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+                    match
+                      pattern.type.unify_extracted_cps
+                        (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                        (((s2 -> (projT1 args2)) -> s0) -> s5)%ptype option
+                        (fun x7 : option => x7)
+                    with
+                    | Some (_, _, _, _)%zrange =>
+                        if
+                         type.type_beq base.type base.type.type_beq
+                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                           (((s2 -> (projT1 args2)) -> s0) -> s5)%ptype
+                        then
+                         v <- type.try_make_transport_cps s2 ℤ;
+                         idc_args <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args2);
+                         v0 <- type.try_make_transport_cps s0 ℤ;
+                         v1 <- type.try_make_transport_cps s5 ℤ;
+                         fv <- (if
+                                 ((let (x7, _) := idc_args in x7) =? 0) &&
+                                 (ZRange.normalize args <=?
+                                  - ZRange.normalize args1)%zrange
+                                then
+                                 Some
+                                   (UnderLet
+                                      (#(Z_cast2
+                                           (Datatypes.fst range,
+                                           - Datatypes.snd range))%expr @
+                                       (#(Z_sub_get_borrow)%expr @
+                                        v (Compile.reflect x3) @
+                                        v0 (Compile.reflect x1) @
+                                        (#(Z_cast args)%expr @
+                                         v1 (Compile.reflect x6))))%expr_pat
+                                      (fun vc : var (ℤ * ℤ)%etype =>
+                                       Base
+                                         (#(Z_cast (Datatypes.fst range))%expr @
+                                          (#(fst)%expr @
+                                           (#(Z_cast2
+                                                (Datatypes.fst range,
+                                                - Datatypes.snd range))%expr @
+                                            ($vc)%expr)),
+                                         #(Z_cast (Datatypes.snd range))%expr @
+                                         (-
+                                          (#(Z_cast (- Datatypes.snd range))%expr @
+                                           (#(snd)%expr @
+                                            (#(Z_cast2
+                                                 (Datatypes.fst range,
+                                                 - Datatypes.snd range))%expr @
+                                             $vc)))%expr_pat)%expr)%expr_pat))
+                                else None);
+                         Some (fv0 <-- fv;
+                               Base fv0)%under_lets
+                        else None
+                    | None => None
+                    end);;
+                   args <- invert_bind_args idc3 Raw.ident.Z_cast;
+                   _ <- invert_bind_args idc2 Raw.ident.Z_opp;
+                   args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                   args2 <- invert_bind_args idc0 Raw.ident.Literal;
+                   _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       (((s2 -> (projT1 args2)) -> s0) -> s5)%ptype option
+                       (fun x7 : option => x7)
+                   with
+                   | Some (_, _, _, _)%zrange =>
+                       if
+                        type.type_beq base.type base.type.type_beq
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          (((s2 -> (projT1 args2)) -> s0) -> s5)%ptype
+                       then
+                        v <- type.try_make_transport_cps s2 ℤ;
+                        idc_args <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args2);
+                        v0 <- type.try_make_transport_cps s0 ℤ;
+                        v1 <- type.try_make_transport_cps s5 ℤ;
+                        fv <- (if
+                                ((let (x7, _) := idc_args in x7) <? 0) &&
+                                (ZRange.normalize args <=?
+                                 - ZRange.normalize args1)%zrange
+                               then
+                                Some
+                                  (UnderLet
+                                     (#(Z_cast2
+                                          (Datatypes.fst range,
+                                          - Datatypes.snd range))%expr @
+                                      (#(Z_sub_with_get_borrow)%expr @
+                                       v (Compile.reflect x3) @
+                                       (##(- (let (x7, _) := idc_args in x7))%Z)%expr @
+                                       v0 (Compile.reflect x1) @
+                                       (#(Z_cast args)%expr @
+                                        v1 (Compile.reflect x6))))%expr_pat
+                                     (fun vc : var (ℤ * ℤ)%etype =>
+                                      Base
+                                        (#(Z_cast (Datatypes.fst range))%expr @
+                                         (#(fst)%expr @
+                                          (#(Z_cast2
+                                               (Datatypes.fst range,
+                                               - Datatypes.snd range))%expr @
+                                           ($vc)%expr)),
+                                        #(Z_cast (Datatypes.snd range))%expr @
+                                        (-
+                                         (#(Z_cast (- Datatypes.snd range))%expr @
+                                          (#(snd)%expr @
+                                           (#(Z_cast2
+                                                (Datatypes.fst range,
+                                                - Datatypes.snd range))%expr @
+                                            $vc)))%expr_pat)%expr)%expr_pat))
+                               else None);
+                        Some (fv0 <-- fv;
+                              Base fv0)%under_lets
+                       else None
+                   | None => None
+                   end
+               | (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _ ($_)%expr
+                   _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
+                   (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _ (_ @ _) _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
+                   (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+               | (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ #(_)))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @
+                  (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                   None
+               | (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ (($_)%expr @ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ (_ @ _ @ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                   None
+               | _ => None
+               end;;
+               match x1 with
+               | @expr.Ident _ _ _ t1 idc1 =>
+                   args <- invert_bind_args idc1 Raw.ident.Literal;
+                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                   _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       (((s2 -> (projT1 args0)) -> (projT1 args)) -> s)%ptype
+                       option (fun x4 : option => x4)
+                   with
+                   | Some (_, _, _, _)%zrange =>
+                       if
+                        type.type_beq base.type base.type.type_beq
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          (((s2 -> (projT1 args0)) -> (projT1 args)) -> s)%ptype
+                       then
+                        v <- type.try_make_transport_cps s2 ℤ;
+                        idc_args <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args0);
+                        idc_args0 <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args);
+                        v0 <- type.try_make_transport_cps s ℤ;
+                        fv <- (if
+                                ((let (x4, _) := idc_args0 in x4) <=? 0) &&
+                                ((let (x4, _) := idc_args in x4) <=? 0) &&
+                                ((let (x4, _) := idc_args0 in x4) +
+                                 (let (x4, _) := idc_args in x4) <? 0)
+                               then
+                                Some
+                                  (UnderLet
+                                     (#(Z_cast2
+                                          (Datatypes.fst range,
+                                          - Datatypes.snd range))%expr @
+                                      (#(Z_sub_with_get_borrow)%expr @
+                                       v (Compile.reflect x3) @
+                                       (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
+                                       v0 (Compile.reflect x0) @
+                                       (##(- (let (x4, _) := idc_args0 in x4))%Z)%expr))%expr_pat
+                                     (fun vc : var (ℤ * ℤ)%etype =>
+                                      Base
+                                        (#(Z_cast (Datatypes.fst range))%expr @
+                                         (#(fst)%expr @
+                                          (#(Z_cast2
+                                               (Datatypes.fst range,
+                                               - Datatypes.snd range))%expr @
+                                           ($vc)%expr)),
+                                        #(Z_cast (Datatypes.snd range))%expr @
+                                        (-
+                                         (#(Z_cast (- Datatypes.snd range))%expr @
+                                          (#(snd)%expr @
+                                           (#(Z_cast2
+                                                (Datatypes.fst range,
+                                                - Datatypes.snd range))%expr @
+                                            $vc)))%expr_pat)%expr)%expr_pat))
+                               else None);
+                        Some (fv0 <-- fv;
+                              Base fv0)%under_lets
+                       else None
+                   | None => None
+                   end
+               | _ => None
+               end;;
+               match x0 with
+               | @expr.Ident _ _ _ t1 idc1 =>
+                   args <- invert_bind_args idc1 Raw.ident.Literal;
+                   args0 <- invert_bind_args idc0 Raw.ident.Literal;
+                   _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+                   match
+                     pattern.type.unify_extracted_cps
+                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                       (((s2 -> (projT1 args0)) -> s0) -> (projT1 args))%ptype
+                       option (fun x4 : option => x4)
+                   with
+                   | Some (_, _, _, _)%zrange =>
+                       if
+                        type.type_beq base.type base.type.type_beq
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          (((s2 -> (projT1 args0)) -> s0) -> (projT1 args))%ptype
+                       then
+                        v <- type.try_make_transport_cps s2 ℤ;
+                        idc_args <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args0);
+                        v0 <- type.try_make_transport_cps s0 ℤ;
+                        idc_args0 <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args);
+                        fv <- (if
+                                ((let (x4, _) := idc_args0 in x4) <=? 0) &&
+                                ((let (x4, _) := idc_args in x4) <=? 0) &&
+                                ((let (x4, _) := idc_args0 in x4) +
+                                 (let (x4, _) := idc_args in x4) <? 0)
+                               then
+                                Some
+                                  (UnderLet
+                                     (#(Z_cast2
+                                          (Datatypes.fst range,
+                                          - Datatypes.snd range))%expr @
+                                      (#(Z_sub_with_get_borrow)%expr @
+                                       v (Compile.reflect x3) @
+                                       (##(- (let (x4, _) := idc_args in x4))%Z)%expr @
+                                       v0 (Compile.reflect x1) @
+                                       (##(- (let (x4, _) := idc_args0 in x4))%Z)%expr))%expr_pat
+                                     (fun vc : var (ℤ * ℤ)%etype =>
+                                      Base
+                                        (#(Z_cast (Datatypes.fst range))%expr @
+                                         (#(fst)%expr @
+                                          (#(Z_cast2
+                                               (Datatypes.fst range,
+                                               - Datatypes.snd range))%expr @
+                                           ($vc)%expr)),
+                                        #(Z_cast (Datatypes.snd range))%expr @
+                                        (-
+                                         (#(Z_cast (- Datatypes.snd range))%expr @
+                                          (#(snd)%expr @
+                                           (#(Z_cast2
+                                                (Datatypes.fst range,
+                                                - Datatypes.snd range))%expr @
+                                            $vc)))%expr_pat)%expr)%expr_pat))
+                               else None);
+                        Some (fv0 <-- fv;
+                              Base fv0)%under_lets
+                       else None
+                   | None => None
+                   end
+               | _ => None
+               end;;
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+               match
+                 pattern.type.unify_extracted_cps
+                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                   (((s2 -> (projT1 args)) -> s0) -> s)%ptype option
+                   (fun x4 : option => x4)
+               with
+               | Some (_, _, _, _)%zrange =>
+                   if
+                    type.type_beq base.type base.type.type_beq
+                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((s2 -> (projT1 args)) -> s0) -> s)%ptype
+                   then
+                    v <- type.try_make_transport_cps s2 ℤ;
+                    idc_args <- ident.unify pattern.ident.Literal
+                                  ##(projT2 args);
+                    v0 <- type.try_make_transport_cps s0 ℤ;
+                    v1 <- type.try_make_transport_cps s ℤ;
+                    fv <- (if (let (x4, _) := idc_args in x4) =? 0
+                           then
+                            Some
+                              (UnderLet
+                                 (#(Z_cast2 range)%expr @
+                                  (#(Z_add_get_carry)%expr @
+                                   v (Compile.reflect x3) @
+                                   v0 (Compile.reflect x1) @
+                                   v1 (Compile.reflect x0)))%expr_pat
+                                 (fun vc : var (ℤ * ℤ)%etype =>
+                                  Base
+                                    (#(Z_cast (Datatypes.fst range))%expr @
+                                     (#(fst)%expr @
+                                      (#(Z_cast2 range)%expr @ ($vc)%expr)),
+                                    #(Z_cast (Datatypes.snd range))%expr @
+                                    (#(snd)%expr @
+                                     (#(Z_cast2 range)%expr @ ($vc)%expr)))%expr_pat))
+                           else None);
+                    Some (fv0 <-- fv;
+                          Base fv0)%under_lets
+                   else None
+               | None => None
+               end
+           | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
+               match x4 with
+               | (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _
+                  (@expr.Ident _ _ _ t2 idc2) x6)%expr_pat =>
+                   match x1 with
+                   | (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       (@expr.Ident _ _ _ t5 idc5) x9))%expr_pat =>
+                       args <- invert_bind_args idc5 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc4 Raw.ident.Z_opp;
+                       args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                       args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc1 Raw.ident.Z_opp;
+                       args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc
+                              Raw.ident.Z_add_with_get_carry;
+                       match
+                         pattern.type.unify_extracted_cps
+                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                           (((s2 -> s5) -> s8) -> s)%ptype option
+                           (fun x10 : option => x10)
+                       with
+                       | Some (_, _, _, _)%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                              (((s2 -> s5) -> s8) -> s)%ptype
+                           then
+                            v <- type.try_make_transport_cps s2 ℤ;
+                            v0 <- type.try_make_transport_cps s5 ℤ;
+                            v1 <- type.try_make_transport_cps s8 ℤ;
+                            v2 <- type.try_make_transport_cps s ℤ;
+                            fv <- (if
+                                    (ZRange.normalize args <=?
+                                     - ZRange.normalize args1)%zrange &&
+                                    (ZRange.normalize args2 <=?
+                                     - ZRange.normalize args4)%zrange
+                                   then
+                                    Some
+                                      (UnderLet
+                                         (#(Z_cast2
+                                              (Datatypes.fst range,
+                                              - Datatypes.snd range))%expr @
+                                          (#(Z_sub_with_get_borrow)%expr @
+                                           v (Compile.reflect x3) @
+                                           (#(Z_cast args2)%expr @
+                                            v0 (Compile.reflect x6)) @
+                                           v2 (Compile.reflect x0) @
+                                           (#(Z_cast args)%expr @
+                                            v1 (Compile.reflect x9))))%expr_pat
+                                         (fun vc : var (ℤ * ℤ)%etype =>
+                                          Base
+                                            (#(Z_cast (Datatypes.fst range))%expr @
+                                             (#(fst)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               ($vc)%expr)),
+                                            #(Z_cast (Datatypes.snd range))%expr @
+                                            (-
+                                             (#(Z_cast
+                                                  (- Datatypes.snd range))%expr @
+                                              (#(snd)%expr @
+                                               (#(Z_cast2
+                                                    (Datatypes.fst range,
+                                                    - Datatypes.snd range))%expr @
+                                                $vc)))%expr_pat)%expr)%expr_pat))
+                                   else None);
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end
+                   | (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       ($_)%expr _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       (_ @ _) _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                   | (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ #(_)))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                       None
+                   | (@expr.Ident _ _ _ t3 idc3 @ #(_))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ (($_)%expr @ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ (_ @ _ @ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                       None
+                   | _ => None
+                   end;;
+                   match x0 with
+                   | (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       (@expr.Ident _ _ _ t5 idc5) x9))%expr_pat =>
+                       args <- invert_bind_args idc5 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc4 Raw.ident.Z_opp;
+                       args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                       args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc1 Raw.ident.Z_opp;
+                       args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc
+                              Raw.ident.Z_add_with_get_carry;
+                       match
+                         pattern.type.unify_extracted_cps
+                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                           (((s2 -> s5) -> s0) -> s8)%ptype option
+                           (fun x10 : option => x10)
+                       with
+                       | Some (_, _, _, _)%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                              (((s2 -> s5) -> s0) -> s8)%ptype
+                           then
+                            v <- type.try_make_transport_cps s2 ℤ;
+                            v0 <- type.try_make_transport_cps s5 ℤ;
+                            v1 <- type.try_make_transport_cps s0 ℤ;
+                            v2 <- type.try_make_transport_cps s8 ℤ;
+                            fv <- (if
+                                    (ZRange.normalize args <=?
+                                     - ZRange.normalize args1)%zrange &&
+                                    (ZRange.normalize args2 <=?
+                                     - ZRange.normalize args4)%zrange
+                                   then
+                                    Some
+                                      (UnderLet
+                                         (#(Z_cast2
+                                              (Datatypes.fst range,
+                                              - Datatypes.snd range))%expr @
+                                          (#(Z_sub_with_get_borrow)%expr @
+                                           v (Compile.reflect x3) @
+                                           (#(Z_cast args2)%expr @
+                                            v0 (Compile.reflect x6)) @
+                                           v1 (Compile.reflect x1) @
+                                           (#(Z_cast args)%expr @
+                                            v2 (Compile.reflect x9))))%expr_pat
+                                         (fun vc : var (ℤ * ℤ)%etype =>
+                                          Base
+                                            (#(Z_cast (Datatypes.fst range))%expr @
+                                             (#(fst)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               ($vc)%expr)),
+                                            #(Z_cast (Datatypes.snd range))%expr @
+                                            (-
+                                             (#(Z_cast
+                                                  (- Datatypes.snd range))%expr @
+                                              (#(snd)%expr @
+                                               (#(Z_cast2
+                                                    (Datatypes.fst range,
+                                                    - Datatypes.snd range))%expr @
+                                                $vc)))%expr_pat)%expr)%expr_pat))
+                                   else None);
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end
+                   | (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       ($_)%expr _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       (_ @ _) _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
+                       (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                   | (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ #(_)))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                       None
+                   | (@expr.Ident _ _ _ t3 idc3 @ #(_))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ (($_)%expr @ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ (_ @ _ @ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @
+                      (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                       None
+                   | _ => None
+                   end;;
+                   match x1 with
+                   | @expr.Ident _ _ _ t3 idc3 =>
+                       args <- invert_bind_args idc3 Raw.ident.Literal;
+                       args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc1 Raw.ident.Z_opp;
+                       args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc
+                              Raw.ident.Z_add_with_get_carry;
+                       match
+                         pattern.type.unify_extracted_cps
+                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                           (((s2 -> s5) -> (projT1 args)) -> s)%ptype option
+                           (fun x7 : option => x7)
+                       with
+                       | Some (_, _, _, _)%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                              (((s2 -> s5) -> (projT1 args)) -> s)%ptype
+                           then
+                            v <- type.try_make_transport_cps s2 ℤ;
+                            v0 <- type.try_make_transport_cps s5 ℤ;
+                            idc_args <- ident.unify pattern.ident.Literal
+                                          ##(projT2 args);
+                            v1 <- type.try_make_transport_cps s ℤ;
+                            fv <- (if
+                                    ((let (x7, _) := idc_args in x7) <=? 0) &&
+                                    (ZRange.normalize args0 <=?
+                                     - ZRange.normalize args2)%zrange
+                                   then
+                                    Some
+                                      (UnderLet
+                                         (#(Z_cast2
+                                              (Datatypes.fst range,
+                                              - Datatypes.snd range))%expr @
+                                          (#(Z_sub_with_get_borrow)%expr @
+                                           v (Compile.reflect x3) @
+                                           (#(Z_cast args0)%expr @
+                                            v0 (Compile.reflect x6)) @
+                                           v1 (Compile.reflect x0) @
+                                           (##(-
+                                               (let (x7, _) := idc_args in x7))%Z)%expr))%expr_pat
+                                         (fun vc : var (ℤ * ℤ)%etype =>
+                                          Base
+                                            (#(Z_cast (Datatypes.fst range))%expr @
+                                             (#(fst)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               ($vc)%expr)),
+                                            #(Z_cast (Datatypes.snd range))%expr @
+                                            (-
+                                             (#(Z_cast
+                                                  (- Datatypes.snd range))%expr @
+                                              (#(snd)%expr @
+                                               (#(Z_cast2
+                                                    (Datatypes.fst range,
+                                                    - Datatypes.snd range))%expr @
+                                                $vc)))%expr_pat)%expr)%expr_pat))
+                                   else None);
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end
+                   | _ => None
+                   end;;
+                   match x0 with
+                   | @expr.Ident _ _ _ t3 idc3 =>
+                       args <- invert_bind_args idc3 Raw.ident.Literal;
+                       args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc1 Raw.ident.Z_opp;
+                       args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc
+                              Raw.ident.Z_add_with_get_carry;
+                       match
+                         pattern.type.unify_extracted_cps
+                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                           (((s2 -> s5) -> s0) -> (projT1 args))%ptype option
+                           (fun x7 : option => x7)
+                       with
+                       | Some (_, _, _, _)%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                              (((s2 -> s5) -> s0) -> (projT1 args))%ptype
+                           then
+                            v <- type.try_make_transport_cps s2 ℤ;
+                            v0 <- type.try_make_transport_cps s5 ℤ;
+                            v1 <- type.try_make_transport_cps s0 ℤ;
+                            idc_args <- ident.unify pattern.ident.Literal
+                                          ##(projT2 args);
+                            fv <- (if
+                                    ((let (x7, _) := idc_args in x7) <=? 0) &&
+                                    (ZRange.normalize args0 <=?
+                                     - ZRange.normalize args2)%zrange
+                                   then
+                                    Some
+                                      (UnderLet
+                                         (#(Z_cast2
+                                              (Datatypes.fst range,
+                                              - Datatypes.snd range))%expr @
+                                          (#(Z_sub_with_get_borrow)%expr @
+                                           v (Compile.reflect x3) @
+                                           (#(Z_cast args0)%expr @
+                                            v0 (Compile.reflect x6)) @
+                                           v1 (Compile.reflect x1) @
+                                           (##(-
+                                               (let (x7, _) := idc_args in x7))%Z)%expr))%expr_pat
+                                         (fun vc : var (ℤ * ℤ)%etype =>
+                                          Base
+                                            (#(Z_cast (Datatypes.fst range))%expr @
+                                             (#(fst)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               ($vc)%expr)),
+                                            #(Z_cast (Datatypes.snd range))%expr @
+                                            (-
+                                             (#(Z_cast
+                                                  (- Datatypes.snd range))%expr @
+                                              (#(snd)%expr @
+                                               (#(Z_cast2
+                                                    (Datatypes.fst range,
+                                                    - Datatypes.snd range))%expr @
+                                                $vc)))%expr_pat)%expr)%expr_pat))
+                                   else None);
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end
+                   | _ => None
+                   end
+               | (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _ ($_)%expr
+                  _)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _
+                  (@expr.Abs _ _ _ _ _ _) _)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _ (_ @ _) _)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _
+                  (@expr.LetIn _ _ _ _ _ _ _) _)%expr_pat => None
+               | (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                 (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                   None
+               | _ => None
+               end;;
+               match x3 with
+               | @expr.Ident _ _ _ t1 idc1 =>
+                   match x1 with
+                   | @expr.Ident _ _ _ t2 idc2 =>
+                       match x0 with
+                       | @expr.Ident _ _ _ t3 idc3 =>
+                           args <- invert_bind_args idc3 Raw.ident.Literal;
+                           args0 <- invert_bind_args idc2 Raw.ident.Literal;
+                           args1 <- invert_bind_args idc1 Raw.ident.Literal;
+                           args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                           _ <- invert_bind_args idc
+                                  Raw.ident.Z_add_with_get_carry;
+                           match
+                             pattern.type.unify_extracted_cps
+                               (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                               ((((projT1 args1) -> s3) -> (projT1 args0)) ->
+                                (projT1 args))%ptype option
+                               (fun x5 : option => x5)
+                           with
+                           | Some (_, _, _, _)%zrange =>
+                               if
+                                type.type_beq base.type base.type.type_beq
+                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                  ((((projT1 args1) -> s3) -> (projT1 args0)) ->
+                                   (projT1 args))%ptype
+                               then
+                                idc_args <- ident.unify pattern.ident.Literal
+                                              ##(projT2 args1);
+                                v <- type.try_make_transport_cps s3 ℤ;
+                                idc_args0 <- ident.unify
+                                               pattern.ident.Literal
+                                               ##(projT2 args0);
+                                idc_args1 <- ident.unify
+                                               pattern.ident.Literal
+                                               ##(projT2 args);
+                                fv <- (if
+                                        ((let (x5, _) := idc_args0 in x5) =?
+                                         0) &&
+                                        ((let (x5, _) := idc_args1 in x5) =?
+                                         0) &&
+                                        (ZRange.normalize args2 <=?
+                                         r[0 ~> (let (x5, _) := idc_args in
+                                                 x5) - 1])%zrange &&
+                                        is_bounded_by_bool 0
+                                          (Datatypes.snd range)
+                                       then
+                                        Some
+                                          (UnderLet
+                                             (#(Z_cast2 range)%expr @
+                                              (#(Z_add_with_get_carry)%expr @
+                                               (##(let (x5, _) := idc_args in
+                                                   x5))%expr @
+                                               (#(Z_cast args2)%expr @
+                                                v (Compile.reflect x4)) @
+                                               (##(let (x5, _) :=
+                                                     idc_args0 in
+                                                   x5))%expr @
+                                               (##(let (x5, _) :=
+                                                     idc_args1 in
+                                                   x5))%expr))%expr_pat
+                                             (fun vc : var (ℤ * ℤ)%etype =>
+                                              Base
+                                                (#(Z_cast
+                                                     (Datatypes.fst range))%expr @
+                                                 (#(fst)%expr @
+                                                  (#(Z_cast2 range)%expr @
+                                                   ($vc)%expr)), (##0)%expr)%expr_pat))
+                                       else None);
+                                Some (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                               else None
+                           | None => None
+                           end
+                       | _ => None
+                       end
+                   | _ => None
+                   end
+               | _ => None
+               end
+           | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
+             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
+             (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
+             (@expr.LetIn _ _ _ _ _ _ _) _ => None
+           | _ => None
+           end;;
+           _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+           match
+             pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+               (((s2 -> s1) -> s0) -> s)%ptype option (fun x4 : option => x4)
+           with
+           | Some (_, _, _, _)%zrange =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                  (((s2 -> s1) -> s0) -> s)%ptype
+               then
+                v <- type.try_make_transport_cps s2 ℤ;
+                v0 <- type.try_make_transport_cps s1 ℤ;
+                v1 <- type.try_make_transport_cps s0 ℤ;
+                v2 <- type.try_make_transport_cps s ℤ;
+                Some
+                  (UnderLet
+                     (#(Z_cast2 range)%expr @
+                      (#(Z_add_with_get_carry)%expr @ v (Compile.reflect x3) @
+                       v0 (Compile.reflect x2) @ v1 (Compile.reflect x1) @
+                       v2 (Compile.reflect x0)))%expr_pat
+                     (fun v3 : var (ℤ * ℤ)%etype =>
+                      Base
+                        (#(Z_cast (Datatypes.fst range))%expr @
+                         (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v3)%expr)),
+                        #(Z_cast (Datatypes.snd range))%expr @
+                        (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v3)%expr)))%expr_pat))
+               else None
+           | None => None
+           end);;
+          _ <- invert_bind_args idc Raw.ident.Z_sub_with_get_borrow;
+          match
+            pattern.type.unify_extracted_cps (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+              (((s2 -> s1) -> s0) -> s)%ptype option (fun x4 : option => x4)
+          with
+          | Some (_, _, _, _)%zrange =>
+              if
+               type.type_beq base.type base.type.type_beq
+                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((s2 -> s1) -> s0) -> s)%ptype
+              then
+               v <- type.try_make_transport_cps s2 ℤ;
+               v0 <- type.try_make_transport_cps s1 ℤ;
+               v1 <- type.try_make_transport_cps s0 ℤ;
+               v2 <- type.try_make_transport_cps s ℤ;
+               Some
+                 (UnderLet
+                    (#(Z_cast2 range)%expr @
+                     (#(Z_sub_with_get_borrow)%expr @ v (Compile.reflect x3) @
+                      v0 (Compile.reflect x2) @ v1 (Compile.reflect x1) @
+                      v2 (Compile.reflect x0)))%expr_pat
+                    (fun v3 : var (ℤ * ℤ)%etype =>
+                     Base
+                       (#(Z_cast (Datatypes.fst range))%expr @
+                        (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v3)%expr)),
+                       #(Z_cast (Datatypes.snd range))%expr @
+                       (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v3)%expr)))%expr_pat))
+              else None
+          | None => None
+          end
+      | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _ (@expr.App _ _ _ s2 _ ($_)%expr _) _) _) _ |
+        @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.App _ _ _ s2 _ (@expr.Abs _ _ _ _ _ _) _) _) _) _ |
+        @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _ (@expr.App _ _ _ s2 _ (_ @ _)%expr_pat _) _)
+         _) _ | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.App _ _ _ s2 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _) _ =>
+          None
+      | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ ($_)%expr _) _) _ |
+        @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _ (@expr.Abs _ _ _ _ _ _) _) _) _ | @expr.App _
+        _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ => None
+      | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
+        _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
+        @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+      | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
+        _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+      | _ => None
+      end;;
+      None);;;
+     Base (#(Z_cast2 range)%expr @ x)%expr_pat)%option
 | fancy_add log2wordmax imm =>
     fun x : expr (ℤ * ℤ)%etype =>
     Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat

--- a/src/Experiments/NewPipeline/nbe_rewrite_head.out
+++ b/src/Experiments/NewPipeline/nbe_rewrite_head.out
@@ -3002,9 +3002,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
               then
                idc_args <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some
-                 (Base
-                    (##(Definitions.Z.bneg (let (x0, _) := idc_args in x0)))%expr)
+               Some (Base (##(Z.bneg (let (x0, _) := idc_args in x0)))%expr)
               else None
           | None => None
           end
@@ -3036,8 +3034,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   ##(projT2 args);
                    Some
                      (Base
-                        (##(Definitions.Z.lnot_modulo
-                              (let (x1, _) := idc_args in x1)
+                        (##(Z.lnot_modulo (let (x1, _) := idc_args in x1)
                               (let (x1, _) := idc_args0 in x1)))%expr)
                   else None
               | None => None
@@ -3080,8 +3077,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (Base
                             (let
                              '(a1, b1)%zrange :=
-                              Definitions.Z.mul_split
-                                (let (x2, _) := idc_args in x2)
+                              Z.mul_split (let (x2, _) := idc_args in x2)
                                 (let (x2, _) := idc_args0 in x2)
                                 (let (x2, _) := idc_args1 in x2) in
                               ((##a1)%expr, (##b1)%expr)%expr_pat))
@@ -3128,7 +3124,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (Base
                             (let
                              '(a1, b1)%zrange :=
-                              Definitions.Z.add_get_carry_full
+                              Z.add_get_carry_full
                                 (let (x2, _) := idc_args in x2)
                                 (let (x2, _) := idc_args0 in x2)
                                 (let (x2, _) := idc_args1 in x2) in
@@ -3174,7 +3170,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       ##(projT2 args);
                        Some
                          (Base
-                            (##(Definitions.Z.add_with_carry
+                            (##(Z.add_with_carry
                                   (let (x2, _) := idc_args in x2)
                                   (let (x2, _) := idc_args0 in x2)
                                   (let (x2, _) := idc_args1 in x2)))%expr)
@@ -3229,7 +3225,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (Base
                                 (let
                                  '(a2, b2)%zrange :=
-                                  Definitions.Z.add_with_get_carry_full
+                                  Z.add_with_get_carry_full
                                     (let (x3, _) := idc_args in x3)
                                     (let (x3, _) := idc_args0 in x3)
                                     (let (x3, _) := idc_args1 in x3)
@@ -3280,7 +3276,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (Base
                             (let
                              '(a1, b1)%zrange :=
-                              Definitions.Z.sub_get_borrow_full
+                              Z.sub_get_borrow_full
                                 (let (x2, _) := idc_args in x2)
                                 (let (x2, _) := idc_args0 in x2)
                                 (let (x2, _) := idc_args1 in x2) in
@@ -3336,7 +3332,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (Base
                                 (let
                                  '(a2, b2)%zrange :=
-                                  Definitions.Z.sub_with_get_borrow_full
+                                  Z.sub_with_get_borrow_full
                                     (let (x3, _) := idc_args in x3)
                                     (let (x3, _) := idc_args0 in x3)
                                     (let (x3, _) := idc_args1 in x3)
@@ -3385,8 +3381,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       ##(projT2 args);
                        Some
                          (Base
-                            (##(Definitions.Z.zselect
-                                  (let (x2, _) := idc_args in x2)
+                            (##(Z.zselect (let (x2, _) := idc_args in x2)
                                   (let (x2, _) := idc_args0 in x2)
                                   (let (x2, _) := idc_args1 in x2)))%expr)
                       else None
@@ -3430,8 +3425,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       ##(projT2 args);
                        Some
                          (Base
-                            (##(Definitions.Z.add_modulo
-                                  (let (x2, _) := idc_args in x2)
+                            (##(Z.add_modulo (let (x2, _) := idc_args in x2)
                                   (let (x2, _) := idc_args0 in x2)
                                   (let (x2, _) := idc_args1 in x2)))%expr)
                       else None
@@ -3483,8 +3477,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                           ##(projT2 args);
                            Some
                              (Base
-                                (##(Definitions.Z.rshi
-                                      (let (x3, _) := idc_args in x3)
+                                (##(Z.rshi (let (x3, _) := idc_args in x3)
                                       (let (x3, _) := idc_args0 in x3)
                                       (let (x3, _) := idc_args1 in x3)
                                       (let (x3, _) := idc_args2 in x3)))%expr)
@@ -3525,8 +3518,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   ##(projT2 args);
                    Some
                      (Base
-                        (##(Definitions.Z.cc_m
-                              (let (x1, _) := idc_args in x1)
+                        (##(Z.cc_m (let (x1, _) := idc_args in x1)
                               (let (x1, _) := idc_args0 in x1)))%expr)
                   else None
               | None => None


### PR DESCRIPTION
Because we need to do extra passes of DCE and subst01 to fully reduce
things, we generalize some of the interp proofs over cast behavior.

For ease of rewriting, we make [ident.interp] an alias (notation) for
[ident.gen_interp], rather than a [Definition].

We also factor out the rewriting wrapper inside the pipeline module into
its own definition.

Unfortunately, this incurs non-trivial slow-down:
```
After     | File Name                                                            | Before    || Change    | % Change
---------------------------------------------------------------------------------------------------------------------
32m09.80s | Total                                                                | 26m07.22s || +6m02.58s | +23.13%
---------------------------------------------------------------------------------------------------------------------
6m41.53s  | p384_32.c                                                            | 0m28.22s  || +6m13.30s | +1322.85%
1m19.67s  | Experiments/NewPipeline/Rewriter.vo                                  | 2m22.97s  || -1m03.29s | -44.27%
0m21.90s  | secp256k1_32.c                                                       | 0m06.46s  || +0m15.43s | +239.00%
0m21.24s  | p256_32.c                                                            | 0m06.32s  || +0m14.91s | +236.07%
6m18.26s  | Experiments/NewPipeline/SlowPrimeSynthesisExamples.vo                | 6m13.65s  || +0m04.61s | +1.23%
0m14.12s  | p384_64.c                                                            | 0m10.22s  || +0m03.89s | +38.16%
0m07.86s  | p224_32.c                                                            | 0m03.92s  || +0m03.94s | +100.51%
4m34.19s  | Experiments/NewPipeline/Toplevel1.vo                                 | 4m37.15s  || -0m02.95s | -1.06%
1m41.50s  | Experiments/NewPipeline/Toplevel2.vo                                 | 1m38.62s  || +0m02.87s | +2.92%
0m37.69s  | p521_64.c                                                            | 0m35.62s  || +0m02.07s | +5.81%
0m29.75s  | Experiments/NewPipeline/ExtractionHaskell/unsaturated_solinas        | 0m27.09s  || +0m02.66s | +9.81%
0m17.88s  | Experiments/NewPipeline/ExtractionOCaml/saturated_solinas            | 0m15.52s  || +0m02.35s | +15.20%
1m47.75s  | Experiments/NewPipeline/RewriterRulesInterpGood.vo                   | 1m46.74s  || +0m01.00s | +0.94%
0m44.38s  | p521_32.c                                                            | 0m42.47s  || +0m01.91s | +4.49%
0m43.92s  | Experiments/NewPipeline/ExtractionHaskell/word_by_word_montgomery    | 0m41.97s  || +0m01.95s | +4.64%
0m24.99s  | Experiments/NewPipeline/ExtractionOCaml/unsaturated_solinas          | 0m26.52s  || -0m01.53s | -5.76%
0m20.62s  | Experiments/NewPipeline/ExtractionHaskell/saturated_solinas          | 0m22.26s  || -0m01.64s | -7.36%
0m11.42s  | Experiments/NewPipeline/ExtractionOCaml/word_by_word_montgomery.ml   | 0m12.88s  || -0m01.46s | -11.33%
0m08.44s  | Experiments/NewPipeline/ExtractionHaskell/word_by_word_montgomery.hs | 0m07.12s  || +0m01.31s | +18.53%
```

Fortunately, the arithmetic rewrite rules are now all proven.  (The fancy-machine rules still need adjustment and proofs.)

In a future version, I hope we can recover the time lost here by fusing bounds analysis into the rewriter, possibly by augmenting the expression tree with abstract state.