### PR TITLE
Switch to a more precise version of interp_related for rewrites

### DIFF
--- a/src/Experiments/NewPipeline/LanguageWf.v
+++ b/src/Experiments/NewPipeline/LanguageWf.v
@@ -565,6 +565,25 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
         End inversion.
       End with_var.
 
+      Section with_interp.
+        Context {interp_base_type : base_type -> Type}
+                {interp_ident : forall t, ident t -> type.interp interp_base_type t}.
+
+        Lemma eqv_of_interp_related {t e v}
+          : expr.interp_related interp_ident e v
+            -> @type.eqv t (expr.interp interp_ident e) v.
+        Proof using Type.
+          induction e; cbn [expr.interp_related expr.interp type.related]; cbv [respectful LetIn.Let_In].
+          all: repeat first [ progress intros
+                            | assumption
+                            | solve [ eauto ]
+                            | progress destruct_head'_ex
+                            | progress destruct_head'_and
+                            | progress subst
+                            | match goal with H : _ |- _ => apply H; clear H end ].
+        Qed.
+      End with_interp.
+
       Section with_var3.
         Context {var1 var2 var3 : type.type base_type -> Type}.
         Local Notation wfvP := (fun t => (var1 t * var2 t * var3 t)%type).

--- a/src/Experiments/NewPipeline/RewriterWf1.v
+++ b/src/Experiments/NewPipeline/RewriterWf1.v
@@ -2049,6 +2049,23 @@ Module Compilers.
                               | apply reify_interp_related ].
           Qed.
 
+          Lemma value_of_rawexpr_interp_related {e v}
+            : rawexpr_interp_related e v -> value_interp_related (value_of_rawexpr e) v.
+          Proof using Type.
+            destruct e; cbn [rawexpr_interp_related value_of_rawexpr]; break_innermost_match.
+            all: repeat first [ progress intros
+                              | exfalso; assumption
+                              | progress inversion_sigma
+                              | progress subst
+                              | progress cbn [eq_rect expr.interp type_of_rawexpr] in *
+                              | progress destruct_head'_ex
+                              | progress destruct_head'_and
+                              | assumption
+                              | apply reflect_interp_related
+                              | progress cbn [expr_interp_related]
+                              | solve [ eauto ] ].
+          Qed.
+
           Fixpoint pattern_default_interp' {K t} (p : pattern t) evm {struct p} : (var (pattern.type.subst_default t evm) -> K) -> @with_unification_resultT' var t p evm K
             := match p in pattern.pattern t return (var (pattern.type.subst_default t evm) -> K) -> @with_unification_resultT' var t p evm K with
                | pattern.Wildcard t => fun k v => k v

--- a/src/Experiments/NewPipeline/RewriterWf2.v
+++ b/src/Experiments/NewPipeline/RewriterWf2.v
@@ -139,8 +139,8 @@ Module Compilers.
           Local Notation wf_with_unification_resultT := (@wf_with_unification_resultT ident pident pident_arg_types type_vars_of_pident var1 var2).
           Local Notation wf_with_unif_rewrite_ruleTP_gen := (@wf_with_unif_rewrite_ruleTP_gen ident pident pident_arg_types type_vars_of_pident var1 var2).
           Local Notation wf_deep_rewrite_ruleTP_gen := (@wf_deep_rewrite_ruleTP_gen ident var1 var2).
-          Local Notation app_with_unification_resultT_cps1 := (@app_with_unification_resultT_cps ident var1 pident pident_arg_types type_vars_of_pident).
-          Local Notation app_with_unification_resultT_cps2 := (@app_with_unification_resultT_cps ident var2 pident pident_arg_types type_vars_of_pident).
+          Local Notation app_with_unification_resultT_cps1 := (@app_with_unification_resultT_cps pident pident_arg_types type_vars_of_pident (@value var1)).
+          Local Notation app_with_unification_resultT_cps2 := (@app_with_unification_resultT_cps pident pident_arg_types type_vars_of_pident (@value var2)).
           Local Notation wf_app_with_unification_resultT := (@wf_app_with_unification_resultT ident pident pident_arg_types type_vars_of_pident var1 var2).
 
           (* Because [proj1] and [proj2] in the stdlib are opaque *)


### PR DESCRIPTION
This version is hopefully the right one.  It seems to be basically
exactly what we want to say, and no more and no less.  The rule for
let-ins, which is almost the only freedom we have here, is chosen to
match exactly with the rule for App+Abs.  Note that using Leibniz
equality is essential in the places where it's used.  The recursive
relation here might actually be a bit clearer as an inductive relation,
but I wanted it to simplify under reduction.

(I still need to actually prove all the generic rewriter interp proofs using this)