### PR TITLE
Insert casts before literals during bounds analysis

### DIFF
--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -311,6 +311,7 @@ Module Pipeline.
                       => RewriteRules.RewriteToFancyWithCasts invert_low invert_high value_range flag_range E
                     | None => E
                     end in
+           let E := RewriteRules.RewriteStripLiteralCasts E in
            Success E
       | inr (inl (b, E))
         => Error (Computed_bounds_are_not_tight_enough b out_bounds E arg_bounds)

--- a/src/RewriterProofs.v
+++ b/src/RewriterProofs.v
@@ -94,6 +94,11 @@ Module Compilers.
       start_Wf_proof arith_with_casts_rewrite_head_eq arith_with_casts_all_rewrite_rules_eq (@arith_with_casts_rewrite_head0).
       apply arith_with_casts_rewrite_rules_good.
     Qed.
+    Lemma Wf_RewriteStripLiteralCasts {t} e (Hwf : Wf e) : Wf (@RewriteStripLiteralCasts t e).
+    Proof.
+      start_Wf_proof strip_literal_casts_rewrite_head_eq strip_literal_casts_all_rewrite_rules_eq (@strip_literal_casts_rewrite_head0).
+      apply strip_literal_casts_rewrite_rules_good.
+    Qed.
     Lemma Wf_RewriteToFancy (invert_low invert_high : Z -> Z -> option Z)
             (Hlow : forall s v v', invert_low s v = Some v' -> v = Z.land v' (2^(s/2)-1))
             (Hhigh : forall s v v', invert_high s v = Some v' -> v = Z.shiftr v' (s/2))
@@ -136,6 +141,14 @@ Module Compilers.
       apply arith_with_casts_rewrite_rules_interp_good.
     Qed.
 
+    Lemma Interp_gen_RewriteStripLiteralCasts {cast_outside_of_range} {t} e (Hwf : Wf e)
+      : expr.Interp (@ident.gen_interp cast_outside_of_range) (@RewriteStripLiteralCasts t e)
+        == expr.Interp (@ident.gen_interp cast_outside_of_range) e.
+    Proof.
+      start_Interp_proof strip_literal_casts_rewrite_head_eq strip_literal_casts_all_rewrite_rules_eq (@strip_literal_casts_rewrite_head0).
+      apply strip_literal_casts_rewrite_rules_interp_good.
+    Qed.
+
     Lemma Interp_gen_RewriteToFancy {cast_outside_of_range} (invert_low invert_high : Z -> Z -> option Z)
           (Hlow : forall s v v', invert_low s v = Some v' -> v = Z.land v' (2^(s/2)-1))
           (Hhigh : forall s v v', invert_high s v = Some v' -> v = Z.shiftr v' (s/2))
@@ -167,6 +180,9 @@ Module Compilers.
     Lemma Interp_RewriteArithWithCasts {t} e (Hwf : Wf e)
       : Interp (@RewriteArithWithCasts t e) == Interp e.
     Proof. apply Interp_gen_RewriteArithWithCasts; assumption. Qed.
+    Lemma Interp_RewriteStripLiteralCasts {t} e (Hwf : Wf e)
+      : Interp (@RewriteStripLiteralCasts t e) == Interp e.
+    Proof. apply Interp_gen_RewriteStripLiteralCasts; assumption. Qed.
     Lemma Interp_RewriteToFancy (invert_low invert_high : Z -> Z -> option Z)
           (Hlow : forall s v v', invert_low s v = Some v' -> v = Z.land v' (2^(s/2)-1))
           (Hhigh : forall s v v', invert_high s v = Some v' -> v = Z.shiftr v' (s/2))
@@ -193,6 +209,6 @@ Module Compilers.
     : Interp (@PartialEvaluate t e) == Interp e.
   Proof. apply Interp_gen_PartialEvaluate; assumption. Qed.
 
-  Hint Resolve Wf_PartialEvaluate Wf_RewriteArith Wf_RewriteNBE Wf_RewriteToFancy Wf_RewriteArithWithCasts Wf_RewriteToFancyWithCasts : wf.
-  Hint Rewrite @Interp_gen_PartialEvaluate @Interp_gen_RewriteArith @Interp_gen_RewriteNBE @Interp_gen_RewriteToFancy @Interp_gen_RewriteArithWithCasts @Interp_gen_RewriteToFancyWithCasts @Interp_PartialEvaluate @Interp_RewriteArith @Interp_RewriteNBE @Interp_RewriteToFancy @Interp_RewriteArithWithCasts @Interp_RewriteToFancyWithCasts : interp.
+  Hint Resolve Wf_PartialEvaluate Wf_RewriteArith Wf_RewriteNBE Wf_RewriteToFancy Wf_RewriteArithWithCasts Wf_RewriteStripLiteralCasts Wf_RewriteToFancyWithCasts : wf.
+  Hint Rewrite @Interp_gen_PartialEvaluate @Interp_gen_RewriteArith @Interp_gen_RewriteNBE @Interp_gen_RewriteToFancy @Interp_gen_RewriteArithWithCasts @Interp_gen_RewriteStripLiteralCasts @Interp_gen_RewriteToFancyWithCasts @Interp_PartialEvaluate @Interp_RewriteArith @Interp_RewriteNBE @Interp_RewriteToFancy @Interp_RewriteArithWithCasts @Interp_RewriteStripLiteralCasts @Interp_RewriteToFancyWithCasts : interp.
 End Compilers.

--- a/src/RewriterRulesGood.v
+++ b/src/RewriterRulesGood.v
@@ -62,6 +62,9 @@ Module Compilers.
     Lemma arith_with_casts_rewrite_head_eq : @arith_with_casts_rewrite_head = @arith_with_casts_rewrite_head0.
     Proof. reflexivity. Qed.
 
+    Lemma strip_literal_casts_rewrite_head_eq : (fun var do_again => @strip_literal_casts_rewrite_head var) = @strip_literal_casts_rewrite_head0.
+    Proof. reflexivity. Qed.
+
     Lemma nbe_all_rewrite_rules_eq : @nbe_all_rewrite_rules = @nbe_rewrite_rules.
     Proof. reflexivity. Qed.
 
@@ -75,6 +78,9 @@ Module Compilers.
     Proof. reflexivity. Qed.
 
     Lemma arith_with_casts_all_rewrite_rules_eq : @arith_with_casts_all_rewrite_rules = @arith_with_casts_rewrite_rules.
+    Proof. reflexivity. Qed.
+
+    Lemma strip_literal_casts_all_rewrite_rules_eq : @strip_literal_casts_all_rewrite_rules = @strip_literal_casts_rewrite_rules.
     Proof. reflexivity. Qed.
 
     Section good.
@@ -353,6 +359,13 @@ Module Compilers.
 
       Lemma arith_with_casts_rewrite_rules_good
         : rewrite_rules_goodT arith_with_casts_rewrite_rules arith_with_casts_rewrite_rules.
+      Proof using Type.
+        Time start_good.
+        Time all: repeat good_t_step.
+      Qed.
+
+      Lemma strip_literal_casts_rewrite_rules_good
+        : rewrite_rules_goodT strip_literal_casts_rewrite_rules strip_literal_casts_rewrite_rules.
       Proof using Type.
         Time start_good.
         Time all: repeat good_t_step.

--- a/src/RewriterRulesInterpGood.v
+++ b/src/RewriterRulesInterpGood.v
@@ -743,6 +743,13 @@ Module Compilers.
         Time all: try solve [ repeat interp_good_t_step_related; repeat interp_good_t_step_arith; fin_with_nia ].
       Qed.
 
+      Lemma strip_literal_casts_rewrite_rules_interp_good
+        : rewrite_rules_interp_goodT strip_literal_casts_rewrite_rules.
+      Proof using Type.
+        Time start_interp_good.
+        Time all: try solve [ repeat interp_good_t_step_related; repeat interp_good_t_step_arith ].
+      Qed.
+
       Local Ltac fancy_local_t :=
         repeat match goal with
                | [ H : forall s v v', ?invert_low s v = Some v' -> v = _,

--- a/src/arith_with_casts_rewrite_head.out
+++ b/src/arith_with_casts_rewrite_head.out
@@ -216,77 +216,150 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | @List_nth_default T =>
     fun (x : expr T) (x0 : expr (list T)) (x1 : expr ℕ) =>
     Base (#(List_nth_default)%expr @ x @ x0 @ x1)%expr_pat
-| Z_add => fun x x0 : expr ℤ => Base (x + x0)%expr
+| Z_add =>
+    fun x x0 : expr ℤ =>
+    (((match x with
+       | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
+           args <- invert_bind_args idc0 Raw.ident.Literal;
+           args0 <- invert_bind_args idc Raw.ident.Z_cast;
+           match
+             pattern.type.unify_extracted (ℤ -> ℤ)%ptype
+               ((projT1 args) -> ℤ)%ptype
+           with
+           | Some (_, _)%zrange =>
+               if
+                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                  ((projT1 args) -> ℤ)%ptype
+               then
+                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
+                fv <- (x2 <- (if
+                               ((let (x2, _) := xv in x2) =? 0) &&
+                               is_bounded_by_bool (let (x2, _) := xv in x2)
+                                 (ZRange.normalize args0)
+                              then Some x0
+                              else None);
+                       Some (Base x2));
+                Some (fv0 <-- fv;
+                      Base fv0)%under_lets
+               else None
+           | None => None
+           end
+       | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+         (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
+         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+           None
+       | _ => None
+       end;;
+       match x0 with
+       | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
+           args <- invert_bind_args idc0 Raw.ident.Literal;
+           args0 <- invert_bind_args idc Raw.ident.Z_cast;
+           match
+             pattern.type.unify_extracted (ℤ -> ℤ)%ptype
+               (ℤ -> (projT1 args))%ptype
+           with
+           | Some (_, _)%zrange =>
+               if
+                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                  (ℤ -> (projT1 args))%ptype
+               then
+                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
+                fv <- (x2 <- (if
+                               ((let (x2, _) := xv in x2) =? 0) &&
+                               is_bounded_by_bool (let (x2, _) := xv in x2)
+                                 (ZRange.normalize args0)
+                              then Some x
+                              else None);
+                       Some (Base x2));
+                Some (fv0 <-- fv;
+                      Base fv0)%under_lets
+               else None
+           | None => None
+           end
+       | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+         (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
+         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+           None
+       | _ => None
+       end);;
+      None);;;
+     Base (x + x0)%expr)%option
 | Z_mul => fun x x0 : expr ℤ => Base (x * x0)%expr
 | Z_pow => fun x x0 : expr ℤ => Base (#(Z_pow)%expr @ x @ x0)%expr_pat
 | Z_sub =>
     fun x x0 : expr ℤ =>
     ((match x with
-      | @expr.Ident _ _ _ t idc =>
+      | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
           match x0 with
-          | (@expr.Ident _ _ _ t0 idc0 @
-             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _
-              (@expr.Ident _ _ _ t2 idc2) x3))%expr_pat =>
-              args <- invert_bind_args idc2 Raw.ident.Z_cast;
-              _ <- invert_bind_args idc1 Raw.ident.Z_opp;
-              args1 <- invert_bind_args idc0 Raw.ident.Z_cast;
-              args2 <- invert_bind_args idc Raw.ident.Literal;
+          | (@expr.Ident _ _ _ t1 idc1 @
+             (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s2 _
+              (@expr.Ident _ _ _ t3 idc3) x4))%expr_pat =>
+              args <- invert_bind_args idc3 Raw.ident.Z_cast;
+              _ <- invert_bind_args idc2 Raw.ident.Z_opp;
+              args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
+              args2 <- invert_bind_args idc0 Raw.ident.Literal;
+              args3 <- invert_bind_args idc Raw.ident.Z_cast;
               match
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
-                  ((projT1 args2) -> s1)%ptype
+                  ((projT1 args2) -> s2)%ptype
               with
               | Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
-                     ((projT1 args2) -> s1)%ptype
+                     ((projT1 args2) -> s2)%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args2);
-                   v <- type.try_make_transport_cps s1 ℤ;
-                   fv <- (x4 <- (if
-                                  ((let (x4, _) := xv in x4) =? 0) &&
+                   v <- type.try_make_transport_cps s2 ℤ;
+                   fv <- (x5 <- (if
+                                  ((let (x5, _) := xv in x5) =? 0) &&
                                   (ZRange.normalize args <=?
-                                   - ZRange.normalize args1)%zrange
+                                   - ZRange.normalize args1)%zrange &&
+                                  is_bounded_by_bool
+                                    (let (x5, _) := xv in x5) args3
                                  then
                                   Some
                                     (#(Z_cast args)%expr @
-                                     v (Compile.reflect x3))%expr_pat
+                                     v (Compile.reflect x4))%expr_pat
                                  else None);
-                          Some (Base x4));
+                          Some (Base x5));
                    Some (fv0 <-- fv;
                          Base fv0)%under_lets
                   else None
               | None => None
               end
-          | (@expr.Ident _ _ _ t0 idc0 @
-             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _ ($_)%expr _))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @
-             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _
+          | (@expr.Ident _ _ _ t1 idc1 @
+             (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s2 _ ($_)%expr _))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @
+             (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s2 _
               (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @
-             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _ (_ @ _) _))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @
-             (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s1 _
+            (@expr.Ident _ _ _ t1 idc1 @
+             (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s2 _ (_ @ _) _))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @
+             (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s2 _
               (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
-          | (@expr.Ident _ _ _ t0 idc0 @ (@expr.Ident _ _ _ t1 idc1 @ #(_)))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @
-             (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @
-             (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @
-             (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+          | (@expr.Ident _ _ _ t1 idc1 @ (@expr.Ident _ _ _ t2 idc2 @ #(_)))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @
+             (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @
+             (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @
+             (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
               None
-          | (@expr.Ident _ _ _ t0 idc0 @ #(_))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @ (($_)%expr @ _))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @ (_ @ _ @ _))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+          | (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @ (($_)%expr @ _))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @ (_ @ _ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
               None
           | _ => None
           end;;
-          args <- invert_bind_args idc Raw.ident.Literal;
+          args <- invert_bind_args idc0 Raw.ident.Literal;
+          args0 <- invert_bind_args idc Raw.ident.Z_cast;
           match
             pattern.type.unify_extracted (ℤ -> ℤ)%ptype
               ((projT1 args) -> ℤ)%ptype
@@ -297,15 +370,23 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((projT1 args) -> ℤ)%ptype
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
+               fv <- (x2 <- (if
+                              ((let (x2, _) := xv in x2) =? 0) &&
+                              is_bounded_by_bool (let (x2, _) := xv in x2)
+                                (ZRange.normalize args0)
                              then Some (- x0)%expr
                              else None);
-                      Some (Base x1));
+                      Some (Base x2));
                Some (fv0 <-- fv;
                      Base fv0)%under_lets
               else None
           | None => None
           end
+      | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+          None
       | _ => None
       end;;
       None);;;
@@ -380,8 +461,9 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_shiftl =>
     fun x x0 : expr ℤ =>
     (match x with
-     | @expr.Ident _ _ _ t idc =>
-         args <- invert_bind_args idc Raw.ident.Literal;
+     | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
+         args <- invert_bind_args idc0 Raw.ident.Literal;
+         args0 <- invert_bind_args idc Raw.ident.Z_cast;
          match
            pattern.type.unify_extracted (ℤ -> ℤ)%ptype
              ((projT1 args) -> ℤ)%ptype
@@ -392,15 +474,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 ((projT1 args) -> ℤ)%ptype
              then
               xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-              fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
+              fv <- (x2 <- (if
+                             ((let (x2, _) := xv in x2) =? 0) &&
+                             is_bounded_by_bool (let (x2, _) := xv in x2)
+                               (ZRange.normalize args0)
                             then Some (##0)%expr
                             else None);
-                     Some (Base x1));
+                     Some (Base x2));
               Some (fv0 <-- fv;
                     Base fv0)%under_lets
              else None
          | None => None
          end
+     | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+       (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+       (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
+       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
      | _ => None
      end;;;
      Base (x << x0)%expr)%option
@@ -411,269 +500,375 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
 | Z_mul_split =>
     fun x x0 x1 : expr ℤ =>
-    ((match x with
-      | @expr.Ident _ _ _ t idc =>
-          match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args <- invert_bind_args idc0 Raw.ident.Literal;
-              args0 <- invert_bind_args idc Raw.ident.Literal;
-              match
-                pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                  (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
-              with
-              | Some (_, _, _)%zrange =>
-                  if
-                   type.type_beq base.type base.type.type_beq
-                     ((ℤ -> ℤ) -> ℤ)%ptype
-                     (((projT1 args0) -> (projT1 args)) -> ℤ)%ptype
-                  then
-                   _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                   xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   fv <- (x2 <- (if (let (x2, _) := xv0 in x2) =? 0
-                                 then Some ((##0)%expr, (##0)%expr)%expr_pat
-                                 else None);
-                          Some (Base x2));
-                   Some (fv0 <-- fv;
-                         Base fv0)%under_lets
-                  else None
-              | None => None
-              end
-          | _ => None
-          end;;
-          match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              (args <- invert_bind_args idc0 Raw.ident.Literal;
-               args0 <- invert_bind_args idc Raw.ident.Literal;
+    (((match x0 with
+       | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
+           args <- invert_bind_args idc0 Raw.ident.Literal;
+           args0 <- invert_bind_args idc Raw.ident.Z_cast;
+           match
+             pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
+               ((ℤ -> (projT1 args)) -> ℤ)%ptype
+           with
+           | Some (_, _, _)%zrange =>
+               if
+                type.type_beq base.type base.type.type_beq
+                  ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> (projT1 args)) -> ℤ)%ptype
+               then
+                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
+                fv <- (x3 <- (if
+                               ((let (x3, _) := xv in x3) =? 0) &&
+                               is_bounded_by_bool (let (x3, _) := xv in x3)
+                                 (ZRange.normalize args0)
+                              then
+                               Some
+                                 (#(Z_cast r[0 ~> 0])%expr @ (##0)%expr,
+                                 #(Z_cast r[0 ~> 0])%expr @ (##0)%expr)%expr_pat
+                              else None);
+                       Some (Base x3));
+                Some (fv0 <-- fv;
+                      Base fv0)%under_lets
+               else None
+           | None => None
+           end
+       | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+         (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
+         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+           None
+       | _ => None
+       end;;
+       match x1 with
+       | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
+           match x2 with
+           | @expr.Ident _ _ _ t0 idc0 =>
+               args <- invert_bind_args idc0 Raw.ident.Literal;
+               args0 <- invert_bind_args idc Raw.ident.Z_cast;
                match
                  pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                   (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
+                   ((ℤ -> ℤ) -> (projT1 args))%ptype
                with
                | Some (_, _, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq
-                      ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args0) -> ℤ) -> (projT1 args))%ptype
+                      ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> (projT1 args))%ptype
                    then
-                    _ <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                    fv <- (x2 <- (if (let (x2, _) := xv0 in x2) =? 0
-                                  then Some ((##0)%expr, (##0)%expr)%expr_pat
+                    xv <- ident.unify pattern.ident.Literal ##(projT2 args);
+                    fv <- (x3 <- (if
+                                   ((let (x3, _) := xv in x3) =? 0) &&
+                                   is_bounded_by_bool
+                                     (let (x3, _) := xv in x3)
+                                     (ZRange.normalize args0)
+                                  then
+                                   Some
+                                     (#(Z_cast r[0 ~> 0])%expr @ (##0)%expr,
+                                     #(Z_cast r[0 ~> 0])%expr @ (##0)%expr)%expr_pat
                                   else None);
-                           Some (Base x2));
+                           Some (Base x3));
                     Some (fv0 <-- fv;
                           Base fv0)%under_lets
                    else None
                | None => None
-               end);;
-              match x0 with
-              | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t1 idc1) x2 =>
-                  args <- invert_bind_args idc1 Raw.ident.Z_cast;
-                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                  args1 <- invert_bind_args idc Raw.ident.Literal;
-                  match
-                    pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args1) -> s) -> (projT1 args0))%ptype
-                  with
-                  | Some (_, _, _)%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         ((ℤ -> ℤ) -> ℤ)%ptype
-                         (((projT1 args1) -> s) -> (projT1 args0))%ptype
-                      then
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args1);
-                       v <- type.try_make_transport_cps s ℤ;
-                       xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args0);
-                       fv <- (x3 <- (if
-                                      ((let (x3, _) := xv0 in x3) =? 1) &&
-                                      (ZRange.normalize args <=?
-                                       r[0 ~> (let (x3, _) := xv in x3) - 1])%zrange
-                                     then
-                                      Some
-                                        (#(Z_cast args)%expr @
-                                         v (Compile.reflect x2), (##0)%expr)%expr_pat
-                                     else None);
-                              Some (Base x3));
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
-                  end
-              | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
-                (_ @ _)%expr_pat _ | @expr.App _ _ _ s _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
-              end
-          | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x2 =>
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args <- invert_bind_args idc1 Raw.ident.Literal;
-                  args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                  args1 <- invert_bind_args idc Raw.ident.Literal;
-                  match
-                    pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args1) -> (projT1 args)) -> s)%ptype
-                  with
-                  | Some (_, _, _)%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         ((ℤ -> ℤ) -> ℤ)%ptype
-                         (((projT1 args1) -> (projT1 args)) -> s)%ptype
-                      then
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args1);
-                       xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args);
-                       v <- type.try_make_transport_cps s ℤ;
-                       fv <- (x3 <- (if
-                                      ((let (x3, _) := xv0 in x3) =? 1) &&
-                                      (ZRange.normalize args0 <=?
-                                       r[0 ~> (let (x3, _) := xv in x3) - 1])%zrange
-                                     then
-                                      Some
-                                        (#(Z_cast args0)%expr @
-                                         v (Compile.reflect x2), (##0)%expr)%expr_pat
-                                     else None);
-                              Some (Base x3));
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
-                  end
-              | _ => None
-              end
-          | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-          | _ => None
-          end
-      | _ => None
-      end;;
+               end
+           | _ => None
+           end;;
+           match x with
+           | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+               match x0 with
+               | @expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t2 idc2) x4 =>
+                   match x4 with
+                   | @expr.Ident _ _ _ t3 idc3 =>
+                       args <- invert_bind_args idc3 Raw.ident.Literal;
+                       args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       args1 <- invert_bind_args idc1 Raw.ident.Literal;
+                       args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       args3 <- invert_bind_args idc Raw.ident.Z_cast;
+                       match
+                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
+                           (((projT1 args1) -> (projT1 args)) -> s)%ptype
+                       with
+                       | Some (_, _, _)%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              ((ℤ -> ℤ) -> ℤ)%ptype
+                              (((projT1 args1) -> (projT1 args)) -> s)%ptype
+                           then
+                            xv <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                            xv0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                            v <- type.try_make_transport_cps s ℤ;
+                            fv <- (x5 <- (if
+                                           ((let (x5, _) := xv0 in x5) =? 1) &&
+                                           (ZRange.normalize args3 <=?
+                                            r[0 ~> (let (x5, _) := xv in x5) -
+                                                   1])%zrange &&
+                                           is_bounded_by_bool
+                                             (let (x5, _) := xv in x5)
+                                             (ZRange.normalize args2) &&
+                                           is_bounded_by_bool
+                                             (let (x5, _) := xv0 in x5)
+                                             (ZRange.normalize args0)
+                                          then
+                                           Some
+                                             (#(Z_cast args3)%expr @
+                                              v (Compile.reflect x2),
+                                             #(Z_cast r[0 ~> 0])%expr @
+                                             (##0)%expr)%expr_pat
+                                          else None);
+                                   Some (Base x5));
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end
+                   | _ => None
+                   end;;
+                   match x2 with
+                   | @expr.Ident _ _ _ t3 idc3 =>
+                       args <- invert_bind_args idc3 Raw.ident.Literal;
+                       args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       args1 <- invert_bind_args idc1 Raw.ident.Literal;
+                       args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       args3 <- invert_bind_args idc Raw.ident.Z_cast;
+                       match
+                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
+                           (((projT1 args1) -> s1) -> (projT1 args))%ptype
+                       with
+                       | Some (_, _, _)%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              ((ℤ -> ℤ) -> ℤ)%ptype
+                              (((projT1 args1) -> s1) -> (projT1 args))%ptype
+                           then
+                            xv <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args1);
+                            v <- type.try_make_transport_cps s1 ℤ;
+                            xv0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                            fv <- (x5 <- (if
+                                           ((let (x5, _) := xv0 in x5) =? 1) &&
+                                           (ZRange.normalize args0 <=?
+                                            r[0 ~> (let (x5, _) := xv in x5) -
+                                                   1])%zrange &&
+                                           is_bounded_by_bool
+                                             (let (x5, _) := xv in x5)
+                                             (ZRange.normalize args2) &&
+                                           is_bounded_by_bool
+                                             (let (x5, _) := xv0 in x5)
+                                             (ZRange.normalize args3)
+                                          then
+                                           Some
+                                             (#(Z_cast args0)%expr @
+                                              v (Compile.reflect x4),
+                                             #(Z_cast r[0 ~> 0])%expr @
+                                             (##0)%expr)%expr_pat
+                                          else None);
+                                   Some (Base x5));
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end
+                   | _ => None
+                   end
+               | @expr.App _ _ _ s1 _ ($_)%expr _ | @expr.App _ _ _ s1 _
+                 (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s1 _
+                 (_ @ _)%expr_pat _ | @expr.App _ _ _ s1 _
+                 (@expr.LetIn _ _ _ _ _ _ _) _ => None
+               | _ => None
+               end
+           | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
+             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+               None
+           | _ => None
+           end
+       | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
+         (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+       | _ => None
+       end);;
       None);;;
      Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_get_carry =>
     fun x x0 x1 : expr ℤ =>
     ((match x with
-      | @expr.Ident _ _ _ t idc =>
+      | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
           match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args <- invert_bind_args idc1 Raw.ident.Literal;
-                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                  args1 <- invert_bind_args idc Raw.ident.Literal;
-                  match
-                    pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
-                  with
-                  | Some (_, _, _)%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         ((ℤ -> ℤ) -> ℤ)%ptype
-                         (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
-                      then
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args1);
-                       xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args0);
-                       xv1 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args);
-                       Some
-                         (Base
-                            (let
-                             '(a1, b1)%zrange :=
-                              Z.add_get_carry_full (let (x2, _) := xv in x2)
-                                (let (x2, _) := xv0 in x2)
-                                (let (x2, _) := xv1 in x2) in
-                              ((##a1)%expr, (##b1)%expr)%expr_pat))
-                      else None
-                  | None => None
+          | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t1 idc1) x3 =>
+              match x3 with
+              | @expr.Ident _ _ _ t2 idc2 =>
+                  match x1 with
+                  | @expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t3 idc3) x4 =>
+                      match x4 with
+                      | @expr.Ident _ _ _ t4 idc4 =>
+                          args <- invert_bind_args idc4 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc2 Raw.ident.Literal;
+                          args2 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                          args3 <- invert_bind_args idc0 Raw.ident.Literal;
+                          args4 <- invert_bind_args idc Raw.ident.Z_cast;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ)%ptype
+                              (((projT1 args3) -> (projT1 args1)) ->
+                               (projT1 args))%ptype
+                          with
+                          | Some (_, _, _)%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ)%ptype
+                                 (((projT1 args3) -> (projT1 args1)) ->
+                                  (projT1 args))%ptype
+                              then
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args3);
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args1);
+                               xv1 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x5 <- (if
+                                              is_bounded_by_bool
+                                                (let (x5, _) := xv in x5)
+                                                (ZRange.normalize args4) &&
+                                              is_bounded_by_bool
+                                                (let (x5, _) := xv0 in x5)
+                                                (ZRange.normalize args2) &&
+                                              is_bounded_by_bool
+                                                (let (x5, _) := xv1 in x5)
+                                                (ZRange.normalize args0)
+                                             then
+                                              Some
+                                                (let
+                                                 '(a1, b1)%zrange :=
+                                                  Z.add_get_carry_full
+                                                    (let (x5, _) := xv in x5)
+                                                    (let (x5, _) := xv0 in x5)
+                                                    (let (x5, _) := xv1 in x5)
+                                                  in
+                                                  ((##a1)%expr, (##b1)%expr)%expr_pat)
+                                             else None);
+                                      Some (Base x5));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | _ => None
+                      end;;
+                      args <- invert_bind_args idc3 Raw.ident.Z_cast;
+                      args0 <- invert_bind_args idc2 Raw.ident.Literal;
+                      args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                      args2 <- invert_bind_args idc0 Raw.ident.Literal;
+                      args3 <- invert_bind_args idc Raw.ident.Z_cast;
+                      match
+                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
+                          (((projT1 args2) -> (projT1 args0)) -> s1)%ptype
+                      with
+                      | Some (_, _, _)%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             ((ℤ -> ℤ) -> ℤ)%ptype
+                             (((projT1 args2) -> (projT1 args0)) -> s1)%ptype
+                          then
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args2);
+                           xv0 <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args0);
+                           v <- type.try_make_transport_cps s1 ℤ;
+                           fv <- (x5 <- (if
+                                          ((let (x5, _) := xv0 in x5) =? 0) &&
+                                          (ZRange.normalize args <=?
+                                           r[0 ~> (let (x5, _) := xv in x5) -
+                                                  1])%zrange &&
+                                          is_bounded_by_bool
+                                            (let (x5, _) := xv0 in x5)
+                                            (ZRange.normalize args1) &&
+                                          is_bounded_by_bool
+                                            (let (x5, _) := xv in x5)
+                                            (ZRange.normalize args3)
+                                         then
+                                          Some
+                                            (#(Z_cast args)%expr @
+                                             v (Compile.reflect x4),
+                                            #(Z_cast r[0 ~> 0])%expr @
+                                            (##0)%expr)%expr_pat
+                                         else None);
+                                  Some (Base x5));
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
+                      end
+                  | @expr.App _ _ _ s1 _ ($_)%expr _ | @expr.App _ _ _ s1 _
+                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s1 _
+                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s1 _
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                  | _ => None
                   end
-              | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t1 idc1) x2 =>
-                  args <- invert_bind_args idc1 Raw.ident.Z_cast;
-                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                  args1 <- invert_bind_args idc Raw.ident.Literal;
+              | _ => None
+              end;;
+              match x1 with
+              | (@expr.Ident _ _ _ t2 idc2 @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
+                  args <- invert_bind_args idc3 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                  args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                  args2 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args3 <- invert_bind_args idc Raw.ident.Z_cast;
                   match
                     pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args1) -> (projT1 args0)) -> s)%ptype
+                      (((projT1 args2) -> s0) -> (projT1 args))%ptype
                   with
                   | Some (_, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          ((ℤ -> ℤ) -> ℤ)%ptype
-                         (((projT1 args1) -> (projT1 args0)) -> s)%ptype
+                         (((projT1 args2) -> s0) -> (projT1 args))%ptype
                       then
                        xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args1);
+                               ##(projT2 args2);
+                       v <- type.try_make_transport_cps s0 ℤ;
                        xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args0);
-                       v <- type.try_make_transport_cps s ℤ;
-                       fv <- (x3 <- (if
-                                      ((let (x3, _) := xv0 in x3) =? 0) &&
-                                      (ZRange.normalize args <=?
-                                       r[0 ~> (let (x3, _) := xv in x3) - 1])%zrange
+                                ##(projT2 args);
+                       fv <- (x5 <- (if
+                                      ((let (x5, _) := xv0 in x5) =? 0) &&
+                                      (ZRange.normalize args1 <=?
+                                       r[0 ~> (let (x5, _) := xv in x5) - 1])%zrange &&
+                                      is_bounded_by_bool
+                                        (let (x5, _) := xv0 in x5)
+                                        (ZRange.normalize args0) &&
+                                      is_bounded_by_bool
+                                        (let (x5, _) := xv in x5)
+                                        (ZRange.normalize args3)
                                      then
                                       Some
-                                        (#(Z_cast args)%expr @
-                                         v (Compile.reflect x2), (##0)%expr)%expr_pat
+                                        (#(Z_cast args1)%expr @
+                                         v (Compile.reflect x3),
+                                        #(Z_cast r[0 ~> 0])%expr @ (##0)%expr)%expr_pat
                                      else None);
-                              Some (Base x3));
+                              Some (Base x5));
                        Some (fv0 <-- fv;
                              Base fv0)%under_lets
                       else None
                   | None => None
                   end
-              | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
-                (_ @ _)%expr_pat _ | @expr.App _ _ _ s _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
+              | (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
+                (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.Ident _ _ _ t2 idc2 @ (_ @ _))%expr_pat |
+                (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                  None
               | _ => None
               end
-          | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x2 =>
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args <- invert_bind_args idc1 Raw.ident.Literal;
-                  args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                  args1 <- invert_bind_args idc Raw.ident.Literal;
-                  match
-                    pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                      (((projT1 args1) -> s) -> (projT1 args))%ptype
-                  with
-                  | Some (_, _, _)%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         ((ℤ -> ℤ) -> ℤ)%ptype
-                         (((projT1 args1) -> s) -> (projT1 args))%ptype
-                      then
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args1);
-                       v <- type.try_make_transport_cps s ℤ;
-                       xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args);
-                       fv <- (x3 <- (if
-                                      ((let (x3, _) := xv0 in x3) =? 0) &&
-                                      (ZRange.normalize args0 <=?
-                                       r[0 ~> (let (x3, _) := xv in x3) - 1])%zrange
-                                     then
-                                      Some
-                                        (#(Z_cast args0)%expr @
-                                         v (Compile.reflect x2), (##0)%expr)%expr_pat
-                                     else None);
-                              Some (Base x3));
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
-                  end
-              | _ => None
-              end
-          | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+          | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
+            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _ (_ @ _)%expr_pat
+            _ | @expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
           | _ => None
           end
+      | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+        (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
+        (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+          None
       | _ => None
       end;;
       None);;;
@@ -681,8 +876,9 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_add_with_carry =>
     fun x x0 x1 : expr ℤ =>
     (match x with
-     | @expr.Ident _ _ _ t idc =>
-         args <- invert_bind_args idc Raw.ident.Literal;
+     | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
+         args <- invert_bind_args idc0 Raw.ident.Literal;
+         args0 <- invert_bind_args idc Raw.ident.Z_cast;
          match
            pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
              (((projT1 args) -> ℤ) -> ℤ)%ptype
@@ -693,170 +889,249 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 ((ℤ -> ℤ) -> ℤ)%ptype (((projT1 args) -> ℤ) -> ℤ)%ptype
              then
               xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-              fv <- (x2 <- (if (let (x2, _) := xv in x2) =? 0
+              fv <- (x3 <- (if
+                             ((let (x3, _) := xv in x3) =? 0) &&
+                             is_bounded_by_bool (let (x3, _) := xv in x3)
+                               (ZRange.normalize args0)
                             then Some (x0 + x1)%expr
                             else None);
-                     Some (Base x2));
+                     Some (Base x3));
               Some (fv0 <-- fv;
                     Base fv0)%under_lets
              else None
          | None => None
          end
+     | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+       (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+       (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
+       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
      | _ => None
      end;;;
      Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_get_carry =>
     fun x x0 x1 x2 : expr ℤ =>
     (match x with
-     | @expr.Ident _ _ _ t idc =>
+     | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
          match x0 with
-         | @expr.Ident _ _ _ t0 idc0 =>
+         | (@expr.Ident _ _ _ t1 idc1 @ @expr.Ident _ _ _ t2 idc2)%expr_pat =>
              match x1 with
-             | @expr.Ident _ _ _ t1 idc1 =>
-                 match x2 with
-                 | @expr.Ident _ _ _ t2 idc2 =>
-                     args <- invert_bind_args idc2 Raw.ident.Literal;
-                     args0 <- invert_bind_args idc1 Raw.ident.Literal;
-                     args1 <- invert_bind_args idc0 Raw.ident.Literal;
-                     args2 <- invert_bind_args idc Raw.ident.Literal;
-                     match
-                       pattern.type.unify_extracted
-                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                         ((((projT1 args2) -> (projT1 args1)) ->
-                           (projT1 args0)) -> (projT1 args))%ptype
-                     with
-                     | Some (_, _, _, _)%zrange =>
-                         if
-                          type.type_beq base.type base.type.type_beq
-                            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                            ((((projT1 args2) -> (projT1 args1)) ->
-                              (projT1 args0)) -> (projT1 args))%ptype
-                         then
-                          xv <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args2);
-                          xv0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                          xv1 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args0);
-                          xv2 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args);
-                          Some
-                            (Base
-                               (let
-                                '(a2, b2)%zrange :=
-                                 Z.add_with_get_carry_full
-                                   (let (x3, _) := xv in x3)
-                                   (let (x3, _) := xv0 in x3)
-                                   (let (x3, _) := xv1 in x3)
-                                   (let (x3, _) := xv2 in x3) in
-                                 ((##a2)%expr, (##b2)%expr)%expr_pat))
-                         else None
-                     | None => None
+             | @expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t3 idc3) x5 =>
+                 match x5 with
+                 | @expr.Ident _ _ _ t4 idc4 =>
+                     match x2 with
+                     | @expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t5 idc5) x6 =>
+                         match x6 with
+                         | @expr.Ident _ _ _ t6 idc6 =>
+                             args <- invert_bind_args idc6 Raw.ident.Literal;
+                             args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                             args1 <- invert_bind_args idc4 Raw.ident.Literal;
+                             args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                             args3 <- invert_bind_args idc2 Raw.ident.Literal;
+                             args4 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                             args5 <- invert_bind_args idc0 Raw.ident.Literal;
+                             args6 <- invert_bind_args idc Raw.ident.Z_cast;
+                             match
+                               pattern.type.unify_extracted
+                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                 ((((projT1 args5) -> (projT1 args3)) ->
+                                   (projT1 args1)) -> (projT1 args))%ptype
+                             with
+                             | Some (_, _, _, _)%zrange =>
+                                 if
+                                  type.type_beq base.type base.type.type_beq
+                                    (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                    ((((projT1 args5) -> (projT1 args3)) ->
+                                      (projT1 args1)) -> (projT1 args))%ptype
+                                 then
+                                  xv <- ident.unify pattern.ident.Literal
+                                          ##(projT2 args5);
+                                  xv0 <- ident.unify pattern.ident.Literal
+                                           ##(projT2 args3);
+                                  xv1 <- ident.unify pattern.ident.Literal
+                                           ##(projT2 args1);
+                                  xv2 <- ident.unify pattern.ident.Literal
+                                           ##(projT2 args);
+                                  fv <- (x7 <- (if
+                                                 is_bounded_by_bool
+                                                   (let (x7, _) := xv in x7)
+                                                   (ZRange.normalize args6) &&
+                                                 is_bounded_by_bool
+                                                   (let (x7, _) := xv0 in x7)
+                                                   (ZRange.normalize args4) &&
+                                                 is_bounded_by_bool
+                                                   (let (x7, _) := xv1 in x7)
+                                                   (ZRange.normalize args2) &&
+                                                 is_bounded_by_bool
+                                                   (let (x7, _) := xv2 in x7)
+                                                   (ZRange.normalize args0)
+                                                then
+                                                 Some
+                                                   (let
+                                                    '(a2, b2)%zrange :=
+                                                     Z.add_with_get_carry_full
+                                                       (let (x7, _) := xv in
+                                                        x7)
+                                                       (let (x7, _) := xv0 in
+                                                        x7)
+                                                       (let (x7, _) := xv1 in
+                                                        x7)
+                                                       (let (x7, _) := xv2 in
+                                                        x7) in
+                                                     ((##a2)%expr,
+                                                     (##b2)%expr)%expr_pat)
+                                                else None);
+                                         Some (Base x7));
+                                  Some (fv0 <-- fv;
+                                        Base fv0)%under_lets
+                                 else None
+                             | None => None
+                             end
+                         | _ => None
+                         end;;
+                         args <- invert_bind_args idc5 Raw.ident.Z_cast;
+                         args0 <- invert_bind_args idc4 Raw.ident.Literal;
+                         args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                         args2 <- invert_bind_args idc2 Raw.ident.Literal;
+                         args3 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                         args4 <- invert_bind_args idc0 Raw.ident.Literal;
+                         args5 <- invert_bind_args idc Raw.ident.Z_cast;
+                         match
+                           pattern.type.unify_extracted
+                             (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                             ((((projT1 args4) -> (projT1 args2)) ->
+                               (projT1 args0)) -> s2)%ptype
+                         with
+                         | Some (_, _, _, _)%zrange =>
+                             if
+                              type.type_beq base.type base.type.type_beq
+                                (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                ((((projT1 args4) -> (projT1 args2)) ->
+                                  (projT1 args0)) -> s2)%ptype
+                             then
+                              xv <- ident.unify pattern.ident.Literal
+                                      ##(projT2 args4);
+                              xv0 <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args2);
+                              xv1 <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args0);
+                              v <- type.try_make_transport_cps s2 ℤ;
+                              fv <- (x7 <- (if
+                                             ((let (x7, _) := xv0 in x7) =? 0) &&
+                                             ((let (x7, _) := xv1 in x7) =? 0) &&
+                                             (ZRange.normalize args <=?
+                                              r[0 ~> (let (x7, _) := xv in x7) -
+                                                     1])%zrange &&
+                                             is_bounded_by_bool
+                                               (let (x7, _) := xv in x7)
+                                               (ZRange.normalize args5) &&
+                                             is_bounded_by_bool
+                                               (let (x7, _) := xv0 in x7)
+                                               (ZRange.normalize args3) &&
+                                             is_bounded_by_bool
+                                               (let (x7, _) := xv1 in x7)
+                                               (ZRange.normalize args1)
+                                            then
+                                             Some
+                                               (#(Z_cast args)%expr @
+                                                v (Compile.reflect x6),
+                                               #(Z_cast r[0 ~> 0])%expr @
+                                               (##0)%expr)%expr_pat
+                                            else None);
+                                     Some (Base x7));
+                              Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                             else None
+                         | None => None
+                         end
+                     | @expr.App _ _ _ s2 _ ($_)%expr _ | @expr.App _ _ _ s2
+                       _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s2 _
+                       (_ @ _)%expr_pat _ | @expr.App _ _ _ s2 _
+                       (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                     | _ => None
                      end
-                 | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t2 idc2) x3 =>
-                     args <- invert_bind_args idc2 Raw.ident.Z_cast;
-                     args0 <- invert_bind_args idc1 Raw.ident.Literal;
-                     args1 <- invert_bind_args idc0 Raw.ident.Literal;
-                     args2 <- invert_bind_args idc Raw.ident.Literal;
-                     match
-                       pattern.type.unify_extracted
-                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                         ((((projT1 args2) -> (projT1 args1)) ->
-                           (projT1 args0)) -> s)%ptype
-                     with
-                     | Some (_, _, _, _)%zrange =>
-                         if
-                          type.type_beq base.type base.type.type_beq
-                            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                            ((((projT1 args2) -> (projT1 args1)) ->
-                              (projT1 args0)) -> s)%ptype
-                         then
-                          xv <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args2);
-                          xv0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                          xv1 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args0);
-                          v <- type.try_make_transport_cps s ℤ;
-                          fv <- (x4 <- (if
-                                         ((let (x4, _) := xv0 in x4) =? 0) &&
-                                         ((let (x4, _) := xv1 in x4) =? 0) &&
-                                         (ZRange.normalize args <=?
-                                          r[0 ~> (let (x4, _) := xv in x4) -
-                                                 1])%zrange
-                                        then
-                                         Some
-                                           (#(Z_cast args)%expr @
-                                            v (Compile.reflect x3),
-                                           (##0)%expr)%expr_pat
-                                        else None);
-                                 Some (Base x4));
-                          Some (fv0 <-- fv;
-                                Base fv0)%under_lets
-                         else None
-                     | None => None
-                     end
-                 | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-                   (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
-                   (_ @ _)%expr_pat _ | @expr.App _ _ _ s _
-                   (@expr.LetIn _ _ _ _ _ _ _) _ => None
                  | _ => None
-                 end
-             | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t1 idc1) x3 =>
+                 end;;
                  match x2 with
-                 | @expr.Ident _ _ _ t2 idc2 =>
-                     args <- invert_bind_args idc2 Raw.ident.Literal;
-                     args0 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                     args1 <- invert_bind_args idc0 Raw.ident.Literal;
-                     args2 <- invert_bind_args idc Raw.ident.Literal;
+                 | (@expr.Ident _ _ _ t4 idc4 @ @expr.Ident _ _ _ t5 idc5)%expr_pat =>
+                     args <- invert_bind_args idc5 Raw.ident.Literal;
+                     args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                     args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                     args2 <- invert_bind_args idc2 Raw.ident.Literal;
+                     args3 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                     args4 <- invert_bind_args idc0 Raw.ident.Literal;
+                     args5 <- invert_bind_args idc Raw.ident.Z_cast;
                      match
                        pattern.type.unify_extracted
                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                         ((((projT1 args2) -> (projT1 args1)) -> s) ->
+                         ((((projT1 args4) -> (projT1 args2)) -> s1) ->
                           (projT1 args))%ptype
                      with
                      | Some (_, _, _, _)%zrange =>
                          if
                           type.type_beq base.type base.type.type_beq
                             (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                            ((((projT1 args2) -> (projT1 args1)) -> s) ->
+                            ((((projT1 args4) -> (projT1 args2)) -> s1) ->
                              (projT1 args))%ptype
                          then
                           xv <- ident.unify pattern.ident.Literal
-                                  ##(projT2 args2);
+                                  ##(projT2 args4);
                           xv0 <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                          v <- type.try_make_transport_cps s ℤ;
+                                   ##(projT2 args2);
+                          v <- type.try_make_transport_cps s1 ℤ;
                           xv1 <- ident.unify pattern.ident.Literal
                                    ##(projT2 args);
-                          fv <- (x4 <- (if
-                                         ((let (x4, _) := xv0 in x4) =? 0) &&
-                                         ((let (x4, _) := xv1 in x4) =? 0) &&
-                                         (ZRange.normalize args0 <=?
-                                          r[0 ~> (let (x4, _) := xv in x4) -
-                                                 1])%zrange
+                          fv <- (x7 <- (if
+                                         ((let (x7, _) := xv0 in x7) =? 0) &&
+                                         ((let (x7, _) := xv1 in x7) =? 0) &&
+                                         (ZRange.normalize args1 <=?
+                                          r[0 ~> (let (x7, _) := xv in x7) -
+                                                 1])%zrange &&
+                                         is_bounded_by_bool
+                                           (let (x7, _) := xv in x7)
+                                           (ZRange.normalize args5) &&
+                                         is_bounded_by_bool
+                                           (let (x7, _) := xv0 in x7)
+                                           (ZRange.normalize args3) &&
+                                         is_bounded_by_bool
+                                           (let (x7, _) := xv1 in x7)
+                                           (ZRange.normalize args0)
                                         then
                                          Some
-                                           (#(Z_cast args0)%expr @
-                                            v (Compile.reflect x3),
+                                           (#(Z_cast args1)%expr @
+                                            v (Compile.reflect x5),
+                                           #(Z_cast r[0 ~> 0])%expr @
                                            (##0)%expr)%expr_pat
                                         else None);
-                                 Some (Base x4));
+                                 Some (Base x7));
                           Some (fv0 <-- fv;
                                 Base fv0)%under_lets
                          else None
                      | None => None
                      end
+                 | (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
+                   (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                   (@expr.Ident _ _ _ t4 idc4 @ (_ @ _))%expr_pat |
+                   (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                     None
                  | _ => None
                  end
-             | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
-               (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
-               (_ @ _)%expr_pat _ | @expr.App _ _ _ s _
+             | @expr.App _ _ _ s1 _ ($_)%expr _ | @expr.App _ _ _ s1 _
+               (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s1 _
+               (_ @ _)%expr_pat _ | @expr.App _ _ _ s1 _
                (@expr.LetIn _ _ _ _ _ _ _) _ => None
              | _ => None
              end
+         | (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
+           (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+           (@expr.Ident _ _ _ t1 idc1 @ (_ @ _))%expr_pat |
+           (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+             None
          | _ => None
          end
+     | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
+       (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+       (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
+       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
      | _ => None
      end;;;
      Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
@@ -882,7 +1157,9 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            if type.type_beq base.type base.type.type_beq ℤ ℤ
            then
             fv <- (x0 <- (if lower range =? upper range
-                          then Some (##(lower range))%expr
+                          then
+                           Some
+                             (#(Z_cast range)%expr @ (##(lower range))%expr)%expr_pat
                           else None);
                    Some (Base x0));
             Some (fv0 <-- fv;
@@ -891,24 +1168,6 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
        | None => None
        end;;
        match x with
-       | @expr.Ident _ _ _ t idc =>
-           args <- invert_bind_args idc Raw.ident.Literal;
-           match pattern.type.unify_extracted ℤ (projT1 args) with
-           | Some _ =>
-               if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
-               then
-                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-                fv <- (x0 <- (if
-                               is_bounded_by_bool (let (x0, _) := xv in x0)
-                                 range
-                              then Some (##(let (x0, _) := xv in x0))%expr
-                              else None);
-                       Some (Base x0));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x0 =>
            args <- invert_bind_args idc Raw.ident.Z_cast;
            match pattern.type.unify_extracted ℤ s with
@@ -930,126 +1189,6 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                else None
            | None => None
            end
-       | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0))
-         (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t1 idc1) x2) =>
-           args <- invert_bind_args idc1 Raw.ident.Z_cast;
-           args0 <- invert_bind_args idc0 Raw.ident.Literal;
-           _ <- invert_bind_args idc Raw.ident.Z_add;
-           match
-             pattern.type.unify_extracted (ℤ -> ℤ)%ptype
-               ((projT1 args0) -> s1)%ptype
-           with
-           | Some (_, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
-                  ((projT1 args0) -> s1)%ptype
-               then
-                xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
-                v <- type.try_make_transport_cps s1 ℤ;
-                fv <- (x3 <- (if
-                               ((let (x3, _) := xv in x3) =? 0) &&
-                               (ZRange.normalize args <=?
-                                ZRange.normalize range)%zrange
-                              then
-                               Some
-                                 (#(Z_cast args)%expr @
-                                  v (Compile.reflect x2))%expr_pat
-                              else None);
-                       Some (Base x3));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
-       | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0)) (@expr.App _ _ _ s1 _ ($_)%expr _) |
-         @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0))
-         (@expr.App _ _ _ s1 _ (@expr.Abs _ _ _ _ _ _) _) | @expr.App _ _ _ s
-         _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0))
-         (@expr.App _ _ _ s1 _ (_ @ _)%expr_pat _) | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0))
-         (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) => None
-       | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0)) #(_)%expr_pat | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0)) ($_)%expr | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0)) (@expr.Abs _ _ _ _ _ _) | @expr.App _
-         _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Ident _ _ _ t0 idc0)) (@expr.LetIn _ _ _ _ _ _ _) => None
-       | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t0 idc0) x2))
-         (@expr.Ident _ _ _ t1 idc1) =>
-           args <- invert_bind_args idc1 Raw.ident.Literal;
-           args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
-           _ <- invert_bind_args idc Raw.ident.Z_add;
-           match
-             pattern.type.unify_extracted (ℤ -> ℤ)%ptype
-               (s1 -> (projT1 args))%ptype
-           with
-           | Some (_, _)%zrange =>
-               if
-                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
-                  (s1 -> (projT1 args))%ptype
-               then
-                v <- type.try_make_transport_cps s1 ℤ;
-                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-                fv <- (x3 <- (if
-                               ((let (x3, _) := xv in x3) =? 0) &&
-                               (ZRange.normalize args0 <=?
-                                ZRange.normalize range)%zrange
-                              then
-                               Some
-                                 (#(Z_cast args0)%expr @
-                                  v (Compile.reflect x2))%expr_pat
-                              else None);
-                       Some (Base x3));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
-           end
-       | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t0 idc0) x2)) ($_)%expr |
-         @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t0 idc0) x2))
-         (@expr.Abs _ _ _ _ _ _) | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t0 idc0) x2))
-         (_ @ _)%expr_pat | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t0 idc0) x2))
-         (@expr.LetIn _ _ _ _ _ _ _) => None
-       | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ ($_)%expr _)) _ | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ (@expr.Abs _ _ _ _ _ _) _)) _ | @expr.App _ _
-         _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ (_ @ _)%expr_pat _)) _ | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _ => None
-       | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) ($_)%expr) _ |
-         @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.Abs _ _ _ _ _ _)) _ | @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-          (@expr.LetIn _ _ _ _ _ _ _)) _ => None
        | @expr.App _ _ _ s _
          (@expr.App _ _ _ s0 _
           (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t idc) x2) x1) x0 =>
@@ -1086,7 +1225,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          _ | @expr.App _ _ _ s _
          (@expr.App _ _ _ s0 _
           (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ => None
-       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
+       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ #(_)%expr_pat _) _ |
+         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
          _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
          @expr.App _ _ _ s _
          (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
@@ -1305,8 +1445,9 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           | _ => None
           end;;
           match x1 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args <- invert_bind_args idc0 Raw.ident.Literal;
+          | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
               _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
               match
                 pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
@@ -1320,7 +1461,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                    v <- type.try_make_transport_cps s1 ℤ;
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                    v0 <- type.try_make_transport_cps s ℤ;
-                   fv <- (if (let (x3, _) := xv in x3) <? 0
+                   fv <- (if
+                           ((let (x4, _) := xv in x4) <? 0) &&
+                           is_bounded_by_bool (let (x4, _) := xv in x4)
+                             (ZRange.normalize args0)
                           then
                            Some
                              (UnderLet
@@ -1330,7 +1474,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                  (#(Z_sub_get_borrow)%expr @
                                   v (Compile.reflect x2) @
                                   v0 (Compile.reflect x0) @
-                                  (##(- (let (x3, _) := xv in x3))%Z)%expr))%expr_pat
+                                  (#(Z_cast (- args0))%expr @
+                                   (##(- (let (x4, _) := xv in x4))%Z)%expr)))%expr_pat
                                 (fun vc : var (ℤ * ℤ)%etype =>
                                  Base
                                    (#(Z_cast (Datatypes.fst range))%expr @
@@ -1352,11 +1497,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   else None
               | None => None
               end
+          | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+              None
           | _ => None
           end;;
           match x0 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              args <- invert_bind_args idc0 Raw.ident.Literal;
+          | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              args <- invert_bind_args idc1 Raw.ident.Literal;
+              args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
               _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
               match
                 pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
@@ -1371,7 +1522,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                    v <- type.try_make_transport_cps s1 ℤ;
                    v0 <- type.try_make_transport_cps s0 ℤ;
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   fv <- (if (let (x3, _) := xv in x3) <? 0
+                   fv <- (if
+                           ((let (x4, _) := xv in x4) <? 0) &&
+                           is_bounded_by_bool (let (x4, _) := xv in x4)
+                             (ZRange.normalize args0)
                           then
                            Some
                              (UnderLet
@@ -1381,7 +1535,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                  (#(Z_sub_get_borrow)%expr @
                                   v (Compile.reflect x2) @
                                   v0 (Compile.reflect x1) @
-                                  (##(- (let (x3, _) := xv in x3))%Z)%expr))%expr_pat
+                                  (#(Z_cast (- args0))%expr @
+                                   (##(- (let (x4, _) := xv in x4))%Z)%expr)))%expr_pat
                                 (fun vc : var (ℤ * ℤ)%etype =>
                                  Base
                                    (#(Z_cast (Datatypes.fst range))%expr @
@@ -1403,6 +1558,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   else None
               | None => None
               end
+          | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+              None
           | _ => None
           end;;
           _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
@@ -1491,472 +1651,541 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.App _ _ _ s1 _
          (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t idc) x3) x2) x1) x0 =>
          (match x2 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              match x1 with
-              | (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
-                  (@expr.Ident _ _ _ t3 idc3) x6))%expr_pat =>
-                  (args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                   _ <- invert_bind_args idc2 Raw.ident.Z_opp;
-                   args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                   args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                   _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
-                   match
-                     pattern.type.unify_extracted
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       (((s2 -> (projT1 args2)) -> s5) -> s)%ptype
-                   with
-                   | Some (_, _, _, _)%zrange =>
-                       if
-                        type.type_beq base.type base.type.type_beq
-                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                          (((s2 -> (projT1 args2)) -> s5) -> s)%ptype
-                       then
-                        v <- type.try_make_transport_cps s2 ℤ;
-                        xv <- ident.unify pattern.ident.Literal
-                                ##(projT2 args2);
-                        v0 <- type.try_make_transport_cps s5 ℤ;
-                        v1 <- type.try_make_transport_cps s ℤ;
-                        fv <- (if
-                                ((let (x7, _) := xv in x7) =? 0) &&
-                                (ZRange.normalize args <=?
-                                 - ZRange.normalize args1)%zrange
-                               then
-                                Some
-                                  (UnderLet
-                                     (#(Z_cast2
-                                          (Datatypes.fst range,
-                                          - Datatypes.snd range))%expr @
-                                      (#(Z_sub_get_borrow)%expr @
-                                       v (Compile.reflect x3) @
-                                       v1 (Compile.reflect x0) @
-                                       (#(Z_cast args)%expr @
-                                        v0 (Compile.reflect x6))))%expr_pat
-                                     (fun vc : var (ℤ * ℤ)%etype =>
-                                      Base
-                                        (#(Z_cast (Datatypes.fst range))%expr @
-                                         (#(fst)%expr @
-                                          (#(Z_cast2
-                                               (Datatypes.fst range,
-                                               - Datatypes.snd range))%expr @
-                                           ($vc)%expr)),
-                                        #(Z_cast (Datatypes.snd range))%expr @
-                                        (-
-                                         (#(Z_cast (- Datatypes.snd range))%expr @
-                                          (#(snd)%expr @
-                                           (#(Z_cast2
-                                                (Datatypes.fst range,
-                                                - Datatypes.snd range))%expr @
-                                            $vc)))%expr_pat)%expr)%expr_pat))
-                               else None);
-                        Some (fv0 <-- fv;
-                              Base fv0)%under_lets
-                       else None
-                   | None => None
-                   end);;
-                  args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                  _ <- invert_bind_args idc2 Raw.ident.Z_opp;
-                  args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                  args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                  _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
-                  match
-                    pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((s2 -> (projT1 args2)) -> s5) -> s)%ptype
-                  with
-                  | Some (_, _, _, _)%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                         (((s2 -> (projT1 args2)) -> s5) -> s)%ptype
-                      then
-                       v <- type.try_make_transport_cps s2 ℤ;
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args2);
-                       v0 <- type.try_make_transport_cps s5 ℤ;
-                       v1 <- type.try_make_transport_cps s ℤ;
-                       fv <- (if
-                               ((let (x7, _) := xv in x7) <? 0) &&
-                               (ZRange.normalize args <=?
-                                - ZRange.normalize args1)%zrange
-                              then
-                               Some
-                                 (UnderLet
-                                    (#(Z_cast2
-                                         (Datatypes.fst range,
-                                         - Datatypes.snd range))%expr @
-                                     (#(Z_sub_with_get_borrow)%expr @
-                                      v (Compile.reflect x3) @
-                                      (##(- (let (x7, _) := xv in x7))%Z)%expr @
-                                      v1 (Compile.reflect x0) @
-                                      (#(Z_cast args)%expr @
-                                       v0 (Compile.reflect x6))))%expr_pat
-                                    (fun vc : var (ℤ * ℤ)%etype =>
-                                     Base
-                                       (#(Z_cast (Datatypes.fst range))%expr @
-                                        (#(fst)%expr @
-                                         (#(Z_cast2
-                                              (Datatypes.fst range,
-                                              - Datatypes.snd range))%expr @
-                                          ($vc)%expr)),
-                                       #(Z_cast (Datatypes.snd range))%expr @
-                                       (-
-                                        (#(Z_cast (- Datatypes.snd range))%expr @
-                                         (#(snd)%expr @
-                                          (#(Z_cast2
-                                               (Datatypes.fst range,
-                                               - Datatypes.snd range))%expr @
-                                           $vc)))%expr_pat)%expr)%expr_pat))
-                              else None);
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
-                  end
-              | (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _ ($_)%expr
-                  _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
-                  (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _ (_ @ _) _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
-                  (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
-              | (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ #(_)))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                  None
-              | (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ (($_)%expr @ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ (_ @ _ @ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                  None
-              | _ => None
-              end;;
-              match x0 with
-              | (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
-                  (@expr.Ident _ _ _ t3 idc3) x6))%expr_pat =>
-                  (args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                   _ <- invert_bind_args idc2 Raw.ident.Z_opp;
-                   args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                   args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                   _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
-                   match
-                     pattern.type.unify_extracted
-                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                       (((s2 -> (projT1 args2)) -> s0) -> s5)%ptype
-                   with
-                   | Some (_, _, _, _)%zrange =>
-                       if
-                        type.type_beq base.type base.type.type_beq
-                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                          (((s2 -> (projT1 args2)) -> s0) -> s5)%ptype
-                       then
-                        v <- type.try_make_transport_cps s2 ℤ;
-                        xv <- ident.unify pattern.ident.Literal
-                                ##(projT2 args2);
-                        v0 <- type.try_make_transport_cps s0 ℤ;
-                        v1 <- type.try_make_transport_cps s5 ℤ;
-                        fv <- (if
-                                ((let (x7, _) := xv in x7) =? 0) &&
-                                (ZRange.normalize args <=?
-                                 - ZRange.normalize args1)%zrange
-                               then
-                                Some
-                                  (UnderLet
-                                     (#(Z_cast2
-                                          (Datatypes.fst range,
-                                          - Datatypes.snd range))%expr @
-                                      (#(Z_sub_get_borrow)%expr @
-                                       v (Compile.reflect x3) @
-                                       v0 (Compile.reflect x1) @
-                                       (#(Z_cast args)%expr @
-                                        v1 (Compile.reflect x6))))%expr_pat
-                                     (fun vc : var (ℤ * ℤ)%etype =>
-                                      Base
-                                        (#(Z_cast (Datatypes.fst range))%expr @
-                                         (#(fst)%expr @
-                                          (#(Z_cast2
-                                               (Datatypes.fst range,
-                                               - Datatypes.snd range))%expr @
-                                           ($vc)%expr)),
-                                        #(Z_cast (Datatypes.snd range))%expr @
-                                        (-
-                                         (#(Z_cast (- Datatypes.snd range))%expr @
-                                          (#(snd)%expr @
-                                           (#(Z_cast2
-                                                (Datatypes.fst range,
-                                                - Datatypes.snd range))%expr @
-                                            $vc)))%expr_pat)%expr)%expr_pat))
-                               else None);
-                        Some (fv0 <-- fv;
-                              Base fv0)%under_lets
-                       else None
-                   | None => None
-                   end);;
-                  args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                  _ <- invert_bind_args idc2 Raw.ident.Z_opp;
-                  args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                  args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                  _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
-                  match
-                    pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((s2 -> (projT1 args2)) -> s0) -> s5)%ptype
-                  with
-                  | Some (_, _, _, _)%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                         (((s2 -> (projT1 args2)) -> s0) -> s5)%ptype
-                      then
-                       v <- type.try_make_transport_cps s2 ℤ;
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args2);
-                       v0 <- type.try_make_transport_cps s0 ℤ;
-                       v1 <- type.try_make_transport_cps s5 ℤ;
-                       fv <- (if
-                               ((let (x7, _) := xv in x7) <? 0) &&
-                               (ZRange.normalize args <=?
-                                - ZRange.normalize args1)%zrange
-                              then
-                               Some
-                                 (UnderLet
-                                    (#(Z_cast2
-                                         (Datatypes.fst range,
-                                         - Datatypes.snd range))%expr @
-                                     (#(Z_sub_with_get_borrow)%expr @
-                                      v (Compile.reflect x3) @
-                                      (##(- (let (x7, _) := xv in x7))%Z)%expr @
-                                      v0 (Compile.reflect x1) @
-                                      (#(Z_cast args)%expr @
-                                       v1 (Compile.reflect x6))))%expr_pat
-                                    (fun vc : var (ℤ * ℤ)%etype =>
-                                     Base
-                                       (#(Z_cast (Datatypes.fst range))%expr @
-                                        (#(fst)%expr @
-                                         (#(Z_cast2
-                                              (Datatypes.fst range,
-                                              - Datatypes.snd range))%expr @
-                                          ($vc)%expr)),
-                                       #(Z_cast (Datatypes.snd range))%expr @
-                                       (-
-                                        (#(Z_cast (- Datatypes.snd range))%expr @
-                                         (#(snd)%expr @
-                                          (#(Z_cast2
-                                               (Datatypes.fst range,
-                                               - Datatypes.snd range))%expr @
-                                           $vc)))%expr_pat)%expr)%expr_pat))
-                              else None);
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
-                  end
-              | (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _ ($_)%expr
-                  _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
-                  (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _ (_ @ _) _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s5 _
-                  (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
-              | (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ #(_)))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @
-                 (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                  None
-              | (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ (($_)%expr @ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ (_ @ _ @ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                  None
-              | _ => None
-              end;;
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args <- invert_bind_args idc1 Raw.ident.Literal;
-                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                  _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
-                  match
-                    pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((s2 -> (projT1 args0)) -> (projT1 args)) -> s)%ptype
-                  with
-                  | Some (_, _, _, _)%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                         (((s2 -> (projT1 args0)) -> (projT1 args)) -> s)%ptype
-                      then
-                       v <- type.try_make_transport_cps s2 ℤ;
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args0);
-                       xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args);
-                       v0 <- type.try_make_transport_cps s ℤ;
-                       fv <- (if
-                               ((let (x4, _) := xv0 in x4) <=? 0) &&
-                               ((let (x4, _) := xv in x4) <=? 0) &&
-                               ((let (x4, _) := xv0 in x4) +
-                                (let (x4, _) := xv in x4) <? 0)
-                              then
-                               Some
-                                 (UnderLet
-                                    (#(Z_cast2
-                                         (Datatypes.fst range,
-                                         - Datatypes.snd range))%expr @
-                                     (#(Z_sub_with_get_borrow)%expr @
-                                      v (Compile.reflect x3) @
-                                      (##(- (let (x4, _) := xv in x4))%Z)%expr @
-                                      v0 (Compile.reflect x0) @
-                                      (##(- (let (x4, _) := xv0 in x4))%Z)%expr))%expr_pat
-                                    (fun vc : var (ℤ * ℤ)%etype =>
-                                     Base
-                                       (#(Z_cast (Datatypes.fst range))%expr @
-                                        (#(fst)%expr @
-                                         (#(Z_cast2
-                                              (Datatypes.fst range,
-                                              - Datatypes.snd range))%expr @
-                                          ($vc)%expr)),
-                                       #(Z_cast (Datatypes.snd range))%expr @
-                                       (-
-                                        (#(Z_cast (- Datatypes.snd range))%expr @
-                                         (#(snd)%expr @
-                                          (#(Z_cast2
-                                               (Datatypes.fst range,
-                                               - Datatypes.snd range))%expr @
-                                           $vc)))%expr_pat)%expr)%expr_pat))
-                              else None);
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
-                  end
-              | _ => None
-              end;;
-              match x0 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  args <- invert_bind_args idc1 Raw.ident.Literal;
-                  args0 <- invert_bind_args idc0 Raw.ident.Literal;
-                  _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
-                  match
-                    pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                      (((s2 -> (projT1 args0)) -> s0) -> (projT1 args))%ptype
-                  with
-                  | Some (_, _, _, _)%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                         (((s2 -> (projT1 args0)) -> s0) -> (projT1 args))%ptype
-                      then
-                       v <- type.try_make_transport_cps s2 ℤ;
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args0);
-                       v0 <- type.try_make_transport_cps s0 ℤ;
-                       xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args);
-                       fv <- (if
-                               ((let (x4, _) := xv0 in x4) <=? 0) &&
-                               ((let (x4, _) := xv in x4) <=? 0) &&
-                               ((let (x4, _) := xv0 in x4) +
-                                (let (x4, _) := xv in x4) <? 0)
-                              then
-                               Some
-                                 (UnderLet
-                                    (#(Z_cast2
-                                         (Datatypes.fst range,
-                                         - Datatypes.snd range))%expr @
-                                     (#(Z_sub_with_get_borrow)%expr @
-                                      v (Compile.reflect x3) @
-                                      (##(- (let (x4, _) := xv in x4))%Z)%expr @
-                                      v0 (Compile.reflect x1) @
-                                      (##(- (let (x4, _) := xv0 in x4))%Z)%expr))%expr_pat
-                                    (fun vc : var (ℤ * ℤ)%etype =>
-                                     Base
-                                       (#(Z_cast (Datatypes.fst range))%expr @
-                                        (#(fst)%expr @
-                                         (#(Z_cast2
-                                              (Datatypes.fst range,
-                                              - Datatypes.snd range))%expr @
-                                          ($vc)%expr)),
-                                       #(Z_cast (Datatypes.snd range))%expr @
-                                       (-
-                                        (#(Z_cast (- Datatypes.snd range))%expr @
-                                         (#(snd)%expr @
-                                          (#(Z_cast2
-                                               (Datatypes.fst range,
-                                               - Datatypes.snd range))%expr @
-                                           $vc)))%expr_pat)%expr)%expr_pat))
-                              else None);
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
-                  end
-              | _ => None
-              end;;
-              args <- invert_bind_args idc0 Raw.ident.Literal;
-              _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
-              match
-                pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                  (((s2 -> (projT1 args)) -> s0) -> s)%ptype
-              with
-              | Some (_, _, _, _)%zrange =>
-                  if
-                   type.type_beq base.type base.type.type_beq
-                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                     (((s2 -> (projT1 args)) -> s0) -> s)%ptype
-                  then
-                   v <- type.try_make_transport_cps s2 ℤ;
-                   xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   v0 <- type.try_make_transport_cps s0 ℤ;
-                   v1 <- type.try_make_transport_cps s ℤ;
-                   fv <- (if (let (x4, _) := xv in x4) =? 0
-                          then
-                           Some
-                             (UnderLet
-                                (#(Z_cast2 range)%expr @
-                                 (#(Z_add_get_carry)%expr @
-                                  v (Compile.reflect x3) @
-                                  v0 (Compile.reflect x1) @
-                                  v1 (Compile.reflect x0)))%expr_pat
-                                (fun vc : var (ℤ * ℤ)%etype =>
-                                 Base
-                                   (#(Z_cast (Datatypes.fst range))%expr @
-                                    (#(fst)%expr @
-                                     (#(Z_cast2 range)%expr @ ($vc)%expr)),
-                                   #(Z_cast (Datatypes.snd range))%expr @
-                                   (#(snd)%expr @
-                                    (#(Z_cast2 range)%expr @ ($vc)%expr)))%expr_pat))
-                          else None);
-                   Some (fv0 <-- fv;
-                         Base fv0)%under_lets
-                  else None
-              | None => None
-              end
           | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t0 idc0) x4 =>
               match x4 with
+              | @expr.Ident _ _ _ t1 idc1 =>
+                  match x1 with
+                  | (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      (@expr.Ident _ _ _ t4 idc4) x7))%expr_pat =>
+                      (args <- invert_bind_args idc4 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc3 Raw.ident.Z_opp;
+                       args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       args2 <- invert_bind_args idc1 Raw.ident.Literal;
+                       args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc
+                              Raw.ident.Z_add_with_get_carry;
+                       match
+                         pattern.type.unify_extracted
+                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                           (((s2 -> (projT1 args2)) -> s6) -> s)%ptype
+                       with
+                       | Some (_, _, _, _)%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                              (((s2 -> (projT1 args2)) -> s6) -> s)%ptype
+                           then
+                            v <- type.try_make_transport_cps s2 ℤ;
+                            xv <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args2);
+                            v0 <- type.try_make_transport_cps s6 ℤ;
+                            v1 <- type.try_make_transport_cps s ℤ;
+                            fv <- (if
+                                    ((let (x8, _) := xv in x8) =? 0) &&
+                                    (ZRange.normalize args <=?
+                                     - ZRange.normalize args1)%zrange &&
+                                    is_bounded_by_bool
+                                      (let (x8, _) := xv in x8)
+                                      (ZRange.normalize args3)
+                                   then
+                                    Some
+                                      (UnderLet
+                                         (#(Z_cast2
+                                              (Datatypes.fst range,
+                                              - Datatypes.snd range))%expr @
+                                          (#(Z_sub_get_borrow)%expr @
+                                           v (Compile.reflect x3) @
+                                           v1 (Compile.reflect x0) @
+                                           (#(Z_cast args)%expr @
+                                            v0 (Compile.reflect x7))))%expr_pat
+                                         (fun vc : var (ℤ * ℤ)%etype =>
+                                          Base
+                                            (#(Z_cast (Datatypes.fst range))%expr @
+                                             (#(fst)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               ($vc)%expr)),
+                                            #(Z_cast (Datatypes.snd range))%expr @
+                                            (-
+                                             (#(Z_cast
+                                                  (- Datatypes.snd range))%expr @
+                                              (#(snd)%expr @
+                                               (#(Z_cast2
+                                                    (Datatypes.fst range,
+                                                    - Datatypes.snd range))%expr @
+                                                $vc)))%expr_pat)%expr)%expr_pat))
+                                   else None);
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end);;
+                      args <- invert_bind_args idc4 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc3 Raw.ident.Z_opp;
+                      args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args2 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc
+                             Raw.ident.Z_add_with_get_carry;
+                      match
+                        pattern.type.unify_extracted
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          (((s2 -> (projT1 args2)) -> s6) -> s)%ptype
+                      with
+                      | Some (_, _, _, _)%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                             (((s2 -> (projT1 args2)) -> s6) -> s)%ptype
+                          then
+                           v <- type.try_make_transport_cps s2 ℤ;
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args2);
+                           v0 <- type.try_make_transport_cps s6 ℤ;
+                           v1 <- type.try_make_transport_cps s ℤ;
+                           fv <- (if
+                                   ((let (x8, _) := xv in x8) <? 0) &&
+                                   (ZRange.normalize args <=?
+                                    - ZRange.normalize args1)%zrange &&
+                                   is_bounded_by_bool
+                                     (let (x8, _) := xv in x8)
+                                     (ZRange.normalize args3)
+                                  then
+                                   Some
+                                     (UnderLet
+                                        (#(Z_cast2
+                                             (Datatypes.fst range,
+                                             - Datatypes.snd range))%expr @
+                                         (#(Z_sub_with_get_borrow)%expr @
+                                          v (Compile.reflect x3) @
+                                          (#(Z_cast (- args3))%expr @
+                                           (##(- (let (x8, _) := xv in x8))%Z)%expr) @
+                                          v1 (Compile.reflect x0) @
+                                          (#(Z_cast args)%expr @
+                                           v0 (Compile.reflect x7))))%expr_pat
+                                        (fun vc : var (ℤ * ℤ)%etype =>
+                                         Base
+                                           (#(Z_cast (Datatypes.fst range))%expr @
+                                            (#(fst)%expr @
+                                             (#(Z_cast2
+                                                  (Datatypes.fst range,
+                                                  - Datatypes.snd range))%expr @
+                                              ($vc)%expr)),
+                                           #(Z_cast (Datatypes.snd range))%expr @
+                                           (-
+                                            (#(Z_cast (- Datatypes.snd range))%expr @
+                                             (#(snd)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               $vc)))%expr_pat)%expr)%expr_pat))
+                                  else None);
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
+                      end
+                  | (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      ($_)%expr _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      (_ @ _) _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                  | (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ #(_)))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                      None
+                  | (@expr.Ident _ _ _ t2 idc2 @ #(_))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ (($_)%expr @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ (_ @ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      None
+                  | _ => None
+                  end;;
+                  match x0 with
+                  | (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      (@expr.Ident _ _ _ t4 idc4) x7))%expr_pat =>
+                      (args <- invert_bind_args idc4 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc3 Raw.ident.Z_opp;
+                       args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       args2 <- invert_bind_args idc1 Raw.ident.Literal;
+                       args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc
+                              Raw.ident.Z_add_with_get_carry;
+                       match
+                         pattern.type.unify_extracted
+                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                           (((s2 -> (projT1 args2)) -> s0) -> s6)%ptype
+                       with
+                       | Some (_, _, _, _)%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                              (((s2 -> (projT1 args2)) -> s0) -> s6)%ptype
+                           then
+                            v <- type.try_make_transport_cps s2 ℤ;
+                            xv <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args2);
+                            v0 <- type.try_make_transport_cps s0 ℤ;
+                            v1 <- type.try_make_transport_cps s6 ℤ;
+                            fv <- (if
+                                    ((let (x8, _) := xv in x8) =? 0) &&
+                                    (ZRange.normalize args <=?
+                                     - ZRange.normalize args1)%zrange &&
+                                    is_bounded_by_bool
+                                      (let (x8, _) := xv in x8)
+                                      (ZRange.normalize args3)
+                                   then
+                                    Some
+                                      (UnderLet
+                                         (#(Z_cast2
+                                              (Datatypes.fst range,
+                                              - Datatypes.snd range))%expr @
+                                          (#(Z_sub_get_borrow)%expr @
+                                           v (Compile.reflect x3) @
+                                           v0 (Compile.reflect x1) @
+                                           (#(Z_cast args)%expr @
+                                            v1 (Compile.reflect x7))))%expr_pat
+                                         (fun vc : var (ℤ * ℤ)%etype =>
+                                          Base
+                                            (#(Z_cast (Datatypes.fst range))%expr @
+                                             (#(fst)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               ($vc)%expr)),
+                                            #(Z_cast (Datatypes.snd range))%expr @
+                                            (-
+                                             (#(Z_cast
+                                                  (- Datatypes.snd range))%expr @
+                                              (#(snd)%expr @
+                                               (#(Z_cast2
+                                                    (Datatypes.fst range,
+                                                    - Datatypes.snd range))%expr @
+                                                $vc)))%expr_pat)%expr)%expr_pat))
+                                   else None);
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end);;
+                      args <- invert_bind_args idc4 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc3 Raw.ident.Z_opp;
+                      args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args2 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc
+                             Raw.ident.Z_add_with_get_carry;
+                      match
+                        pattern.type.unify_extracted
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          (((s2 -> (projT1 args2)) -> s0) -> s6)%ptype
+                      with
+                      | Some (_, _, _, _)%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                             (((s2 -> (projT1 args2)) -> s0) -> s6)%ptype
+                          then
+                           v <- type.try_make_transport_cps s2 ℤ;
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args2);
+                           v0 <- type.try_make_transport_cps s0 ℤ;
+                           v1 <- type.try_make_transport_cps s6 ℤ;
+                           fv <- (if
+                                   ((let (x8, _) := xv in x8) <? 0) &&
+                                   (ZRange.normalize args <=?
+                                    - ZRange.normalize args1)%zrange &&
+                                   is_bounded_by_bool
+                                     (let (x8, _) := xv in x8)
+                                     (ZRange.normalize args3)
+                                  then
+                                   Some
+                                     (UnderLet
+                                        (#(Z_cast2
+                                             (Datatypes.fst range,
+                                             - Datatypes.snd range))%expr @
+                                         (#(Z_sub_with_get_borrow)%expr @
+                                          v (Compile.reflect x3) @
+                                          (#(Z_cast (- args3))%expr @
+                                           (##(- (let (x8, _) := xv in x8))%Z)%expr) @
+                                          v0 (Compile.reflect x1) @
+                                          (#(Z_cast args)%expr @
+                                           v1 (Compile.reflect x7))))%expr_pat
+                                        (fun vc : var (ℤ * ℤ)%etype =>
+                                         Base
+                                           (#(Z_cast (Datatypes.fst range))%expr @
+                                            (#(fst)%expr @
+                                             (#(Z_cast2
+                                                  (Datatypes.fst range,
+                                                  - Datatypes.snd range))%expr @
+                                              ($vc)%expr)),
+                                           #(Z_cast (Datatypes.snd range))%expr @
+                                           (-
+                                            (#(Z_cast (- Datatypes.snd range))%expr @
+                                             (#(snd)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               $vc)))%expr_pat)%expr)%expr_pat))
+                                  else None);
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
+                      end
+                  | (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      ($_)%expr _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      (_ @ _) _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                  | (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ #(_)))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                      None
+                  | (@expr.Ident _ _ _ t2 idc2 @ #(_))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ (($_)%expr @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ (_ @ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @
+                     (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      None
+                  | _ => None
+                  end;;
+                  match x1 with
+                  | (@expr.Ident _ _ _ t2 idc2 @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
+                      args <- invert_bind_args idc3 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc
+                             Raw.ident.Z_add_with_get_carry;
+                      match
+                        pattern.type.unify_extracted
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          (((s2 -> (projT1 args1)) -> (projT1 args)) -> s)%ptype
+                      with
+                      | Some (_, _, _, _)%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                             (((s2 -> (projT1 args1)) -> (projT1 args)) -> s)%ptype
+                          then
+                           v <- type.try_make_transport_cps s2 ℤ;
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args1);
+                           xv0 <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args);
+                           v0 <- type.try_make_transport_cps s ℤ;
+                           fv <- (if
+                                   ((let (x6, _) := xv0 in x6) <=? 0) &&
+                                   ((let (x6, _) := xv in x6) <=? 0) &&
+                                   ((let (x6, _) := xv0 in x6) +
+                                    (let (x6, _) := xv in x6) <? 0) &&
+                                   is_bounded_by_bool
+                                     (let (x6, _) := xv0 in x6)
+                                     (ZRange.normalize args0) &&
+                                   is_bounded_by_bool
+                                     (let (x6, _) := xv in x6)
+                                     (ZRange.normalize args2)
+                                  then
+                                   Some
+                                     (UnderLet
+                                        (#(Z_cast2
+                                             (Datatypes.fst range,
+                                             - Datatypes.snd range))%expr @
+                                         (#(Z_sub_with_get_borrow)%expr @
+                                          v (Compile.reflect x3) @
+                                          (#(Z_cast (- args2))%expr @
+                                           (##(- (let (x6, _) := xv in x6))%Z)%expr) @
+                                          v0 (Compile.reflect x0) @
+                                          (#(Z_cast (- args0))%expr @
+                                           (##(- (let (x6, _) := xv0 in x6))%Z)%expr)))%expr_pat
+                                        (fun vc : var (ℤ * ℤ)%etype =>
+                                         Base
+                                           (#(Z_cast (Datatypes.fst range))%expr @
+                                            (#(fst)%expr @
+                                             (#(Z_cast2
+                                                  (Datatypes.fst range,
+                                                  - Datatypes.snd range))%expr @
+                                              ($vc)%expr)),
+                                           #(Z_cast (Datatypes.snd range))%expr @
+                                           (-
+                                            (#(Z_cast (- Datatypes.snd range))%expr @
+                                             (#(snd)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               $vc)))%expr_pat)%expr)%expr_pat))
+                                  else None);
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
+                      end
+                  | (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ (_ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      None
+                  | _ => None
+                  end;;
+                  match x0 with
+                  | (@expr.Ident _ _ _ t2 idc2 @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
+                      args <- invert_bind_args idc3 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc
+                             Raw.ident.Z_add_with_get_carry;
+                      match
+                        pattern.type.unify_extracted
+                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                          (((s2 -> (projT1 args1)) -> s0) -> (projT1 args))%ptype
+                      with
+                      | Some (_, _, _, _)%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                             (((s2 -> (projT1 args1)) -> s0) -> (projT1 args))%ptype
+                          then
+                           v <- type.try_make_transport_cps s2 ℤ;
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args1);
+                           v0 <- type.try_make_transport_cps s0 ℤ;
+                           xv0 <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args);
+                           fv <- (if
+                                   ((let (x6, _) := xv0 in x6) <=? 0) &&
+                                   ((let (x6, _) := xv in x6) <=? 0) &&
+                                   ((let (x6, _) := xv0 in x6) +
+                                    (let (x6, _) := xv in x6) <? 0) &&
+                                   is_bounded_by_bool
+                                     (let (x6, _) := xv0 in x6)
+                                     (ZRange.normalize args0) &&
+                                   is_bounded_by_bool
+                                     (let (x6, _) := xv in x6)
+                                     (ZRange.normalize args2)
+                                  then
+                                   Some
+                                     (UnderLet
+                                        (#(Z_cast2
+                                             (Datatypes.fst range,
+                                             - Datatypes.snd range))%expr @
+                                         (#(Z_sub_with_get_borrow)%expr @
+                                          v (Compile.reflect x3) @
+                                          (#(Z_cast (- args2))%expr @
+                                           (##(- (let (x6, _) := xv in x6))%Z)%expr) @
+                                          v0 (Compile.reflect x1) @
+                                          (#(Z_cast (- args0))%expr @
+                                           (##(- (let (x6, _) := xv0 in x6))%Z)%expr)))%expr_pat
+                                        (fun vc : var (ℤ * ℤ)%etype =>
+                                         Base
+                                           (#(Z_cast (Datatypes.fst range))%expr @
+                                            (#(fst)%expr @
+                                             (#(Z_cast2
+                                                  (Datatypes.fst range,
+                                                  - Datatypes.snd range))%expr @
+                                              ($vc)%expr)),
+                                           #(Z_cast (Datatypes.snd range))%expr @
+                                           (-
+                                            (#(Z_cast (- Datatypes.snd range))%expr @
+                                             (#(snd)%expr @
+                                              (#(Z_cast2
+                                                   (Datatypes.fst range,
+                                                   - Datatypes.snd range))%expr @
+                                               $vc)))%expr_pat)%expr)%expr_pat))
+                                  else None);
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
+                      end
+                  | (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ (_ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      None
+                  | _ => None
+                  end;;
+                  args <- invert_bind_args idc1 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                  _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
+                  match
+                    pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                      (((s2 -> (projT1 args)) -> s0) -> s)%ptype
+                  with
+                  | Some (_, _, _, _)%zrange =>
+                      if
+                       type.type_beq base.type base.type.type_beq
+                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                         (((s2 -> (projT1 args)) -> s0) -> s)%ptype
+                      then
+                       v <- type.try_make_transport_cps s2 ℤ;
+                       xv <- ident.unify pattern.ident.Literal
+                               ##(projT2 args);
+                       v0 <- type.try_make_transport_cps s0 ℤ;
+                       v1 <- type.try_make_transport_cps s ℤ;
+                       fv <- (if
+                               ((let (x5, _) := xv in x5) =? 0) &&
+                               is_bounded_by_bool (let (x5, _) := xv in x5)
+                                 (ZRange.normalize args0)
+                              then
+                               Some
+                                 (UnderLet
+                                    (#(Z_cast2 range)%expr @
+                                     (#(Z_add_get_carry)%expr @
+                                      v (Compile.reflect x3) @
+                                      v0 (Compile.reflect x1) @
+                                      v1 (Compile.reflect x0)))%expr_pat
+                                    (fun vc : var (ℤ * ℤ)%etype =>
+                                     Base
+                                       (#(Z_cast (Datatypes.fst range))%expr @
+                                        (#(fst)%expr @
+                                         (#(Z_cast2 range)%expr @ ($vc)%expr)),
+                                       #(Z_cast (Datatypes.snd range))%expr @
+                                       (#(snd)%expr @
+                                        (#(Z_cast2 range)%expr @ ($vc)%expr)))%expr_pat))
+                              else None);
+                       Some (fv0 <-- fv;
+                             Base fv0)%under_lets
+                      else None
+                  | None => None
+                  end
               | (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _
                  (@expr.Ident _ _ _ t2 idc2) x6)%expr_pat =>
                   match x1 with
@@ -2160,11 +2389,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   | _ => None
                   end;;
                   match x1 with
-                  | @expr.Ident _ _ _ t3 idc3 =>
-                      args <- invert_bind_args idc3 Raw.ident.Literal;
-                      args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                  | (@expr.Ident _ _ _ t3 idc3 @ @expr.Ident _ _ _ t4 idc4)%expr_pat =>
+                      args <- invert_bind_args idc4 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc1 Raw.ident.Z_opp;
-                      args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc
                              Raw.ident.Z_add_with_get_carry;
                       match
@@ -2184,9 +2414,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                    ##(projT2 args);
                            v1 <- type.try_make_transport_cps s ℤ;
                            fv <- (if
-                                   ((let (x7, _) := xv in x7) <=? 0) &&
-                                   (ZRange.normalize args0 <=?
-                                    - ZRange.normalize args2)%zrange
+                                   ((let (x8, _) := xv in x8) <=? 0) &&
+                                   (ZRange.normalize args1 <=?
+                                    - ZRange.normalize args3)%zrange &&
+                                   is_bounded_by_bool
+                                     (let (x8, _) := xv in x8)
+                                     (ZRange.normalize args0)
                                   then
                                    Some
                                      (UnderLet
@@ -2195,10 +2428,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                              - Datatypes.snd range))%expr @
                                          (#(Z_sub_with_get_borrow)%expr @
                                           v (Compile.reflect x3) @
-                                          (#(Z_cast args0)%expr @
+                                          (#(Z_cast args1)%expr @
                                            v0 (Compile.reflect x6)) @
                                           v1 (Compile.reflect x0) @
-                                          (##(- (let (x7, _) := xv in x7))%Z)%expr))%expr_pat
+                                          (#(Z_cast (- args0))%expr @
+                                           (##(- (let (x8, _) := xv in x8))%Z)%expr)))%expr_pat
                                         (fun vc : var (ℤ * ℤ)%etype =>
                                          Base
                                            (#(Z_cast (Datatypes.fst range))%expr @
@@ -2221,14 +2455,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           else None
                       | None => None
                       end
+                  | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      None
                   | _ => None
                   end;;
                   match x0 with
-                  | @expr.Ident _ _ _ t3 idc3 =>
-                      args <- invert_bind_args idc3 Raw.ident.Literal;
-                      args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                  | (@expr.Ident _ _ _ t3 idc3 @ @expr.Ident _ _ _ t4 idc4)%expr_pat =>
+                      args <- invert_bind_args idc4 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc1 Raw.ident.Z_opp;
-                      args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc
                              Raw.ident.Z_add_with_get_carry;
                       match
@@ -2248,9 +2488,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            xv <- ident.unify pattern.ident.Literal
                                    ##(projT2 args);
                            fv <- (if
-                                   ((let (x7, _) := xv in x7) <=? 0) &&
-                                   (ZRange.normalize args0 <=?
-                                    - ZRange.normalize args2)%zrange
+                                   ((let (x8, _) := xv in x8) <=? 0) &&
+                                   (ZRange.normalize args1 <=?
+                                    - ZRange.normalize args3)%zrange &&
+                                   is_bounded_by_bool
+                                     (let (x8, _) := xv in x8)
+                                     (ZRange.normalize args0)
                                   then
                                    Some
                                      (UnderLet
@@ -2259,10 +2502,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                              - Datatypes.snd range))%expr @
                                          (#(Z_sub_with_get_borrow)%expr @
                                           v (Compile.reflect x3) @
-                                          (#(Z_cast args0)%expr @
+                                          (#(Z_cast args1)%expr @
                                            v0 (Compile.reflect x6)) @
                                           v1 (Compile.reflect x1) @
-                                          (##(- (let (x7, _) := xv in x7))%Z)%expr))%expr_pat
+                                          (#(Z_cast (- args0))%expr @
+                                           (##(- (let (x8, _) := xv in x8))%Z)%expr)))%expr_pat
                                         (fun vc : var (ℤ * ℤ)%etype =>
                                          Base
                                            (#(Z_cast (Datatypes.fst range))%expr @
@@ -2285,6 +2529,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           else None
                       | None => None
                       end
+                  | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      None
                   | _ => None
                   end
               | (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _ ($_)%expr _)%expr_pat |
@@ -2301,71 +2550,104 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               | _ => None
               end;;
               match x3 with
-              | @expr.Ident _ _ _ t1 idc1 =>
+              | (@expr.Ident _ _ _ t1 idc1 @ @expr.Ident _ _ _ t2 idc2)%expr_pat =>
                   match x1 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
+                  | (@expr.Ident _ _ _ t3 idc3 @ @expr.Ident _ _ _ t4 idc4)%expr_pat =>
                       match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args <- invert_bind_args idc3 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc2 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc1 Raw.ident.Literal;
-                          args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      | (@expr.Ident _ _ _ t5 idc5 @ @expr.Ident _ _ _ t6
+                         idc6)%expr_pat =>
+                          args <- invert_bind_args idc6 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args3 <- invert_bind_args idc2 Raw.ident.Literal;
+                          args4 <- invert_bind_args idc1 Raw.ident.Z_cast;
+                          args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
                           _ <- invert_bind_args idc
                                  Raw.ident.Z_add_with_get_carry;
                           match
                             pattern.type.unify_extracted
                               (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args1) -> s3) -> (projT1 args0)) ->
+                              ((((projT1 args3) -> s3) -> (projT1 args1)) ->
                                (projT1 args))%ptype
                           with
                           | Some (_, _, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args1) -> s3) -> (projT1 args0)) ->
+                                 ((((projT1 args3) -> s3) -> (projT1 args1)) ->
                                   (projT1 args))%ptype
                               then
                                xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args1);
+                                       ##(projT2 args3);
                                v <- type.try_make_transport_cps s3 ℤ;
                                xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
+                                        ##(projT2 args1);
                                xv1 <- ident.unify pattern.ident.Literal
                                         ##(projT2 args);
                                fv <- (if
-                                       ((let (x5, _) := xv0 in x5) =? 0) &&
-                                       ((let (x5, _) := xv1 in x5) =? 0) &&
-                                       (ZRange.normalize args2 <=?
-                                        r[0 ~> (let (x5, _) := xv in x5) - 1])%zrange &&
+                                       ((let (x8, _) := xv0 in x8) =? 0) &&
+                                       ((let (x8, _) := xv1 in x8) =? 0) &&
+                                       (ZRange.normalize args5 <=?
+                                        r[0 ~> (let (x8, _) := xv in x8) - 1])%zrange &&
                                        is_bounded_by_bool 0
-                                         (Datatypes.snd range)
+                                         (Datatypes.snd range) &&
+                                       is_bounded_by_bool
+                                         (let (x8, _) := xv in x8)
+                                         (ZRange.normalize args4) &&
+                                       is_bounded_by_bool
+                                         (let (x8, _) := xv0 in x8)
+                                         (ZRange.normalize args2) &&
+                                       is_bounded_by_bool
+                                         (let (x8, _) := xv1 in x8)
+                                         (ZRange.normalize args0)
                                       then
                                        Some
                                          (UnderLet
                                             (#(Z_cast2 range)%expr @
                                              (#(Z_add_with_get_carry)%expr @
-                                              (##(let (x5, _) := xv in x5))%expr @
-                                              (#(Z_cast args2)%expr @
+                                              (#(Z_cast args4)%expr @
+                                               (##(let (x8, _) := xv in x8))%expr) @
+                                              (#(Z_cast args5)%expr @
                                                v (Compile.reflect x4)) @
-                                              (##(let (x5, _) := xv0 in x5))%expr @
-                                              (##(let (x5, _) := xv1 in x5))%expr))%expr_pat
+                                              (#(Z_cast args2)%expr @
+                                               (##(let (x8, _) := xv0 in x8))%expr) @
+                                              (#(Z_cast args0)%expr @
+                                               (##(let (x8, _) := xv1 in x8))%expr)))%expr_pat
                                             (fun vc : var (ℤ * ℤ)%etype =>
                                              Base
                                                (#(Z_cast
                                                     (Datatypes.fst range))%expr @
                                                 (#(fst)%expr @
                                                  (#(Z_cast2 range)%expr @
-                                                  ($vc)%expr)), (##0)%expr)%expr_pat))
+                                                  ($vc)%expr)),
+                                               #(Z_cast r[0 ~> 0])%expr @
+                                               (##0)%expr)%expr_pat))
                                       else None);
                                Some (fv0 <-- fv;
                                      Base fv0)%under_lets
                               else None
                           | None => None
                           end
+                      | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
                       | _ => None
                       end
+                  | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      None
                   | _ => None
                   end
+              | (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
+                (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.Ident _ _ _ t1 idc1 @ (_ @ _))%expr_pat |
+                (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                  None
               | _ => None
               end
           | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _

--- a/src/fancy_with_casts_rewrite_head.out
+++ b/src/fancy_with_casts_rewrite_head.out
@@ -178,1232 +178,1890 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
     ((match x with
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (@expr.Ident _ _ _ t2 idc2 @ x4 @ x3))%expr_pat =>
-          match x4 with
-          | @expr.Ident _ _ _ t3 idc3 =>
-              match x3 with
-              | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t4 idc4) x5 =>
-                  (args <- invert_bind_args idc4 Raw.ident.Z_cast;
-                   args0 <- invert_bind_args idc3 Raw.ident.Literal;
-                   _ <- invert_bind_args idc2 Raw.ident.Z_land;
-                   args2 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                   args3 <- invert_bind_args idc0 Raw.ident.Literal;
-                   _ <- invert_bind_args idc Raw.ident.Z_mul;
-                   match
-                     pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
-                       ((projT1 args3) -> (projT1 args0) -> s4)%ptype
-                   with
-                   | Some (_, (_, _))%zrange =>
-                       if
-                        type.type_beq base.type base.type.type_beq
-                          (ℤ -> ℤ -> ℤ)%ptype
-                          ((projT1 args3) -> (projT1 args0) -> s4)%ptype
-                       then
-                        xv <- ident.unify pattern.ident.Literal
-                                ##(projT2 args3);
-                        xv0 <- ident.unify pattern.ident.Literal
-                                 ##(projT2 args0);
-                        v <- type.try_make_transport_cps s4 ℤ;
-                        fv <- (x6 <- (if
-                                       ((let (x6, _) := xv0 in x6) =?
-                                        2
-                                        ^ (2 *
-                                           Z.log2_up
-                                             (let (x6, _) := xv0 in x6) / 2) -
-                                        1) &&
-                                       (ZRange.normalize
-                                          (ZRange.constant
-                                             (let (x6, _) := xv0 in x6)) &'
-                                        ZRange.normalize args <=?
-                                        ZRange.normalize args2)%zrange
-                                      then
-                                       x6 <- invert_low
-                                               (2 *
-                                                Z.log2_up
-                                                  (let (x6, _) := xv0 in x6))
-                                               (let (x6, _) := xv in x6);
-                                       Some
-                                         (#(Z_cast range)%expr @
-                                          (#(fancy_mulll
-                                               (2 *
-                                                Z.log2_up
-                                                  (let (x7, _) := xv0 in x7)))%expr @
-                                           ((##x6)%expr,
-                                           #(Z_cast args)%expr @
-                                           v (Compile.reflect x5))))%expr_pat
-                                      else None);
-                               Some (Base x6));
-                        Some (fv0 <-- fv;
-                              Base fv0)%under_lets
-                       else None
-                   | None => None
-                   end);;
-                  args <- invert_bind_args idc4 Raw.ident.Z_cast;
-                  args0 <- invert_bind_args idc3 Raw.ident.Literal;
-                  _ <- invert_bind_args idc2 Raw.ident.Z_land;
-                  args2 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                  args3 <- invert_bind_args idc0 Raw.ident.Literal;
-                  _ <- invert_bind_args idc Raw.ident.Z_mul;
-                  match
-                    pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
-                      ((projT1 args3) -> (projT1 args0) -> s4)%ptype
-                  with
-                  | Some (_, (_, _))%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         (ℤ -> ℤ -> ℤ)%ptype
-                         ((projT1 args3) -> (projT1 args0) -> s4)%ptype
-                      then
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args3);
-                       xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args0);
-                       v <- type.try_make_transport_cps s4 ℤ;
-                       fv <- (x6 <- (if
-                                      ((let (x6, _) := xv0 in x6) =?
-                                       2
-                                       ^ (2 *
-                                          Z.log2_up
-                                            (let (x6, _) := xv0 in x6) / 2) -
-                                       1) &&
-                                      (ZRange.normalize
-                                         (ZRange.constant
-                                            (let (x6, _) := xv0 in x6)) &'
-                                       ZRange.normalize args <=?
-                                       ZRange.normalize args2)%zrange
-                                     then
-                                      x6 <- invert_high
-                                              (2 *
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (@expr.Ident _ _ _ t3 idc3 @ x5 @ x4))%expr_pat =>
+          match x5 with
+          | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t4 idc4) x6 =>
+              match x4 with
+              | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t5 idc5) x7 =>
+                  match x7 with
+                  | @expr.Ident _ _ _ t6 idc6 =>
+                      args <- invert_bind_args idc6 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc3 Raw.ident.Z_land;
+                      args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args4 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc Raw.ident.Z_mul;
+                      match
+                        pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
+                          ((projT1 args4) -> s5 -> (projT1 args))%ptype
+                      with
+                      | Some (_, (_, _))%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             (ℤ -> ℤ -> ℤ)%ptype
+                             ((projT1 args4) -> s5 -> (projT1 args))%ptype
+                          then
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args4);
+                           v <- type.try_make_transport_cps s5 ℤ;
+                           xv0 <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args);
+                           fv <- (x8 <- (if
+                                          ((let (x8, _) := xv0 in x8) =?
+                                           2
+                                           ^ (2 *
+                                              Z.log2_up
+                                                (let (x8, _) := xv0 in x8) /
+                                              2) - 1) &&
+                                          (ZRange.normalize args1 &'
+                                           ZRange.normalize
+                                             (ZRange.constant
+                                                (let (x8, _) := xv0 in x8)) <=?
+                                           ZRange.normalize args3)%zrange &&
+                                          is_bounded_by_bool
+                                            (let (x8, _) := xv in x8)
+                                            (ZRange.normalize args5) &&
+                                          is_bounded_by_bool
+                                            (let (x8, _) := xv0 in x8)
+                                            (ZRange.normalize args0)
+                                         then
+                                          x8 <- invert_low
+                                                  (2 *
+                                                   Z.log2_up
+                                                     (let (x8, _) := xv0 in
+                                                      x8))
+                                                  (let (x8, _) := xv in x8);
+                                          Some
+                                            (#(Z_cast range)%expr @
+                                             (#(fancy_mulll
+                                                  (2 *
+                                                   Z.log2_up
+                                                     (let (x9, _) := xv0 in
+                                                      x9)))%expr @
+                                              ((##x8)%expr,
+                                              #(Z_cast args1)%expr @
+                                              v (Compile.reflect x6))))%expr_pat
+                                         else None);
+                                  Some (Base x8));
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
+                      end
+                  | _ => None
+                  end;;
+                  match x6 with
+                  | @expr.Ident _ _ _ t6 idc6 =>
+                      (args <- invert_bind_args idc6 Raw.ident.Literal;
+                       args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                       args1 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc3 Raw.ident.Z_land;
+                       args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                       args4 <- invert_bind_args idc1 Raw.ident.Literal;
+                       args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       _ <- invert_bind_args idc Raw.ident.Z_mul;
+                       match
+                         pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
+                           ((projT1 args4) -> (projT1 args) -> s6)%ptype
+                       with
+                       | Some (_, (_, _))%zrange =>
+                           if
+                            type.type_beq base.type base.type.type_beq
+                              (ℤ -> ℤ -> ℤ)%ptype
+                              ((projT1 args4) -> (projT1 args) -> s6)%ptype
+                           then
+                            xv <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args4);
+                            xv0 <- ident.unify pattern.ident.Literal
+                                     ##(projT2 args);
+                            v <- type.try_make_transport_cps s6 ℤ;
+                            fv <- (x8 <- (if
+                                           ((let (x8, _) := xv0 in x8) =?
+                                            2
+                                            ^ (2 *
                                                Z.log2_up
-                                                 (let (x6, _) := xv0 in x6))
-                                              (let (x6, _) := xv in x6);
-                                      Some
-                                        (#(Z_cast range)%expr @
-                                         (#(fancy_mulhl
-                                              (2 *
-                                               Z.log2_up
-                                                 (let (x7, _) := xv0 in x7)))%expr @
-                                          ((##x6)%expr,
-                                          #(Z_cast args)%expr @
-                                          v (Compile.reflect x5))))%expr_pat
-                                     else None);
-                              Some (Base x6));
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
+                                                 (let (x8, _) := xv0 in x8) /
+                                               2) - 1) &&
+                                           (ZRange.normalize
+                                              (ZRange.constant
+                                                 (let (x8, _) := xv0 in x8)) &'
+                                            ZRange.normalize args0 <=?
+                                            ZRange.normalize args3)%zrange &&
+                                           is_bounded_by_bool
+                                             (let (x8, _) := xv in x8)
+                                             (ZRange.normalize args5) &&
+                                           is_bounded_by_bool
+                                             (let (x8, _) := xv0 in x8)
+                                             (ZRange.normalize args1)
+                                          then
+                                           x8 <- invert_low
+                                                   (2 *
+                                                    Z.log2_up
+                                                      (let (x8, _) := xv0 in
+                                                       x8))
+                                                   (let (x8, _) := xv in x8);
+                                           Some
+                                             (#(Z_cast range)%expr @
+                                              (#(fancy_mulll
+                                                   (2 *
+                                                    Z.log2_up
+                                                      (let (x9, _) := xv0 in
+                                                       x9)))%expr @
+                                               ((##x8)%expr,
+                                               #(Z_cast args0)%expr @
+                                               v (Compile.reflect x7))))%expr_pat
+                                          else None);
+                                   Some (Base x8));
+                            Some (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                           else None
+                       | None => None
+                       end);;
+                      args <- invert_bind_args idc6 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc3 Raw.ident.Z_land;
+                      args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args4 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc Raw.ident.Z_mul;
+                      match
+                        pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
+                          ((projT1 args4) -> (projT1 args) -> s6)%ptype
+                      with
+                      | Some (_, (_, _))%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             (ℤ -> ℤ -> ℤ)%ptype
+                             ((projT1 args4) -> (projT1 args) -> s6)%ptype
+                          then
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args4);
+                           xv0 <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args);
+                           v <- type.try_make_transport_cps s6 ℤ;
+                           fv <- (x8 <- (if
+                                          ((let (x8, _) := xv0 in x8) =?
+                                           2
+                                           ^ (2 *
+                                              Z.log2_up
+                                                (let (x8, _) := xv0 in x8) /
+                                              2) - 1) &&
+                                          (ZRange.normalize
+                                             (ZRange.constant
+                                                (let (x8, _) := xv0 in x8)) &'
+                                           ZRange.normalize args0 <=?
+                                           ZRange.normalize args3)%zrange &&
+                                          is_bounded_by_bool
+                                            (let (x8, _) := xv in x8)
+                                            (ZRange.normalize args5) &&
+                                          is_bounded_by_bool
+                                            (let (x8, _) := xv0 in x8)
+                                            (ZRange.normalize args1)
+                                         then
+                                          x8 <- invert_high
+                                                  (2 *
+                                                   Z.log2_up
+                                                     (let (x8, _) := xv0 in
+                                                      x8))
+                                                  (let (x8, _) := xv in x8);
+                                          Some
+                                            (#(Z_cast range)%expr @
+                                             (#(fancy_mulhl
+                                                  (2 *
+                                                   Z.log2_up
+                                                     (let (x9, _) := xv0 in
+                                                      x9)))%expr @
+                                              ((##x8)%expr,
+                                              #(Z_cast args0)%expr @
+                                              v (Compile.reflect x7))))%expr_pat
+                                         else None);
+                                  Some (Base x8));
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
+                      end
+                  | _ => None
+                  end;;
+                  match x7 with
+                  | @expr.Ident _ _ _ t6 idc6 =>
+                      args <- invert_bind_args idc6 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc3 Raw.ident.Z_land;
+                      args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args4 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc Raw.ident.Z_mul;
+                      match
+                        pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
+                          ((projT1 args4) -> s5 -> (projT1 args))%ptype
+                      with
+                      | Some (_, (_, _))%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             (ℤ -> ℤ -> ℤ)%ptype
+                             ((projT1 args4) -> s5 -> (projT1 args))%ptype
+                          then
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args4);
+                           v <- type.try_make_transport_cps s5 ℤ;
+                           xv0 <- ident.unify pattern.ident.Literal
+                                    ##(projT2 args);
+                           fv <- (x8 <- (if
+                                          ((let (x8, _) := xv0 in x8) =?
+                                           2
+                                           ^ (2 *
+                                              Z.log2_up
+                                                (let (x8, _) := xv0 in x8) /
+                                              2) - 1) &&
+                                          (ZRange.normalize args1 &'
+                                           ZRange.normalize
+                                             (ZRange.constant
+                                                (let (x8, _) := xv0 in x8)) <=?
+                                           ZRange.normalize args3)%zrange &&
+                                          is_bounded_by_bool
+                                            (let (x8, _) := xv in x8)
+                                            (ZRange.normalize args5) &&
+                                          is_bounded_by_bool
+                                            (let (x8, _) := xv0 in x8)
+                                            (ZRange.normalize args0)
+                                         then
+                                          x8 <- invert_high
+                                                  (2 *
+                                                   Z.log2_up
+                                                     (let (x8, _) := xv0 in
+                                                      x8))
+                                                  (let (x8, _) := xv in x8);
+                                          Some
+                                            (#(Z_cast range)%expr @
+                                             (#(fancy_mulhl
+                                                  (2 *
+                                                   Z.log2_up
+                                                     (let (x9, _) := xv0 in
+                                                      x9)))%expr @
+                                              ((##x8)%expr,
+                                              #(Z_cast args1)%expr @
+                                              v (Compile.reflect x6))))%expr_pat
+                                         else None);
+                                  Some (Base x8));
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
+                      end
+                  | _ => None
                   end
-              | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
-                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
-                (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
+              | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6 _
+                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
+                (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
                 (@expr.LetIn _ _ _ _ _ _ _) _ => None
               | _ => None
               end
-          | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3) x5 =>
-              match x3 with
-              | @expr.Ident _ _ _ t4 idc4 =>
-                  (args <- invert_bind_args idc4 Raw.ident.Literal;
-                   args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                   _ <- invert_bind_args idc2 Raw.ident.Z_land;
-                   args2 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                   args3 <- invert_bind_args idc0 Raw.ident.Literal;
-                   _ <- invert_bind_args idc Raw.ident.Z_mul;
-                   match
-                     pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
-                       ((projT1 args3) -> s4 -> (projT1 args))%ptype
-                   with
-                   | Some (_, (_, _))%zrange =>
-                       if
-                        type.type_beq base.type base.type.type_beq
-                          (ℤ -> ℤ -> ℤ)%ptype
-                          ((projT1 args3) -> s4 -> (projT1 args))%ptype
-                       then
-                        xv <- ident.unify pattern.ident.Literal
-                                ##(projT2 args3);
-                        v <- type.try_make_transport_cps s4 ℤ;
-                        xv0 <- ident.unify pattern.ident.Literal
-                                 ##(projT2 args);
-                        fv <- (x6 <- (if
-                                       ((let (x6, _) := xv0 in x6) =?
-                                        2
-                                        ^ (2 *
-                                           Z.log2_up
-                                             (let (x6, _) := xv0 in x6) / 2) -
-                                        1) &&
-                                       (ZRange.normalize args0 &'
-                                        ZRange.normalize
-                                          (ZRange.constant
-                                             (let (x6, _) := xv0 in x6)) <=?
-                                        ZRange.normalize args2)%zrange
-                                      then
-                                       x6 <- invert_low
-                                               (2 *
-                                                Z.log2_up
-                                                  (let (x6, _) := xv0 in x6))
-                                               (let (x6, _) := xv in x6);
-                                       Some
-                                         (#(Z_cast range)%expr @
-                                          (#(fancy_mulll
-                                               (2 *
-                                                Z.log2_up
-                                                  (let (x7, _) := xv0 in x7)))%expr @
-                                           ((##x6)%expr,
-                                           #(Z_cast args0)%expr @
-                                           v (Compile.reflect x5))))%expr_pat
-                                      else None);
-                               Some (Base x6));
-                        Some (fv0 <-- fv;
-                              Base fv0)%under_lets
-                       else None
-                   | None => None
-                   end);;
-                  args <- invert_bind_args idc4 Raw.ident.Literal;
-                  args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                  _ <- invert_bind_args idc2 Raw.ident.Z_land;
-                  args2 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                  args3 <- invert_bind_args idc0 Raw.ident.Literal;
-                  _ <- invert_bind_args idc Raw.ident.Z_mul;
-                  match
-                    pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
-                      ((projT1 args3) -> s4 -> (projT1 args))%ptype
-                  with
-                  | Some (_, (_, _))%zrange =>
-                      if
-                       type.type_beq base.type base.type.type_beq
-                         (ℤ -> ℤ -> ℤ)%ptype
-                         ((projT1 args3) -> s4 -> (projT1 args))%ptype
-                      then
-                       xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args3);
-                       v <- type.try_make_transport_cps s4 ℤ;
-                       xv0 <- ident.unify pattern.ident.Literal
-                                ##(projT2 args);
-                       fv <- (x6 <- (if
-                                      ((let (x6, _) := xv0 in x6) =?
-                                       2
-                                       ^ (2 *
-                                          Z.log2_up
-                                            (let (x6, _) := xv0 in x6) / 2) -
-                                       1) &&
-                                      (ZRange.normalize args0 &'
-                                       ZRange.normalize
-                                         (ZRange.constant
-                                            (let (x6, _) := xv0 in x6)) <=?
-                                       ZRange.normalize args2)%zrange
-                                     then
-                                      x6 <- invert_high
-                                              (2 *
-                                               Z.log2_up
-                                                 (let (x6, _) := xv0 in x6))
-                                              (let (x6, _) := xv in x6);
-                                      Some
-                                        (#(Z_cast range)%expr @
-                                         (#(fancy_mulhl
-                                              (2 *
-                                               Z.log2_up
-                                                 (let (x7, _) := xv0 in x7)))%expr @
-                                          ((##x6)%expr,
-                                          #(Z_cast args0)%expr @
-                                          v (Compile.reflect x5))))%expr_pat
-                                     else None);
-                              Some (Base x6));
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
-                  end
-              | _ => None
-              end
-          | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
-            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+          | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
+            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _ (_ @ _)%expr_pat
+            _ | @expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
           | _ => None
           end;;
-          match x4 with
-          | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3) x5 =>
-              match x3 with
-              | @expr.Ident _ _ _ t4 idc4 =>
-                  (args <- invert_bind_args idc4 Raw.ident.Literal;
-                   args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                   _ <- invert_bind_args idc2 Raw.ident.Z_shiftr;
-                   args2 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                   args3 <- invert_bind_args idc0 Raw.ident.Literal;
+          match x5 with
+          | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t4 idc4) x6 =>
+              match x4 with
+              | (@expr.Ident _ _ _ t5 idc5 @ @expr.Ident _ _ _ t6 idc6)%expr_pat =>
+                  (args <- invert_bind_args idc6 Raw.ident.Literal;
+                   args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                   args1 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                   _ <- invert_bind_args idc3 Raw.ident.Z_shiftr;
+                   args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                   args4 <- invert_bind_args idc1 Raw.ident.Literal;
+                   args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
                    _ <- invert_bind_args idc Raw.ident.Z_mul;
                    match
                      pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
-                       ((projT1 args3) -> s4 -> (projT1 args))%ptype
+                       ((projT1 args4) -> s5 -> (projT1 args))%ptype
                    with
                    | Some (_, (_, _))%zrange =>
                        if
                         type.type_beq base.type base.type.type_beq
                           (ℤ -> ℤ -> ℤ)%ptype
-                          ((projT1 args3) -> s4 -> (projT1 args))%ptype
+                          ((projT1 args4) -> s5 -> (projT1 args))%ptype
                        then
                         xv <- ident.unify pattern.ident.Literal
-                                ##(projT2 args3);
-                        v <- type.try_make_transport_cps s4 ℤ;
+                                ##(projT2 args4);
+                        v <- type.try_make_transport_cps s5 ℤ;
                         xv0 <- ident.unify pattern.ident.Literal
                                  ##(projT2 args);
-                        fv <- (x6 <- (if
-                                       (ZRange.normalize args0 >>
+                        fv <- (x8 <- (if
+                                       (ZRange.normalize args1 >>
                                         ZRange.normalize
                                           (ZRange.constant
-                                             (let (x6, _) := xv0 in x6)) <=?
-                                        ZRange.normalize args2)%zrange
+                                             (let (x8, _) := xv0 in x8)) <=?
+                                        ZRange.normalize args3)%zrange &&
+                                       is_bounded_by_bool
+                                         (let (x8, _) := xv in x8)
+                                         (ZRange.normalize args5) &&
+                                       is_bounded_by_bool
+                                         (let (x8, _) := xv0 in x8)
+                                         (ZRange.normalize args0)
                                       then
-                                       x6 <- invert_low
+                                       x8 <- invert_low
                                                (2 *
-                                                (let (x6, _) := xv0 in x6))
-                                               (let (x6, _) := xv in x6);
+                                                (let (x8, _) := xv0 in x8))
+                                               (let (x8, _) := xv in x8);
                                        Some
                                          (#(Z_cast range)%expr @
                                           (#(fancy_mullh
                                                (2 *
-                                                (let (x7, _) := xv0 in x7)))%expr @
-                                           ((##x6)%expr,
-                                           #(Z_cast args0)%expr @
-                                           v (Compile.reflect x5))))%expr_pat
+                                                (let (x9, _) := xv0 in x9)))%expr @
+                                           ((##x8)%expr,
+                                           #(Z_cast args1)%expr @
+                                           v (Compile.reflect x6))))%expr_pat
                                       else None);
-                               Some (Base x6));
+                               Some (Base x8));
                         Some (fv0 <-- fv;
                               Base fv0)%under_lets
                        else None
                    | None => None
                    end);;
-                  args <- invert_bind_args idc4 Raw.ident.Literal;
-                  args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                  _ <- invert_bind_args idc2 Raw.ident.Z_shiftr;
-                  args2 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                  args3 <- invert_bind_args idc0 Raw.ident.Literal;
+                  args <- invert_bind_args idc6 Raw.ident.Literal;
+                  args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                  args1 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                  _ <- invert_bind_args idc3 Raw.ident.Z_shiftr;
+                  args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                  args4 <- invert_bind_args idc1 Raw.ident.Literal;
+                  args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
                   _ <- invert_bind_args idc Raw.ident.Z_mul;
                   match
                     pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
-                      ((projT1 args3) -> s4 -> (projT1 args))%ptype
+                      ((projT1 args4) -> s5 -> (projT1 args))%ptype
                   with
                   | Some (_, (_, _))%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          (ℤ -> ℤ -> ℤ)%ptype
-                         ((projT1 args3) -> s4 -> (projT1 args))%ptype
+                         ((projT1 args4) -> s5 -> (projT1 args))%ptype
                       then
                        xv <- ident.unify pattern.ident.Literal
-                               ##(projT2 args3);
-                       v <- type.try_make_transport_cps s4 ℤ;
+                               ##(projT2 args4);
+                       v <- type.try_make_transport_cps s5 ℤ;
                        xv0 <- ident.unify pattern.ident.Literal
                                 ##(projT2 args);
-                       fv <- (x6 <- (if
-                                      (ZRange.normalize args0 >>
+                       fv <- (x8 <- (if
+                                      (ZRange.normalize args1 >>
                                        ZRange.normalize
                                          (ZRange.constant
-                                            (let (x6, _) := xv0 in x6)) <=?
-                                       ZRange.normalize args2)%zrange
+                                            (let (x8, _) := xv0 in x8)) <=?
+                                       ZRange.normalize args3)%zrange &&
+                                      is_bounded_by_bool
+                                        (let (x8, _) := xv in x8)
+                                        (ZRange.normalize args5) &&
+                                      is_bounded_by_bool
+                                        (let (x8, _) := xv0 in x8)
+                                        (ZRange.normalize args0)
                                      then
-                                      x6 <- invert_high
-                                              (2 * (let (x6, _) := xv0 in x6))
-                                              (let (x6, _) := xv in x6);
+                                      x8 <- invert_high
+                                              (2 * (let (x8, _) := xv0 in x8))
+                                              (let (x8, _) := xv in x8);
                                       Some
                                         (#(Z_cast range)%expr @
                                          (#(fancy_mulhh
-                                              (2 * (let (x7, _) := xv0 in x7)))%expr @
-                                          ((##x6)%expr,
-                                          #(Z_cast args0)%expr @
-                                          v (Compile.reflect x5))))%expr_pat
+                                              (2 * (let (x9, _) := xv0 in x9)))%expr @
+                                          ((##x8)%expr,
+                                          #(Z_cast args1)%expr @
+                                          v (Compile.reflect x6))))%expr_pat
                                      else None);
-                              Some (Base x6));
+                              Some (Base x8));
                        Some (fv0 <-- fv;
                              Base fv0)%under_lets
                       else None
                   | None => None
                   end
+              | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
+                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                  None
               | _ => None
               end
-          | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
-            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
+          | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
+            (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _ (_ @ _)%expr_pat
+            _ | @expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
           | _ => None
           end
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat | @expr.App _ _ _ s _
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ #(_))%expr_pat | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat | @expr.App _ _ _ s
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat | @expr.App _ _ _ s
         _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
         @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (#(_) @ _))%expr_pat | @expr.App _ _ _ s
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (#(_) @ _))%expr_pat | @expr.App _ _ _ s
         _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (($_)%expr @ _))%expr_pat | @expr.App _
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (($_)%expr @ _))%expr_pat | @expr.App _
         _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
         @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (($_)%expr @ _ @ _))%expr_pat |
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (($_)%expr @ _ @ _))%expr_pat |
         @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
         @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (_ @ _ @ _ @ _))%expr_pat | @expr.App _
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (_ @ _ @ _ @ _))%expr_pat | @expr.App _
         _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
         @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
         @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
           None
+      | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        #(_)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        ($_)%expr | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Abs _ _ _ _ _ _) | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (($_)%expr @ _)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.Abs _ _ _ _ _ _ @ _)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (_ @ _ @ _)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
+         (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
+        (@expr.LetIn _ _ _ _ _ _ _) => None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
          (@expr.Ident _ _ _ t0 idc0 @ (@expr.Ident _ _ _ t1 idc1 @ x4 @ x3))%expr_pat)
         x0 =>
           match x4 with
-          | @expr.Ident _ _ _ t2 idc2 =>
-              match x3 with
-              | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3) x5 =>
-                  match x0 with
-                  | @expr.Ident _ _ _ t4 idc4 =>
-                      (args <- invert_bind_args idc4 Raw.ident.Literal;
-                       args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                       args1 <- invert_bind_args idc2 Raw.ident.Literal;
-                       _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                       args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                       _ <- invert_bind_args idc Raw.ident.Z_mul;
-                       match
-                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                           (((projT1 args1) -> s4) -> (projT1 args))%ptype
-                       with
-                       | Some (_, _, _)%zrange =>
-                           if
-                            type.type_beq base.type base.type.type_beq
-                              ((ℤ -> ℤ) -> ℤ)%ptype
-                              (((projT1 args1) -> s4) -> (projT1 args))%ptype
-                           then
-                            xv <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args1);
-                            v <- type.try_make_transport_cps s4 ℤ;
-                            xv0 <- ident.unify pattern.ident.Literal
-                                     ##(projT2 args);
-                            fv <- (x6 <- (if
-                                           ((let (x6, _) := xv in x6) =?
-                                            2
-                                            ^ (2 *
-                                               Z.log2_up
-                                                 (let (x6, _) := xv in x6) /
-                                               2) - 1) &&
-                                           (ZRange.normalize
-                                              (ZRange.constant
-                                                 (let (x6, _) := xv in x6)) &'
-                                            ZRange.normalize args0 <=?
-                                            ZRange.normalize args3)%zrange
-                                          then
-                                           y <- invert_low
-                                                  (2 *
-                                                   Z.log2_up
-                                                     (let (x6, _) := xv in x6))
-                                                  (let (x6, _) := xv0 in x6);
-                                           Some
-                                             (#(Z_cast range)%expr @
-                                              (#(fancy_mulll
-                                                   (2 *
-                                                    Z.log2_up
-                                                      (let (x6, _) := xv in
-                                                       x6)))%expr @
-                                               (#(Z_cast args0)%expr @
-                                                v (Compile.reflect x5),
-                                               (##y)%expr)))%expr_pat
-                                          else None);
-                                   Some (Base x6));
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
-                       end);;
-                      args <- invert_bind_args idc4 Raw.ident.Literal;
-                      args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                      args1 <- invert_bind_args idc2 Raw.ident.Literal;
-                      _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                      args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                      _ <- invert_bind_args idc Raw.ident.Z_mul;
-                      match
-                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          (((projT1 args1) -> s4) -> (projT1 args))%ptype
-                      with
-                      | Some (_, _, _)%zrange =>
-                          if
-                           type.type_beq base.type base.type.type_beq
-                             ((ℤ -> ℤ) -> ℤ)%ptype
-                             (((projT1 args1) -> s4) -> (projT1 args))%ptype
-                          then
-                           xv <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                           v <- type.try_make_transport_cps s4 ℤ;
-                           xv0 <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args);
-                           fv <- (x6 <- (if
-                                          ((let (x6, _) := xv in x6) =?
-                                           2
-                                           ^ (2 *
-                                              Z.log2_up
-                                                (let (x6, _) := xv in x6) / 2) -
-                                           1) &&
-                                          (ZRange.normalize
-                                             (ZRange.constant
-                                                (let (x6, _) := xv in x6)) &'
-                                           ZRange.normalize args0 <=?
-                                           ZRange.normalize args3)%zrange
-                                         then
-                                          y <- invert_high
-                                                 (2 *
-                                                  Z.log2_up
-                                                    (let (x6, _) := xv in x6))
-                                                 (let (x6, _) := xv0 in x6);
-                                          Some
-                                            (#(Z_cast range)%expr @
-                                             (#(fancy_mullh
-                                                  (2 *
-                                                   Z.log2_up
-                                                     (let (x6, _) := xv in x6)))%expr @
-                                              (#(Z_cast args0)%expr @
-                                               v (Compile.reflect x5),
-                                              (##y)%expr)))%expr_pat
-                                         else None);
-                                  Some (Base x6));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
-                      end
-                  | (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.Ident _ _ _ t5 idc5 @ x8 @ x7))%expr_pat =>
-                      match x8 with
-                      | @expr.Ident _ _ _ t6 idc6 =>
-                          match x7 with
-                          | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t7 idc7)
-                            x9 =>
-                              args <- invert_bind_args idc7 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc6
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args4 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_mul;
-                              match
-                                pattern.type.unify_extracted
-                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  (((projT1 args4) -> s4) ->
-                                   (projT1 args0) -> s8)%ptype
-                              with
-                              | Some (_, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     (((projT1 args4) -> s4) ->
-                                      (projT1 args0) -> s8)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args4);
-                                   v <- type.try_make_transport_cps s4 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       Z.log2_up
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10) / 2) - 1) &&
-                                                   ((let (x10, _) := xv0 in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       Z.log2_up
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10) / 2) - 1) &&
-                                                   (ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10)) &'
-                                                    ZRange.normalize args3 <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv0 in
-                                                          x10)) &'
-                                                    ZRange.normalize args <=?
-                                                    ZRange.normalize args2)%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast range)%expr @
-                                                      (#(fancy_mulll
-                                                           (2 *
-                                                            Z.log2_up
-                                                              (let
-                                                                 (x10, _) :=
-                                                                 xv in
-                                                               x10)))%expr @
-                                                       (#(Z_cast args3)%expr @
-                                                        v
-                                                          (Compile.reflect x5),
-                                                       #(Z_cast args)%expr @
-                                                       v0
-                                                         (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _
-                            _ s8 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s8 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
-                      | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t6 idc6)
-                        x9 =>
-                          match x7 with
-                          | @expr.Ident _ _ _ t7 idc7 =>
-                              args <- invert_bind_args idc7 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc6 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args4 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_mul;
-                              match
-                                pattern.type.unify_extracted
-                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  (((projT1 args4) -> s4) ->
-                                   s8 -> (projT1 args))%ptype
-                              with
-                              | Some (_, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     (((projT1 args4) -> s4) ->
-                                      s8 -> (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args4);
-                                   v <- type.try_make_transport_cps s4 ℤ;
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       Z.log2_up
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10) / 2) - 1) &&
-                                                   ((let (x10, _) := xv0 in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       Z.log2_up
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10) / 2) - 1) &&
-                                                   (ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10)) &'
-                                                    ZRange.normalize args3 <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize args0 &'
-                                                    ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv0 in
-                                                          x10)) <=?
-                                                    ZRange.normalize args2)%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast range)%expr @
-                                                      (#(fancy_mulll
-                                                           (2 *
-                                                            Z.log2_up
-                                                              (let
-                                                                 (x10, _) :=
-                                                                 xv in
-                                                               x10)))%expr @
-                                                       (#(Z_cast args3)%expr @
-                                                        v
-                                                          (Compile.reflect x5),
-                                                       #(Z_cast args0)%expr @
-                                                       v0
-                                                         (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | _ => None
-                          end
-                      | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _ _ s8
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s8 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end;;
-                      match x8 with
-                      | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t6 idc6)
-                        x9 =>
-                          match x7 with
-                          | @expr.Ident _ _ _ t7 idc7 =>
-                              args <- invert_bind_args idc7 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc6 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_shiftr;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args4 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_mul;
-                              match
-                                pattern.type.unify_extracted
-                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  (((projT1 args4) -> s4) ->
-                                   s8 -> (projT1 args))%ptype
-                              with
-                              | Some (_, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     (((projT1 args4) -> s4) ->
-                                      s8 -> (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args4);
-                                   v <- type.try_make_transport_cps s4 ℤ;
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       (let (x10, _) :=
-                                                          xv0 in
-                                                        x10) / 2) - 1) &&
-                                                   (ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10)) &'
-                                                    ZRange.normalize args3 <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize args0 >>
-                                                    ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv0 in
-                                                          x10)) <=?
-                                                    ZRange.normalize args2)%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast range)%expr @
-                                                      (#(fancy_mullh
-                                                           (2 *
-                                                            (let (x10, _) :=
-                                                               xv0 in
-                                                             x10)))%expr @
-                                                       (#(Z_cast args3)%expr @
-                                                        v
-                                                          (Compile.reflect x5),
-                                                       #(Z_cast args0)%expr @
-                                                       v0
-                                                         (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | _ => None
-                          end
-                      | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _ _ s8
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s8 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end
-                  | (@expr.Ident _ _ _ t4 idc4 @ #(_))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
-                  end
-              | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
-                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
-                (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
-              end
           | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5 =>
-              match x3 with
+              match x5 with
               | @expr.Ident _ _ _ t3 idc3 =>
-                  match x0 with
-                  | @expr.Ident _ _ _ t4 idc4 =>
-                      (args <- invert_bind_args idc4 Raw.ident.Literal;
-                       args0 <- invert_bind_args idc3 Raw.ident.Literal;
-                       args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                       _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                       args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                       _ <- invert_bind_args idc Raw.ident.Z_mul;
-                       match
-                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                           ((s4 -> (projT1 args0)) -> (projT1 args))%ptype
-                       with
-                       | Some (_, _, _)%zrange =>
-                           if
-                            type.type_beq base.type base.type.type_beq
+                  match x3 with
+                  | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t4 idc4) x6 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @ @expr.Ident _ _ _ t6
+                         idc6)%expr_pat =>
+                          args <- invert_bind_args idc6 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                          args2 <- invert_bind_args idc3 Raw.ident.Literal;
+                          args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
                               ((ℤ -> ℤ) -> ℤ)%ptype
-                              ((s4 -> (projT1 args0)) -> (projT1 args))%ptype
-                           then
-                            v <- type.try_make_transport_cps s4 ℤ;
-                            xv <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args0);
-                            xv0 <- ident.unify pattern.ident.Literal
-                                     ##(projT2 args);
-                            fv <- (x6 <- (if
-                                           ((let (x6, _) := xv in x6) =?
-                                            2
-                                            ^ (2 *
-                                               Z.log2_up
-                                                 (let (x6, _) := xv in x6) /
-                                               2) - 1) &&
-                                           (ZRange.normalize args1 &'
-                                            ZRange.normalize
-                                              (ZRange.constant
-                                                 (let (x6, _) := xv in x6)) <=?
-                                            ZRange.normalize args3)%zrange
-                                          then
-                                           y <- invert_low
-                                                  (2 *
-                                                   Z.log2_up
-                                                     (let (x6, _) := xv in x6))
-                                                  (let (x6, _) := xv0 in x6);
-                                           Some
-                                             (#(Z_cast range)%expr @
-                                              (#(fancy_mulll
-                                                   (2 *
-                                                    Z.log2_up
-                                                      (let (x6, _) := xv in
-                                                       x6)))%expr @
-                                               (#(Z_cast args1)%expr @
-                                                v (Compile.reflect x5),
-                                               (##y)%expr)))%expr_pat
-                                          else None);
-                                   Some (Base x6));
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
-                       end);;
-                      args <- invert_bind_args idc4 Raw.ident.Literal;
-                      args0 <- invert_bind_args idc3 Raw.ident.Literal;
-                      args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                      _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                      args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                      _ <- invert_bind_args idc Raw.ident.Z_mul;
-                      match
-                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          ((s4 -> (projT1 args0)) -> (projT1 args))%ptype
-                      with
-                      | Some (_, _, _)%zrange =>
-                          if
-                           type.type_beq base.type base.type.type_beq
-                             ((ℤ -> ℤ) -> ℤ)%ptype
-                             ((s4 -> (projT1 args0)) -> (projT1 args))%ptype
-                          then
-                           v <- type.try_make_transport_cps s4 ℤ;
-                           xv <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args0);
-                           xv0 <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args);
-                           fv <- (x6 <- (if
-                                          ((let (x6, _) := xv in x6) =?
-                                           2
-                                           ^ (2 *
-                                              Z.log2_up
-                                                (let (x6, _) := xv in x6) / 2) -
-                                           1) &&
-                                          (ZRange.normalize args1 &'
-                                           ZRange.normalize
-                                             (ZRange.constant
-                                                (let (x6, _) := xv in x6)) <=?
-                                           ZRange.normalize args3)%zrange
-                                         then
-                                          y <- invert_high
-                                                 (2 *
+                              (((projT1 args2) -> s5) -> (projT1 args))%ptype
+                          with
+                          | Some (_, _, _)%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ)%ptype
+                                 (((projT1 args2) -> s5) -> (projT1 args))%ptype
+                              then
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args2);
+                               v <- type.try_make_transport_cps s5 ℤ;
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x8 <- (if
+                                              ((let (x8, _) := xv in x8) =?
+                                               2
+                                               ^ (2 *
                                                   Z.log2_up
-                                                    (let (x6, _) := xv in x6))
-                                                 (let (x6, _) := xv0 in x6);
-                                          Some
-                                            (#(Z_cast range)%expr @
-                                             (#(fancy_mullh
-                                                  (2 *
-                                                   Z.log2_up
-                                                     (let (x6, _) := xv in x6)))%expr @
-                                              (#(Z_cast args1)%expr @
-                                               v (Compile.reflect x5),
-                                              (##y)%expr)))%expr_pat
-                                         else None);
-                                  Some (Base x6));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
-                      end
-                  | (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.Ident _ _ _ t5 idc5 @ x8 @ x7))%expr_pat =>
-                      match x8 with
-                      | @expr.Ident _ _ _ t6 idc6 =>
-                          match x7 with
-                          | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t7 idc7)
-                            x9 =>
-                              args <- invert_bind_args idc7 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc6
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3
-                                         Raw.ident.Literal;
-                              args4 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_mul;
-                              match
-                                pattern.type.unify_extracted
-                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  ((s4 -> (projT1 args3)) ->
-                                   (projT1 args0) -> s8)%ptype
-                              with
-                              | Some (_, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     ((s4 -> (projT1 args3)) ->
-                                      (projT1 args0) -> s8)%ptype
-                                  then
-                                   v <- type.try_make_transport_cps s4 ℤ;
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args3);
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
+                                                    (let (x8, _) := xv in x8) /
+                                                  2) - 1) &&
+                                              (ZRange.normalize
+                                                 (ZRange.constant
+                                                    (let (x8, _) := xv in x8)) &'
+                                               ZRange.normalize args1 <=?
+                                               ZRange.normalize args5)%zrange &&
+                                              is_bounded_by_bool
+                                                (let (x8, _) := xv0 in x8)
+                                                (ZRange.normalize args0) &&
+                                              is_bounded_by_bool
+                                                (let (x8, _) := xv in x8)
+                                                (ZRange.normalize args3)
+                                             then
+                                              y <- invert_low
+                                                     (2 *
+                                                      Z.log2_up
+                                                        (let (x8, _) := xv in
+                                                         x8))
+                                                     (let (x8, _) := xv0 in
+                                                      x8);
+                                              Some
+                                                (#(Z_cast range)%expr @
+                                                 (#(fancy_mulll
+                                                      (2 *
                                                        Z.log2_up
-                                                         (let (x10, _) :=
+                                                         (let (x8, _) :=
                                                             xv in
-                                                          x10) / 2) - 1) &&
-                                                   ((let (x10, _) := xv0 in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       Z.log2_up
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10) / 2) - 1) &&
-                                                   (ZRange.normalize args4 &'
-                                                    ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10)) <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv0 in
-                                                          x10)) &'
-                                                    ZRange.normalize args <=?
-                                                    ZRange.normalize args2)%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast range)%expr @
-                                                      (#(fancy_mulll
-                                                           (2 *
-                                                            Z.log2_up
-                                                              (let
-                                                                 (x10, _) :=
-                                                                 xv in
-                                                               x10)))%expr @
-                                                       (#(Z_cast args4)%expr @
-                                                        v
-                                                          (Compile.reflect x5),
-                                                       #(Z_cast args)%expr @
-                                                       v0
-                                                         (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _
-                            _ s8 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s8 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
+                                                          x8)))%expr @
+                                                  (#(Z_cast args1)%expr @
+                                                   v (Compile.reflect x6),
+                                                  (##y)%expr)))%expr_pat
+                                             else None);
+                                      Some (Base x8));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
                           end
-                      | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t6 idc6)
-                        x9 =>
-                          match x7 with
-                          | @expr.Ident _ _ _ t7 idc7 =>
-                              args <- invert_bind_args idc7 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc6 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3
-                                         Raw.ident.Literal;
-                              args4 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_mul;
-                              match
-                                pattern.type.unify_extracted
-                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  ((s4 -> (projT1 args3)) ->
-                                   s8 -> (projT1 args))%ptype
-                              with
-                              | Some (_, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     ((s4 -> (projT1 args3)) ->
-                                      s8 -> (projT1 args))%ptype
-                                  then
-                                   v <- type.try_make_transport_cps s4 ℤ;
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args3);
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       Z.log2_up
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10) / 2) - 1) &&
-                                                   ((let (x10, _) := xv0 in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       Z.log2_up
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10) / 2) - 1) &&
-                                                   (ZRange.normalize args4 &'
-                                                    ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10)) <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize args0 &'
-                                                    ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv0 in
-                                                          x10)) <=?
-                                                    ZRange.normalize args2)%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast range)%expr @
-                                                      (#(fancy_mulll
-                                                           (2 *
-                                                            Z.log2_up
-                                                              (let
-                                                                 (x10, _) :=
-                                                                 xv in
-                                                               x10)))%expr @
-                                                       (#(Z_cast args4)%expr @
-                                                        v
-                                                          (Compile.reflect x5),
-                                                       #(Z_cast args0)%expr @
-                                                       v0
-                                                         (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | _ => None
-                          end
-                      | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _ _ s8
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s8 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end;;
-                      match x8 with
-                      | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t6 idc6)
-                        x9 =>
-                          match x7 with
-                          | @expr.Ident _ _ _ t7 idc7 =>
-                              args <- invert_bind_args idc7 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc6 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_shiftr;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3
-                                         Raw.ident.Literal;
-                              args4 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_mul;
-                              match
-                                pattern.type.unify_extracted
-                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  ((s4 -> (projT1 args3)) ->
-                                   s8 -> (projT1 args))%ptype
-                              with
-                              | Some (_, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     ((s4 -> (projT1 args3)) ->
-                                      s8 -> (projT1 args))%ptype
-                                  then
-                                   v <- type.try_make_transport_cps s4 ℤ;
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args3);
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       (let (x10, _) :=
-                                                          xv0 in
-                                                        x10) / 2) - 1) &&
-                                                   (ZRange.normalize args4 &'
-                                                    ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10)) <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize args0 >>
-                                                    ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv0 in
-                                                          x10)) <=?
-                                                    ZRange.normalize args2)%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast range)%expr @
-                                                      (#(fancy_mullh
-                                                           (2 *
-                                                            (let (x10, _) :=
-                                                               xv0 in
-                                                             x10)))%expr @
-                                                       (#(Z_cast args4)%expr @
-                                                        v
-                                                          (Compile.reflect x5),
-                                                       #(Z_cast args0)%expr @
-                                                       v0
-                                                         (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | _ => None
-                          end
-                      | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _ _ s8
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s8 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                      | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
                       | _ => None
                       end
-                  | (@expr.Ident _ _ _ t4 idc4 @ #(_))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
+                  | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
+                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
+                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
                   | _ => None
                   end
+              | _ => None
+              end;;
+              match x3 with
+              | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6 =>
+                  match x6 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @ @expr.Ident _ _ _ t6
+                         idc6)%expr_pat =>
+                          args <- invert_bind_args idc6 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ)%ptype
+                              ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
+                          with
+                          | Some (_, _, _)%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ)%ptype
+                                 ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
+                              then
+                               v <- type.try_make_transport_cps s4 ℤ;
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args1);
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x8 <- (if
+                                              ((let (x8, _) := xv in x8) =?
+                                               2
+                                               ^ (2 *
+                                                  Z.log2_up
+                                                    (let (x8, _) := xv in x8) /
+                                                  2) - 1) &&
+                                              (ZRange.normalize args3 &'
+                                               ZRange.normalize
+                                                 (ZRange.constant
+                                                    (let (x8, _) := xv in x8)) <=?
+                                               ZRange.normalize args5)%zrange &&
+                                              is_bounded_by_bool
+                                                (let (x8, _) := xv0 in x8)
+                                                (ZRange.normalize args0) &&
+                                              is_bounded_by_bool
+                                                (let (x8, _) := xv in x8)
+                                                (ZRange.normalize args2)
+                                             then
+                                              y <- invert_low
+                                                     (2 *
+                                                      Z.log2_up
+                                                        (let (x8, _) := xv in
+                                                         x8))
+                                                     (let (x8, _) := xv0 in
+                                                      x8);
+                                              Some
+                                                (#(Z_cast range)%expr @
+                                                 (#(fancy_mulll
+                                                      (2 *
+                                                       Z.log2_up
+                                                         (let (x8, _) :=
+                                                            xv in
+                                                          x8)))%expr @
+                                                  (#(Z_cast args3)%expr @
+                                                   v (Compile.reflect x5),
+                                                  (##y)%expr)))%expr_pat
+                                             else None);
+                                      Some (Base x8));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end;;
+                  match x5 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @ @expr.Ident _ _ _ t6
+                         idc6)%expr_pat =>
+                          args <- invert_bind_args idc6 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ)%ptype
+                              (((projT1 args1) -> s5) -> (projT1 args))%ptype
+                          with
+                          | Some (_, _, _)%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ)%ptype
+                                 (((projT1 args1) -> s5) -> (projT1 args))%ptype
+                              then
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args1);
+                               v <- type.try_make_transport_cps s5 ℤ;
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x8 <- (if
+                                              ((let (x8, _) := xv in x8) =?
+                                               2
+                                               ^ (2 *
+                                                  Z.log2_up
+                                                    (let (x8, _) := xv in x8) /
+                                                  2) - 1) &&
+                                              (ZRange.normalize
+                                                 (ZRange.constant
+                                                    (let (x8, _) := xv in x8)) &'
+                                               ZRange.normalize args2 <=?
+                                               ZRange.normalize args5)%zrange &&
+                                              is_bounded_by_bool
+                                                (let (x8, _) := xv0 in x8)
+                                                (ZRange.normalize args0) &&
+                                              is_bounded_by_bool
+                                                (let (x8, _) := xv in x8)
+                                                (ZRange.normalize args3)
+                                             then
+                                              y <- invert_high
+                                                     (2 *
+                                                      Z.log2_up
+                                                        (let (x8, _) := xv in
+                                                         x8))
+                                                     (let (x8, _) := xv0 in
+                                                      x8);
+                                              Some
+                                                (#(Z_cast range)%expr @
+                                                 (#(fancy_mullh
+                                                      (2 *
+                                                       Z.log2_up
+                                                         (let (x8, _) :=
+                                                            xv in
+                                                          x8)))%expr @
+                                                  (#(Z_cast args2)%expr @
+                                                   v (Compile.reflect x6),
+                                                  (##y)%expr)))%expr_pat
+                                             else None);
+                                      Some (Base x8));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end;;
+                  match x6 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @ @expr.Ident _ _ _ t6
+                         idc6)%expr_pat =>
+                          args <- invert_bind_args idc6 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ)%ptype
+                              ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
+                          with
+                          | Some (_, _, _)%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ)%ptype
+                                 ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
+                              then
+                               v <- type.try_make_transport_cps s4 ℤ;
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args1);
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x8 <- (if
+                                              ((let (x8, _) := xv in x8) =?
+                                               2
+                                               ^ (2 *
+                                                  Z.log2_up
+                                                    (let (x8, _) := xv in x8) /
+                                                  2) - 1) &&
+                                              (ZRange.normalize args3 &'
+                                               ZRange.normalize
+                                                 (ZRange.constant
+                                                    (let (x8, _) := xv in x8)) <=?
+                                               ZRange.normalize args5)%zrange &&
+                                              is_bounded_by_bool
+                                                (let (x8, _) := xv0 in x8)
+                                                (ZRange.normalize args0) &&
+                                              is_bounded_by_bool
+                                                (let (x8, _) := xv in x8)
+                                                (ZRange.normalize args2)
+                                             then
+                                              y <- invert_high
+                                                     (2 *
+                                                      Z.log2_up
+                                                        (let (x8, _) := xv in
+                                                         x8))
+                                                     (let (x8, _) := xv0 in
+                                                      x8);
+                                              Some
+                                                (#(Z_cast range)%expr @
+                                                 (#(fancy_mullh
+                                                      (2 *
+                                                       Z.log2_up
+                                                         (let (x8, _) :=
+                                                            xv in
+                                                          x8)))%expr @
+                                                  (#(Z_cast args3)%expr @
+                                                   v (Compile.reflect x5),
+                                                  (##y)%expr)))%expr_pat
+                                             else None);
+                                      Some (Base x8));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end;;
+                  match x5 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _
+                          (@expr.Ident _ _ _ t9 idc9) x11))%expr_pat =>
+                          args <- invert_bind_args idc9 Raw.ident.Z_cast;
+                          args0 <- invert_bind_args idc8 Raw.ident.Literal;
+                          args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                          args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args4 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args8 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                              (((projT1 args4) -> s5) ->
+                               (projT1 args0) -> s10)%ptype
+                          with
+                          | Some (_, _, (_, _))%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                 (((projT1 args4) -> s5) ->
+                                  (projT1 args0) -> s10)%ptype
+                              then
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args4);
+                               v <- type.try_make_transport_cps s5 ℤ;
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args0);
+                               v0 <- type.try_make_transport_cps s10 ℤ;
+                               fv <- (x12 <- (if
+                                               ((let (x12, _) := xv in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   Z.log2_up
+                                                     (let (x12, _) := xv in
+                                                      x12) / 2) - 1) &&
+                                               ((let (x12, _) := xv0 in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   Z.log2_up
+                                                     (let (x12, _) := xv in
+                                                      x12) / 2) - 1) &&
+                                               (ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv in
+                                                      x12)) &'
+                                                ZRange.normalize args5 <=?
+                                                ZRange.normalize args8)%zrange &&
+                                               (ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv0 in
+                                                      x12)) &'
+                                                ZRange.normalize args <=?
+                                                ZRange.normalize args3)%zrange &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv in x12)
+                                                 (ZRange.normalize args6) &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv0 in x12)
+                                                 (ZRange.normalize args1)
+                                              then
+                                               Some
+                                                 (#(Z_cast range)%expr @
+                                                  (#(fancy_mulll
+                                                       (2 *
+                                                        Z.log2_up
+                                                          (let (x12, _) :=
+                                                             xv in
+                                                           x12)))%expr @
+                                                   (#(Z_cast args5)%expr @
+                                                    v (Compile.reflect x6),
+                                                   #(Z_cast args)%expr @
+                                                   v0 (Compile.reflect x11))))%expr_pat
+                                              else None);
+                                      Some (Base x12));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _ ($_)%expr _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _
+                          (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _ (_ @ _) _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _
+                          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ #(_)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                          None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _ _ _ _ _ _) @
+                          _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ (_ @ _)) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _ _ _
+                           _ _) @ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _ @
+                          _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ (($_)%expr @ _) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Abs _ _ _ _ _ _ @ _) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ (_ @ _ @ _) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
+                          _ @ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end;;
+                  match x6 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _
+                          (@expr.Ident _ _ _ t9 idc9) x11))%expr_pat =>
+                          args <- invert_bind_args idc9 Raw.ident.Z_cast;
+                          args0 <- invert_bind_args idc8 Raw.ident.Literal;
+                          args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                          args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args4 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args8 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                              ((s4 -> (projT1 args4)) ->
+                               (projT1 args0) -> s10)%ptype
+                          with
+                          | Some (_, _, (_, _))%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                 ((s4 -> (projT1 args4)) ->
+                                  (projT1 args0) -> s10)%ptype
+                              then
+                               v <- type.try_make_transport_cps s4 ℤ;
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args4);
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args0);
+                               v0 <- type.try_make_transport_cps s10 ℤ;
+                               fv <- (x12 <- (if
+                                               ((let (x12, _) := xv in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   Z.log2_up
+                                                     (let (x12, _) := xv in
+                                                      x12) / 2) - 1) &&
+                                               ((let (x12, _) := xv0 in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   Z.log2_up
+                                                     (let (x12, _) := xv in
+                                                      x12) / 2) - 1) &&
+                                               (ZRange.normalize args6 &'
+                                                ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv in
+                                                      x12)) <=?
+                                                ZRange.normalize args8)%zrange &&
+                                               (ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv0 in
+                                                      x12)) &'
+                                                ZRange.normalize args <=?
+                                                ZRange.normalize args3)%zrange &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv in x12)
+                                                 (ZRange.normalize args5) &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv0 in x12)
+                                                 (ZRange.normalize args1)
+                                              then
+                                               Some
+                                                 (#(Z_cast range)%expr @
+                                                  (#(fancy_mulll
+                                                       (2 *
+                                                        Z.log2_up
+                                                          (let (x12, _) :=
+                                                             xv in
+                                                           x12)))%expr @
+                                                   (#(Z_cast args6)%expr @
+                                                    v (Compile.reflect x5),
+                                                   #(Z_cast args)%expr @
+                                                   v0 (Compile.reflect x11))))%expr_pat
+                                              else None);
+                                      Some (Base x12));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _ ($_)%expr _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _
+                          (@expr.Abs _ _ _ _ _ _) _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _ (_ @ _) _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.App _ _ _ s10 _
+                          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ #(_)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
+                           idc8) @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                          None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _ _ _ _ _ _) @
+                          _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ (_ @ _)) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _ _ _
+                           _ _) @ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _ @
+                          _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ (($_)%expr @ _) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.Abs _ _ _ _ _ _ @ _) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ (_ @ _ @ _) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @
+                          (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
+                          _ @ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end;;
+                  match x5 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                           idc9)))%expr_pat =>
+                          args <- invert_bind_args idc9 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                          args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args4 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args8 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                              (((projT1 args4) -> s5) -> s9 -> (projT1 args))%ptype
+                          with
+                          | Some (_, _, (_, _))%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                 (((projT1 args4) -> s5) ->
+                                  s9 -> (projT1 args))%ptype
+                              then
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args4);
+                               v <- type.try_make_transport_cps s5 ℤ;
+                               v0 <- type.try_make_transport_cps s9 ℤ;
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x12 <- (if
+                                               ((let (x12, _) := xv in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   Z.log2_up
+                                                     (let (x12, _) := xv in
+                                                      x12) / 2) - 1) &&
+                                               ((let (x12, _) := xv0 in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   Z.log2_up
+                                                     (let (x12, _) := xv in
+                                                      x12) / 2) - 1) &&
+                                               (ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv in
+                                                      x12)) &'
+                                                ZRange.normalize args5 <=?
+                                                ZRange.normalize args8)%zrange &&
+                                               (ZRange.normalize args1 &'
+                                                ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv0 in
+                                                      x12)) <=?
+                                                ZRange.normalize args3)%zrange &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv in x12)
+                                                 (ZRange.normalize args6) &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv0 in x12)
+                                                 (ZRange.normalize args0)
+                                              then
+                                               Some
+                                                 (#(Z_cast range)%expr @
+                                                  (#(fancy_mulll
+                                                       (2 *
+                                                        Z.log2_up
+                                                          (let (x12, _) :=
+                                                             xv in
+                                                           x12)))%expr @
+                                                   (#(Z_cast args5)%expr @
+                                                    v (Compile.reflect x6),
+                                                   #(Z_cast args1)%expr @
+                                                   v0 (Compile.reflect x10))))%expr_pat
+                                              else None);
+                                      Some (Base x12));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
+                           _ _)))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ #(_)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.Abs _ _ _ _
+                          _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ (($_)%expr @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Abs _ _ _ _ _ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ (_ @ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.LetIn _ _ _ _ _ _ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.LetIn _ _ _
+                          _ _ _ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          ($_)%expr _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (_ @ _) _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
+                          None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _ @
+                          _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
+                          _ @ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end;;
+                  match x6 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                           idc9)))%expr_pat =>
+                          args <- invert_bind_args idc9 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                          args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args4 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args8 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                              ((s4 -> (projT1 args4)) -> s9 -> (projT1 args))%ptype
+                          with
+                          | Some (_, _, (_, _))%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                 ((s4 -> (projT1 args4)) ->
+                                  s9 -> (projT1 args))%ptype
+                              then
+                               v <- type.try_make_transport_cps s4 ℤ;
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args4);
+                               v0 <- type.try_make_transport_cps s9 ℤ;
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x12 <- (if
+                                               ((let (x12, _) := xv in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   Z.log2_up
+                                                     (let (x12, _) := xv in
+                                                      x12) / 2) - 1) &&
+                                               ((let (x12, _) := xv0 in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   Z.log2_up
+                                                     (let (x12, _) := xv in
+                                                      x12) / 2) - 1) &&
+                                               (ZRange.normalize args6 &'
+                                                ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv in
+                                                      x12)) <=?
+                                                ZRange.normalize args8)%zrange &&
+                                               (ZRange.normalize args1 &'
+                                                ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv0 in
+                                                      x12)) <=?
+                                                ZRange.normalize args3)%zrange &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv in x12)
+                                                 (ZRange.normalize args5) &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv0 in x12)
+                                                 (ZRange.normalize args0)
+                                              then
+                                               Some
+                                                 (#(Z_cast range)%expr @
+                                                  (#(fancy_mulll
+                                                       (2 *
+                                                        Z.log2_up
+                                                          (let (x12, _) :=
+                                                             xv in
+                                                           x12)))%expr @
+                                                   (#(Z_cast args6)%expr @
+                                                    v (Compile.reflect x5),
+                                                   #(Z_cast args1)%expr @
+                                                   v0 (Compile.reflect x10))))%expr_pat
+                                              else None);
+                                      Some (Base x12));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
+                           _ _)))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ #(_)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.Abs _ _ _ _
+                          _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ (($_)%expr @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Abs _ _ _ _ _ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ (_ @ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.LetIn _ _ _ _ _ _ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.LetIn _ _ _
+                          _ _ _ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          ($_)%expr _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (_ @ _) _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
+                          None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _ @
+                          _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
+                          _ @ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end;;
+                  match x5 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                           idc9)))%expr_pat =>
+                          args <- invert_bind_args idc9 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc6 Raw.ident.Z_shiftr;
+                          args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args4 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args8 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                              (((projT1 args4) -> s5) -> s9 -> (projT1 args))%ptype
+                          with
+                          | Some (_, _, (_, _))%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                 (((projT1 args4) -> s5) ->
+                                  s9 -> (projT1 args))%ptype
+                              then
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args4);
+                               v <- type.try_make_transport_cps s5 ℤ;
+                               v0 <- type.try_make_transport_cps s9 ℤ;
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x12 <- (if
+                                               ((let (x12, _) := xv in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   (let (x12, _) := xv0 in
+                                                    x12) / 2) - 1) &&
+                                               (ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv in
+                                                      x12)) &'
+                                                ZRange.normalize args5 <=?
+                                                ZRange.normalize args8)%zrange &&
+                                               (ZRange.normalize args1 >>
+                                                ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv0 in
+                                                      x12)) <=?
+                                                ZRange.normalize args3)%zrange &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv in x12)
+                                                 (ZRange.normalize args6) &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv0 in x12)
+                                                 (ZRange.normalize args0)
+                                              then
+                                               Some
+                                                 (#(Z_cast range)%expr @
+                                                  (#(fancy_mullh
+                                                       (2 *
+                                                        (let (x12, _) :=
+                                                           xv0 in
+                                                         x12)))%expr @
+                                                   (#(Z_cast args5)%expr @
+                                                    v (Compile.reflect x6),
+                                                   #(Z_cast args1)%expr @
+                                                   v0 (Compile.reflect x10))))%expr_pat
+                                              else None);
+                                      Some (Base x12));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
+                           _ _)))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ #(_)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.Abs _ _ _ _
+                          _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ (($_)%expr @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Abs _ _ _ _ _ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ (_ @ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.LetIn _ _ _ _ _ _ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.LetIn _ _ _
+                          _ _ _ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          ($_)%expr _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (_ @ _) _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
+                          None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _ @
+                          _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
+                          _ @ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end;;
+                  match x6 with
+                  | @expr.Ident _ _ _ t4 idc4 =>
+                      match x0 with
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                           idc9)))%expr_pat =>
+                          args <- invert_bind_args idc9 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc6 Raw.ident.Z_shiftr;
+                          args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          args4 <- invert_bind_args idc4 Raw.ident.Literal;
+                          args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                          args8 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc Raw.ident.Z_mul;
+                          match
+                            pattern.type.unify_extracted
+                              ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                              ((s4 -> (projT1 args4)) -> s9 -> (projT1 args))%ptype
+                          with
+                          | Some (_, _, (_, _))%zrange =>
+                              if
+                               type.type_beq base.type base.type.type_beq
+                                 ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                 ((s4 -> (projT1 args4)) ->
+                                  s9 -> (projT1 args))%ptype
+                              then
+                               v <- type.try_make_transport_cps s4 ℤ;
+                               xv <- ident.unify pattern.ident.Literal
+                                       ##(projT2 args4);
+                               v0 <- type.try_make_transport_cps s9 ℤ;
+                               xv0 <- ident.unify pattern.ident.Literal
+                                        ##(projT2 args);
+                               fv <- (x12 <- (if
+                                               ((let (x12, _) := xv in x12) =?
+                                                2
+                                                ^ (2 *
+                                                   (let (x12, _) := xv0 in
+                                                    x12) / 2) - 1) &&
+                                               (ZRange.normalize args6 &'
+                                                ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv in
+                                                      x12)) <=?
+                                                ZRange.normalize args8)%zrange &&
+                                               (ZRange.normalize args1 >>
+                                                ZRange.normalize
+                                                  (ZRange.constant
+                                                     (let (x12, _) := xv0 in
+                                                      x12)) <=?
+                                                ZRange.normalize args3)%zrange &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv in x12)
+                                                 (ZRange.normalize args5) &&
+                                               is_bounded_by_bool
+                                                 (let (x12, _) := xv0 in x12)
+                                                 (ZRange.normalize args0)
+                                              then
+                                               Some
+                                                 (#(Z_cast range)%expr @
+                                                  (#(fancy_mullh
+                                                       (2 *
+                                                        (let (x12, _) :=
+                                                           xv0 in
+                                                         x12)))%expr @
+                                                   (#(Z_cast args6)%expr @
+                                                    v (Compile.reflect x5),
+                                                   #(Z_cast args1)%expr @
+                                                   v0 (Compile.reflect x10))))%expr_pat
+                                              else None);
+                                      Some (Base x12));
+                               Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                              else None
+                          | None => None
+                          end
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
+                           _ _)))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ #(_)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.Abs _ _ _ _
+                          _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ (($_)%expr @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.Abs _ _ _ _ _ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ (_ @ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @
+                          (@expr.LetIn _ _ _ _ _ _ _ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.LetIn _ _ _
+                          _ _ _ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          ($_)%expr _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (_ @ _) _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
+                          (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
+                          None
+                      | (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _ @
+                          _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
+                          _ @ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
+                         _)%expr_pat => None
+                      | _ => None
+                      end
+                  | _ => None
+                  end
+              | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
+                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
+                (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
+                (@expr.LetIn _ _ _ _ _ _ _) _ => None
               | _ => None
               end
           | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
@@ -1414,371 +2072,462 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           match x4 with
           | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5 =>
               match x3 with
-              | @expr.Ident _ _ _ t3 idc3 =>
+              | (@expr.Ident _ _ _ t3 idc3 @ @expr.Ident _ _ _ t4 idc4)%expr_pat =>
                   match x0 with
-                  | @expr.Ident _ _ _ t4 idc4 =>
-                      (args <- invert_bind_args idc4 Raw.ident.Literal;
-                       args0 <- invert_bind_args idc3 Raw.ident.Literal;
-                       args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                  | (@expr.Ident _ _ _ t5 idc5 @ @expr.Ident _ _ _ t6 idc6)%expr_pat =>
+                      (args <- invert_bind_args idc6 Raw.ident.Literal;
+                       args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                       args1 <- invert_bind_args idc4 Raw.ident.Literal;
+                       args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                       args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
                        _ <- invert_bind_args idc1 Raw.ident.Z_shiftr;
-                       args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                       args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
                        _ <- invert_bind_args idc Raw.ident.Z_mul;
                        match
                          pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                           ((s4 -> (projT1 args0)) -> (projT1 args))%ptype
+                           ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
                        with
                        | Some (_, _, _)%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               ((ℤ -> ℤ) -> ℤ)%ptype
-                              ((s4 -> (projT1 args0)) -> (projT1 args))%ptype
+                              ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
                            then
                             v <- type.try_make_transport_cps s4 ℤ;
                             xv <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args0);
+                                    ##(projT2 args1);
                             xv0 <- ident.unify pattern.ident.Literal
                                      ##(projT2 args);
-                            fv <- (x6 <- (if
-                                           (ZRange.normalize args1 >>
+                            fv <- (x8 <- (if
+                                           (ZRange.normalize args3 >>
                                             ZRange.normalize
                                               (ZRange.constant
-                                                 (let (x6, _) := xv in x6)) <=?
-                                            ZRange.normalize args3)%zrange
+                                                 (let (x8, _) := xv in x8)) <=?
+                                            ZRange.normalize args5)%zrange &&
+                                           is_bounded_by_bool
+                                             (let (x8, _) := xv0 in x8)
+                                             (ZRange.normalize args0) &&
+                                           is_bounded_by_bool
+                                             (let (x8, _) := xv in x8)
+                                             (ZRange.normalize args2)
                                           then
                                            y <- invert_low
                                                   (2 *
-                                                   (let (x6, _) := xv in x6))
-                                                  (let (x6, _) := xv0 in x6);
+                                                   (let (x8, _) := xv in x8))
+                                                  (let (x8, _) := xv0 in x8);
                                            Some
                                              (#(Z_cast range)%expr @
                                               (#(fancy_mulhl
                                                    (2 *
-                                                    (let (x6, _) := xv in x6)))%expr @
-                                               (#(Z_cast args1)%expr @
+                                                    (let (x8, _) := xv in x8)))%expr @
+                                               (#(Z_cast args3)%expr @
                                                 v (Compile.reflect x5),
                                                (##y)%expr)))%expr_pat
                                           else None);
-                                   Some (Base x6));
+                                   Some (Base x8));
                             Some (fv0 <-- fv;
                                   Base fv0)%under_lets
                            else None
                        | None => None
                        end);;
-                      args <- invert_bind_args idc4 Raw.ident.Literal;
-                      args0 <- invert_bind_args idc3 Raw.ident.Literal;
-                      args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args <- invert_bind_args idc6 Raw.ident.Literal;
+                      args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc4 Raw.ident.Literal;
+                      args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                      args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc1 Raw.ident.Z_shiftr;
-                      args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc Raw.ident.Z_mul;
                       match
                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          ((s4 -> (projT1 args0)) -> (projT1 args))%ptype
+                          ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
                       with
                       | Some (_, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              ((ℤ -> ℤ) -> ℤ)%ptype
-                             ((s4 -> (projT1 args0)) -> (projT1 args))%ptype
+                             ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
                           then
                            v <- type.try_make_transport_cps s4 ℤ;
                            xv <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args0);
+                                   ##(projT2 args1);
                            xv0 <- ident.unify pattern.ident.Literal
                                     ##(projT2 args);
-                           fv <- (x6 <- (if
-                                          (ZRange.normalize args1 >>
+                           fv <- (x8 <- (if
+                                          (ZRange.normalize args3 >>
                                            ZRange.normalize
                                              (ZRange.constant
-                                                (let (x6, _) := xv in x6)) <=?
-                                           ZRange.normalize args3)%zrange
+                                                (let (x8, _) := xv in x8)) <=?
+                                           ZRange.normalize args5)%zrange &&
+                                          is_bounded_by_bool
+                                            (let (x8, _) := xv0 in x8)
+                                            (ZRange.normalize args0) &&
+                                          is_bounded_by_bool
+                                            (let (x8, _) := xv in x8)
+                                            (ZRange.normalize args2)
                                          then
                                           y <- invert_high
                                                  (2 *
-                                                  (let (x6, _) := xv in x6))
-                                                 (let (x6, _) := xv0 in x6);
+                                                  (let (x8, _) := xv in x8))
+                                                 (let (x8, _) := xv0 in x8);
                                           Some
                                             (#(Z_cast range)%expr @
                                              (#(fancy_mulhh
                                                   (2 *
-                                                   (let (x6, _) := xv in x6)))%expr @
-                                              (#(Z_cast args1)%expr @
+                                                   (let (x8, _) := xv in x8)))%expr @
+                                              (#(Z_cast args3)%expr @
                                                v (Compile.reflect x5),
                                               (##y)%expr)))%expr_pat
                                          else None);
-                                  Some (Base x6));
+                                  Some (Base x8));
                            Some (fv0 <-- fv;
                                  Base fv0)%under_lets
                           else None
                       | None => None
                       end
-                  | (@expr.Ident _ _ _ t4 idc4 @
-                     (@expr.Ident _ _ _ t5 idc5 @ x8 @ x7))%expr_pat =>
-                      match x8 with
-                      | @expr.Ident _ _ _ t6 idc6 =>
-                          match x7 with
-                          | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t7 idc7)
-                            x9 =>
-                              args <- invert_bind_args idc7 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc6
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3
-                                         Raw.ident.Literal;
-                              args4 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_shiftr;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_mul;
-                              match
-                                pattern.type.unify_extracted
-                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  ((s4 -> (projT1 args3)) ->
-                                   (projT1 args0) -> s8)%ptype
-                              with
-                              | Some (_, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     ((s4 -> (projT1 args3)) ->
-                                      (projT1 args0) -> s8)%ptype
-                                  then
-                                   v <- type.try_make_transport_cps s4 ℤ;
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args3);
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv0 in
-                                                     x10) =?
-                                                    2
-                                                    ^ (2 *
-                                                       (let (x10, _) := xv in
-                                                        x10) / 2) - 1) &&
-                                                   (ZRange.normalize args4 >>
-                                                    ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
-                                                            xv in
-                                                          x10)) <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize
-                                                      (ZRange.constant
-                                                         (let (x10, _) :=
+                  | (@expr.Ident _ _ _ t5 idc5 @
+                     (@expr.Ident _ _ _ t6 idc6 @ x9 @ x8))%expr_pat =>
+                      match x9 with
+                      | @expr.App _ _ _ s9 _ (@expr.Ident _ _ _ t7 idc7)
+                        x10 =>
+                          match x10 with
+                          | @expr.Ident _ _ _ t8 idc8 =>
+                              match x8 with
+                              | @expr.App _ _ _ s10 _
+                                (@expr.Ident _ _ _ t9 idc9) x11 =>
+                                  args <- invert_bind_args idc9
+                                            Raw.ident.Z_cast;
+                                  args0 <- invert_bind_args idc8
+                                             Raw.ident.Literal;
+                                  args1 <- invert_bind_args idc7
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                                  args3 <- invert_bind_args idc5
+                                             Raw.ident.Z_cast;
+                                  args4 <- invert_bind_args idc4
+                                             Raw.ident.Literal;
+                                  args5 <- invert_bind_args idc3
+                                             Raw.ident.Z_cast;
+                                  args6 <- invert_bind_args idc2
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc1
+                                         Raw.ident.Z_shiftr;
+                                  args8 <- invert_bind_args idc0
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc Raw.ident.Z_mul;
+                                  match
+                                    pattern.type.unify_extracted
+                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                      ((s4 -> (projT1 args4)) ->
+                                       (projT1 args0) -> s10)%ptype
+                                  with
+                                  | Some (_, _, (_, _))%zrange =>
+                                      if
+                                       type.type_beq base.type
+                                         base.type.type_beq
+                                         ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                         ((s4 -> (projT1 args4)) ->
+                                          (projT1 args0) -> s10)%ptype
+                                      then
+                                       v <- type.try_make_transport_cps s4 ℤ;
+                                       xv <- ident.unify
+                                               pattern.ident.Literal
+                                               ##(projT2 args4);
+                                       xv0 <- ident.unify
+                                                pattern.ident.Literal
+                                                ##(projT2 args0);
+                                       v0 <- type.try_make_transport_cps s10 ℤ;
+                                       fv <- (x12 <- (if
+                                                       ((let (x12, _) :=
+                                                           xv0 in
+                                                         x12) =?
+                                                        2
+                                                        ^ (2 *
+                                                           (let (x12, _) :=
+                                                              xv in
+                                                            x12) / 2) - 1) &&
+                                                       (ZRange.normalize
+                                                          args6 >>
+                                                        ZRange.normalize
+                                                          (ZRange.constant
+                                                             (let (x12, _) :=
+                                                                xv in
+                                                              x12)) <=?
+                                                        ZRange.normalize
+                                                          args8)%zrange &&
+                                                       (ZRange.normalize
+                                                          (ZRange.constant
+                                                             (let (x12, _) :=
+                                                                xv0 in
+                                                              x12)) &'
+                                                        ZRange.normalize args <=?
+                                                        ZRange.normalize
+                                                          args3)%zrange &&
+                                                       is_bounded_by_bool
+                                                         (let (x12, _) :=
                                                             xv0 in
-                                                          x10)) &'
-                                                    ZRange.normalize args <=?
-                                                    ZRange.normalize args2)%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast range)%expr @
-                                                      (#(fancy_mulhl
-                                                           (2 *
-                                                            (let (x10, _) :=
-                                                               xv in
-                                                             x10)))%expr @
-                                                       (#(Z_cast args4)%expr @
-                                                        v
-                                                          (Compile.reflect x5),
-                                                       #(Z_cast args)%expr @
-                                                       v0
-                                                         (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                                          x12)
+                                                         (ZRange.normalize
+                                                            args1) &&
+                                                       is_bounded_by_bool
+                                                         (let (x12, _) :=
+                                                            xv in
+                                                          x12)
+                                                         (ZRange.normalize
+                                                            args5)
+                                                      then
+                                                       Some
+                                                         (#(Z_cast range)%expr @
+                                                          (#(fancy_mulhl
+                                                               (2 *
+                                                                (let
+                                                                   (x12,
+                                                                    _) :=
+                                                                   xv in
+                                                                 x12)))%expr @
+                                                           (#(Z_cast args6)%expr @
+                                                            v
+                                                              (Compile.reflect
+                                                                 x5),
+                                                           #(Z_cast args)%expr @
+                                                           v0
+                                                             (Compile.reflect
+                                                                x11))))%expr_pat
+                                                      else None);
+                                              Some (Base x12));
+                                       Some (fv0 <-- fv;
+                                             Base fv0)%under_lets
+                                      else None
+                                  | None => None
+                                  end
+                              | @expr.App _ _ _ s10 _ ($_)%expr _ | @expr.App
+                                _ _ _ s10 _ (@expr.Abs _ _ _ _ _ _) _ |
+                                @expr.App _ _ _ s10 _ (_ @ _)%expr_pat _ |
+                                @expr.App _ _ _ s10 _
+                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                              | _ => None
                               end
-                          | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _
-                            _ s8 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s8 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
                           | _ => None
-                          end
-                      | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t6 idc6)
-                        x9 =>
-                          match x7 with
-                          | @expr.Ident _ _ _ t7 idc7 =>
-                              args <- invert_bind_args idc7 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc6 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3
+                          end;;
+                          match x8 with
+                          | (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                             idc9)%expr_pat =>
+                              args <- invert_bind_args idc9 Raw.ident.Literal;
+                              args0 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                              args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                              args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                              args4 <- invert_bind_args idc4
                                          Raw.ident.Literal;
-                              args4 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                              args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                              args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
                               _ <- invert_bind_args idc1 Raw.ident.Z_shiftr;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                              args8 <- invert_bind_args idc0 Raw.ident.Z_cast;
                               _ <- invert_bind_args idc Raw.ident.Z_mul;
                               match
                                 pattern.type.unify_extracted
                                   ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  ((s4 -> (projT1 args3)) ->
-                                   s8 -> (projT1 args))%ptype
+                                  ((s4 -> (projT1 args4)) ->
+                                   s9 -> (projT1 args))%ptype
                               with
                               | Some (_, _, (_, _))%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     ((s4 -> (projT1 args3)) ->
-                                      s8 -> (projT1 args))%ptype
+                                     ((s4 -> (projT1 args4)) ->
+                                      s9 -> (projT1 args))%ptype
                                   then
                                    v <- type.try_make_transport_cps s4 ℤ;
                                    xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args3);
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
+                                           ##(projT2 args4);
+                                   v0 <- type.try_make_transport_cps s9 ℤ;
                                    xv0 <- ident.unify pattern.ident.Literal
                                             ##(projT2 args);
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv0 in
-                                                     x10) =?
+                                   fv <- (x12 <- (if
+                                                   ((let (x12, _) := xv0 in
+                                                     x12) =?
                                                     2
                                                     ^ (2 *
-                                                       (let (x10, _) := xv in
-                                                        x10) / 2) - 1) &&
-                                                   (ZRange.normalize args4 >>
+                                                       (let (x12, _) := xv in
+                                                        x12) / 2) - 1) &&
+                                                   (ZRange.normalize args6 >>
                                                     ZRange.normalize
                                                       (ZRange.constant
-                                                         (let (x10, _) :=
+                                                         (let (x12, _) :=
                                                             xv in
-                                                          x10)) <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize args0 &'
+                                                          x12)) <=?
+                                                    ZRange.normalize args8)%zrange &&
+                                                   (ZRange.normalize args1 &'
                                                     ZRange.normalize
                                                       (ZRange.constant
-                                                         (let (x10, _) :=
+                                                         (let (x12, _) :=
                                                             xv0 in
-                                                          x10)) <=?
-                                                    ZRange.normalize args2)%zrange
+                                                          x12)) <=?
+                                                    ZRange.normalize args3)%zrange &&
+                                                   is_bounded_by_bool
+                                                     (let (x12, _) := xv0 in
+                                                      x12)
+                                                     (ZRange.normalize args0) &&
+                                                   is_bounded_by_bool
+                                                     (let (x12, _) := xv in
+                                                      x12)
+                                                     (ZRange.normalize args5)
                                                   then
                                                    Some
                                                      (#(Z_cast range)%expr @
                                                       (#(fancy_mulhl
                                                            (2 *
-                                                            (let (x10, _) :=
+                                                            (let (x12, _) :=
                                                                xv in
-                                                             x10)))%expr @
-                                                       (#(Z_cast args4)%expr @
+                                                             x12)))%expr @
+                                                       (#(Z_cast args6)%expr @
                                                         v
                                                           (Compile.reflect x5),
-                                                       #(Z_cast args0)%expr @
+                                                       #(Z_cast args1)%expr @
                                                        v0
-                                                         (Compile.reflect x9))))%expr_pat
+                                                         (Compile.reflect x10))))%expr_pat
                                                   else None);
-                                          Some (Base x10));
+                                          Some (Base x12));
                                    Some (fv0 <-- fv;
                                          Base fv0)%under_lets
                                   else None
                               | None => None
                               end
+                          | (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)%expr_pat |
+                            (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _
+                             _ _ _)%expr_pat => None
                           | _ => None
                           end
-                      | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _ _ s8
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s8 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
+                      | @expr.App _ _ _ s9 _ ($_)%expr _ | @expr.App _ _ _ s9
+                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s9 _
+                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s9 _
                         (@expr.LetIn _ _ _ _ _ _ _) _ => None
                       | _ => None
                       end;;
-                      match x8 with
-                      | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t6 idc6)
-                        x9 =>
-                          match x7 with
-                          | @expr.Ident _ _ _ t7 idc7 =>
-                              args <- invert_bind_args idc7 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc6 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc5 Raw.ident.Z_shiftr;
-                              args2 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc3
+                      match x9 with
+                      | @expr.App _ _ _ s9 _ (@expr.Ident _ _ _ t7 idc7)
+                        x10 =>
+                          match x8 with
+                          | (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                             idc9)%expr_pat =>
+                              args <- invert_bind_args idc9 Raw.ident.Literal;
+                              args0 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                              args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc6 Raw.ident.Z_shiftr;
+                              args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                              args4 <- invert_bind_args idc4
                                          Raw.ident.Literal;
-                              args4 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                              args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                              args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
                               _ <- invert_bind_args idc1 Raw.ident.Z_shiftr;
-                              args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                              args8 <- invert_bind_args idc0 Raw.ident.Z_cast;
                               _ <- invert_bind_args idc Raw.ident.Z_mul;
                               match
                                 pattern.type.unify_extracted
                                   ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                  ((s4 -> (projT1 args3)) ->
-                                   s8 -> (projT1 args))%ptype
+                                  ((s4 -> (projT1 args4)) ->
+                                   s9 -> (projT1 args))%ptype
                               with
                               | Some (_, _, (_, _))%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                     ((s4 -> (projT1 args3)) ->
-                                      s8 -> (projT1 args))%ptype
+                                     ((s4 -> (projT1 args4)) ->
+                                      s9 -> (projT1 args))%ptype
                                   then
                                    v <- type.try_make_transport_cps s4 ℤ;
                                    xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args3);
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
+                                           ##(projT2 args4);
+                                   v0 <- type.try_make_transport_cps s9 ℤ;
                                    xv0 <- ident.unify pattern.ident.Literal
                                             ##(projT2 args);
-                                   fv <- (x10 <- (if
-                                                   ((let (x10, _) := xv in
-                                                     x10) =?
-                                                    (let (x10, _) := xv0 in
-                                                     x10)) &&
-                                                   (ZRange.normalize args4 >>
+                                   fv <- (x12 <- (if
+                                                   ((let (x12, _) := xv in
+                                                     x12) =?
+                                                    (let (x12, _) := xv0 in
+                                                     x12)) &&
+                                                   (ZRange.normalize args6 >>
                                                     ZRange.normalize
                                                       (ZRange.constant
-                                                         (let (x10, _) :=
+                                                         (let (x12, _) :=
                                                             xv in
-                                                          x10)) <=?
-                                                    ZRange.normalize args6)%zrange &&
-                                                   (ZRange.normalize args0 >>
+                                                          x12)) <=?
+                                                    ZRange.normalize args8)%zrange &&
+                                                   (ZRange.normalize args1 >>
                                                     ZRange.normalize
                                                       (ZRange.constant
-                                                         (let (x10, _) :=
+                                                         (let (x12, _) :=
                                                             xv0 in
-                                                          x10)) <=?
-                                                    ZRange.normalize args2)%zrange
+                                                          x12)) <=?
+                                                    ZRange.normalize args3)%zrange &&
+                                                   is_bounded_by_bool
+                                                     (let (x12, _) := xv in
+                                                      x12)
+                                                     (ZRange.normalize args5) &&
+                                                   is_bounded_by_bool
+                                                     (let (x12, _) := xv0 in
+                                                      x12)
+                                                     (ZRange.normalize args0)
                                                   then
                                                    Some
                                                      (#(Z_cast range)%expr @
                                                       (#(fancy_mulhh
                                                            (2 *
-                                                            (let (x10, _) :=
+                                                            (let (x12, _) :=
                                                                xv in
-                                                             x10)))%expr @
-                                                       (#(Z_cast args4)%expr @
+                                                             x12)))%expr @
+                                                       (#(Z_cast args6)%expr @
                                                         v
                                                           (Compile.reflect x5),
-                                                       #(Z_cast args0)%expr @
+                                                       #(Z_cast args1)%expr @
                                                        v0
-                                                         (Compile.reflect x9))))%expr_pat
+                                                         (Compile.reflect x10))))%expr_pat
                                                   else None);
-                                          Some (Base x10));
+                                          Some (Base x12));
                                    Some (fv0 <-- fv;
                                          Base fv0)%under_lets
                                   else None
                               | None => None
                               end
+                          | (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)%expr_pat |
+                            (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _
+                             _ _ _)%expr_pat => None
                           | _ => None
                           end
-                      | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _ _ s8
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s8 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
+                      | @expr.App _ _ _ s9 _ ($_)%expr _ | @expr.App _ _ _ s9
+                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s9 _
+                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s9 _
                         (@expr.LetIn _ _ _ _ _ _ _) _ => None
                       | _ => None
                       end
-                  | (@expr.Ident _ _ _ t4 idc4 @ #(_))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
+                  | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t5 idc5 @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t5 idc5 @
                      (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
+                    (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t5 idc5 @
                      (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @
+                    (@expr.Ident _ _ _ t5 idc5 @
                      (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                    (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                    (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
                       None
                   | _ => None
                   end
+              | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
+                (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
+                (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                  None
               | _ => None
               end
           | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
@@ -1787,30 +2536,6 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           | _ => None
           end
       | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0)) #(_)%expr_pat | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0)) ($_)%expr | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0)) (@expr.Abs _ _ _ _ _ _) | @expr.App _ _
-        _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0)) (($_)%expr @ _)%expr_pat | @expr.App _
-        _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0)) (@expr.Abs _ _ _ _ _ _ @ _)%expr_pat |
-        @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0)) (_ @ _ @ _)%expr_pat | @expr.App _ _ _
-        s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0))
-        (@expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0)) (@expr.LetIn _ _ _ _ _ _ _) | @expr.App
-        _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.Ident _ _ _ t0 idc0 @ #(_))%expr_pat) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
          (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat) _ | @expr.App _ _
         _ s _
@@ -1845,6 +2570,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat)
         _ => None
       | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) #(_)%expr_pat) _ |
+        @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) ($_)%expr) _ |
         @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
@@ -1866,779 +2593,202 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           | (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ x5 @ x4))%expr_pat =>
               match x5 with
-              | @expr.Ident _ _ _ t2 idc2 =>
+              | (@expr.Ident _ _ _ t2 idc2 @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
                   match x4 with
-                  | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6 =>
+                  | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t4 idc4) x7 =>
                       match x1 with
-                      | @expr.Ident _ _ _ t4 idc4 =>
+                      | @expr.App _ _ _ s7 _ (@expr.Ident _ _ _ t5 idc5)
+                        x8 =>
                           match x0 with
-                          | @expr.Ident _ _ _ t5 idc5 =>
-                              args <- invert_bind_args idc5 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc4
+                          | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t6 idc6)
+                            x9 =>
+                              args <- invert_bind_args idc6 Raw.ident.Z_cast;
+                              args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                              args1 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                              args2 <- invert_bind_args idc3
                                          Raw.ident.Literal;
-                              args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args2 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
+                              args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
                               _ <- invert_bind_args idc1 Raw.ident.Z_cc_m;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                              args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
                               _ <- invert_bind_args idc Raw.ident.Z_zselect;
                               match
                                 pattern.type.unify_extracted
                                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args2) -> s5) -> (projT1 args0)) ->
-                                   (projT1 args))%ptype
+                                  ((((projT1 args2) -> s6) -> s7) -> s8)%ptype
                               with
                               | Some (_, _, _, _)%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args2) -> s5) ->
-                                       (projT1 args0)) -> (projT1 args))%ptype
+                                     ((((projT1 args2) -> s6) -> s7) -> s8)%ptype
                                   then
                                    xv <- ident.unify pattern.ident.Literal
                                            ##(projT2 args2);
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x7 <- (if
-                                                  ((let (x7, _) := xv in x7) =?
-                                                   2
-                                                   ^ Z.log2
-                                                       (let (x7, _) := xv in
-                                                        x7)) &&
-                                                  ((ZRange.cc_m
-                                                      (let (x7, _) := xv in
-                                                       x7))
-                                                     (ZRange.normalize args1) <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_selm
-                                                          (Z.log2
-                                                             (let (x7, _) :=
-                                                                xv in
-                                                              x7)))%expr @
-                                                      (#(Z_cast args1)%expr @
-                                                       v (Compile.reflect x6),
-                                                      (##(let (x7, _) :=
-                                                            xv0 in
-                                                          x7))%expr,
-                                                      (##(let (x7, _) :=
-                                                            xv1 in
-                                                          x7))%expr)))%expr_pat
-                                                 else None);
-                                          Some (Base x7));
+                                   v <- type.try_make_transport_cps s6 ℤ;
+                                   v0 <- type.try_make_transport_cps s7 ℤ;
+                                   v1 <- type.try_make_transport_cps s8 ℤ;
+                                   fv <- (x10 <- (if
+                                                   ((let (x10, _) := xv in
+                                                     x10) =?
+                                                    2
+                                                    ^ Z.log2
+                                                        (let (x10, _) :=
+                                                           xv in
+                                                         x10)) &&
+                                                   ((ZRange.cc_m
+                                                       (let (x10, _) := xv in
+                                                        x10))
+                                                      (ZRange.normalize args1) <=?
+                                                    ZRange.normalize args5)%zrange &&
+                                                   is_bounded_by_bool
+                                                     (let (x10, _) := xv in
+                                                      x10)
+                                                     (ZRange.normalize args3)
+                                                  then
+                                                   Some
+                                                     (#(Z_cast range)%expr @
+                                                      (#(fancy_selm
+                                                           (Z.log2
+                                                              (let
+                                                                 (x10, _) :=
+                                                                 xv in
+                                                               x10)))%expr @
+                                                       (#(Z_cast args1)%expr @
+                                                        v
+                                                          (Compile.reflect x7),
+                                                       #(Z_cast args0)%expr @
+                                                       v0
+                                                         (Compile.reflect x8),
+                                                       #(Z_cast args)%expr @
+                                                       v1
+                                                         (Compile.reflect x9))))%expr_pat
+                                                  else None);
+                                          Some (Base x10));
                                    Some (fv0 <-- fv;
                                          Base fv0)%under_lets
                                   else None
                               | None => None
                               end
-                          | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t5 idc5)
-                            x7 =>
-                              args <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc4
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args2 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_cc_m;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args2) -> s5) -> (projT1 args0)) ->
-                                   s6)%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args2) -> s5) ->
-                                       (projT1 args0)) -> s6)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args2);
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   fv <- (x8 <- (if
-                                                  ((let (x8, _) := xv in x8) =?
-                                                   2
-                                                   ^ Z.log2
-                                                       (let (x8, _) := xv in
-                                                        x8)) &&
-                                                  ((ZRange.cc_m
-                                                      (let (x8, _) := xv in
-                                                       x8))
-                                                     (ZRange.normalize args1) <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_selm
-                                                          (Z.log2
-                                                             (let (x8, _) :=
-                                                                xv in
-                                                              x8)))%expr @
-                                                      (#(Z_cast args1)%expr @
-                                                       v (Compile.reflect x6),
-                                                      (##(let (x8, _) :=
-                                                            xv0 in
-                                                          x8))%expr,
-                                                      #(Z_cast args)%expr @
-                                                      v0 (Compile.reflect x7))))%expr_pat
-                                                 else None);
-                                          Some (Base x8));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _
-                            _ s6 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s6 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
+                          | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _
+                            _ s8 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
+                            _ s8 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
                             (@expr.LetIn _ _ _ _ _ _ _) _ => None
                           | _ => None
                           end
-                      | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t4 idc4)
-                        x7 =>
-                          match x0 with
-                          | @expr.Ident _ _ _ t5 idc5 =>
-                              args <- invert_bind_args idc5 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args2 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_cc_m;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args2) -> s5) -> s6) ->
-                                   (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args2) -> s5) -> s6) ->
-                                      (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args2);
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x8 <- (if
-                                                  ((let (x8, _) := xv in x8) =?
-                                                   2
-                                                   ^ Z.log2
-                                                       (let (x8, _) := xv in
-                                                        x8)) &&
-                                                  ((ZRange.cc_m
-                                                      (let (x8, _) := xv in
-                                                       x8))
-                                                     (ZRange.normalize args1) <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_selm
-                                                          (Z.log2
-                                                             (let (x8, _) :=
-                                                                xv in
-                                                              x8)))%expr @
-                                                      (#(Z_cast args1)%expr @
-                                                       v (Compile.reflect x6),
-                                                      #(Z_cast args0)%expr @
-                                                      v0 (Compile.reflect x7),
-                                                      (##(let (x8, _) :=
-                                                            xv0 in
-                                                          x8))%expr)))%expr_pat
-                                                 else None);
-                                          Some (Base x8));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s7 _ (@expr.Ident _ _ _ t5 idc5)
-                            x8 =>
-                              args <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args2 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_cc_m;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args2) -> s5) -> s6) -> s7)%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args2) -> s5) -> s6) -> s7)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args2);
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   v1 <- type.try_make_transport_cps s7 ℤ;
-                                   fv <- (x9 <- (if
-                                                  ((let (x9, _) := xv in x9) =?
-                                                   2
-                                                   ^ Z.log2
-                                                       (let (x9, _) := xv in
-                                                        x9)) &&
-                                                  ((ZRange.cc_m
-                                                      (let (x9, _) := xv in
-                                                       x9))
-                                                     (ZRange.normalize args1) <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_selm
-                                                          (Z.log2
-                                                             (let (x9, _) :=
-                                                                xv in
-                                                              x9)))%expr @
-                                                      (#(Z_cast args1)%expr @
-                                                       v (Compile.reflect x6),
-                                                      #(Z_cast args0)%expr @
-                                                      v0 (Compile.reflect x7),
-                                                      #(Z_cast args)%expr @
-                                                      v1 (Compile.reflect x8))))%expr_pat
-                                                 else None);
-                                          Some (Base x9));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _
-                            _ s7 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s7 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
-                      | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
+                      | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _ _ s7
+                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s7 _
+                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
                         (@expr.LetIn _ _ _ _ _ _ _) _ => None
                       | _ => None
                       end
-                  | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
+                  | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6 _
+                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
+                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
                     (@expr.LetIn _ _ _ _ _ _ _) _ => None
                   | _ => None
                   end
+              | (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
+                (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                (@expr.Ident _ _ _ t2 idc2 @ (_ @ _))%expr_pat |
+                (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                  None
               | _ => None
               end;;
               match x5 with
-              | @expr.Ident _ _ _ t2 idc2 =>
-                  match x4 with
-                  | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6 =>
-                      match x1 with
-                      | @expr.Ident _ _ _ t4 idc4 =>
-                          match x0 with
-                          | @expr.Ident _ _ _ t5 idc5 =>
-                              args <- invert_bind_args idc5 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc4
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args2 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args2) -> s5) -> (projT1 args0)) ->
-                                   (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args2) -> s5) ->
-                                       (projT1 args0)) -> (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args2);
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x7 <- (if
-                                                  ((let (x7, _) := xv in x7) =?
-                                                   1) &&
-                                                  (ZRange.normalize
-                                                     (ZRange.constant
-                                                        (let (x7, _) := xv in
-                                                         x7)) &'
-                                                   ZRange.normalize args1 <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_sell)%expr @
-                                                      (#(Z_cast args1)%expr @
-                                                       v (Compile.reflect x6),
-                                                      (##(let (x7, _) :=
-                                                            xv0 in
-                                                          x7))%expr,
-                                                      (##(let (x7, _) :=
-                                                            xv1 in
-                                                          x7))%expr)))%expr_pat
-                                                 else None);
-                                          Some (Base x7));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t5 idc5)
-                            x7 =>
-                              args <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc4
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args2 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args2) -> s5) -> (projT1 args0)) ->
-                                   s6)%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args2) -> s5) ->
-                                       (projT1 args0)) -> s6)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args2);
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   fv <- (x8 <- (if
-                                                  ((let (x8, _) := xv in x8) =?
-                                                   1) &&
-                                                  (ZRange.normalize
-                                                     (ZRange.constant
-                                                        (let (x8, _) := xv in
-                                                         x8)) &'
-                                                   ZRange.normalize args1 <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_sell)%expr @
-                                                      (#(Z_cast args1)%expr @
-                                                       v (Compile.reflect x6),
-                                                      (##(let (x8, _) :=
-                                                            xv0 in
-                                                          x8))%expr,
-                                                      #(Z_cast args)%expr @
-                                                      v0 (Compile.reflect x7))))%expr_pat
-                                                 else None);
-                                          Some (Base x8));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _
-                            _ s6 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s6 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
-                      | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t4 idc4)
-                        x7 =>
-                          match x0 with
-                          | @expr.Ident _ _ _ t5 idc5 =>
-                              args <- invert_bind_args idc5 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args2 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args2) -> s5) -> s6) ->
-                                   (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args2) -> s5) -> s6) ->
-                                      (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args2);
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x8 <- (if
-                                                  ((let (x8, _) := xv in x8) =?
-                                                   1) &&
-                                                  (ZRange.normalize
-                                                     (ZRange.constant
-                                                        (let (x8, _) := xv in
-                                                         x8)) &'
-                                                   ZRange.normalize args1 <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_sell)%expr @
-                                                      (#(Z_cast args1)%expr @
-                                                       v (Compile.reflect x6),
-                                                      #(Z_cast args0)%expr @
-                                                      v0 (Compile.reflect x7),
-                                                      (##(let (x8, _) :=
-                                                            xv0 in
-                                                          x8))%expr)))%expr_pat
-                                                 else None);
-                                          Some (Base x8));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s7 _ (@expr.Ident _ _ _ t5 idc5)
-                            x8 =>
-                              args <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args2 <- invert_bind_args idc2
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args2) -> s5) -> s6) -> s7)%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args2) -> s5) -> s6) -> s7)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args2);
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   v1 <- type.try_make_transport_cps s7 ℤ;
-                                   fv <- (x9 <- (if
-                                                  ((let (x9, _) := xv in x9) =?
-                                                   1) &&
-                                                  (ZRange.normalize
-                                                     (ZRange.constant
-                                                        (let (x9, _) := xv in
-                                                         x9)) &'
-                                                   ZRange.normalize args1 <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_sell)%expr @
-                                                      (#(Z_cast args1)%expr @
-                                                       v (Compile.reflect x6),
-                                                      #(Z_cast args0)%expr @
-                                                      v0 (Compile.reflect x7),
-                                                      #(Z_cast args)%expr @
-                                                      v1 (Compile.reflect x8))))%expr_pat
-                                                 else None);
-                                          Some (Base x9));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _
-                            _ s7 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s7 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
-                      | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end
-                  | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
-                  end
               | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t2 idc2) x6 =>
-                  match x4 with
+                  match x6 with
                   | @expr.Ident _ _ _ t3 idc3 =>
-                      match x1 with
-                      | @expr.Ident _ _ _ t4 idc4 =>
-                          match x0 with
-                          | @expr.Ident _ _ _ t5 idc5 =>
-                              args <- invert_bind_args idc5 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc4
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc3
-                                         Raw.ident.Literal;
-                              args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  (((s5 -> (projT1 args1)) -> (projT1 args0)) ->
-                                   (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     (((s5 -> (projT1 args1)) ->
-                                       (projT1 args0)) -> (projT1 args))%ptype
-                                  then
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args1);
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x7 <- (if
-                                                  ((let (x7, _) := xv in x7) =?
-                                                   1) &&
-                                                  (ZRange.normalize args2 &'
-                                                   ZRange.normalize
-                                                     (ZRange.constant
-                                                        (let (x7, _) := xv in
-                                                         x7)) <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_sell)%expr @
-                                                      (#(Z_cast args2)%expr @
-                                                       v (Compile.reflect x6),
-                                                      (##(let (x7, _) :=
-                                                            xv0 in
-                                                          x7))%expr,
-                                                      (##(let (x7, _) :=
-                                                            xv1 in
-                                                          x7))%expr)))%expr_pat
-                                                 else None);
-                                          Some (Base x7));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t5 idc5)
-                            x7 =>
-                              args <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc4
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc3
-                                         Raw.ident.Literal;
-                              args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  (((s5 -> (projT1 args1)) -> (projT1 args0)) ->
-                                   s6)%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     (((s5 -> (projT1 args1)) ->
-                                       (projT1 args0)) -> s6)%ptype
-                                  then
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args1);
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   fv <- (x8 <- (if
-                                                  ((let (x8, _) := xv in x8) =?
-                                                   1) &&
-                                                  (ZRange.normalize args2 &'
-                                                   ZRange.normalize
-                                                     (ZRange.constant
-                                                        (let (x8, _) := xv in
-                                                         x8)) <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_sell)%expr @
-                                                      (#(Z_cast args2)%expr @
-                                                       v (Compile.reflect x6),
-                                                      (##(let (x8, _) :=
-                                                            xv0 in
-                                                          x8))%expr,
-                                                      #(Z_cast args)%expr @
-                                                      v0 (Compile.reflect x7))))%expr_pat
-                                                 else None);
-                                          Some (Base x8));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _
-                            _ s6 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s6 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
+                      match x4 with
                       | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t4 idc4)
                         x7 =>
-                          match x0 with
-                          | @expr.Ident _ _ _ t5 idc5 =>
-                              args <- invert_bind_args idc5 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args1 <- invert_bind_args idc3
-                                         Raw.ident.Literal;
-                              args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  (((s5 -> (projT1 args1)) -> s6) ->
-                                   (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     (((s5 -> (projT1 args1)) -> s6) ->
-                                      (projT1 args))%ptype
-                                  then
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args1);
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x8 <- (if
-                                                  ((let (x8, _) := xv in x8) =?
-                                                   1) &&
-                                                  (ZRange.normalize args2 &'
-                                                   ZRange.normalize
-                                                     (ZRange.constant
-                                                        (let (x8, _) := xv in
-                                                         x8)) <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_sell)%expr @
-                                                      (#(Z_cast args2)%expr @
-                                                       v (Compile.reflect x6),
-                                                      #(Z_cast args0)%expr @
-                                                      v0 (Compile.reflect x7),
-                                                      (##(let (x8, _) :=
-                                                            xv0 in
-                                                          x8))%expr)))%expr_pat
-                                                 else None);
-                                          Some (Base x8));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
+                          match x1 with
                           | @expr.App _ _ _ s7 _ (@expr.Ident _ _ _ t5 idc5)
                             x8 =>
-                              args <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                              args1 <- invert_bind_args idc3
-                                         Raw.ident.Literal;
-                              args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
-                              args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  (((s5 -> (projT1 args1)) -> s6) -> s7)%ptype
-                              with
-                              | Some (_, _, _, _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     (((s5 -> (projT1 args1)) -> s6) -> s7)%ptype
-                                  then
-                                   v <- type.try_make_transport_cps s5 ℤ;
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args1);
-                                   v0 <- type.try_make_transport_cps s6 ℤ;
-                                   v1 <- type.try_make_transport_cps s7 ℤ;
-                                   fv <- (x9 <- (if
-                                                  ((let (x9, _) := xv in x9) =?
-                                                   1) &&
-                                                  (ZRange.normalize args2 &'
-                                                   ZRange.normalize
-                                                     (ZRange.constant
-                                                        (let (x9, _) := xv in
-                                                         x9)) <=?
-                                                   ZRange.normalize args4)%zrange
-                                                 then
-                                                  Some
-                                                    (#(Z_cast range)%expr @
-                                                     (#(fancy_sell)%expr @
-                                                      (#(Z_cast args2)%expr @
-                                                       v (Compile.reflect x6),
-                                                      #(Z_cast args0)%expr @
-                                                      v0 (Compile.reflect x7),
-                                                      #(Z_cast args)%expr @
-                                                      v1 (Compile.reflect x8))))%expr_pat
-                                                 else None);
-                                          Some (Base x9));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                              match x0 with
+                              | @expr.App _ _ _ s8 _
+                                (@expr.Ident _ _ _ t6 idc6) x9 =>
+                                  args <- invert_bind_args idc6
+                                            Raw.ident.Z_cast;
+                                  args0 <- invert_bind_args idc5
+                                             Raw.ident.Z_cast;
+                                  args1 <- invert_bind_args idc4
+                                             Raw.ident.Z_cast;
+                                  args2 <- invert_bind_args idc3
+                                             Raw.ident.Literal;
+                                  args3 <- invert_bind_args idc2
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                                  args5 <- invert_bind_args idc0
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc
+                                         Raw.ident.Z_zselect;
+                                  match
+                                    pattern.type.unify_extracted
+                                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                      ((((projT1 args2) -> s6) -> s7) -> s8)%ptype
+                                  with
+                                  | Some (_, _, _, _)%zrange =>
+                                      if
+                                       type.type_beq base.type
+                                         base.type.type_beq
+                                         (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                         ((((projT1 args2) -> s6) -> s7) ->
+                                          s8)%ptype
+                                      then
+                                       xv <- ident.unify
+                                               pattern.ident.Literal
+                                               ##(projT2 args2);
+                                       v <- type.try_make_transport_cps s6 ℤ;
+                                       v0 <- type.try_make_transport_cps s7 ℤ;
+                                       v1 <- type.try_make_transport_cps s8 ℤ;
+                                       fv <- (x10 <- (if
+                                                       ((let (x10, _) :=
+                                                           xv in
+                                                         x10) =? 1) &&
+                                                       (ZRange.normalize
+                                                          (ZRange.constant
+                                                             (let (x10, _) :=
+                                                                xv in
+                                                              x10)) &'
+                                                        ZRange.normalize
+                                                          args1 <=?
+                                                        ZRange.normalize
+                                                          args5)%zrange &&
+                                                       is_bounded_by_bool
+                                                         (let (x10, _) :=
+                                                            xv in
+                                                          x10)
+                                                         (ZRange.normalize
+                                                            args3)
+                                                      then
+                                                       Some
+                                                         (#(Z_cast range)%expr @
+                                                          (#(fancy_sell)%expr @
+                                                           (#(Z_cast args1)%expr @
+                                                            v
+                                                              (Compile.reflect
+                                                                 x7),
+                                                           #(Z_cast args0)%expr @
+                                                           v0
+                                                             (Compile.reflect
+                                                                x8),
+                                                           #(Z_cast args)%expr @
+                                                           v1
+                                                             (Compile.reflect
+                                                                x9))))%expr_pat
+                                                      else None);
+                                              Some (Base x10));
+                                       Some (fv0 <-- fv;
+                                             Base fv0)%under_lets
+                                      else None
+                                  | None => None
+                                  end
+                              | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App
+                                _ _ _ s8 _ (@expr.Abs _ _ _ _ _ _) _ |
+                                @expr.App _ _ _ s8 _ (_ @ _)%expr_pat _ |
+                                @expr.App _ _ _ s8 _
+                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                              | _ => None
                               end
                           | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _
                             _ s7 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
@@ -2652,6 +2802,92 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.LetIn _ _ _ _ _ _ _) _ => None
                       | _ => None
                       end
+                  | _ => None
+                  end;;
+                  match x4 with
+                  | (@expr.Ident _ _ _ t3 idc3 @ @expr.Ident _ _ _ t4 idc4)%expr_pat =>
+                      match x1 with
+                      | @expr.App _ _ _ s7 _ (@expr.Ident _ _ _ t5 idc5)
+                        x8 =>
+                          match x0 with
+                          | @expr.App _ _ _ s8 _ (@expr.Ident _ _ _ t6 idc6)
+                            x9 =>
+                              args <- invert_bind_args idc6 Raw.ident.Z_cast;
+                              args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                              args1 <- invert_bind_args idc4
+                                         Raw.ident.Literal;
+                              args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                              args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc1 Raw.ident.Z_land;
+                              args5 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc Raw.ident.Z_zselect;
+                              match
+                                pattern.type.unify_extracted
+                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                  (((s5 -> (projT1 args1)) -> s7) -> s8)%ptype
+                              with
+                              | Some (_, _, _, _)%zrange =>
+                                  if
+                                   type.type_beq base.type base.type.type_beq
+                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                     (((s5 -> (projT1 args1)) -> s7) -> s8)%ptype
+                                  then
+                                   v <- type.try_make_transport_cps s5 ℤ;
+                                   xv <- ident.unify pattern.ident.Literal
+                                           ##(projT2 args1);
+                                   v0 <- type.try_make_transport_cps s7 ℤ;
+                                   v1 <- type.try_make_transport_cps s8 ℤ;
+                                   fv <- (x10 <- (if
+                                                   ((let (x10, _) := xv in
+                                                     x10) =? 1) &&
+                                                   (ZRange.normalize args3 &'
+                                                    ZRange.normalize
+                                                      (ZRange.constant
+                                                         (let (x10, _) :=
+                                                            xv in
+                                                          x10)) <=?
+                                                    ZRange.normalize args5)%zrange &&
+                                                   is_bounded_by_bool
+                                                     (let (x10, _) := xv in
+                                                      x10)
+                                                     (ZRange.normalize args2)
+                                                  then
+                                                   Some
+                                                     (#(Z_cast range)%expr @
+                                                      (#(fancy_sell)%expr @
+                                                       (#(Z_cast args3)%expr @
+                                                        v
+                                                          (Compile.reflect x6),
+                                                       #(Z_cast args0)%expr @
+                                                       v0
+                                                         (Compile.reflect x8),
+                                                       #(Z_cast args)%expr @
+                                                       v1
+                                                         (Compile.reflect x9))))%expr_pat
+                                                  else None);
+                                          Some (Base x10));
+                                   Some (fv0 <-- fv;
+                                         Base fv0)%under_lets
+                                  else None
+                              | None => None
+                              end
+                          | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _
+                            _ s8 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
+                            _ s8 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
+                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                          | _ => None
+                          end
+                      | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _ _ s7
+                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s7 _
+                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                      | _ => None
+                      end
+                  | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
+                    (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      None
                   | _ => None
                   end
               | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
@@ -2700,219 +2936,51 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1))
-         (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4))
-        (@expr.Ident _ _ _ t3 idc3) =>
-          args <- invert_bind_args idc3 Raw.ident.Literal;
-          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-          args1 <- invert_bind_args idc1 Raw.ident.Literal;
-          args2 <- invert_bind_args idc0 Raw.ident.Literal;
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (@expr.Ident _ _ _ t4 idc4 @ @expr.Ident _ _ _ t5 idc5)%expr_pat =>
+          args <- invert_bind_args idc5 Raw.ident.Literal;
+          args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
+          args1 <- invert_bind_args idc3 Raw.ident.Z_cast;
+          args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
+          args3 <- invert_bind_args idc1 Raw.ident.Literal;
+          args4 <- invert_bind_args idc0 Raw.ident.Z_cast;
           _ <- invert_bind_args idc Raw.ident.Z_rshi;
           match
             pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-              ((((projT1 args2) -> (projT1 args1)) -> s3) -> (projT1 args))%ptype
+              ((((projT1 args3) -> s4) -> s5) -> (projT1 args))%ptype
           with
           | Some (_, _, _, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                 ((((projT1 args2) -> (projT1 args1)) -> s3) -> (projT1 args))%ptype
+                 ((((projT1 args3) -> s4) -> s5) -> (projT1 args))%ptype
               then
-               xv <- ident.unify pattern.ident.Literal ##(projT2 args2);
-               xv0 <- ident.unify pattern.ident.Literal ##(projT2 args1);
-               v <- type.try_make_transport_cps s3 ℤ;
-               xv1 <- ident.unify pattern.ident.Literal ##(projT2 args);
-               fv <- (x5 <- (if
-                              (let (x5, _) := xv in x5) =?
-                              2 ^ Z.log2 (let (x5, _) := xv in x5)
-                             then
-                              Some
-                                (#(Z_cast range)%expr @
-                                 (#(fancy_rshi
-                                      (Z.log2 (let (x5, _) := xv in x5))
-                                      (let (x5, _) := xv1 in x5))%expr @
-                                  ((##(let (x5, _) := xv0 in x5))%expr,
-                                  #(Z_cast args0)%expr @
-                                  v (Compile.reflect x4))))%expr_pat
-                             else None);
-                      Some (Base x5));
-               Some (fv0 <-- fv;
-                     Base fv0)%under_lets
-              else None
-          | None => None
-          end
-      | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1)) (@expr.App _ _ _ s3 _ ($_)%expr _))
-        _ | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1))
-         (@expr.App _ _ _ s3 _ (@expr.Abs _ _ _ _ _ _) _)) _ | @expr.App _ _
-        _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1))
-         (@expr.App _ _ _ s3 _ (_ @ _)%expr_pat _)) _ | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1))
-         (@expr.App _ _ _ s3 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _ => None
-      | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1)) #(_)%expr_pat) _ | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1)) ($_)%expr) _ | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1)) (@expr.Abs _ _ _ _ _ _)) _ | @expr.App
-        _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1)) (@expr.LetIn _ _ _ _ _ _ _)) _ => None
-      | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.Ident _ _ _ t2 idc2)) (@expr.Ident _ _ _ t3 idc3) =>
-          args <- invert_bind_args idc3 Raw.ident.Literal;
-          args0 <- invert_bind_args idc2 Raw.ident.Literal;
-          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-          _ <- invert_bind_args idc Raw.ident.Z_rshi;
-          match
-            pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-              ((((projT1 args2) -> s3) -> (projT1 args0)) -> (projT1 args))%ptype
-          with
-          | Some (_, _, _, _)%zrange =>
-              if
-               type.type_beq base.type base.type.type_beq
-                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                 ((((projT1 args2) -> s3) -> (projT1 args0)) -> (projT1 args))%ptype
-              then
-               xv <- ident.unify pattern.ident.Literal ##(projT2 args2);
-               v <- type.try_make_transport_cps s3 ℤ;
-               xv0 <- ident.unify pattern.ident.Literal ##(projT2 args0);
-               xv1 <- ident.unify pattern.ident.Literal ##(projT2 args);
-               fv <- (x5 <- (if
-                              (let (x5, _) := xv in x5) =?
-                              2 ^ Z.log2 (let (x5, _) := xv in x5)
-                             then
-                              Some
-                                (#(Z_cast range)%expr @
-                                 (#(fancy_rshi
-                                      (Z.log2 (let (x5, _) := xv in x5))
-                                      (let (x5, _) := xv1 in x5))%expr @
-                                  (#(Z_cast args1)%expr @
-                                   v (Compile.reflect x4),
-                                  (##(let (x5, _) := xv0 in x5))%expr)))%expr_pat
-                             else None);
-                      Some (Base x5));
-               Some (fv0 <-- fv;
-                     Base fv0)%under_lets
-              else None
-          | None => None
-          end
-      | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1))
-         (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4)) ($_)%expr |
-        @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1))
-         (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4))
-        (@expr.Abs _ _ _ _ _ _) | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1))
-         (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4))
-        (_ @ _)%expr_pat | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.Ident _ _ _ t1 idc1))
-         (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4))
-        (@expr.LetIn _ _ _ _ _ _ _) | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.Ident _ _ _ t2 idc2)) ($_)%expr | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.Ident _ _ _ t2 idc2)) (@expr.Abs _ _ _ _ _ _) | @expr.App _ _
-        _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.Ident _ _ _ t2 idc2)) (_ @ _)%expr_pat | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.Ident _ _ _ t2 idc2)) (@expr.LetIn _ _ _ _ _ _ _) => None
-      | @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
-        (@expr.Ident _ _ _ t3 idc3) =>
-          args <- invert_bind_args idc3 Raw.ident.Literal;
-          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-          _ <- invert_bind_args idc Raw.ident.Z_rshi;
-          match
-            pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-              ((((projT1 args2) -> s3) -> s4) -> (projT1 args))%ptype
-          with
-          | Some (_, _, _, _)%zrange =>
-              if
-               type.type_beq base.type base.type.type_beq
-                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                 ((((projT1 args2) -> s3) -> s4) -> (projT1 args))%ptype
-              then
-               xv <- ident.unify pattern.ident.Literal ##(projT2 args2);
-               v <- type.try_make_transport_cps s3 ℤ;
-               v0 <- type.try_make_transport_cps s4 ℤ;
+               xv <- ident.unify pattern.ident.Literal ##(projT2 args3);
+               v <- type.try_make_transport_cps s4 ℤ;
+               v0 <- type.try_make_transport_cps s5 ℤ;
                xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-               fv <- (x6 <- (if
-                              (let (x6, _) := xv in x6) =?
-                              2 ^ Z.log2 (let (x6, _) := xv in x6)
+               fv <- (x8 <- (if
+                              ((let (x8, _) := xv in x8) =?
+                               2 ^ Z.log2 (let (x8, _) := xv in x8)) &&
+                              is_bounded_by_bool (let (x8, _) := xv in x8)
+                                (ZRange.normalize args4) &&
+                              is_bounded_by_bool (let (x8, _) := xv0 in x8)
+                                (ZRange.normalize args0)
                              then
                               Some
                                 (#(Z_cast range)%expr @
                                  (#(fancy_rshi
-                                      (Z.log2 (let (x6, _) := xv in x6))
-                                      (let (x6, _) := xv0 in x6))%expr @
-                                  (#(Z_cast args1)%expr @
-                                   v (Compile.reflect x4),
-                                  #(Z_cast args0)%expr @
-                                  v0 (Compile.reflect x5))))%expr_pat
+                                      (Z.log2 (let (x8, _) := xv in x8))
+                                      (let (x8, _) := xv0 in x8))%expr @
+                                  (#(Z_cast args2)%expr @
+                                   v (Compile.reflect x5),
+                                  #(Z_cast args1)%expr @
+                                  v0 (Compile.reflect x6))))%expr_pat
                              else None);
-                      Some (Base x6));
+                      Some (Base x8));
                Some (fv0 <-- fv;
                      Base fv0)%under_lets
               else None
@@ -2921,99 +2989,210 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5)) ($_)%expr |
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat | @expr.App _ _ _ s
+        _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
         @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (@expr.Ident _ _ _ t4 idc4 @ (_ @ _))%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+          None
+      | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        #(_)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6)) ($_)%expr |
+        @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
         (@expr.Abs _ _ _ _ _ _) | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
-        (_ @ _)%expr_pat | @expr.App _ _ _ s _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (($_)%expr @ _)%expr_pat | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (@expr.Abs _ _ _ _ _ _ @ _)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (_ @ _ @ _)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
+        (@expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
         (@expr.LetIn _ _ _ _ _ _ _) => None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ ($_)%expr _)) _ | @expr.App _ _ _ s _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ ($_)%expr _)) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ (@expr.Abs _ _ _ _ _ _) _)) _ | @expr.App _ _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.Abs _ _ _ _ _ _) _)) _ | @expr.App _ _
         _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ (_ @ _)%expr_pat _)) _ | @expr.App _ _ _ s _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (_ @ _)%expr_pat _)) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
-         (@expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _ => None
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         (@expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _ => None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4)) ($_)%expr)
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
+         #(_)%expr_pat) _ | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5)) ($_)%expr)
         _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
          (@expr.Abs _ _ _ _ _ _)) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4))
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
          (@expr.LetIn _ _ _ _ _ _ _)) _ => None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ ($_)%expr _)) _) _ | @expr.App _ _ _ s _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ ($_)%expr _)) _) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.Abs _ _ _ _ _ _) _)) _) _ | @expr.App
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.Abs _ _ _ _ _ _) _)) _) _ | @expr.App
         _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (_ @ _)%expr_pat _)) _) _ | @expr.App _ _ _ s
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (_ @ _)%expr_pat _)) _) _ | @expr.App _ _ _ s
         _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
-          (@expr.App _ _ _ s3 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _) _ => None
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          (@expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _) _ => None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
+          #(_)%expr_pat) _) _ | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
           ($_)%expr) _) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
           (@expr.Abs _ _ _ _ _ _)) _) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
-          (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
           (@expr.LetIn _ _ _ _ _ _ _)) _) _ => None
       | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr))%expr_pat
+          _) _) _ | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _))%expr_pat _)
+         _) _ | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ (_ @ _)))%expr_pat
+          _) _) _ | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @
+           (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat
+          _) _) _ => None
+      | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t idc @ #(_))%expr_pat _)
+         _) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat
           _) _) _ | @expr.App _ _ _ s _
@@ -3022,7 +3201,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat _) _)
         _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @ (($_)%expr @ _))%expr_pat _) _) _ |
+        @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat _)
+         _) _ | @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @ (_ @ _ @ _))%expr_pat _) _) _ |
+        @expr.App _ _ _ s _
+        (@expr.App _ _ _ s0 _
+         (@expr.App _ _ _ s1 _
+          (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat
           _) _) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
@@ -3077,700 +3269,65 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
     ((match x with
       | (@expr.Ident _ _ _ t idc @ x2 @ x1 @ x0)%expr_pat =>
           match x2 with
-          | @expr.Ident _ _ _ t0 idc0 =>
+          | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
               match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
+              | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4 =>
                   match x0 with
-                  | @expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t2 idc2) x3 =>
-                      match x3 with
-                      | (@expr.Ident _ _ _ t3 idc3 @ x5 @ x4)%expr_pat =>
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.Ident
-                              _ _ _ t7 idc7))%expr_pat =>
-                              match x4 with
-                              | @expr.Ident _ _ _ t8 idc8 =>
-                                  args <- invert_bind_args idc8
-                                            Raw.ident.Literal;
-                                  args0 <- invert_bind_args idc7
-                                             Raw.ident.Literal;
-                                  args1 <- invert_bind_args idc6
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                                  args3 <- invert_bind_args idc4
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc3
-                                         Raw.ident.Z_shiftl;
-                                  args5 <- invert_bind_args idc2
-                                             Raw.ident.Z_cast;
-                                  args6 <- invert_bind_args idc1
-                                             Raw.ident.Literal;
-                                  args7 <- invert_bind_args idc0
-                                             Raw.ident.Literal;
-                                  _ <- invert_bind_args idc
-                                         Raw.ident.Z_add_get_carry;
-                                  match
-                                    pattern.type.unify_extracted
-                                      ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                      (((projT1 args7) -> (projT1 args6)) ->
-                                       (s8 -> (projT1 args0)) ->
-                                       (projT1 args))%ptype
-                                  with
-                                  | Some (_, _, (_, _, _))%zrange =>
-                                      if
-                                       type.type_beq base.type
-                                         base.type.type_beq
-                                         ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                         (((projT1 args7) -> (projT1 args6)) ->
-                                          (s8 -> (projT1 args0)) ->
-                                          (projT1 args))%ptype
-                                      then
-                                       xv <- ident.unify
-                                               pattern.ident.Literal
-                                               ##(projT2 args7);
-                                       xv0 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args6);
-                                       v <- type.try_make_transport_cps s8 ℤ;
-                                       xv1 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args0);
-                                       xv2 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args);
-                                       fv <- (x10 <- (let
-                                                      '(r1, r2)%zrange :=
-                                                       range in
-                                                       fun (s9 xx : Z)
-                                                         (rshiftl rland
-                                                          ry : zrange)
-                                                         (y : expr ℤ)
-                                                         (mask offset : Z) =>
-                                                       if
-                                                        (s9 =? 2 ^ Z.log2 s9) &&
-                                                        (ZRange.normalize
-                                                           rland <<
-                                                         ZRange.normalize
-                                                           (ZRange.constant
-                                                              offset) <=?
-                                                         ZRange.normalize
-                                                           rshiftl)%zrange &&
-                                                        (ZRange.normalize ry &'
-                                                         ZRange.normalize
-                                                           (ZRange.constant
-                                                              mask) <=?
-                                                         ZRange.normalize
-                                                           rland)%zrange &&
-                                                        (ZRange.normalize
-                                                           rshiftl <=?
-                                                         r[0 ~> s9 - 1])%zrange &&
-                                                        (mask =?
-                                                         Z.ones
-                                                           (Z.log2 s9 -
-                                                            offset)) &&
-                                                        (0 <=? offset) &&
-                                                        (offset <=? Z.log2 s9)
-                                                       then
-                                                        Some
-                                                          (#(Z_cast2 (r1, r2))%expr @
-                                                           (#(fancy_add
-                                                                (Z.log2 s9)
-                                                                offset)%expr @
-                                                            ((##xx)%expr,
-                                                            #(Z_cast ry)%expr @
-                                                            y)))%expr_pat
-                                                       else None)
-                                                       (let (x10, _) := xv in
-                                                        x10)
-                                                       (let (x10, _) :=
-                                                          xv0 in
-                                                        x10) args5 args3
-                                                       args1
-                                                       (v
-                                                          (Compile.reflect x9))
-                                                       (let (x10, _) :=
-                                                          xv1 in
-                                                        x10)
-                                                       (let (x10, _) :=
-                                                          xv2 in
-                                                        x10);
-                                              Some (Base x10));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
-                                  end
-                              | _ => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ ($_)%expr))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.Abs _
-                              _ _ _ _ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ (_ @ _)))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.LetIn
-                              _ _ _ _ _ _ _))%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ ($_)%expr _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (_ @ _) _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
-                              _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                              _ _ _ @ _))%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x5 with
-                          | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t4 idc4)
-                            x6 =>
-                              match x4 with
-                              | @expr.Ident _ _ _ t5 idc5 =>
-                                  args <- invert_bind_args idc5
-                                            Raw.ident.Literal;
-                                  args0 <- invert_bind_args idc4
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc3
-                                         Raw.ident.Z_shiftr;
-                                  args2 <- invert_bind_args idc2
-                                             Raw.ident.Z_cast;
-                                  args3 <- invert_bind_args idc1
-                                             Raw.ident.Literal;
-                                  args4 <- invert_bind_args idc0
-                                             Raw.ident.Literal;
-                                  _ <- invert_bind_args idc
-                                         Raw.ident.Z_add_get_carry;
-                                  match
-                                    pattern.type.unify_extracted
-                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                      (((projT1 args4) -> (projT1 args3)) ->
-                                       s5 -> (projT1 args))%ptype
-                                  with
-                                  | Some (_, _, (_, _))%zrange =>
-                                      if
-                                       type.type_beq base.type
-                                         base.type.type_beq
-                                         ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                         (((projT1 args4) -> (projT1 args3)) ->
-                                          s5 -> (projT1 args))%ptype
-                                      then
-                                       xv <- ident.unify
-                                               pattern.ident.Literal
-                                               ##(projT2 args4);
-                                       xv0 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args3);
-                                       v <- type.try_make_transport_cps s5 ℤ;
-                                       xv1 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args);
-                                       fv <- (x7 <- (let
-                                                     '(r1, r2)%zrange :=
-                                                      range in
-                                                      fun (s6 xx : Z)
-                                                        (rshiftr ry : zrange)
-                                                        (y : expr ℤ)
-                                                        (offset : Z) =>
-                                                      if
-                                                       (s6 =? 2 ^ Z.log2 s6) &&
-                                                       (ZRange.normalize ry >>
-                                                        ZRange.normalize
-                                                          (ZRange.constant
-                                                             offset) <=?
-                                                        ZRange.normalize
-                                                          rshiftr)%zrange &&
-                                                       (ZRange.normalize
-                                                          rshiftr <=?
-                                                        r[0 ~> s6 - 1])%zrange
-                                                      then
-                                                       Some
-                                                         (#(Z_cast2 (r1, r2))%expr @
-                                                          (#(fancy_add
-                                                               (Z.log2 s6)
-                                                               (- offset))%expr @
-                                                           ((##xx)%expr,
-                                                           #(Z_cast ry)%expr @
-                                                           y)))%expr_pat
-                                                      else None)
-                                                      (let (x7, _) := xv in
-                                                       x7)
-                                                      (let (x7, _) := xv0 in
-                                                       x7) args2 args0
-                                                      (v (Compile.reflect x6))
-                                                      (let (x7, _) := xv1 in
-                                                       x7);
-                                              Some (Base x7));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
-                                  end
-                              | _ => None
-                              end
-                          | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _
-                            _ s5 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s5 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
-                      | _ => None
-                      end;;
-                      args <- invert_bind_args idc2 Raw.ident.Z_cast;
-                      args0 <- invert_bind_args idc1 Raw.ident.Literal;
-                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
-                      _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
-                      match
-                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          (((projT1 args1) -> (projT1 args0)) -> s2)%ptype
-                      with
-                      | Some (_, _, _)%zrange =>
-                          if
-                           type.type_beq base.type base.type.type_beq
-                             ((ℤ -> ℤ) -> ℤ)%ptype
-                             (((projT1 args1) -> (projT1 args0)) -> s2)%ptype
-                          then
-                           xv <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                           xv0 <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args0);
-                           v <- type.try_make_transport_cps s2 ℤ;
-                           fv <- (x4 <- (let
-                                         '(r1, r2)%zrange := range in
-                                          fun (s3 xx : Z) (ry : zrange)
-                                            (y : expr ℤ) =>
-                                          if
-                                           (s3 =? 2 ^ Z.log2 s3) &&
-                                           (ZRange.normalize ry <=?
-                                            r[0 ~> s3 - 1])%zrange
-                                          then
-                                           Some
-                                             (#(Z_cast2 (r1, r2))%expr @
-                                              (#(fancy_add (Z.log2 s3) 0)%expr @
-                                               ((##xx)%expr,
-                                               #(Z_cast ry)%expr @ y)))%expr_pat
-                                          else None)
-                                          (let (x4, _) := xv in x4)
-                                          (let (x4, _) := xv0 in x4) args
-                                          (v (Compile.reflect x3));
-                                  Some (Base x4));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
-                      end
-                  | @expr.App _ _ _ s2 _ ($_)%expr _ | @expr.App _ _ _ s2 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s2 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s2 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
-                  end
-              | @expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x3 =>
-                  match x0 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      match x3 with
-                      | (@expr.Ident _ _ _ t3 idc3 @ x5 @ x4)%expr_pat =>
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.Ident
-                              _ _ _ t7 idc7))%expr_pat =>
-                              match x4 with
-                              | @expr.Ident _ _ _ t8 idc8 =>
-                                  args <- invert_bind_args idc8
-                                            Raw.ident.Literal;
-                                  args0 <- invert_bind_args idc7
-                                             Raw.ident.Literal;
-                                  args1 <- invert_bind_args idc6
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                                  args3 <- invert_bind_args idc4
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc3
-                                         Raw.ident.Z_shiftl;
-                                  args5 <- invert_bind_args idc2
-                                             Raw.ident.Literal;
-                                  args6 <- invert_bind_args idc1
-                                             Raw.ident.Z_cast;
-                                  args7 <- invert_bind_args idc0
-                                             Raw.ident.Literal;
-                                  _ <- invert_bind_args idc
-                                         Raw.ident.Z_add_get_carry;
-                                  match
-                                    pattern.type.unify_extracted
-                                      ((ℤ -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                      (((projT1 args7) ->
-                                        (s8 -> (projT1 args0)) ->
-                                        (projT1 args)) -> (projT1 args5))%ptype
-                                  with
-                                  | Some (_, (_, _, _), _)%zrange =>
-                                      if
-                                       type.type_beq base.type
-                                         base.type.type_beq
-                                         ((ℤ -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                         (((projT1 args7) ->
-                                           (s8 -> (projT1 args0)) ->
-                                           (projT1 args)) -> (projT1 args5))%ptype
-                                      then
-                                       xv <- ident.unify
-                                               pattern.ident.Literal
-                                               ##(projT2 args7);
-                                       v <- type.try_make_transport_cps s8 ℤ;
-                                       xv0 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args0);
-                                       xv1 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args);
-                                       xv2 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args5);
-                                       fv <- (x10 <- (let
-                                                      '(r1, r2)%zrange :=
-                                                       range in
-                                                       fun (s9 : Z)
-                                                         (rshiftl rland
-                                                          ry : zrange)
-                                                         (y : expr ℤ)
-                                                         (mask offset xx : Z)
-                                                       =>
-                                                       if
-                                                        (s9 =? 2 ^ Z.log2 s9) &&
-                                                        (ZRange.normalize
-                                                           rland <<
-                                                         ZRange.normalize
-                                                           (ZRange.constant
-                                                              offset) <=?
-                                                         ZRange.normalize
-                                                           rshiftl)%zrange &&
-                                                        (ZRange.normalize ry &'
-                                                         ZRange.normalize
-                                                           (ZRange.constant
-                                                              mask) <=?
-                                                         ZRange.normalize
-                                                           rland)%zrange &&
-                                                        (ZRange.normalize
-                                                           rshiftl <=?
-                                                         r[0 ~> s9 - 1])%zrange &&
-                                                        (mask =?
-                                                         Z.ones
-                                                           (Z.log2 s9 -
-                                                            offset)) &&
-                                                        (0 <=? offset) &&
-                                                        (offset <=? Z.log2 s9)
-                                                       then
-                                                        Some
-                                                          (#(Z_cast2 (r1, r2))%expr @
-                                                           (#(fancy_add
-                                                                (Z.log2 s9)
-                                                                offset)%expr @
-                                                            ((##xx)%expr,
-                                                            #(Z_cast ry)%expr @
-                                                            y)))%expr_pat
-                                                       else None)
-                                                       (let (x10, _) := xv in
-                                                        x10) args6 args3
-                                                       args1
-                                                       (v
-                                                          (Compile.reflect x9))
-                                                       (let (x10, _) :=
-                                                          xv0 in
-                                                        x10)
-                                                       (let (x10, _) :=
-                                                          xv1 in
-                                                        x10)
-                                                       (let (x10, _) :=
-                                                          xv2 in
-                                                        x10);
-                                              Some (Base x10));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
-                                  end
-                              | _ => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ ($_)%expr))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.Abs _
-                              _ _ _ _ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ (_ @ _)))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.LetIn
-                              _ _ _ _ _ _ _))%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ ($_)%expr _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (_ @ _) _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
-                              _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                              _ _ _ @ _))%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x5 with
-                          | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t4 idc4)
-                            x6 =>
-                              match x4 with
-                              | @expr.Ident _ _ _ t5 idc5 =>
-                                  args <- invert_bind_args idc5
-                                            Raw.ident.Literal;
-                                  args0 <- invert_bind_args idc4
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc3
-                                         Raw.ident.Z_shiftr;
-                                  args2 <- invert_bind_args idc2
-                                             Raw.ident.Literal;
-                                  args3 <- invert_bind_args idc1
-                                             Raw.ident.Z_cast;
-                                  args4 <- invert_bind_args idc0
-                                             Raw.ident.Literal;
-                                  _ <- invert_bind_args idc
-                                         Raw.ident.Z_add_get_carry;
-                                  match
-                                    pattern.type.unify_extracted
-                                      ((ℤ -> ℤ -> ℤ) -> ℤ)%ptype
-                                      (((projT1 args4) -> s5 -> (projT1 args)) ->
-                                       (projT1 args2))%ptype
-                                  with
-                                  | Some (_, (_, _), _)%zrange =>
-                                      if
-                                       type.type_beq base.type
-                                         base.type.type_beq
-                                         ((ℤ -> ℤ -> ℤ) -> ℤ)%ptype
-                                         (((projT1 args4) ->
-                                           s5 -> (projT1 args)) ->
-                                          (projT1 args2))%ptype
-                                      then
-                                       xv <- ident.unify
-                                               pattern.ident.Literal
-                                               ##(projT2 args4);
-                                       v <- type.try_make_transport_cps s5 ℤ;
-                                       xv0 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args);
-                                       xv1 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args2);
-                                       fv <- (x7 <- (let
-                                                     '(r1, r2)%zrange :=
-                                                      range in
-                                                      fun (s6 : Z)
-                                                        (rshiftr ry : zrange)
-                                                        (y : expr ℤ)
-                                                        (offset xx : Z) =>
-                                                      if
-                                                       (s6 =? 2 ^ Z.log2 s6) &&
-                                                       (ZRange.normalize ry >>
-                                                        ZRange.normalize
-                                                          (ZRange.constant
-                                                             offset) <=?
-                                                        ZRange.normalize
-                                                          rshiftr)%zrange &&
-                                                       (ZRange.normalize
-                                                          rshiftr <=?
-                                                        r[0 ~> s6 - 1])%zrange
-                                                      then
-                                                       Some
-                                                         (#(Z_cast2 (r1, r2))%expr @
-                                                          (#(fancy_add
-                                                               (Z.log2 s6)
-                                                               (- offset))%expr @
-                                                           ((##xx)%expr,
-                                                           #(Z_cast ry)%expr @
-                                                           y)))%expr_pat
-                                                      else None)
-                                                      (let (x7, _) := xv in
-                                                       x7) args3 args0
-                                                      (v (Compile.reflect x6))
-                                                      (let (x7, _) := xv0 in
-                                                       x7)
-                                                      (let (x7, _) := xv1 in
-                                                       x7);
-                                              Some (Base x7));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
-                                  end
-                              | _ => None
-                              end
-                          | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _
-                            _ s5 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s5 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
-                      | _ => None
-                      end;;
-                      args <- invert_bind_args idc2 Raw.ident.Literal;
-                      args0 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
-                      _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
-                      match
-                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          (((projT1 args1) -> s2) -> (projT1 args))%ptype
-                      with
-                      | Some (_, _, _)%zrange =>
-                          if
-                           type.type_beq base.type base.type.type_beq
-                             ((ℤ -> ℤ) -> ℤ)%ptype
-                             (((projT1 args1) -> s2) -> (projT1 args))%ptype
-                          then
-                           xv <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                           v <- type.try_make_transport_cps s2 ℤ;
-                           xv0 <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args);
-                           fv <- (x4 <- (let
-                                         '(r1, r2)%zrange := range in
-                                          fun (s3 : Z) (rx : zrange)
-                                            (x4 : expr ℤ) (yy : Z) =>
-                                          if
-                                           (s3 =? 2 ^ Z.log2 s3) &&
-                                           (ZRange.normalize
-                                              (ZRange.constant yy) <=?
-                                            r[0 ~> s3 - 1])%zrange
-                                          then
-                                           Some
-                                             (#(Z_cast2 (r1, r2))%expr @
-                                              (#(fancy_add (Z.log2 s3) 0)%expr @
-                                               (#(Z_cast rx)%expr @ x4,
-                                               (##yy)%expr)))%expr_pat
-                                          else None)
-                                          (let (x4, _) := xv in x4) args0
-                                          (v (Compile.reflect x3))
-                                          (let (x4, _) := xv0 in x4);
-                                  Some (Base x4));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
-                      end
-                  | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4 =>
-                      match x4 with
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ @expr.Ident _ _ _ t8 idc8)%expr_pat =>
-                          args <- invert_bind_args idc8 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc7 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc6 Raw.ident.Z_cast;
-                          _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                          args3 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                          _ <- invert_bind_args idc3 Raw.ident.Z_shiftl;
-                          args5 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args6 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args7 <- invert_bind_args idc0 Raw.ident.Literal;
+                  | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3) x5 =>
+                      match x5 with
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @
+                         (@expr.Ident _ _ _ t10 idc10 @ @expr.Ident _ _ _ t11
+                          idc11))%expr_pat =>
+                          args <- invert_bind_args idc11 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc10 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc9 Raw.ident.Literal;
+                          args2 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                          args3 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                          args5 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc4 Raw.ident.Z_shiftl;
+                          args7 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args8 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          args9 <- invert_bind_args idc1 Raw.ident.Literal;
+                          args10 <- invert_bind_args idc0 Raw.ident.Z_cast;
                           _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
                           match
                             pattern.type.unify_extracted
                               ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                              (((projT1 args7) -> s2) ->
-                               (s9 -> (projT1 args0)) -> (projT1 args))%ptype
+                              (((projT1 args9) -> s3) ->
+                               (s10 -> (projT1 args1)) -> (projT1 args))%ptype
                           with
                           | Some (_, _, (_, _, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                 (((projT1 args7) -> s2) ->
-                                  (s9 -> (projT1 args0)) -> (projT1 args))%ptype
+                                 (((projT1 args9) -> s3) ->
+                                  (s10 -> (projT1 args1)) -> (projT1 args))%ptype
                               then
                                xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args7);
-                               v <- type.try_make_transport_cps s2 ℤ;
-                               v0 <- type.try_make_transport_cps s9 ℤ;
+                                       ##(projT2 args9);
+                               v <- type.try_make_transport_cps s3 ℤ;
+                               v0 <- type.try_make_transport_cps s10 ℤ;
                                xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
+                                        ##(projT2 args1);
                                xv1 <- ident.unify pattern.ident.Literal
                                         ##(projT2 args);
-                               fv <- (x11 <- (let
+                               fv <- (x14 <- (let
                                               '(r1, r2)%zrange := range in
-                                               fun (s10 : Z) (rx : zrange)
-                                                 (x11 : expr ℤ)
+                                               fun (rs : zrange) (s13 : Z)
+                                                 (rx : zrange) (x14 : expr ℤ)
                                                  (rshiftl rland ry : zrange)
                                                  (y : expr ℤ)
-                                                 (mask offset : Z) =>
+                                                 (rmask : zrange) (mask : Z)
+                                                 (roffset : zrange)
+                                                 (offset : Z) =>
                                                if
-                                                (s10 =? 2 ^ Z.log2 s10) &&
+                                                (s13 =? 2 ^ Z.log2 s13) &&
                                                 (ZRange.normalize rland <<
                                                  ZRange.normalize
                                                    (ZRange.constant offset) <=?
@@ -3780,195 +3337,308 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (ZRange.constant mask) <=?
                                                  ZRange.normalize rland)%zrange &&
                                                 (ZRange.normalize rshiftl <=?
-                                                 r[0 ~> s10 - 1])%zrange &&
+                                                 r[0 ~> s13 - 1])%zrange &&
                                                 (mask =?
-                                                 Z.ones (Z.log2 s10 - offset)) &&
+                                                 Z.ones (Z.log2 s13 - offset)) &&
                                                 (0 <=? offset) &&
-                                                (offset <=? Z.log2 s10)
+                                                (offset <=? Z.log2 s13) &&
+                                                is_bounded_by_bool s13
+                                                  (ZRange.normalize rs) &&
+                                                is_bounded_by_bool mask
+                                                  (ZRange.normalize rmask) &&
+                                                is_bounded_by_bool offset
+                                                  (ZRange.normalize roffset)
                                                then
                                                 Some
                                                   (#(Z_cast2 (r1, r2))%expr @
-                                                   (#(fancy_add (Z.log2 s10)
+                                                   (#(fancy_add (Z.log2 s13)
                                                         offset)%expr @
-                                                    (#(Z_cast rx)%expr @ x11,
+                                                    (#(Z_cast rx)%expr @ x14,
                                                     #(Z_cast ry)%expr @ y)))%expr_pat
-                                               else None)
-                                               (let (x11, _) := xv in x11)
-                                               args6 (v (Compile.reflect x3))
-                                               args5 args3 args1
-                                               (v0 (Compile.reflect x10))
-                                               (let (x11, _) := xv0 in x11)
-                                               (let (x11, _) := xv1 in x11);
-                                      Some (Base x11));
+                                               else None) args10
+                                               (let (x14, _) := xv in x14)
+                                               args8 (v (Compile.reflect x4))
+                                               args7 args5 args3
+                                               (v0 (Compile.reflect x11))
+                                               args2
+                                               (let (x14, _) := xv0 in x14)
+                                               args0
+                                               (let (x14, _) := xv1 in x14);
+                                      Some (Base x14));
                                Some (fv0 <-- fv;
                                      Base fv0)%under_lets
                               else None
                           | None => None
                           end
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ ($_)%expr)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ (_ @ _))%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @
+                         (@expr.Ident _ _ _ t10 idc10 @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @
+                         (@expr.Ident _ _ _ t10 idc10 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (@expr.Ident _ _ _ t10 idc10 @ (_ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @
+                         (@expr.Ident _ _ _ t10 idc10 @ @expr.LetIn _ _ _ _ _
+                          _ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (_ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
                           None
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ ($_)%expr)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Abs _ _ _
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _ _))) @
+                         _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ (_ @ _)))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
+                            _ _))) @ _)%expr_pat => None
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ #(_))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ ($_)%expr)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.Abs _ _ _
                            _ _ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ (_ @ _))) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.LetIn _ _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ (($_)%expr @ _))) @
+                         _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Abs _ _ _ _ _ _ @ _))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ (_ @ _ @ _))) @
+                         _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.LetIn _ _ _ _ _ _ _ @ _))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.LetIn _ _
                            _ _ _ _ _)) @ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            ($_)%expr _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.Abs _ _ _ _ _ _) _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (_ @ _) _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
                           None
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _ @
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _ @
                            _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _
                            _ _ @ _)) @ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ #(_)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _) @
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ #(_)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _) @
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Abs _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _)) @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _)) @
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Abs _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
                           _) @ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @ #(_) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _ @
+                      | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _ @
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ (($_)%expr @ _) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
+                        (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ (_ @ _ @ _) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
+                        (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
                          _ @ _)%expr_pat => None
                       | _ => None
                       end;;
-                      match x3 with
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ @expr.Ident _ _ _ t8 idc8)%expr_pat =>
-                          args <- invert_bind_args idc8 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc7 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc6 Raw.ident.Z_cast;
-                          _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                          args3 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                          _ <- invert_bind_args idc3 Raw.ident.Z_shiftl;
-                          args5 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args6 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args7 <- invert_bind_args idc0 Raw.ident.Literal;
+                      match x4 with
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @
+                         (@expr.Ident _ _ _ t10 idc10 @ @expr.Ident _ _ _ t11
+                          idc11))%expr_pat =>
+                          args <- invert_bind_args idc11 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc10 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc9 Raw.ident.Literal;
+                          args2 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                          args3 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                          args5 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc4 Raw.ident.Z_shiftl;
+                          args7 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args8 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          args9 <- invert_bind_args idc1 Raw.ident.Literal;
+                          args10 <- invert_bind_args idc0 Raw.ident.Z_cast;
                           _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
                           match
                             pattern.type.unify_extracted
                               ((ℤ -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              (((projT1 args7) ->
-                                (s9 -> (projT1 args0)) -> (projT1 args)) ->
-                               s3)%ptype
+                              (((projT1 args9) ->
+                                (s10 -> (projT1 args1)) -> (projT1 args)) ->
+                               s4)%ptype
                           with
                           | Some (_, (_, _, _), _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 (((projT1 args7) ->
-                                   (s9 -> (projT1 args0)) -> (projT1 args)) ->
-                                  s3)%ptype
+                                 (((projT1 args9) ->
+                                   (s10 -> (projT1 args1)) -> (projT1 args)) ->
+                                  s4)%ptype
                               then
                                xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args7);
-                               v <- type.try_make_transport_cps s9 ℤ;
+                                       ##(projT2 args9);
+                               v <- type.try_make_transport_cps s10 ℤ;
                                xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
+                                        ##(projT2 args1);
                                xv1 <- ident.unify pattern.ident.Literal
                                         ##(projT2 args);
-                               v0 <- type.try_make_transport_cps s3 ℤ;
-                               fv <- (x11 <- (let
+                               v0 <- type.try_make_transport_cps s4 ℤ;
+                               fv <- (x14 <- (let
                                               '(r1, r2)%zrange := range in
-                                               fun (s10 : Z)
+                                               fun (rs : zrange) (s13 : Z)
                                                  (rshiftl rland ry : zrange)
                                                  (y : expr ℤ)
-                                                 (mask offset : Z)
-                                                 (rx : zrange) (x11 : expr ℤ)
-                                               =>
+                                                 (rmask : zrange) (mask : Z)
+                                                 (roffset : zrange)
+                                                 (offset : Z) (rx : zrange)
+                                                 (x14 : expr ℤ) =>
                                                if
-                                                (s10 =? 2 ^ Z.log2 s10) &&
+                                                (s13 =? 2 ^ Z.log2 s13) &&
                                                 (ZRange.normalize rland <<
                                                  ZRange.normalize
                                                    (ZRange.constant offset) <=?
@@ -3978,4112 +3648,540 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (ZRange.constant mask) <=?
                                                  ZRange.normalize rland)%zrange &&
                                                 (ZRange.normalize rshiftl <=?
-                                                 r[0 ~> s10 - 1])%zrange &&
+                                                 r[0 ~> s13 - 1])%zrange &&
                                                 (mask =?
-                                                 Z.ones (Z.log2 s10 - offset)) &&
+                                                 Z.ones (Z.log2 s13 - offset)) &&
                                                 (0 <=? offset) &&
-                                                (offset <=? Z.log2 s10)
+                                                (offset <=? Z.log2 s13) &&
+                                                is_bounded_by_bool s13
+                                                  (ZRange.normalize rs) &&
+                                                is_bounded_by_bool mask
+                                                  (ZRange.normalize rmask) &&
+                                                is_bounded_by_bool offset
+                                                  (ZRange.normalize roffset)
                                                then
                                                 Some
                                                   (#(Z_cast2 (r1, r2))%expr @
-                                                   (#(fancy_add (Z.log2 s10)
+                                                   (#(fancy_add (Z.log2 s13)
                                                         offset)%expr @
-                                                    (#(Z_cast rx)%expr @ x11,
+                                                    (#(Z_cast rx)%expr @ x14,
                                                     #(Z_cast ry)%expr @ y)))%expr_pat
-                                               else None)
-                                               (let (x11, _) := xv in x11)
-                                               args6 args3 args1
-                                               (v (Compile.reflect x10))
-                                               (let (x11, _) := xv0 in x11)
-                                               (let (x11, _) := xv1 in x11)
-                                               args5
-                                               (v0 (Compile.reflect x4));
-                                      Some (Base x11));
+                                               else None) args10
+                                               (let (x14, _) := xv in x14)
+                                               args8 args5 args3
+                                               (v (Compile.reflect x11))
+                                               args2
+                                               (let (x14, _) := xv0 in x14)
+                                               args0
+                                               (let (x14, _) := xv1 in x14)
+                                               args7
+                                               (v0 (Compile.reflect x5));
+                                      Some (Base x14));
                                Some (fv0 <-- fv;
                                      Base fv0)%under_lets
                               else None
                           | None => None
                           end
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ ($_)%expr)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ (_ @ _))%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident _ _
-                           _ t7 idc7)) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @
+                         (@expr.Ident _ _ _ t10 idc10 @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @
+                         (@expr.Ident _ _ _ t10 idc10 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (@expr.Ident _ _ _ t10 idc10 @ (_ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @
+                         (@expr.Ident _ _ _ t10 idc10 @ @expr.LetIn _ _ _ _ _
+                          _ _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (_ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
+                            idc9))) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
                           None
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ ($_)%expr)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Abs _ _ _
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _ _))) @
+                         _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ (_ @ _)))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
+                            _ _))) @ _)%expr_pat => None
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ #(_))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ ($_)%expr)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.Abs _ _ _
                            _ _ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ (_ @ _))) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
-                           (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.LetIn _ _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ (($_)%expr @ _))) @
+                         _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.Abs _ _ _ _ _ _ @ _))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ (_ @ _ @ _))) @
+                         _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @
+                           (@expr.LetIn _ _ _ _ _ _ _ @ _))) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
+                           (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.LetIn _ _
                            _ _ _ _ _)) @ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            ($_)%expr _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.Abs _ _ _ _ _ _) _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (_ @ _) _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
                           None
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _ @
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _ @
                            _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
-                          (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
+                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _
                            _ _ @ _)) @ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ #(_)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _) @
+                      | (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ #(_)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _) @
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Abs _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _)) @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _)) @
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Abs _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _)) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
-                         (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @
+                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
                           _) @ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @ #(_) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _ @
+                      | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _ @
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ (($_)%expr @ _) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
+                        (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ (_ @ _ @ _) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @
+                        (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
                          _ @ _)%expr_pat => None
                       | _ => None
                       end;;
-                      match x4 with
-                      | (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ @expr.Ident _ _ _
-                         t5 idc5)%expr_pat =>
-                          args <- invert_bind_args idc5 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                          _ <- invert_bind_args idc3 Raw.ident.Z_shiftr;
-                          args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args3 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args4 <- invert_bind_args idc0 Raw.ident.Literal;
+                      match x5 with
+                      | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Ident _ _ _ t7
+                          idc7))%expr_pat =>
+                          args <- invert_bind_args idc7 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc6 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc4 Raw.ident.Z_shiftr;
+                          args3 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args4 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          args5 <- invert_bind_args idc1 Raw.ident.Literal;
+                          args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
                           _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
                           match
                             pattern.type.unify_extracted
                               ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                              (((projT1 args4) -> s2) -> s6 -> (projT1 args))%ptype
+                              (((projT1 args5) -> s3) -> s7 -> (projT1 args))%ptype
                           with
                           | Some (_, _, (_, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                 (((projT1 args4) -> s2) ->
-                                  s6 -> (projT1 args))%ptype
+                                 (((projT1 args5) -> s3) ->
+                                  s7 -> (projT1 args))%ptype
                               then
                                xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args4);
-                               v <- type.try_make_transport_cps s2 ℤ;
-                               v0 <- type.try_make_transport_cps s6 ℤ;
+                                       ##(projT2 args5);
+                               v <- type.try_make_transport_cps s3 ℤ;
+                               v0 <- type.try_make_transport_cps s7 ℤ;
                                xv0 <- ident.unify pattern.ident.Literal
                                         ##(projT2 args);
-                               fv <- (x8 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s7 : Z) (rx : zrange)
-                                                (x8 : expr ℤ)
-                                                (rshiftr ry : zrange)
-                                                (y : expr ℤ) (offset : Z) =>
-                                              if
-                                               (s7 =? 2 ^ Z.log2 s7) &&
-                                               (ZRange.normalize ry >>
-                                                ZRange.normalize
-                                                  (ZRange.constant offset) <=?
-                                                ZRange.normalize rshiftr)%zrange &&
-                                               (ZRange.normalize rshiftr <=?
-                                                r[0 ~> s7 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_add (Z.log2 s7)
-                                                       (- offset))%expr @
-                                                   (#(Z_cast rx)%expr @ x8,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x8, _) := xv in x8) args3
-                                              (v (Compile.reflect x3)) args2
-                                              args0 (v0 (Compile.reflect x7))
-                                              (let (x8, _) := xv0 in x8);
-                                      Some (Base x8));
+                               fv <- (x10 <- (let
+                                              '(r1, r2)%zrange := range in
+                                               fun (rs : zrange) (s9 : Z)
+                                                 (rx : zrange) (x10 : expr ℤ)
+                                                 (rshiftr ry : zrange)
+                                                 (y : expr ℤ)
+                                                 (roffset : zrange)
+                                                 (offset : Z) =>
+                                               if
+                                                (s9 =? 2 ^ Z.log2 s9) &&
+                                                (ZRange.normalize ry >>
+                                                 ZRange.normalize
+                                                   (ZRange.constant offset) <=?
+                                                 ZRange.normalize rshiftr)%zrange &&
+                                                (ZRange.normalize rshiftr <=?
+                                                 r[0 ~> s9 - 1])%zrange &&
+                                                is_bounded_by_bool s9
+                                                  (ZRange.normalize rs) &&
+                                                is_bounded_by_bool offset
+                                                  (ZRange.normalize roffset)
+                                               then
+                                                Some
+                                                  (#(Z_cast2 (r1, r2))%expr @
+                                                   (#(fancy_add (Z.log2 s9)
+                                                        (- offset))%expr @
+                                                    (#(Z_cast rx)%expr @ x10,
+                                                    #(Z_cast ry)%expr @ y)))%expr_pat
+                                               else None) args6
+                                               (let (x10, _) := xv in x10)
+                                               args4 (v (Compile.reflect x4))
+                                               args3 args1
+                                               (v0 (Compile.reflect x8))
+                                               args0
+                                               (let (x10, _) := xv0 in x10);
+                                      Some (Base x10));
                                Some (fv0 <-- fv;
                                      Base fv0)%under_lets
                               else None
                           | None => None
                           end
-                      | (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ ($_)%expr)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ @expr.Abs _ _ _ _ _
+                      | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ (_ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
+                          _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.Abs _ _ _ _ _
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ (_ @ _))%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ @expr.LetIn _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ (_ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.LetIn _ _ _ _
                          _ _ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          ($_)%expr _ @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (_ @ _) _ @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @ #(_) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _ @
+                      | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _ @
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
                          _ @ _)%expr_pat => None
                       | _ => None
                       end;;
-                      match x3 with
-                      | (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ @expr.Ident _ _ _
-                         t5 idc5)%expr_pat =>
-                          args <- invert_bind_args idc5 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc4 Raw.ident.Z_cast;
-                          _ <- invert_bind_args idc3 Raw.ident.Z_shiftr;
-                          args2 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args3 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args4 <- invert_bind_args idc0 Raw.ident.Literal;
+                      match x4 with
+                      | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Ident _ _ _ t7
+                          idc7))%expr_pat =>
+                          args <- invert_bind_args idc7 Raw.ident.Literal;
+                          args0 <- invert_bind_args idc6 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc5 Raw.ident.Z_cast;
+                          _ <- invert_bind_args idc4 Raw.ident.Z_shiftr;
+                          args3 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args4 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          args5 <- invert_bind_args idc1 Raw.ident.Literal;
+                          args6 <- invert_bind_args idc0 Raw.ident.Z_cast;
                           _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
                           match
                             pattern.type.unify_extracted
                               ((ℤ -> ℤ -> ℤ) -> ℤ)%ptype
-                              (((projT1 args4) -> s6 -> (projT1 args)) -> s3)%ptype
+                              (((projT1 args5) -> s7 -> (projT1 args)) -> s4)%ptype
                           with
                           | Some (_, (_, _), _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ -> ℤ) -> ℤ)%ptype
-                                 (((projT1 args4) -> s6 -> (projT1 args)) ->
-                                  s3)%ptype
+                                 (((projT1 args5) -> s7 -> (projT1 args)) ->
+                                  s4)%ptype
                               then
                                xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args4);
-                               v <- type.try_make_transport_cps s6 ℤ;
+                                       ##(projT2 args5);
+                               v <- type.try_make_transport_cps s7 ℤ;
                                xv0 <- ident.unify pattern.ident.Literal
                                         ##(projT2 args);
-                               v0 <- type.try_make_transport_cps s3 ℤ;
-                               fv <- (x8 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s7 : Z)
-                                                (rshiftr ry : zrange)
-                                                (y : expr ℤ) (offset : Z)
-                                                (rx : zrange) (x8 : expr ℤ)
-                                              =>
-                                              if
-                                               (s7 =? 2 ^ Z.log2 s7) &&
-                                               (ZRange.normalize ry >>
-                                                ZRange.normalize
-                                                  (ZRange.constant offset) <=?
-                                                ZRange.normalize rshiftr)%zrange &&
-                                               (ZRange.normalize rshiftr <=?
-                                                r[0 ~> s7 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_add (Z.log2 s7)
-                                                       (- offset))%expr @
-                                                   (#(Z_cast rx)%expr @ x8,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x8, _) := xv in x8) args3
-                                              args0 (v (Compile.reflect x7))
-                                              (let (x8, _) := xv0 in x8)
-                                              args2 (v0 (Compile.reflect x4));
-                                      Some (Base x8));
+                               v0 <- type.try_make_transport_cps s4 ℤ;
+                               fv <- (x10 <- (let
+                                              '(r1, r2)%zrange := range in
+                                               fun (rs : zrange) (s9 : Z)
+                                                 (rshiftr ry : zrange)
+                                                 (y : expr ℤ)
+                                                 (roffset : zrange)
+                                                 (offset : Z) (rx : zrange)
+                                                 (x10 : expr ℤ) =>
+                                               if
+                                                (s9 =? 2 ^ Z.log2 s9) &&
+                                                (ZRange.normalize ry >>
+                                                 ZRange.normalize
+                                                   (ZRange.constant offset) <=?
+                                                 ZRange.normalize rshiftr)%zrange &&
+                                                (ZRange.normalize rshiftr <=?
+                                                 r[0 ~> s9 - 1])%zrange &&
+                                                is_bounded_by_bool s9
+                                                  (ZRange.normalize rs) &&
+                                                is_bounded_by_bool offset
+                                                  (ZRange.normalize roffset)
+                                               then
+                                                Some
+                                                  (#(Z_cast2 (r1, r2))%expr @
+                                                   (#(fancy_add (Z.log2 s9)
+                                                        (- offset))%expr @
+                                                    (#(Z_cast rx)%expr @ x10,
+                                                    #(Z_cast ry)%expr @ y)))%expr_pat
+                                               else None) args6
+                                               (let (x10, _) := xv in x10)
+                                               args4 args1
+                                               (v (Compile.reflect x8)) args0
+                                               (let (x10, _) := xv0 in x10)
+                                               args3
+                                               (v0 (Compile.reflect x5));
+                                      Some (Base x10));
                                Some (fv0 <-- fv;
                                      Base fv0)%under_lets
                               else None
                           | None => None
                           end
-                      | (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ ($_)%expr)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ @expr.Abs _ _ _ _ _
+                      | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ (_ @ _)))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
+                          _))%expr_pat => None
+                      | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ #(_))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ ($_)%expr)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.Abs _ _ _ _ _
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ (_ @ _))%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                         (@expr.Ident _ _ _ t4 idc4) x7 @ @expr.LetIn _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ (($_)%expr @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ (_ @ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @
+                         (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
+                         (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.LetIn _ _ _ _
                          _ _ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                      | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          ($_)%expr _ @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (_ @ _) _ @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat => None
-                      | (@expr.Ident _ _ _ t3 idc3 @ #(_) @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr @ _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _ @
+                      | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _ @
                          _)%expr_pat |
-                        (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _
+                        (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
                          _ @ _)%expr_pat => None
                       | _ => None
                       end;;
-                      args <- invert_bind_args idc2 Raw.ident.Z_cast;
-                      args0 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
+                      args <- invert_bind_args idc3 Raw.ident.Z_cast;
+                      args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
                       match
                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          (((projT1 args1) -> s2) -> s3)%ptype
+                          (((projT1 args1) -> s3) -> s4)%ptype
                       with
                       | Some (_, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              ((ℤ -> ℤ) -> ℤ)%ptype
-                             (((projT1 args1) -> s2) -> s3)%ptype
+                             (((projT1 args1) -> s3) -> s4)%ptype
                           then
                            xv <- ident.unify pattern.ident.Literal
                                    ##(projT2 args1);
-                           v <- type.try_make_transport_cps s2 ℤ;
-                           v0 <- type.try_make_transport_cps s3 ℤ;
-                           fv <- (x5 <- (let
+                           v <- type.try_make_transport_cps s3 ℤ;
+                           v0 <- type.try_make_transport_cps s4 ℤ;
+                           fv <- (x6 <- (let
                                          '(r1, r2)%zrange := range in
-                                          fun (s4 : Z) (rx : zrange)
-                                            (x5 : expr ℤ) (ry : zrange)
-                                            (y : expr ℤ) =>
+                                          fun (rs : zrange) (s5 : Z)
+                                            (rx : zrange) (x6 : expr ℤ)
+                                            (ry : zrange) (y : expr ℤ) =>
                                           if
-                                           (s4 =? 2 ^ Z.log2 s4) &&
+                                           (s5 =? 2 ^ Z.log2 s5) &&
                                            (ZRange.normalize ry <=?
-                                            r[0 ~> s4 - 1])%zrange
+                                            r[0 ~> s5 - 1])%zrange &&
+                                           is_bounded_by_bool s5
+                                             (ZRange.normalize rs)
                                           then
                                            Some
                                              (#(Z_cast2 (r1, r2))%expr @
-                                              (#(fancy_add (Z.log2 s4) 0)%expr @
-                                               (#(Z_cast rx)%expr @ x5,
+                                              (#(fancy_add (Z.log2 s5) 0)%expr @
+                                               (#(Z_cast rx)%expr @ x6,
                                                #(Z_cast ry)%expr @ y)))%expr_pat
-                                          else None)
-                                          (let (x5, _) := xv in x5) args0
-                                          (v (Compile.reflect x3)) args
-                                          (v0 (Compile.reflect x4));
-                                  Some (Base x5));
+                                          else None) args2
+                                          (let (x6, _) := xv in x6) args0
+                                          (v (Compile.reflect x4)) args
+                                          (v0 (Compile.reflect x5));
+                                  Some (Base x6));
                            Some (fv0 <-- fv;
                                  Base fv0)%under_lets
                           else None
                       | None => None
-                      end
-                  | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
-                  end
-              | @expr.App _ _ _ s2 _ ($_)%expr _ | @expr.App _ _ _ s2 _
-                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s2 _
-                (_ @ _)%expr_pat _ | @expr.App _ _ _ s2 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
-              end
-          | _ => None
-          end;;
-          match x2 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              match x1 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  match x0 with
-                  | @expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t2 idc2) x3 =>
-                      match x3 with
-                      | (@expr.Ident _ _ _ t3 idc3 @ x5 @ x4)%expr_pat =>
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.Ident
-                              _ _ _ t7 idc7))%expr_pat =>
-                              match x4 with
-                              | @expr.Ident _ _ _ t8 idc8 =>
-                                  args <- invert_bind_args idc8
-                                            Raw.ident.Literal;
-                                  args0 <- invert_bind_args idc7
-                                             Raw.ident.Literal;
-                                  args1 <- invert_bind_args idc6
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                                  args3 <- invert_bind_args idc4
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc3
-                                         Raw.ident.Z_shiftl;
-                                  args5 <- invert_bind_args idc2
-                                             Raw.ident.Z_cast;
-                                  args6 <- invert_bind_args idc1
-                                             Raw.ident.Literal;
-                                  args7 <- invert_bind_args idc0
-                                             Raw.ident.Literal;
-                                  _ <- invert_bind_args idc
-                                         Raw.ident.Z_sub_get_borrow;
-                                  match
-                                    pattern.type.unify_extracted
-                                      ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                      (((projT1 args7) -> (projT1 args6)) ->
-                                       (s8 -> (projT1 args0)) ->
-                                       (projT1 args))%ptype
-                                  with
-                                  | Some (_, _, (_, _, _))%zrange =>
-                                      if
-                                       type.type_beq base.type
-                                         base.type.type_beq
-                                         ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                         (((projT1 args7) -> (projT1 args6)) ->
-                                          (s8 -> (projT1 args0)) ->
-                                          (projT1 args))%ptype
-                                      then
-                                       xv <- ident.unify
-                                               pattern.ident.Literal
-                                               ##(projT2 args7);
-                                       xv0 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args6);
-                                       v <- type.try_make_transport_cps s8 ℤ;
-                                       xv1 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args0);
-                                       xv2 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args);
-                                       fv <- (x10 <- (let
-                                                      '(r1, r2)%zrange :=
-                                                       range in
-                                                       fun (s9 xx : Z)
-                                                         (rshiftl rland
-                                                          ry : zrange)
-                                                         (y : expr ℤ)
-                                                         (mask offset : Z) =>
-                                                       if
-                                                        (s9 =? 2 ^ Z.log2 s9) &&
-                                                        (ZRange.normalize
-                                                           rland <<
-                                                         ZRange.normalize
-                                                           (ZRange.constant
-                                                              offset) <=?
-                                                         ZRange.normalize
-                                                           rshiftl)%zrange &&
-                                                        (ZRange.normalize
-                                                           rshiftl <=?
-                                                         r[0 ~> s9 - 1])%zrange &&
-                                                        (ZRange.normalize ry &'
-                                                         ZRange.normalize
-                                                           (ZRange.constant
-                                                              mask) <=?
-                                                         ZRange.normalize
-                                                           rland)%zrange &&
-                                                        (mask =?
-                                                         Z.ones
-                                                           (Z.log2 s9 -
-                                                            offset)) &&
-                                                        (0 <=? offset) &&
-                                                        (offset <=? Z.log2 s9)
-                                                       then
-                                                        Some
-                                                          (#(Z_cast2 (r1, r2))%expr @
-                                                           (#(fancy_sub
-                                                                (Z.log2 s9)
-                                                                offset)%expr @
-                                                            ((##xx)%expr,
-                                                            #(Z_cast ry)%expr @
-                                                            y)))%expr_pat
-                                                       else None)
-                                                       (let (x10, _) := xv in
-                                                        x10)
-                                                       (let (x10, _) :=
-                                                          xv0 in
-                                                        x10) args5 args3
-                                                       args1
-                                                       (v
-                                                          (Compile.reflect x9))
-                                                       (let (x10, _) :=
-                                                          xv1 in
-                                                        x10)
-                                                       (let (x10, _) :=
-                                                          xv2 in
-                                                        x10);
-                                              Some (Base x10));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
-                                  end
-                              | _ => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ ($_)%expr))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.Abs _
-                              _ _ _ _ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ (_ @ _)))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Ident _ _ _ t6 idc6) x9 @ @expr.LetIn
-                              _ _ _ _ _ _ _))%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ ($_)%expr _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (_ @ _) _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s8
-                              _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
-                              _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                              _ _ _ @ _))%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x5 with
-                          | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t4 idc4)
-                            x6 =>
-                              match x4 with
-                              | @expr.Ident _ _ _ t5 idc5 =>
-                                  args <- invert_bind_args idc5
-                                            Raw.ident.Literal;
-                                  args0 <- invert_bind_args idc4
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc3
-                                         Raw.ident.Z_shiftr;
-                                  args2 <- invert_bind_args idc2
-                                             Raw.ident.Z_cast;
-                                  args3 <- invert_bind_args idc1
-                                             Raw.ident.Literal;
-                                  args4 <- invert_bind_args idc0
-                                             Raw.ident.Literal;
-                                  _ <- invert_bind_args idc
-                                         Raw.ident.Z_sub_get_borrow;
-                                  match
-                                    pattern.type.unify_extracted
-                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                      (((projT1 args4) -> (projT1 args3)) ->
-                                       s5 -> (projT1 args))%ptype
-                                  with
-                                  | Some (_, _, (_, _))%zrange =>
-                                      if
-                                       type.type_beq base.type
-                                         base.type.type_beq
-                                         ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                         (((projT1 args4) -> (projT1 args3)) ->
-                                          s5 -> (projT1 args))%ptype
-                                      then
-                                       xv <- ident.unify
-                                               pattern.ident.Literal
-                                               ##(projT2 args4);
-                                       xv0 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args3);
-                                       v <- type.try_make_transport_cps s5 ℤ;
-                                       xv1 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args);
-                                       fv <- (x7 <- (let
-                                                     '(r1, r2)%zrange :=
-                                                      range in
-                                                      fun (s6 xx : Z)
-                                                        (rshiftr ry : zrange)
-                                                        (y : expr ℤ)
-                                                        (offset : Z) =>
-                                                      if
-                                                       (s6 =? 2 ^ Z.log2 s6) &&
-                                                       (ZRange.normalize ry >>
-                                                        ZRange.normalize
-                                                          (ZRange.constant
-                                                             offset) <=?
-                                                        ZRange.normalize
-                                                          rshiftr)%zrange &&
-                                                       (ZRange.normalize
-                                                          rshiftr <=?
-                                                        r[0 ~> s6 - 1])%zrange
-                                                      then
-                                                       Some
-                                                         (#(Z_cast2 (r1, r2))%expr @
-                                                          (#(fancy_sub
-                                                               (Z.log2 s6)
-                                                               (- offset))%expr @
-                                                           ((##xx)%expr,
-                                                           #(Z_cast ry)%expr @
-                                                           y)))%expr_pat
-                                                      else None)
-                                                      (let (x7, _) := xv in
-                                                       x7)
-                                                      (let (x7, _) := xv0 in
-                                                       x7) args2 args0
-                                                      (v (Compile.reflect x6))
-                                                      (let (x7, _) := xv1 in
-                                                       x7);
-                                              Some (Base x7));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
-                                  end
-                              | _ => None
-                              end
-                          | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _
-                            _ s5 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s5 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
-                      | _ => None
-                      end;;
-                      args <- invert_bind_args idc2 Raw.ident.Z_cast;
-                      args0 <- invert_bind_args idc1 Raw.ident.Literal;
-                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
-                      _ <- invert_bind_args idc Raw.ident.Z_sub_get_borrow;
-                      match
-                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          (((projT1 args1) -> (projT1 args0)) -> s2)%ptype
-                      with
-                      | Some (_, _, _)%zrange =>
-                          if
-                           type.type_beq base.type base.type.type_beq
-                             ((ℤ -> ℤ) -> ℤ)%ptype
-                             (((projT1 args1) -> (projT1 args0)) -> s2)%ptype
-                          then
-                           xv <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                           xv0 <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args0);
-                           v <- type.try_make_transport_cps s2 ℤ;
-                           fv <- (x4 <- (let
-                                         '(r1, r2)%zrange := range in
-                                          fun (s3 xx : Z) (ry : zrange)
-                                            (y : expr ℤ) =>
-                                          if
-                                           (s3 =? 2 ^ Z.log2 s3) &&
-                                           (ZRange.normalize ry <=?
-                                            r[0 ~> s3 - 1])%zrange
-                                          then
-                                           Some
-                                             (#(Z_cast2 (r1, r2))%expr @
-                                              (#(fancy_sub (Z.log2 s3) 0)%expr @
-                                               ((##xx)%expr,
-                                               #(Z_cast ry)%expr @ y)))%expr_pat
-                                          else None)
-                                          (let (x4, _) := xv in x4)
-                                          (let (x4, _) := xv0 in x4) args
-                                          (v (Compile.reflect x3));
-                                  Some (Base x4));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
-                      end
-                  | @expr.App _ _ _ s2 _ ($_)%expr _ | @expr.App _ _ _ s2 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s2 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s2 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
-                  end
-              | @expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x3 =>
-                  match x0 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      args <- invert_bind_args idc2 Raw.ident.Literal;
-                      args0 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
-                      _ <- invert_bind_args idc Raw.ident.Z_sub_get_borrow;
-                      match
-                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          (((projT1 args1) -> s2) -> (projT1 args))%ptype
-                      with
-                      | Some (_, _, _)%zrange =>
-                          if
-                           type.type_beq base.type base.type.type_beq
-                             ((ℤ -> ℤ) -> ℤ)%ptype
-                             (((projT1 args1) -> s2) -> (projT1 args))%ptype
-                          then
-                           xv <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                           v <- type.try_make_transport_cps s2 ℤ;
-                           xv0 <- ident.unify pattern.ident.Literal
-                                    ##(projT2 args);
-                           fv <- (x4 <- (let
-                                         '(r1, r2)%zrange := range in
-                                          fun (s3 : Z) (rx : zrange)
-                                            (x4 : expr ℤ) (yy : Z) =>
-                                          if
-                                           (s3 =? 2 ^ Z.log2 s3) &&
-                                           (ZRange.normalize
-                                              (ZRange.constant yy) <=?
-                                            r[0 ~> s3 - 1])%zrange
-                                          then
-                                           Some
-                                             (#(Z_cast2 (r1, r2))%expr @
-                                              (#(fancy_sub (Z.log2 s3) 0)%expr @
-                                               (#(Z_cast rx)%expr @ x4,
-                                               (##yy)%expr)))%expr_pat
-                                          else None)
-                                          (let (x4, _) := xv in x4) args0
-                                          (v (Compile.reflect x3))
-                                          (let (x4, _) := xv0 in x4);
-                                  Some (Base x4));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
-                      end
-                  | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4 =>
-                      match x4 with
-                      | (@expr.Ident _ _ _ t3 idc3 @ x6 @ x5)%expr_pat =>
-                          match x6 with
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Ident
-                              _ _ _ t7 idc7))%expr_pat =>
-                              match x5 with
-                              | @expr.Ident _ _ _ t8 idc8 =>
-                                  args <- invert_bind_args idc8
-                                            Raw.ident.Literal;
-                                  args0 <- invert_bind_args idc7
-                                             Raw.ident.Literal;
-                                  args1 <- invert_bind_args idc6
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc5 Raw.ident.Z_land;
-                                  args3 <- invert_bind_args idc4
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc3
-                                         Raw.ident.Z_shiftl;
-                                  args5 <- invert_bind_args idc2
-                                             Raw.ident.Z_cast;
-                                  args6 <- invert_bind_args idc1
-                                             Raw.ident.Z_cast;
-                                  args7 <- invert_bind_args idc0
-                                             Raw.ident.Literal;
-                                  _ <- invert_bind_args idc
-                                         Raw.ident.Z_sub_get_borrow;
-                                  match
-                                    pattern.type.unify_extracted
-                                      ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                      (((projT1 args7) -> s2) ->
-                                       (s9 -> (projT1 args0)) ->
-                                       (projT1 args))%ptype
-                                  with
-                                  | Some (_, _, (_, _, _))%zrange =>
-                                      if
-                                       type.type_beq base.type
-                                         base.type.type_beq
-                                         ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                         (((projT1 args7) -> s2) ->
-                                          (s9 -> (projT1 args0)) ->
-                                          (projT1 args))%ptype
-                                      then
-                                       xv <- ident.unify
-                                               pattern.ident.Literal
-                                               ##(projT2 args7);
-                                       v <- type.try_make_transport_cps s2 ℤ;
-                                       v0 <- type.try_make_transport_cps s9 ℤ;
-                                       xv0 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args0);
-                                       xv1 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args);
-                                       fv <- (x11 <- (let
-                                                      '(r1, r2)%zrange :=
-                                                       range in
-                                                       fun (s10 : Z)
-                                                         (rx : zrange)
-                                                         (x11 : expr ℤ)
-                                                         (rshiftl rland
-                                                          ry : zrange)
-                                                         (y : expr ℤ)
-                                                         (mask offset : Z) =>
-                                                       if
-                                                        (s10 =?
-                                                         2 ^ Z.log2 s10) &&
-                                                        (ZRange.normalize
-                                                           rland <<
-                                                         ZRange.normalize
-                                                           (ZRange.constant
-                                                              offset) <=?
-                                                         ZRange.normalize
-                                                           rshiftl)%zrange &&
-                                                        (ZRange.normalize
-                                                           rshiftl <=?
-                                                         r[0 ~> s10 - 1])%zrange &&
-                                                        (ZRange.normalize ry &'
-                                                         ZRange.normalize
-                                                           (ZRange.constant
-                                                              mask) <=?
-                                                         ZRange.normalize
-                                                           rland)%zrange &&
-                                                        (mask =?
-                                                         Z.ones
-                                                           (Z.log2 s10 -
-                                                            offset)) &&
-                                                        (0 <=? offset) &&
-                                                        (offset <=?
-                                                         Z.log2 s10)
-                                                       then
-                                                        Some
-                                                          (#(Z_cast2 (r1, r2))%expr @
-                                                           (#(fancy_sub
-                                                                (Z.log2 s10)
-                                                                offset)%expr @
-                                                            (#(Z_cast rx)%expr @
-                                                             x11,
-                                                            #(Z_cast ry)%expr @
-                                                            y)))%expr_pat
-                                                       else None)
-                                                       (let (x11, _) := xv in
-                                                        x11) args6
-                                                       (v
-                                                          (Compile.reflect x3))
-                                                       args5 args3 args1
-                                                       (v0
-                                                          (Compile.reflect
-                                                             x10))
-                                                       (let (x11, _) :=
-                                                          xv0 in
-                                                        x11)
-                                                       (let (x11, _) :=
-                                                          xv1 in
-                                                        x11);
-                                              Some (Base x11));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
-                                  end
-                              | _ => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ (@expr.Ident _ _ _ t6 idc6) x10 @ ($_)%expr))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Abs _
-                              _ _ _ _ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ (@expr.Ident _ _ _ t6 idc6) x10 @ (_ @ _)))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.LetIn
-                              _ _ _ _ _ _ _))%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ ($_)%expr _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ (_ @ _) _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9
-                              _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
-                              _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                              _ _ _ @ _))%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (#(_) @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x6 with
-                          | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t4 idc4)
-                            x7 =>
-                              match x5 with
-                              | @expr.Ident _ _ _ t5 idc5 =>
-                                  args <- invert_bind_args idc5
-                                            Raw.ident.Literal;
-                                  args0 <- invert_bind_args idc4
-                                             Raw.ident.Z_cast;
-                                  _ <- invert_bind_args idc3
-                                         Raw.ident.Z_shiftr;
-                                  args2 <- invert_bind_args idc2
-                                             Raw.ident.Z_cast;
-                                  args3 <- invert_bind_args idc1
-                                             Raw.ident.Z_cast;
-                                  args4 <- invert_bind_args idc0
-                                             Raw.ident.Literal;
-                                  _ <- invert_bind_args idc
-                                         Raw.ident.Z_sub_get_borrow;
-                                  match
-                                    pattern.type.unify_extracted
-                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                      (((projT1 args4) -> s2) ->
-                                       s6 -> (projT1 args))%ptype
-                                  with
-                                  | Some (_, _, (_, _))%zrange =>
-                                      if
-                                       type.type_beq base.type
-                                         base.type.type_beq
-                                         ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
-                                         (((projT1 args4) -> s2) ->
-                                          s6 -> (projT1 args))%ptype
-                                      then
-                                       xv <- ident.unify
-                                               pattern.ident.Literal
-                                               ##(projT2 args4);
-                                       v <- type.try_make_transport_cps s2 ℤ;
-                                       v0 <- type.try_make_transport_cps s6 ℤ;
-                                       xv0 <- ident.unify
-                                                pattern.ident.Literal
-                                                ##(projT2 args);
-                                       fv <- (x8 <- (let
-                                                     '(r1, r2)%zrange :=
-                                                      range in
-                                                      fun (s7 : Z)
-                                                        (rx : zrange)
-                                                        (x8 : expr ℤ)
-                                                        (rshiftr ry : zrange)
-                                                        (y : expr ℤ)
-                                                        (offset : Z) =>
-                                                      if
-                                                       (s7 =? 2 ^ Z.log2 s7) &&
-                                                       (ZRange.normalize ry >>
-                                                        ZRange.normalize
-                                                          (ZRange.constant
-                                                             offset) <=?
-                                                        ZRange.normalize
-                                                          rshiftr)%zrange &&
-                                                       (ZRange.normalize
-                                                          rshiftr <=?
-                                                        r[0 ~> s7 - 1])%zrange
-                                                      then
-                                                       Some
-                                                         (#(Z_cast2 (r1, r2))%expr @
-                                                          (#(fancy_sub
-                                                               (Z.log2 s7)
-                                                               (- offset))%expr @
-                                                           (#(Z_cast rx)%expr @
-                                                            x8,
-                                                           #(Z_cast ry)%expr @
-                                                           y)))%expr_pat
-                                                      else None)
-                                                      (let (x8, _) := xv in
-                                                       x8) args3
-                                                      (v (Compile.reflect x3))
-                                                      args2 args0
-                                                      (v0
-                                                         (Compile.reflect x7))
-                                                      (let (x8, _) := xv0 in
-                                                       x8);
-                                              Some (Base x8));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
-                                  end
-                              | _ => None
-                              end
-                          | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _
-                            _ s6 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
-                            _ s6 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
-                          end
-                      | _ => None
-                      end;;
-                      args <- invert_bind_args idc2 Raw.ident.Z_cast;
-                      args0 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                      args1 <- invert_bind_args idc0 Raw.ident.Literal;
-                      _ <- invert_bind_args idc Raw.ident.Z_sub_get_borrow;
-                      match
-                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
-                          (((projT1 args1) -> s2) -> s3)%ptype
-                      with
-                      | Some (_, _, _)%zrange =>
-                          if
-                           type.type_beq base.type base.type.type_beq
-                             ((ℤ -> ℤ) -> ℤ)%ptype
-                             (((projT1 args1) -> s2) -> s3)%ptype
-                          then
-                           xv <- ident.unify pattern.ident.Literal
-                                   ##(projT2 args1);
-                           v <- type.try_make_transport_cps s2 ℤ;
-                           v0 <- type.try_make_transport_cps s3 ℤ;
-                           fv <- (x5 <- (let
-                                         '(r1, r2)%zrange := range in
-                                          fun (s4 : Z) (rx : zrange)
-                                            (x5 : expr ℤ) (ry : zrange)
-                                            (y : expr ℤ) =>
-                                          if
-                                           (s4 =? 2 ^ Z.log2 s4) &&
-                                           (ZRange.normalize ry <=?
-                                            r[0 ~> s4 - 1])%zrange
-                                          then
-                                           Some
-                                             (#(Z_cast2 (r1, r2))%expr @
-                                              (#(fancy_sub (Z.log2 s4) 0)%expr @
-                                               (#(Z_cast rx)%expr @ x5,
-                                               #(Z_cast ry)%expr @ y)))%expr_pat
-                                          else None)
-                                          (let (x5, _) := xv in x5) args0
-                                          (v (Compile.reflect x3)) args
-                                          (v0 (Compile.reflect x4));
-                                  Some (Base x5));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
-                      end
-                  | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
-                  end
-              | @expr.App _ _ _ s2 _ ($_)%expr _ | @expr.App _ _ _ s2 _
-                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s2 _
-                (_ @ _)%expr_pat _ | @expr.App _ _ _ s2 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
-              end
-          | _ => None
-          end
-      | (@expr.Ident _ _ _ t idc @ x3 @ x2 @ x1 @ x0)%expr_pat =>
-          match x3 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              match x2 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  match x1 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      match x0 with
-                      | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t3 idc3)
-                        x4 =>
-                          match x4 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ x6 @ x5)%expr_pat =>
-                              match x6 with
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.Ident _ _ _ t8 idc8))%expr_pat =>
-                                  match x5 with
-                                  | @expr.Ident _ _ _ t9 idc9 =>
-                                      args <- invert_bind_args idc9
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc8
-                                                 Raw.ident.Literal;
-                                      args1 <- invert_bind_args idc7
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc6
-                                             Raw.ident.Z_land;
-                                      args3 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftl;
-                                      args5 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args6 <- invert_bind_args idc2
-                                                 Raw.ident.Literal;
-                                      args7 <- invert_bind_args idc1
-                                                 Raw.ident.Literal;
-                                      args8 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_add_with_get_carry;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args8) -> (projT1 args7)) ->
-                                            (projT1 args6)) ->
-                                           (s9 -> (projT1 args0)) ->
-                                           (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) ->
-                                              (ℤ -> ℤ) -> ℤ)%ptype
-                                             ((((projT1 args8) ->
-                                                (projT1 args7)) ->
-                                               (projT1 args6)) ->
-                                              (s9 -> (projT1 args0)) ->
-                                              (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args8);
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args7);
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args6);
-                                           v <- type.try_make_transport_cps s9 ℤ;
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args0);
-                                           xv3 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x11 <- (let
-                                                          '(r1, r2)%zrange :=
-                                                           range in
-                                                           fun
-                                                             (s10 cc xx : Z)
-                                                             (rshiftl rland
-                                                              ry : zrange)
-                                                             (y : expr ℤ)
-                                                             (mask
-                                                              offset : Z) =>
-                                                           if
-                                                            (s10 =?
-                                                             2 ^ Z.log2 s10) &&
-                                                            (ZRange.normalize
-                                                               rland <<
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  offset) <=?
-                                                             ZRange.normalize
-                                                               rshiftl)%zrange &&
-                                                            (ZRange.normalize
-                                                               rshiftl <=?
-                                                             r[0 ~> s10 - 1])%zrange &&
-                                                            (ZRange.normalize
-                                                               ry &'
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  mask) <=?
-                                                             ZRange.normalize
-                                                               rland)%zrange &&
-                                                            (mask =?
-                                                             Z.ones
-                                                               (Z.log2 s10 -
-                                                                offset)) &&
-                                                            (0 <=? offset) &&
-                                                            (offset <=?
-                                                             Z.log2 s10)
-                                                           then
-                                                            Some
-                                                              (#(Z_cast2
-                                                                   (r1, r2))%expr @
-                                                               (#(fancy_addc
-                                                                    (Z.log2
-                                                                    s10)
-                                                                    offset)%expr @
-                                                                ((##cc)%expr,
-                                                                (##xx)%expr,
-                                                                #(Z_cast ry)%expr @
-                                                                y)))%expr_pat
-                                                           else None)
-                                                           (let (x11, _) :=
-                                                              xv in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv0 in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv1 in
-                                                            x11) args5 args3
-                                                           args1
-                                                           (v
-                                                              (Compile.reflect
-                                                                 x10))
-                                                           (let (x11, _) :=
-                                                              xv2 in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv3 in
-                                                            x11);
-                                                  Some (Base x11));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  ($_)%expr))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  (_ @ _)))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ ($_)%expr _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (_ @ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
-                                  _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
-                              | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _
-                                 _ _ _)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (($_)%expr @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
-                              end;;
-                              match x6 with
-                              | @expr.App _ _ _ s6 _
-                                (@expr.Ident _ _ _ t5 idc5) x7 =>
-                                  match x5 with
-                                  | @expr.Ident _ _ _ t6 idc6 =>
-                                      args <- invert_bind_args idc6
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftr;
-                                      args2 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args3 <- invert_bind_args idc2
-                                                 Raw.ident.Literal;
-                                      args4 <- invert_bind_args idc1
-                                                 Raw.ident.Literal;
-                                      args5 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_add_with_get_carry;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                          ((((projT1 args5) -> (projT1 args4)) ->
-                                            (projT1 args3)) ->
-                                           s6 -> (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                             ((((projT1 args5) ->
-                                                (projT1 args4)) ->
-                                               (projT1 args3)) ->
-                                              s6 -> (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args5);
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args4);
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args3);
-                                           v <- type.try_make_transport_cps s6 ℤ;
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x8 <- (let
-                                                         '(r1, r2)%zrange :=
-                                                          range in
-                                                          fun (s7 cc xx : Z)
-                                                            (rshiftr
-                                                             ry : zrange)
-                                                            (y : expr ℤ)
-                                                            (offset : Z) =>
-                                                          if
-                                                           (s7 =?
-                                                            2 ^ Z.log2 s7) &&
-                                                           (ZRange.normalize
-                                                              ry >>
-                                                            ZRange.normalize
-                                                              (ZRange.constant
-                                                                 offset) <=?
-                                                            ZRange.normalize
-                                                              rshiftr)%zrange &&
-                                                           (ZRange.normalize
-                                                              rshiftr <=?
-                                                            r[0 ~> s7 - 1])%zrange
-                                                          then
-                                                           Some
-                                                             (#(Z_cast2
-                                                                  (r1, r2))%expr @
-                                                              (#(fancy_addc
-                                                                   (Z.log2 s7)
-                                                                   (- offset))%expr @
-                                                               ((##cc)%expr,
-                                                               (##xx)%expr,
-                                                               #(Z_cast ry)%expr @
-                                                               y)))%expr_pat
-                                                          else None)
-                                                          (let (x8, _) :=
-                                                             xv in
-                                                           x8)
-                                                          (let (x8, _) :=
-                                                             xv0 in
-                                                           x8)
-                                                          (let (x8, _) :=
-                                                             xv1 in
-                                                           x8) args2 args0
-                                                          (v
-                                                             (Compile.reflect
-                                                                x7))
-                                                          (let (x8, _) :=
-                                                             xv2 in
-                                                           x8);
-                                                  Some (Base x8));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App
-                                _ _ _ s6 _ (@expr.Abs _ _ _ _ _ _) _ |
-                                @expr.App _ _ _ s6 _ (_ @ _)%expr_pat _ |
-                                @expr.App _ _ _ s6 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
-                              end
-                          | _ => None
-                          end;;
-                          args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                          args0 <- invert_bind_args idc2 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc1 Raw.ident.Literal;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_add_with_get_carry;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> (projT1 args1)) ->
-                                (projT1 args0)) -> s3)%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> (projT1 args1)) ->
-                                   (projT1 args0)) -> s3)%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args1);
-                               xv1 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               fv <- (x5 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s4 cc xx : Z)
-                                                (ry : zrange) (y : expr ℤ) =>
-                                              if
-                                               (s4 =? 2 ^ Z.log2 s4) &&
-                                               (ZRange.normalize ry <=?
-                                                r[0 ~> s4 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_addc (Z.log2 s4) 0)%expr @
-                                                   ((##cc)%expr, (##xx)%expr,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x5, _) := xv in x5)
-                                              (let (x5, _) := xv0 in x5)
-                                              (let (x5, _) := xv1 in x5) args
-                                              (v (Compile.reflect x4));
-                                      Some (Base x5));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end
-                  | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4 =>
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          match x4 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ x6 @ x5)%expr_pat =>
-                              match x6 with
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.Ident _ _ _ t8 idc8))%expr_pat =>
-                                  match x5 with
-                                  | @expr.Ident _ _ _ t9 idc9 =>
-                                      args <- invert_bind_args idc9
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc8
-                                                 Raw.ident.Literal;
-                                      args1 <- invert_bind_args idc7
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc6
-                                             Raw.ident.Z_land;
-                                      args3 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftl;
-                                      args5 <- invert_bind_args idc3
-                                                 Raw.ident.Literal;
-                                      args6 <- invert_bind_args idc2
-                                                 Raw.ident.Z_cast;
-                                      args7 <- invert_bind_args idc1
-                                                 Raw.ident.Literal;
-                                      args8 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_add_with_get_carry;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args8) -> (projT1 args7)) ->
-                                            (s9 -> (projT1 args0)) ->
-                                            (projT1 args)) -> (projT1 args5))%ptype
-                                      with
-                                      | Some (_, _, (_, _, _), _)%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) ->
-                                              ℤ)%ptype
-                                             ((((projT1 args8) ->
-                                                (projT1 args7)) ->
-                                               (s9 -> (projT1 args0)) ->
-                                               (projT1 args)) ->
-                                              (projT1 args5))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args8);
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args7);
-                                           v <- type.try_make_transport_cps s9 ℤ;
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args0);
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           xv3 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args5);
-                                           fv <- (x11 <- (let
-                                                          '(r1, r2)%zrange :=
-                                                           range in
-                                                           fun (s10 cc : Z)
-                                                             (rshiftl rland
-                                                              ry : zrange)
-                                                             (y : expr ℤ)
-                                                             (mask offset
-                                                              xx : Z) =>
-                                                           if
-                                                            (s10 =?
-                                                             2 ^ Z.log2 s10) &&
-                                                            (ZRange.normalize
-                                                               rland <<
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  offset) <=?
-                                                             ZRange.normalize
-                                                               rshiftl)%zrange &&
-                                                            (ZRange.normalize
-                                                               rshiftl <=?
-                                                             r[0 ~> s10 - 1])%zrange &&
-                                                            (ZRange.normalize
-                                                               ry &'
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  mask) <=?
-                                                             ZRange.normalize
-                                                               rland)%zrange &&
-                                                            (mask =?
-                                                             Z.ones
-                                                               (Z.log2 s10 -
-                                                                offset)) &&
-                                                            (0 <=? offset) &&
-                                                            (offset <=?
-                                                             Z.log2 s10)
-                                                           then
-                                                            Some
-                                                              (#(Z_cast2
-                                                                   (r1, r2))%expr @
-                                                               (#(fancy_addc
-                                                                    (Z.log2
-                                                                    s10)
-                                                                    offset)%expr @
-                                                                ((##cc)%expr,
-                                                                (##xx)%expr,
-                                                                #(Z_cast ry)%expr @
-                                                                y)))%expr_pat
-                                                           else None)
-                                                           (let (x11, _) :=
-                                                              xv in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv0 in
-                                                            x11) args6 args3
-                                                           args1
-                                                           (v
-                                                              (Compile.reflect
-                                                                 x10))
-                                                           (let (x11, _) :=
-                                                              xv1 in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv2 in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv3 in
-                                                            x11);
-                                                  Some (Base x11));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  ($_)%expr))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  (_ @ _)))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ ($_)%expr _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (_ @ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
-                                  _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
-                              | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _
-                                 _ _ _)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (($_)%expr @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
-                              end;;
-                              match x6 with
-                              | @expr.App _ _ _ s6 _
-                                (@expr.Ident _ _ _ t5 idc5) x7 =>
-                                  match x5 with
-                                  | @expr.Ident _ _ _ t6 idc6 =>
-                                      args <- invert_bind_args idc6
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftr;
-                                      args2 <- invert_bind_args idc3
-                                                 Raw.ident.Literal;
-                                      args3 <- invert_bind_args idc2
-                                                 Raw.ident.Z_cast;
-                                      args4 <- invert_bind_args idc1
-                                                 Raw.ident.Literal;
-                                      args5 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_add_with_get_carry;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args5) -> (projT1 args4)) ->
-                                            s6 -> (projT1 args)) ->
-                                           (projT1 args2))%ptype
-                                      with
-                                      | Some (_, _, (_, _), _)%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
-                                             ((((projT1 args5) ->
-                                                (projT1 args4)) ->
-                                               s6 -> (projT1 args)) ->
-                                              (projT1 args2))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args5);
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args4);
-                                           v <- type.try_make_transport_cps s6 ℤ;
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args2);
-                                           fv <- (x8 <- (let
-                                                         '(r1, r2)%zrange :=
-                                                          range in
-                                                          fun (s7 cc : Z)
-                                                            (rshiftr
-                                                             ry : zrange)
-                                                            (y : expr ℤ)
-                                                            (offset xx : Z)
-                                                          =>
-                                                          if
-                                                           (s7 =?
-                                                            2 ^ Z.log2 s7) &&
-                                                           (ZRange.normalize
-                                                              ry >>
-                                                            ZRange.normalize
-                                                              (ZRange.constant
-                                                                 offset) <=?
-                                                            ZRange.normalize
-                                                              rshiftr)%zrange &&
-                                                           (ZRange.normalize
-                                                              rshiftr <=?
-                                                            r[0 ~> s7 - 1])%zrange
-                                                          then
-                                                           Some
-                                                             (#(Z_cast2
-                                                                  (r1, r2))%expr @
-                                                              (#(fancy_addc
-                                                                   (Z.log2 s7)
-                                                                   (- offset))%expr @
-                                                               ((##cc)%expr,
-                                                               (##xx)%expr,
-                                                               #(Z_cast ry)%expr @
-                                                               y)))%expr_pat
-                                                          else None)
-                                                          (let (x8, _) :=
-                                                             xv in
-                                                           x8)
-                                                          (let (x8, _) :=
-                                                             xv0 in
-                                                           x8) args3 args0
-                                                          (v
-                                                             (Compile.reflect
-                                                                x7))
-                                                          (let (x8, _) :=
-                                                             xv1 in
-                                                           x8)
-                                                          (let (x8, _) :=
-                                                             xv2 in
-                                                           x8);
-                                                  Some (Base x8));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App
-                                _ _ _ s6 _ (@expr.Abs _ _ _ _ _ _) _ |
-                                @expr.App _ _ _ s6 _ (_ @ _)%expr_pat _ |
-                                @expr.App _ _ _ s6 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
-                              end
-                          | _ => None
-                          end;;
-                          args <- invert_bind_args idc3 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args1 <- invert_bind_args idc1 Raw.ident.Literal;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_add_with_get_carry;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> (projT1 args1)) -> s3) ->
-                               (projT1 args))%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> (projT1 args1)) -> s3) ->
-                                  (projT1 args))%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args1);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               xv1 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args);
-                               fv <- (x5 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s4 cc : Z) (rx : zrange)
-                                                (x5 : expr ℤ) (yy : Z) =>
-                                              if
-                                               (s4 =? 2 ^ Z.log2 s4) &&
-                                               (ZRange.normalize
-                                                  (ZRange.constant yy) <=?
-                                                r[0 ~> s4 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_addc (Z.log2 s4) 0)%expr @
-                                                   ((##cc)%expr,
-                                                   #(Z_cast rx)%expr @ x5,
-                                                   (##yy)%expr)))%expr_pat
-                                              else None)
-                                              (let (x5, _) := xv in x5)
-                                              (let (x5, _) := xv0 in x5)
-                                              args0 (v (Compile.reflect x4))
-                                              (let (x5, _) := xv1 in x5);
-                                      Some (Base x5));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3)
-                        x5 =>
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.Ident _ _
-                             _ t9 idc9)%expr_pat =>
-                              args <- invert_bind_args idc9 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc8
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc6 Raw.ident.Z_land;
-                              args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc4 Raw.ident.Z_shiftl;
-                              args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              args7 <- invert_bind_args idc1
-                                         Raw.ident.Literal;
-                              args8 <- invert_bind_args idc0
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc
-                                     Raw.ident.Z_add_with_get_carry;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args8) -> (projT1 args7)) -> s3) ->
-                                   (s10 -> (projT1 args0)) -> (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, (_, _, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args8) -> (projT1 args7)) ->
-                                       s3) ->
-                                      (s10 -> (projT1 args0)) ->
-                                      (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args8);
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args7);
-                                   v <- type.try_make_transport_cps s3 ℤ;
-                                   v0 <- type.try_make_transport_cps s10 ℤ;
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   xv2 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x12 <- (let
-                                                  '(r1, r2)%zrange := range
-                                                   in
-                                                   fun (s11 cc : Z)
-                                                     (rx : zrange)
-                                                     (x12 : expr ℤ)
-                                                     (rshiftl rland
-                                                      ry : zrange)
-                                                     (y : expr ℤ)
-                                                     (mask offset : Z) =>
-                                                   if
-                                                    (s11 =? 2 ^ Z.log2 s11) &&
-                                                    (ZRange.normalize rland <<
-                                                     ZRange.normalize
-                                                       (ZRange.constant
-                                                          offset) <=?
-                                                     ZRange.normalize rshiftl)%zrange &&
-                                                    (ZRange.normalize rshiftl <=?
-                                                     r[0 ~> s11 - 1])%zrange &&
-                                                    (ZRange.normalize ry &'
-                                                     ZRange.normalize
-                                                       (ZRange.constant mask) <=?
-                                                     ZRange.normalize rland)%zrange &&
-                                                    (mask =?
-                                                     Z.ones
-                                                       (Z.log2 s11 - offset)) &&
-                                                    (0 <=? offset) &&
-                                                    (offset <=? Z.log2 s11)
-                                                   then
-                                                    Some
-                                                      (#(Z_cast2 (r1, r2))%expr @
-                                                       (#(fancy_addc
-                                                            (Z.log2 s11)
-                                                            offset)%expr @
-                                                        ((##cc)%expr,
-                                                        #(Z_cast rx)%expr @
-                                                        x12,
-                                                        #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None)
-                                                   (let (x12, _) := xv in x12)
-                                                   (let (x12, _) := xv0 in
-                                                    x12) args6
-                                                   (v (Compile.reflect x4))
-                                                   args5 args3 args1
-                                                   (v0 (Compile.reflect x11))
-                                                   (let (x12, _) := xv1 in
-                                                    x12)
-                                                   (let (x12, _) := xv2 in
-                                                    x12);
-                                          Some (Base x12));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.Abs _ _ _
-                             _ _ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ (_ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.LetIn _ _
-                             _ _ _ _ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               ($_)%expr)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Abs _ _ _ _ _ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               (_ @ _))) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.LetIn _ _ _ _ _ _ _)) @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ ($_)%expr _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Abs _ _ _ _ _ _) _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (_ @ _) _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _
-                               _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _
-                               _ _ _ _ @ _)) @ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ #(_)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
-                              _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Abs _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Abs _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                              _ _ _) @ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x4 with
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.Ident _ _
-                             _ t9 idc9)%expr_pat =>
-                              args <- invert_bind_args idc9 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc8
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc6 Raw.ident.Z_land;
-                              args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc4 Raw.ident.Z_shiftl;
-                              args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              args7 <- invert_bind_args idc1
-                                         Raw.ident.Literal;
-                              args8 <- invert_bind_args idc0
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc
-                                     Raw.ident.Z_add_with_get_carry;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args8) -> (projT1 args7)) ->
-                                    (s10 -> (projT1 args0)) -> (projT1 args)) ->
-                                   s4)%ptype
-                              with
-                              | Some (_, _, (_, _, _), _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args8) -> (projT1 args7)) ->
-                                       (s10 -> (projT1 args0)) ->
-                                       (projT1 args)) -> s4)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args8);
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args7);
-                                   v <- type.try_make_transport_cps s10 ℤ;
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   xv2 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   v0 <- type.try_make_transport_cps s4 ℤ;
-                                   fv <- (x12 <- (let
-                                                  '(r1, r2)%zrange := range
-                                                   in
-                                                   fun (s11 cc : Z)
-                                                     (rshiftl rland
-                                                      ry : zrange)
-                                                     (y : expr ℤ)
-                                                     (mask offset : Z)
-                                                     (rx : zrange)
-                                                     (x12 : expr ℤ) =>
-                                                   if
-                                                    (s11 =? 2 ^ Z.log2 s11) &&
-                                                    (ZRange.normalize rland <<
-                                                     ZRange.normalize
-                                                       (ZRange.constant
-                                                          offset) <=?
-                                                     ZRange.normalize rshiftl)%zrange &&
-                                                    (ZRange.normalize rshiftl <=?
-                                                     r[0 ~> s11 - 1])%zrange &&
-                                                    (ZRange.normalize ry &'
-                                                     ZRange.normalize
-                                                       (ZRange.constant mask) <=?
-                                                     ZRange.normalize rland)%zrange &&
-                                                    (mask =?
-                                                     Z.ones
-                                                       (Z.log2 s11 - offset)) &&
-                                                    (0 <=? offset) &&
-                                                    (offset <=? Z.log2 s11)
-                                                   then
-                                                    Some
-                                                      (#(Z_cast2 (r1, r2))%expr @
-                                                       (#(fancy_addc
-                                                            (Z.log2 s11)
-                                                            offset)%expr @
-                                                        ((##cc)%expr,
-                                                        #(Z_cast rx)%expr @
-                                                        x12,
-                                                        #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None)
-                                                   (let (x12, _) := xv in x12)
-                                                   (let (x12, _) := xv0 in
-                                                    x12) args6 args3 args1
-                                                   (v (Compile.reflect x11))
-                                                   (let (x12, _) := xv1 in
-                                                    x12)
-                                                   (let (x12, _) := xv2 in
-                                                    x12) args5
-                                                   (v0 (Compile.reflect x5));
-                                          Some (Base x12));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.Abs _ _ _
-                             _ _ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ (_ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.LetIn _ _
-                             _ _ _ _ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               ($_)%expr)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.Abs _ _ _ _ _ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               (_ @ _))) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                               @expr.LetIn _ _ _ _ _ _ _)) @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ ($_)%expr _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.Abs _ _ _ _ _ _) _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (_ @ _) _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s10 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _
-                               _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _
-                               _ _ _ _ @ _)) @ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ #(_)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
-                              _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Abs _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Abs _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                              _ _ _) @ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.Ident _ _
-                             _ t6 idc6)%expr_pat =>
-                              args <- invert_bind_args idc6 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc4 Raw.ident.Z_shiftr;
-                              args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              args4 <- invert_bind_args idc1
-                                         Raw.ident.Literal;
-                              args5 <- invert_bind_args idc0
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc
-                                     Raw.ident.Z_add_with_get_carry;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                  ((((projT1 args5) -> (projT1 args4)) -> s3) ->
-                                   s7 -> (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                     ((((projT1 args5) -> (projT1 args4)) ->
-                                       s3) -> s7 -> (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args5);
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args4);
-                                   v <- type.try_make_transport_cps s3 ℤ;
-                                   v0 <- type.try_make_transport_cps s7 ℤ;
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x9 <- (let
-                                                 '(r1, r2)%zrange := range in
-                                                  fun (s8 cc : Z)
-                                                    (rx : zrange)
-                                                    (x9 : expr ℤ)
-                                                    (rshiftr ry : zrange)
-                                                    (y : expr ℤ) (offset : Z)
-                                                  =>
-                                                  if
-                                                   (s8 =? 2 ^ Z.log2 s8) &&
-                                                   (ZRange.normalize ry >>
-                                                    ZRange.normalize
-                                                      (ZRange.constant offset) <=?
-                                                    ZRange.normalize rshiftr)%zrange &&
-                                                   (ZRange.normalize rshiftr <=?
-                                                    r[0 ~> s8 - 1])%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast2 (r1, r2))%expr @
-                                                      (#(fancy_addc
-                                                           (Z.log2 s8)
-                                                           (- offset))%expr @
-                                                       ((##cc)%expr,
-                                                       #(Z_cast rx)%expr @ x9,
-                                                       #(Z_cast ry)%expr @ y)))%expr_pat
-                                                  else None)
-                                                  (let (x9, _) := xv in x9)
-                                                  (let (x9, _) := xv0 in x9)
-                                                  args3
-                                                  (v (Compile.reflect x4))
-                                                  args2 args0
-                                                  (v0 (Compile.reflect x8))
-                                                  (let (x9, _) := xv1 in x9);
-                                          Some (Base x9));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.Abs _ _ _
-                             _ _ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ (_ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.LetIn _ _
-                             _ _ _ _ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             ($_)%expr _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (_ @ _) _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x4 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.Ident _ _
-                             _ t6 idc6)%expr_pat =>
-                              args <- invert_bind_args idc6 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc4 Raw.ident.Z_shiftr;
-                              args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              args4 <- invert_bind_args idc1
-                                         Raw.ident.Literal;
-                              args5 <- invert_bind_args idc0
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc
-                                     Raw.ident.Z_add_with_get_carry;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args5) -> (projT1 args4)) ->
-                                    s7 -> (projT1 args)) -> s4)%ptype
-                              with
-                              | Some (_, _, (_, _), _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args5) -> (projT1 args4)) ->
-                                       s7 -> (projT1 args)) -> s4)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args5);
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args4);
-                                   v <- type.try_make_transport_cps s7 ℤ;
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   v0 <- type.try_make_transport_cps s4 ℤ;
-                                   fv <- (x9 <- (let
-                                                 '(r1, r2)%zrange := range in
-                                                  fun (s8 cc : Z)
-                                                    (rshiftr ry : zrange)
-                                                    (y : expr ℤ) (offset : Z)
-                                                    (rx : zrange)
-                                                    (x9 : expr ℤ) =>
-                                                  if
-                                                   (s8 =? 2 ^ Z.log2 s8) &&
-                                                   (ZRange.normalize ry >>
-                                                    ZRange.normalize
-                                                      (ZRange.constant offset) <=?
-                                                    ZRange.normalize rshiftr)%zrange &&
-                                                   (ZRange.normalize rshiftr <=?
-                                                    r[0 ~> s8 - 1])%zrange
-                                                  then
-                                                   Some
-                                                     (#(Z_cast2 (r1, r2))%expr @
-                                                      (#(fancy_addc
-                                                           (Z.log2 s8)
-                                                           (- offset))%expr @
-                                                       ((##cc)%expr,
-                                                       #(Z_cast rx)%expr @ x9,
-                                                       #(Z_cast ry)%expr @ y)))%expr_pat
-                                                  else None)
-                                                  (let (x9, _) := xv in x9)
-                                                  (let (x9, _) := xv0 in x9)
-                                                  args3 args0
-                                                  (v (Compile.reflect x8))
-                                                  (let (x9, _) := xv1 in x9)
-                                                  args2
-                                                  (v0 (Compile.reflect x5));
-                                          Some (Base x9));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.Abs _ _ _
-                             _ _ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ (_ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.LetIn _ _
-                             _ _ _ _ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             ($_)%expr _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (_ @ _) _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                             (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args1 <- invert_bind_args idc1 Raw.ident.Literal;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_add_with_get_carry;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> (projT1 args1)) -> s3) ->
-                               s4)%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> (projT1 args1)) -> s3) ->
-                                  s4)%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args1);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               v0 <- type.try_make_transport_cps s4 ℤ;
-                               fv <- (x6 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s5 cc : Z) (rx : zrange)
-                                                (x6 : expr ℤ) (ry : zrange)
-                                                (y : expr ℤ) =>
-                                              if
-                                               (s5 =? 2 ^ Z.log2 s5) &&
-                                               (ZRange.normalize ry <=?
-                                                r[0 ~> s5 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_addc (Z.log2 s5) 0)%expr @
-                                                   ((##cc)%expr,
-                                                   #(Z_cast rx)%expr @ x6,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x6, _) := xv in x6)
-                                              (let (x6, _) := xv0 in x6)
-                                              args0 (v (Compile.reflect x4))
-                                              args (v0 (Compile.reflect x5));
-                                      Some (Base x6));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end
-                  | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
-                  end
-              | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4 =>
-                  match x1 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args <- invert_bind_args idc3 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc2 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_add_with_get_carry;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> s3) -> (projT1 args0)) ->
-                               (projT1 args))%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> s3) -> (projT1 args0)) ->
-                                  (projT1 args))%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
-                               xv1 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args);
-                               fv <- (x5 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s4 : Z) (rc : zrange)
-                                                (c : expr ℤ) (xx yy : Z) =>
-                                              if
-                                               (s4 =? 2 ^ Z.log2 s4) &&
-                                               (ZRange.normalize
-                                                  (ZRange.constant yy) <=?
-                                                r[0 ~> s4 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_addc (Z.log2 s4) 0)%expr @
-                                                   (#(Z_cast rc)%expr @ c,
-                                                   (##xx)%expr, (##yy)%expr)))%expr_pat
-                                              else None)
-                                              (let (x5, _) := xv in x5) args1
-                                              (v (Compile.reflect x4))
-                                              (let (x5, _) := xv0 in x5)
-                                              (let (x5, _) := xv1 in x5);
-                                      Some (Base x5));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3)
-                        x5 =>
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ x7 @ x6)%expr_pat =>
-                              match x7 with
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.Ident _ _ _ t8 idc8))%expr_pat =>
-                                  match x6 with
-                                  | @expr.Ident _ _ _ t9 idc9 =>
-                                      args <- invert_bind_args idc9
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc8
-                                                 Raw.ident.Literal;
-                                      args1 <- invert_bind_args idc7
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc6
-                                             Raw.ident.Z_land;
-                                      args3 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftl;
-                                      args5 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args6 <- invert_bind_args idc2
-                                                 Raw.ident.Literal;
-                                      args7 <- invert_bind_args idc1
-                                                 Raw.ident.Z_cast;
-                                      args8 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_add_with_get_carry;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args8) -> s3) ->
-                                            (projT1 args6)) ->
-                                           (s10 -> (projT1 args0)) ->
-                                           (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) ->
-                                              (ℤ -> ℤ) -> ℤ)%ptype
-                                             ((((projT1 args8) -> s3) ->
-                                               (projT1 args6)) ->
-                                              (s10 -> (projT1 args0)) ->
-                                              (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args8);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args6);
-                                           v0 <- type.try_make_transport_cps s10 ℤ;
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args0);
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x12 <- (let
-                                                          '(r1, r2)%zrange :=
-                                                           range in
-                                                           fun (s11 : Z)
-                                                             (rc : zrange)
-                                                             (c : expr ℤ)
-                                                             (xx : Z)
-                                                             (rshiftl rland
-                                                              ry : zrange)
-                                                             (y : expr ℤ)
-                                                             (mask
-                                                              offset : Z) =>
-                                                           if
-                                                            (s11 =?
-                                                             2 ^ Z.log2 s11) &&
-                                                            (ZRange.normalize
-                                                               rland <<
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  offset) <=?
-                                                             ZRange.normalize
-                                                               rshiftl)%zrange &&
-                                                            (ZRange.normalize
-                                                               rshiftl <=?
-                                                             r[0 ~> s11 - 1])%zrange &&
-                                                            (ZRange.normalize
-                                                               ry &'
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  mask) <=?
-                                                             ZRange.normalize
-                                                               rland)%zrange &&
-                                                            (mask =?
-                                                             Z.ones
-                                                               (Z.log2 s11 -
-                                                                offset)) &&
-                                                            (0 <=? offset) &&
-                                                            (offset <=?
-                                                             Z.log2 s11)
-                                                           then
-                                                            Some
-                                                              (#(Z_cast2
-                                                                   (r1, r2))%expr @
-                                                               (#(fancy_addc
-                                                                    (Z.log2
-                                                                    s11)
-                                                                    offset)%expr @
-                                                                (#(Z_cast rc)%expr @
-                                                                 c,
-                                                                (##xx)%expr,
-                                                                #(Z_cast ry)%expr @
-                                                                y)))%expr_pat
-                                                           else None)
-                                                           (let (x12, _) :=
-                                                              xv in
-                                                            x12) args7
-                                                           (v
-                                                              (Compile.reflect
-                                                                 x4))
-                                                           (let (x12, _) :=
-                                                              xv0 in
-                                                            x12) args5 args3
-                                                           args1
-                                                           (v0
-                                                              (Compile.reflect
-                                                                 x11))
-                                                           (let (x12, _) :=
-                                                              xv1 in
-                                                            x12)
-                                                           (let (x12, _) :=
-                                                              xv2 in
-                                                            x12);
-                                                  Some (Base x12));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  ($_)%expr))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  (_ @ _)))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ ($_)%expr _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (_ @ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
-                                  _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
-                              | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _
-                                 _ _ _)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (($_)%expr @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
-                              end;;
-                              match x7 with
-                              | @expr.App _ _ _ s7 _
-                                (@expr.Ident _ _ _ t5 idc5) x8 =>
-                                  match x6 with
-                                  | @expr.Ident _ _ _ t6 idc6 =>
-                                      args <- invert_bind_args idc6
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftr;
-                                      args2 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args3 <- invert_bind_args idc2
-                                                 Raw.ident.Literal;
-                                      args4 <- invert_bind_args idc1
-                                                 Raw.ident.Z_cast;
-                                      args5 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_add_with_get_carry;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                          ((((projT1 args5) -> s3) ->
-                                            (projT1 args3)) ->
-                                           s7 -> (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                             ((((projT1 args5) -> s3) ->
-                                               (projT1 args3)) ->
-                                              s7 -> (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args5);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args3);
-                                           v0 <- type.try_make_transport_cps s7 ℤ;
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x9 <- (let
-                                                         '(r1, r2)%zrange :=
-                                                          range in
-                                                          fun (s8 : Z)
-                                                            (rc : zrange)
-                                                            (c : expr ℤ)
-                                                            (xx : Z)
-                                                            (rshiftr
-                                                             ry : zrange)
-                                                            (y : expr ℤ)
-                                                            (offset : Z) =>
-                                                          if
-                                                           (s8 =?
-                                                            2 ^ Z.log2 s8) &&
-                                                           (ZRange.normalize
-                                                              ry >>
-                                                            ZRange.normalize
-                                                              (ZRange.constant
-                                                                 offset) <=?
-                                                            ZRange.normalize
-                                                              rshiftr)%zrange &&
-                                                           (ZRange.normalize
-                                                              rshiftr <=?
-                                                            r[0 ~> s8 - 1])%zrange
-                                                          then
-                                                           Some
-                                                             (#(Z_cast2
-                                                                  (r1, r2))%expr @
-                                                              (#(fancy_addc
-                                                                   (Z.log2 s8)
-                                                                   (- offset))%expr @
-                                                               (#(Z_cast rc)%expr @
-                                                                c,
-                                                               (##xx)%expr,
-                                                               #(Z_cast ry)%expr @
-                                                               y)))%expr_pat
-                                                          else None)
-                                                          (let (x9, _) :=
-                                                             xv in
-                                                           x9) args4
-                                                          (v
-                                                             (Compile.reflect
-                                                                x4))
-                                                          (let (x9, _) :=
-                                                             xv0 in
-                                                           x9) args2 args0
-                                                          (v0
-                                                             (Compile.reflect
-                                                                x8))
-                                                          (let (x9, _) :=
-                                                             xv1 in
-                                                           x9);
-                                                  Some (Base x9));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App
-                                _ _ _ s7 _ (@expr.Abs _ _ _ _ _ _) _ |
-                                @expr.App _ _ _ s7 _ (_ @ _)%expr_pat _ |
-                                @expr.App _ _ _ s7 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
-                              end
-                          | _ => None
-                          end;;
-                          args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                          args0 <- invert_bind_args idc2 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_add_with_get_carry;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> s3) -> (projT1 args0)) ->
-                               s4)%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> s3) -> (projT1 args0)) ->
-                                  s4)%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
-                               v0 <- type.try_make_transport_cps s4 ℤ;
-                               fv <- (x6 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s5 : Z) (rc : zrange)
-                                                (c : expr ℤ) (xx : Z)
-                                                (ry : zrange) (y : expr ℤ) =>
-                                              if
-                                               (s5 =? 2 ^ Z.log2 s5) &&
-                                               (ZRange.normalize ry <=?
-                                                r[0 ~> s5 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_addc (Z.log2 s5) 0)%expr @
-                                                   (#(Z_cast rc)%expr @ c,
-                                                   (##xx)%expr,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x6, _) := xv in x6) args1
-                                              (v (Compile.reflect x4))
-                                              (let (x6, _) := xv0 in x6) args
-                                              (v0 (Compile.reflect x5));
-                                      Some (Base x6));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end
-                  | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5 =>
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ x7 @ x6)%expr_pat =>
-                              match x7 with
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.Ident _ _ _ t8 idc8))%expr_pat =>
-                                  match x6 with
-                                  | @expr.Ident _ _ _ t9 idc9 =>
-                                      args <- invert_bind_args idc9
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc8
-                                                 Raw.ident.Literal;
-                                      args1 <- invert_bind_args idc7
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc6
-                                             Raw.ident.Z_land;
-                                      args3 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftl;
-                                      args5 <- invert_bind_args idc3
-                                                 Raw.ident.Literal;
-                                      args6 <- invert_bind_args idc2
-                                                 Raw.ident.Z_cast;
-                                      args7 <- invert_bind_args idc1
-                                                 Raw.ident.Z_cast;
-                                      args8 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_add_with_get_carry;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args8) -> s3) ->
-                                            (s10 -> (projT1 args0)) ->
-                                            (projT1 args)) -> (projT1 args5))%ptype
-                                      with
-                                      | Some (_, _, (_, _, _), _)%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) ->
-                                              ℤ)%ptype
-                                             ((((projT1 args8) -> s3) ->
-                                               (s10 -> (projT1 args0)) ->
-                                               (projT1 args)) ->
-                                              (projT1 args5))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args8);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           v0 <- type.try_make_transport_cps s10 ℤ;
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args0);
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args5);
-                                           fv <- (x12 <- (let
-                                                          '(r1, r2)%zrange :=
-                                                           range in
-                                                           fun (s11 : Z)
-                                                             (rc : zrange)
-                                                             (c : expr ℤ)
-                                                             (rshiftl rland
-                                                              ry : zrange)
-                                                             (y : expr ℤ)
-                                                             (mask offset
-                                                              xx : Z) =>
-                                                           if
-                                                            (s11 =?
-                                                             2 ^ Z.log2 s11) &&
-                                                            (ZRange.normalize
-                                                               rland <<
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  offset) <=?
-                                                             ZRange.normalize
-                                                               rshiftl)%zrange &&
-                                                            (ZRange.normalize
-                                                               rshiftl <=?
-                                                             r[0 ~> s11 - 1])%zrange &&
-                                                            (ZRange.normalize
-                                                               ry &'
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  mask) <=?
-                                                             ZRange.normalize
-                                                               rland)%zrange &&
-                                                            (mask =?
-                                                             Z.ones
-                                                               (Z.log2 s11 -
-                                                                offset)) &&
-                                                            (0 <=? offset) &&
-                                                            (offset <=?
-                                                             Z.log2 s11)
-                                                           then
-                                                            Some
-                                                              (#(Z_cast2
-                                                                   (r1, r2))%expr @
-                                                               (#(fancy_addc
-                                                                    (Z.log2
-                                                                    s11)
-                                                                    offset)%expr @
-                                                                (#(Z_cast rc)%expr @
-                                                                 c,
-                                                                (##xx)%expr,
-                                                                #(Z_cast ry)%expr @
-                                                                y)))%expr_pat
-                                                           else None)
-                                                           (let (x12, _) :=
-                                                              xv in
-                                                            x12) args7
-                                                           (v
-                                                              (Compile.reflect
-                                                                 x4)) args6
-                                                           args3 args1
-                                                           (v0
-                                                              (Compile.reflect
-                                                                 x11))
-                                                           (let (x12, _) :=
-                                                              xv0 in
-                                                            x12)
-                                                           (let (x12, _) :=
-                                                              xv1 in
-                                                            x12)
-                                                           (let (x12, _) :=
-                                                              xv2 in
-                                                            x12);
-                                                  Some (Base x12));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  ($_)%expr))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  (_ @ _)))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ ($_)%expr _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (_ @ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
-                                  _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
-                              | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _
-                                 _ _ _)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (($_)%expr @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
-                              end;;
-                              match x7 with
-                              | @expr.App _ _ _ s7 _
-                                (@expr.Ident _ _ _ t5 idc5) x8 =>
-                                  match x6 with
-                                  | @expr.Ident _ _ _ t6 idc6 =>
-                                      args <- invert_bind_args idc6
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftr;
-                                      args2 <- invert_bind_args idc3
-                                                 Raw.ident.Literal;
-                                      args3 <- invert_bind_args idc2
-                                                 Raw.ident.Z_cast;
-                                      args4 <- invert_bind_args idc1
-                                                 Raw.ident.Z_cast;
-                                      args5 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_add_with_get_carry;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args5) -> s3) ->
-                                            s7 -> (projT1 args)) ->
-                                           (projT1 args2))%ptype
-                                      with
-                                      | Some (_, _, (_, _), _)%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
-                                             ((((projT1 args5) -> s3) ->
-                                               s7 -> (projT1 args)) ->
-                                              (projT1 args2))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args5);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           v0 <- type.try_make_transport_cps s7 ℤ;
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args2);
-                                           fv <- (x9 <- (let
-                                                         '(r1, r2)%zrange :=
-                                                          range in
-                                                          fun (s8 : Z)
-                                                            (rc : zrange)
-                                                            (c : expr ℤ)
-                                                            (rshiftr
-                                                             ry : zrange)
-                                                            (y : expr ℤ)
-                                                            (offset xx : Z)
-                                                          =>
-                                                          if
-                                                           (s8 =?
-                                                            2 ^ Z.log2 s8) &&
-                                                           (ZRange.normalize
-                                                              ry >>
-                                                            ZRange.normalize
-                                                              (ZRange.constant
-                                                                 offset) <=?
-                                                            ZRange.normalize
-                                                              rshiftr)%zrange &&
-                                                           (ZRange.normalize
-                                                              rshiftr <=?
-                                                            r[0 ~> s8 - 1])%zrange
-                                                          then
-                                                           Some
-                                                             (#(Z_cast2
-                                                                  (r1, r2))%expr @
-                                                              (#(fancy_addc
-                                                                   (Z.log2 s8)
-                                                                   (- offset))%expr @
-                                                               (#(Z_cast rc)%expr @
-                                                                c,
-                                                               (##xx)%expr,
-                                                               #(Z_cast ry)%expr @
-                                                               y)))%expr_pat
-                                                          else None)
-                                                          (let (x9, _) :=
-                                                             xv in
-                                                           x9) args4
-                                                          (v
-                                                             (Compile.reflect
-                                                                x4)) args3
-                                                          args0
-                                                          (v0
-                                                             (Compile.reflect
-                                                                x8))
-                                                          (let (x9, _) :=
-                                                             xv0 in
-                                                           x9)
-                                                          (let (x9, _) :=
-                                                             xv1 in
-                                                           x9);
-                                                  Some (Base x9));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App
-                                _ _ _ s7 _ (@expr.Abs _ _ _ _ _ _) _ |
-                                @expr.App _ _ _ s7 _ (_ @ _)%expr_pat _ |
-                                @expr.App _ _ _ s7 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
-                              end
-                          | _ => None
-                          end;;
-                          args <- invert_bind_args idc3 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_add_with_get_carry;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> s3) -> s4) ->
-                               (projT1 args))%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> s3) -> s4) ->
-                                  (projT1 args))%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               v0 <- type.try_make_transport_cps s4 ℤ;
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args);
-                               fv <- (x6 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s5 : Z) (rc : zrange)
-                                                (c : expr ℤ) (rx : zrange)
-                                                (x6 : expr ℤ) (yy : Z) =>
-                                              if
-                                               (s5 =? 2 ^ Z.log2 s5) &&
-                                               (ZRange.normalize
-                                                  (ZRange.constant yy) <=?
-                                                r[0 ~> s5 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_addc (Z.log2 s5) 0)%expr @
-                                                   (#(Z_cast rc)%expr @ c,
-                                                   #(Z_cast rx)%expr @ x6,
-                                                   (##yy)%expr)))%expr_pat
-                                              else None)
-                                              (let (x6, _) := xv in x6) args1
-                                              (v (Compile.reflect x4)) args0
-                                              (v0 (Compile.reflect x5))
-                                              (let (x6, _) := xv0 in x6);
-                                      Some (Base x6));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3)
-                        x6 =>
-                          match x6 with
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.Ident _ _
-                             _ t9 idc9)%expr_pat =>
-                              args <- invert_bind_args idc9 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc8
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc6 Raw.ident.Z_land;
-                              args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc4 Raw.ident.Z_shiftl;
-                              args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              args7 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                              args8 <- invert_bind_args idc0
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc
-                                     Raw.ident.Z_add_with_get_carry;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args8) -> s3) -> s4) ->
-                                   (s11 -> (projT1 args0)) -> (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, (_, _, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args8) -> s3) -> s4) ->
-                                      (s11 -> (projT1 args0)) ->
-                                      (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args8);
-                                   v <- type.try_make_transport_cps s3 ℤ;
-                                   v0 <- type.try_make_transport_cps s4 ℤ;
-                                   v1 <- type.try_make_transport_cps s11 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x13 <- (let
-                                                  '(r1, r2)%zrange := range
-                                                   in
-                                                   fun (s12 : Z)
-                                                     (rc : zrange)
-                                                     (c : expr ℤ)
-                                                     (rx : zrange)
-                                                     (x13 : expr ℤ)
-                                                     (rshiftl rland
-                                                      ry : zrange)
-                                                     (y : expr ℤ)
-                                                     (mask offset : Z) =>
-                                                   if
-                                                    (s12 =? 2 ^ Z.log2 s12) &&
-                                                    (ZRange.normalize rland <<
-                                                     ZRange.normalize
-                                                       (ZRange.constant
-                                                          offset) <=?
-                                                     ZRange.normalize rshiftl)%zrange &&
-                                                    (ZRange.normalize ry &'
-                                                     ZRange.normalize
-                                                       (ZRange.constant mask) <=?
-                                                     ZRange.normalize rland)%zrange &&
-                                                    (ZRange.normalize rshiftl <=?
-                                                     r[0 ~> s12 - 1])%zrange &&
-                                                    (mask =?
-                                                     Z.ones
-                                                       (Z.log2 s12 - offset)) &&
-                                                    (0 <=? offset) &&
-                                                    (offset <=? Z.log2 s12)
-                                                   then
-                                                    Some
-                                                      (#(Z_cast2 (r1, r2))%expr @
-                                                       (#(fancy_addc
-                                                            (Z.log2 s12)
-                                                            offset)%expr @
-                                                        (#(Z_cast rc)%expr @
-                                                         c,
-                                                        #(Z_cast rx)%expr @
-                                                        x13,
-                                                        #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None)
-                                                   (let (x13, _) := xv in x13)
-                                                   args7
-                                                   (v (Compile.reflect x4))
-                                                   args6
-                                                   (v0 (Compile.reflect x5))
-                                                   args5 args3 args1
-                                                   (v1 (Compile.reflect x12))
-                                                   (let (x13, _) := xv0 in
-                                                    x13)
-                                                   (let (x13, _) := xv1 in
-                                                    x13);
-                                          Some (Base x13));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.Abs _ _ _
-                             _ _ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ (_ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.LetIn _ _
-                             _ _ _ _ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               ($_)%expr)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Abs _ _ _ _ _ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               (_ @ _))) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.LetIn _ _ _ _ _ _ _)) @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ ($_)%expr _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Abs _ _ _ _ _ _) _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (_ @ _) _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _
-                               _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _
-                               _ _ _ _ @ _)) @ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ #(_)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
-                              _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Abs _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Abs _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                              _ _ _) @ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.Ident _ _
-                             _ t9 idc9)%expr_pat =>
-                              args <- invert_bind_args idc9 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc8
-                                         Raw.ident.Literal;
-                              args1 <- invert_bind_args idc7 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc6 Raw.ident.Z_land;
-                              args3 <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc4 Raw.ident.Z_shiftl;
-                              args5 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args6 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              args7 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                              args8 <- invert_bind_args idc0
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc
-                                     Raw.ident.Z_add_with_get_carry;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args8) -> s3) ->
-                                    (s11 -> (projT1 args0)) -> (projT1 args)) ->
-                                   s5)%ptype
-                              with
-                              | Some (_, _, (_, _, _), _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args8) -> s3) ->
-                                       (s11 -> (projT1 args0)) ->
-                                       (projT1 args)) -> s5)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args8);
-                                   v <- type.try_make_transport_cps s3 ℤ;
-                                   v0 <- type.try_make_transport_cps s11 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args0);
-                                   xv1 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   v1 <- type.try_make_transport_cps s5 ℤ;
-                                   fv <- (x13 <- (let
-                                                  '(r1, r2)%zrange := range
-                                                   in
-                                                   fun (s12 : Z)
-                                                     (rc : zrange)
-                                                     (c : expr ℤ)
-                                                     (rshiftl rland
-                                                      ry : zrange)
-                                                     (y : expr ℤ)
-                                                     (mask offset : Z)
-                                                     (rx : zrange)
-                                                     (x13 : expr ℤ) =>
-                                                   if
-                                                    (s12 =? 2 ^ Z.log2 s12) &&
-                                                    (ZRange.normalize rland <<
-                                                     ZRange.normalize
-                                                       (ZRange.constant
-                                                          offset) <=?
-                                                     ZRange.normalize rshiftl)%zrange &&
-                                                    (ZRange.normalize rshiftl <=?
-                                                     r[0 ~> s12 - 1])%zrange &&
-                                                    (ZRange.normalize ry &'
-                                                     ZRange.normalize
-                                                       (ZRange.constant mask) <=?
-                                                     ZRange.normalize rland)%zrange &&
-                                                    (mask =?
-                                                     Z.ones
-                                                       (Z.log2 s12 - offset)) &&
-                                                    (0 <=? offset) &&
-                                                    (offset <=? Z.log2 s12)
-                                                   then
-                                                    Some
-                                                      (#(Z_cast2 (r1, r2))%expr @
-                                                       (#(fancy_addc
-                                                            (Z.log2 s12)
-                                                            offset)%expr @
-                                                        (#(Z_cast rc)%expr @
-                                                         c,
-                                                        #(Z_cast rx)%expr @
-                                                        x13,
-                                                        #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None)
-                                                   (let (x13, _) := xv in x13)
-                                                   args7
-                                                   (v (Compile.reflect x4))
-                                                   args6 args3 args1
-                                                   (v0 (Compile.reflect x12))
-                                                   (let (x13, _) := xv0 in
-                                                    x13)
-                                                   (let (x13, _) := xv1 in
-                                                    x13) args5
-                                                   (v1 (Compile.reflect x6));
-                                          Some (Base x13));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.Abs _ _ _
-                             _ _ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ (_ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Ident _ _ _ t8 idc8)) @ @expr.LetIn _ _
-                             _ _ _ _ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               ($_)%expr)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.Abs _ _ _ _ _ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               (_ @ _))) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                               @expr.LetIn _ _ _ _ _ _ _)) @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ ($_)%expr _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.Abs _ _ _ _ _ _) _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (_ @ _) _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                               s11 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _
-                               _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _
-                               _ _ _ _ @ _)) @ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ #(_)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
-                              _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Abs _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.Abs _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _)) @
-                             _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @
-                              (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                              _ _ _) @ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (($_)%expr @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ (_ @ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @
-                             (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x6 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ @expr.Ident _ _
-                             _ t6 idc6)%expr_pat =>
-                              args <- invert_bind_args idc6 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc4 Raw.ident.Z_shiftr;
-                              args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              args4 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                              args5 <- invert_bind_args idc0
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc
-                                     Raw.ident.Z_add_with_get_carry;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                  ((((projT1 args5) -> s3) -> s4) ->
-                                   s8 -> (projT1 args))%ptype
-                              with
-                              | Some (_, _, _, (_, _))%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                     ((((projT1 args5) -> s3) -> s4) ->
-                                      s8 -> (projT1 args))%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args5);
-                                   v <- type.try_make_transport_cps s3 ℤ;
-                                   v0 <- type.try_make_transport_cps s4 ℤ;
-                                   v1 <- type.try_make_transport_cps s8 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   fv <- (x10 <- (let
-                                                  '(r1, r2)%zrange := range
-                                                   in
-                                                   fun (s9 : Z) (rc : zrange)
-                                                     (c : expr ℤ)
-                                                     (rx : zrange)
-                                                     (x10 : expr ℤ)
-                                                     (rshiftr ry : zrange)
-                                                     (y : expr ℤ)
-                                                     (offset : Z) =>
-                                                   if
-                                                    (s9 =? 2 ^ Z.log2 s9) &&
-                                                    (ZRange.normalize ry >>
-                                                     ZRange.normalize
-                                                       (ZRange.constant
-                                                          offset) <=?
-                                                     ZRange.normalize rshiftr)%zrange &&
-                                                    (ZRange.normalize rshiftr <=?
-                                                     r[0 ~> s9 - 1])%zrange
-                                                   then
-                                                    Some
-                                                      (#(Z_cast2 (r1, r2))%expr @
-                                                       (#(fancy_addc
-                                                            (Z.log2 s9)
-                                                            (- offset))%expr @
-                                                        (#(Z_cast rc)%expr @
-                                                         c,
-                                                        #(Z_cast rx)%expr @
-                                                        x10,
-                                                        #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None)
-                                                   (let (x10, _) := xv in x10)
-                                                   args4
-                                                   (v (Compile.reflect x4))
-                                                   args3
-                                                   (v0 (Compile.reflect x5))
-                                                   args2 args0
-                                                   (v1 (Compile.reflect x9))
-                                                   (let (x10, _) := xv0 in
-                                                    x10);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ @expr.Abs _ _ _
-                             _ _ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ (_ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ @expr.LetIn _ _
-                             _ _ _ _ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             ($_)%expr _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (_ @ _) _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ @expr.Ident _ _
-                             _ t6 idc6)%expr_pat =>
-                              args <- invert_bind_args idc6 Raw.ident.Literal;
-                              args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
-                              _ <- invert_bind_args idc4 Raw.ident.Z_shiftr;
-                              args2 <- invert_bind_args idc3 Raw.ident.Z_cast;
-                              args3 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                              args4 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                              args5 <- invert_bind_args idc0
-                                         Raw.ident.Literal;
-                              _ <- invert_bind_args idc
-                                     Raw.ident.Z_add_with_get_carry;
-                              match
-                                pattern.type.unify_extracted
-                                  (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
-                                  ((((projT1 args5) -> s3) ->
-                                    s8 -> (projT1 args)) -> s5)%ptype
-                              with
-                              | Some (_, _, (_, _), _)%zrange =>
-                                  if
-                                   type.type_beq base.type base.type.type_beq
-                                     (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
-                                     ((((projT1 args5) -> s3) ->
-                                       s8 -> (projT1 args)) -> s5)%ptype
-                                  then
-                                   xv <- ident.unify pattern.ident.Literal
-                                           ##(projT2 args5);
-                                   v <- type.try_make_transport_cps s3 ℤ;
-                                   v0 <- type.try_make_transport_cps s8 ℤ;
-                                   xv0 <- ident.unify pattern.ident.Literal
-                                            ##(projT2 args);
-                                   v1 <- type.try_make_transport_cps s5 ℤ;
-                                   fv <- (x10 <- (let
-                                                  '(r1, r2)%zrange := range
-                                                   in
-                                                   fun (s9 : Z) (rc : zrange)
-                                                     (c : expr ℤ)
-                                                     (rshiftr ry : zrange)
-                                                     (y : expr ℤ)
-                                                     (offset : Z)
-                                                     (rx : zrange)
-                                                     (x10 : expr ℤ) =>
-                                                   if
-                                                    (s9 =? 2 ^ Z.log2 s9) &&
-                                                    (ZRange.normalize ry >>
-                                                     ZRange.normalize
-                                                       (ZRange.constant
-                                                          offset) <=?
-                                                     ZRange.normalize rshiftr)%zrange &&
-                                                    (ZRange.normalize rshiftr <=?
-                                                     r[0 ~> s9 - 1])%zrange
-                                                   then
-                                                    Some
-                                                      (#(Z_cast2 (r1, r2))%expr @
-                                                       (#(fancy_addc
-                                                            (Z.log2 s9)
-                                                            (- offset))%expr @
-                                                        (#(Z_cast rc)%expr @
-                                                         c,
-                                                        #(Z_cast rx)%expr @
-                                                        x10,
-                                                        #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None)
-                                                   (let (x10, _) := xv in x10)
-                                                   args4
-                                                   (v (Compile.reflect x4))
-                                                   args3 args0
-                                                   (v0 (Compile.reflect x9))
-                                                   (let (x10, _) := xv0 in
-                                                    x10) args2
-                                                   (v1 (Compile.reflect x6));
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
-                              end
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ ($_)%expr)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ @expr.Abs _ _ _
-                             _ _ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ (_ @ _))%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Ident _ _ _ t5 idc5) x9 @ @expr.LetIn _ _
-                             _ _ _ _ _)%expr_pat => None
-                          | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             ($_)%expr _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (_ @ _) _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                             (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-                              None
-                          | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _
-                             _ @ _)%expr_pat |
-                            (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
-                          end;;
-                          args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_add_with_get_carry;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> s3) -> s4) -> s5)%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> s3) -> s4) -> s5)%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               v0 <- type.try_make_transport_cps s4 ℤ;
-                               v1 <- type.try_make_transport_cps s5 ℤ;
-                               fv <- (x7 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s6 : Z) (rc : zrange)
-                                                (c : expr ℤ) (rx : zrange)
-                                                (x7 : expr ℤ) (ry : zrange)
-                                                (y : expr ℤ) =>
-                                              if
-                                               (s6 =? 2 ^ Z.log2 s6) &&
-                                               (ZRange.normalize ry <=?
-                                                r[0 ~> s6 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_addc (Z.log2 s6) 0)%expr @
-                                                   (#(Z_cast rc)%expr @ c,
-                                                   #(Z_cast rx)%expr @ x7,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x7, _) := xv in x7) args1
-                                              (v (Compile.reflect x4)) args0
-                                              (v0 (Compile.reflect x5)) args
-                                              (v1 (Compile.reflect x6));
-                                      Some (Base x7));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
                       end
                   | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
                     (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
@@ -8097,937 +4195,1562 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 (@expr.LetIn _ _ _ _ _ _ _) _ => None
               | _ => None
               end
+          | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+              None
           | _ => None
           end;;
-          match x3 with
-          | @expr.Ident _ _ _ t0 idc0 =>
-              match x2 with
-              | @expr.Ident _ _ _ t1 idc1 =>
-                  match x1 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
-                      match x0 with
-                      | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t3 idc3)
-                        x4 =>
-                          match x4 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ x6 @ x5)%expr_pat =>
+          match x2 with
+          | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              match x1 with
+              | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4 =>
+                  match x0 with
+                  | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3) x5 =>
+                      match x5 with
+                      | (@expr.Ident _ _ _ t4 idc4 @ x7 @ x6)%expr_pat =>
+                          match x7 with
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @
+                              (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _
+                               t9 idc9)))%expr_pat =>
                               match x6 with
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.Ident _ _ _ t8 idc8))%expr_pat =>
-                                  match x5 with
-                                  | @expr.Ident _ _ _ t9 idc9 =>
-                                      args <- invert_bind_args idc9
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc8
-                                                 Raw.ident.Literal;
-                                      args1 <- invert_bind_args idc7
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc6
-                                             Raw.ident.Z_land;
-                                      args3 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftl;
-                                      args5 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args6 <- invert_bind_args idc2
-                                                 Raw.ident.Literal;
-                                      args7 <- invert_bind_args idc1
-                                                 Raw.ident.Literal;
-                                      args8 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_sub_with_get_borrow;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args8) -> (projT1 args7)) ->
-                                            (projT1 args6)) ->
-                                           (s9 -> (projT1 args0)) ->
-                                           (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) ->
-                                              (ℤ -> ℤ) -> ℤ)%ptype
-                                             ((((projT1 args8) ->
-                                                (projT1 args7)) ->
-                                               (projT1 args6)) ->
-                                              (s9 -> (projT1 args0)) ->
-                                              (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args8);
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args7);
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args6);
-                                           v <- type.try_make_transport_cps s9 ℤ;
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args0);
-                                           xv3 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x11 <- (let
-                                                          '(r1, r2)%zrange :=
-                                                           range in
-                                                           fun
-                                                             (s10 bb xx : Z)
-                                                             (rshiftl rland
-                                                              ry : zrange)
-                                                             (y : expr ℤ)
-                                                             (mask
-                                                              offset : Z) =>
-                                                           if
-                                                            (s10 =?
-                                                             2 ^ Z.log2 s10) &&
-                                                            (ZRange.normalize
-                                                               rland <<
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  offset) <=?
-                                                             ZRange.normalize
-                                                               rshiftl)%zrange &&
-                                                            (ZRange.normalize
-                                                               rshiftl <=?
-                                                             r[0 ~> s10 - 1])%zrange &&
-                                                            (ZRange.normalize
-                                                               ry &'
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  mask) <=?
-                                                             ZRange.normalize
-                                                               rland)%zrange &&
-                                                            (mask =?
-                                                             Z.ones
-                                                               (Z.log2 s10 -
-                                                                offset)) &&
-                                                            (0 <=? offset) &&
-                                                            (offset <=?
-                                                             Z.log2 s10)
-                                                           then
-                                                            Some
-                                                              (#(Z_cast2
-                                                                   (r1, r2))%expr @
-                                                               (#(fancy_subb
-                                                                    (Z.log2
-                                                                    s10)
-                                                                    offset)%expr @
-                                                                ((##bb)%expr,
-                                                                (##xx)%expr,
-                                                                #(Z_cast ry)%expr @
-                                                                y)))%expr_pat
-                                                           else None)
-                                                           (let (x11, _) :=
-                                                              xv in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv0 in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv1 in
-                                                            x11) args5 args3
-                                                           args1
-                                                           (v
-                                                              (Compile.reflect
-                                                                 x10))
-                                                           (let (x11, _) :=
-                                                              xv2 in
-                                                            x11)
-                                                           (let (x11, _) :=
-                                                              xv3 in
-                                                            x11);
-                                                  Some (Base x11));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
+                              | (@expr.Ident _ _ _ t10 idc10 @ @expr.Ident _
+                                 _ _ t11 idc11)%expr_pat =>
+                                  args <- invert_bind_args idc11
+                                            Raw.ident.Literal;
+                                  args0 <- invert_bind_args idc10
+                                             Raw.ident.Z_cast;
+                                  args1 <- invert_bind_args idc9
+                                             Raw.ident.Literal;
+                                  args2 <- invert_bind_args idc8
+                                             Raw.ident.Z_cast;
+                                  args3 <- invert_bind_args idc7
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc6 Raw.ident.Z_land;
+                                  args5 <- invert_bind_args idc5
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc4
+                                         Raw.ident.Z_shiftl;
+                                  args7 <- invert_bind_args idc3
+                                             Raw.ident.Z_cast;
+                                  args8 <- invert_bind_args idc2
+                                             Raw.ident.Z_cast;
+                                  args9 <- invert_bind_args idc1
+                                             Raw.ident.Literal;
+                                  args10 <- invert_bind_args idc0
+                                              Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc
+                                         Raw.ident.Z_sub_get_borrow;
+                                  match
+                                    pattern.type.unify_extracted
+                                      ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
+                                      (((projT1 args9) -> s3) ->
+                                       (s10 -> (projT1 args1)) ->
+                                       (projT1 args))%ptype
+                                  with
+                                  | Some (_, _, (_, _, _))%zrange =>
+                                      if
+                                       type.type_beq base.type
+                                         base.type.type_beq
+                                         ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
+                                         (((projT1 args9) -> s3) ->
+                                          (s10 -> (projT1 args1)) ->
+                                          (projT1 args))%ptype
+                                      then
+                                       xv <- ident.unify
+                                               pattern.ident.Literal
+                                               ##(projT2 args9);
+                                       v <- type.try_make_transport_cps s3 ℤ;
+                                       v0 <- type.try_make_transport_cps s10 ℤ;
+                                       xv0 <- ident.unify
+                                                pattern.ident.Literal
+                                                ##(projT2 args1);
+                                       xv1 <- ident.unify
+                                                pattern.ident.Literal
+                                                ##(projT2 args);
+                                       fv <- (x14 <- (let
+                                                      '(r1, r2)%zrange :=
+                                                       range in
+                                                       fun (rs : zrange)
+                                                         (s13 : Z)
+                                                         (rx : zrange)
+                                                         (x14 : expr ℤ)
+                                                         (rshiftl rland
+                                                          ry : zrange)
+                                                         (y : expr ℤ)
+                                                         (rmask : zrange)
+                                                         (mask : Z)
+                                                         (roffset : zrange)
+                                                         (offset : Z) =>
+                                                       if
+                                                        (s13 =?
+                                                         2 ^ Z.log2 s13) &&
+                                                        (ZRange.normalize
+                                                           rland <<
+                                                         ZRange.normalize
+                                                           (ZRange.constant
+                                                              offset) <=?
+                                                         ZRange.normalize
+                                                           rshiftl)%zrange &&
+                                                        (ZRange.normalize
+                                                           rshiftl <=?
+                                                         r[0 ~> s13 - 1])%zrange &&
+                                                        (ZRange.normalize ry &'
+                                                         ZRange.normalize
+                                                           (ZRange.constant
+                                                              mask) <=?
+                                                         ZRange.normalize
+                                                           rland)%zrange &&
+                                                        (mask =?
+                                                         Z.ones
+                                                           (Z.log2 s13 -
+                                                            offset)) &&
+                                                        (0 <=? offset) &&
+                                                        (offset <=?
+                                                         Z.log2 s13) &&
+                                                        is_bounded_by_bool
+                                                          s13
+                                                          (ZRange.normalize
+                                                             rs) &&
+                                                        is_bounded_by_bool
+                                                          mask
+                                                          (ZRange.normalize
+                                                             rmask) &&
+                                                        is_bounded_by_bool
+                                                          offset
+                                                          (ZRange.normalize
+                                                             roffset)
+                                                       then
+                                                        Some
+                                                          (#(Z_cast2 (r1, r2))%expr @
+                                                           (#(fancy_sub
+                                                                (Z.log2 s13)
+                                                                offset)%expr @
+                                                            (#(Z_cast rx)%expr @
+                                                             x14,
+                                                            #(Z_cast ry)%expr @
+                                                            y)))%expr_pat
+                                                       else None) args10
+                                                       (let (x14, _) := xv in
+                                                        x14) args8
+                                                       (v
+                                                          (Compile.reflect x4))
+                                                       args7 args5 args3
+                                                       (v0
+                                                          (Compile.reflect
+                                                             x11)) args2
+                                                       (let (x14, _) :=
+                                                          xv0 in
+                                                        x14) args0
+                                                       (let (x14, _) :=
+                                                          xv1 in
+                                                        x14);
+                                              Some (Base x14));
+                                       Some (fv0 <-- fv;
+                                             Base fv0)%under_lets
+                                      else None
+                                  | None => None
                                   end
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  ($_)%expr))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  (_ @ _)))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Ident _ _ _ t7 idc7) x10 @
-                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ ($_)%expr _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (_ @ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s9 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
-                                  _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
-                              | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _
-                                 _ _ _)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (($_)%expr @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
-                              end;;
-                              match x6 with
-                              | @expr.App _ _ _ s6 _
-                                (@expr.Ident _ _ _ t5 idc5) x7 =>
-                                  match x5 with
-                                  | @expr.Ident _ _ _ t6 idc6 =>
-                                      args <- invert_bind_args idc6
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftr;
-                                      args2 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args3 <- invert_bind_args idc2
-                                                 Raw.ident.Literal;
-                                      args4 <- invert_bind_args idc1
-                                                 Raw.ident.Literal;
-                                      args5 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_sub_with_get_borrow;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                          ((((projT1 args5) -> (projT1 args4)) ->
-                                            (projT1 args3)) ->
-                                           s6 -> (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                             ((((projT1 args5) ->
-                                                (projT1 args4)) ->
-                                               (projT1 args3)) ->
-                                              s6 -> (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args5);
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args4);
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args3);
-                                           v <- type.try_make_transport_cps s6 ℤ;
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x8 <- (let
-                                                         '(r1, r2)%zrange :=
-                                                          range in
-                                                          fun (s7 bb xx : Z)
-                                                            (rshiftr
-                                                             ry : zrange)
-                                                            (y : expr ℤ)
-                                                            (offset : Z) =>
-                                                          if
-                                                           (s7 =?
-                                                            2 ^ Z.log2 s7) &&
-                                                           (ZRange.normalize
-                                                              ry >>
-                                                            ZRange.normalize
-                                                              (ZRange.constant
-                                                                 offset) <=?
-                                                            ZRange.normalize
-                                                              rshiftr)%zrange &&
-                                                           (ZRange.normalize
-                                                              rshiftr <=?
-                                                            r[0 ~> s7 - 1])%zrange
-                                                          then
-                                                           Some
-                                                             (#(Z_cast2
-                                                                  (r1, r2))%expr @
-                                                              (#(fancy_subb
-                                                                   (Z.log2 s7)
-                                                                   (- offset))%expr @
-                                                               ((##bb)%expr,
-                                                               (##xx)%expr,
-                                                               #(Z_cast ry)%expr @
-                                                               y)))%expr_pat
-                                                          else None)
-                                                          (let (x8, _) :=
-                                                             xv in
-                                                           x8)
-                                                          (let (x8, _) :=
-                                                             xv0 in
-                                                           x8)
-                                                          (let (x8, _) :=
-                                                             xv1 in
-                                                           x8) args2 args0
-                                                          (v
-                                                             (Compile.reflect
-                                                                x7))
-                                                          (let (x8, _) :=
-                                                             xv2 in
-                                                           x8);
-                                                  Some (Base x8));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App
-                                _ _ _ s6 _ (@expr.Abs _ _ _ _ _ _) _ |
-                                @expr.App _ _ _ s6 _ (_ @ _)%expr_pat _ |
-                                @expr.App _ _ _ s6 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                              | (@expr.Ident _ _ _ t10 idc10 @ ($_)%expr)%expr_pat |
+                                (@expr.Ident _ _ _ t10 idc10 @ @expr.Abs _ _
+                                 _ _ _ _)%expr_pat |
+                                (@expr.Ident _ _ _ t10 idc10 @ (_ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t10 idc10 @ @expr.LetIn _
+                                 _ _ _ _ _ _)%expr_pat => None
                               | _ => None
                               end
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @
+                              (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @
+                              (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _
+                               _ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @
+                              (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @
+                              (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _
+                               _ _ _ _)))%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @ #(_)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @ ($_)%expr))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.Abs _
+                              _ _ _ _ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @
+                              (($_)%expr @ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @
+                              (@expr.Abs _ _ _ _ _ _ @ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @ (_ @ _ @ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @
+                              (@expr.LetIn _ _ _ _ _ _ _ @ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.LetIn
+                              _ _ _ _ _ _ _))%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ ($_)%expr _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (_ @ _) _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
+                              _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _
+                              _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _
+                              _ _ _ @ _))%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
+                             _ _ _)%expr_pat => None
                           | _ => None
                           end;;
-                          args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                          args0 <- invert_bind_args idc2 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc1 Raw.ident.Literal;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_sub_with_get_borrow;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> (projT1 args1)) ->
-                                (projT1 args0)) -> s3)%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> (projT1 args1)) ->
-                                   (projT1 args0)) -> s3)%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args1);
-                               xv1 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               fv <- (x5 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s4 bb xx : Z)
-                                                (ry : zrange) (y : expr ℤ) =>
-                                              if
-                                               (s4 =? 2 ^ Z.log2 s4) &&
-                                               (ZRange.normalize ry <=?
-                                                r[0 ~> s4 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_subb (Z.log2 s4) 0)%expr @
-                                                   ((##bb)%expr, (##xx)%expr,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x5, _) := xv in x5)
-                                              (let (x5, _) := xv0 in x5)
-                                              (let (x5, _) := xv1 in x5) args
-                                              (v (Compile.reflect x4));
-                                      Some (Base x5));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end
-                  | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t2 idc2) x4 =>
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args <- invert_bind_args idc3 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args1 <- invert_bind_args idc1 Raw.ident.Literal;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_sub_with_get_borrow;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> (projT1 args1)) -> s3) ->
-                               (projT1 args))%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> (projT1 args1)) -> s3) ->
-                                  (projT1 args))%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args1);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               xv1 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args);
-                               fv <- (x5 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s4 bb : Z) (rx : zrange)
-                                                (x5 : expr ℤ) (yy : Z) =>
-                                              if
-                                               (s4 =? 2 ^ Z.log2 s4) &&
-                                               (ZRange.normalize
-                                                  (ZRange.constant yy) <=?
-                                                r[0 ~> s4 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_subb (Z.log2 s4) 0)%expr @
-                                                   ((##bb)%expr,
-                                                   #(Z_cast rx)%expr @ x5,
-                                                   (##yy)%expr)))%expr_pat
-                                              else None)
-                                              (let (x5, _) := xv in x5)
-                                              (let (x5, _) := xv0 in x5)
-                                              args0 (v (Compile.reflect x4))
-                                              (let (x5, _) := xv1 in x5);
-                                      Some (Base x5));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3)
-                        x5 =>
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ x7 @ x6)%expr_pat =>
-                              match x7 with
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.Ident _ _ _ t8 idc8))%expr_pat =>
-                                  match x6 with
-                                  | @expr.Ident _ _ _ t9 idc9 =>
-                                      args <- invert_bind_args idc9
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc8
-                                                 Raw.ident.Literal;
-                                      args1 <- invert_bind_args idc7
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc6
-                                             Raw.ident.Z_land;
-                                      args3 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftl;
-                                      args5 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args6 <- invert_bind_args idc2
-                                                 Raw.ident.Z_cast;
-                                      args7 <- invert_bind_args idc1
-                                                 Raw.ident.Literal;
-                                      args8 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_sub_with_get_borrow;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args8) -> (projT1 args7)) ->
-                                            s3) ->
-                                           (s10 -> (projT1 args0)) ->
-                                           (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) ->
-                                              (ℤ -> ℤ) -> ℤ)%ptype
-                                             ((((projT1 args8) ->
-                                                (projT1 args7)) -> s3) ->
-                                              (s10 -> (projT1 args0)) ->
-                                              (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args8);
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args7);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           v0 <- type.try_make_transport_cps s10 ℤ;
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args0);
-                                           xv2 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x12 <- (let
-                                                          '(r1, r2)%zrange :=
-                                                           range in
-                                                           fun (s11 bb : Z)
-                                                             (rx : zrange)
-                                                             (x12 : expr ℤ)
-                                                             (rshiftl rland
-                                                              ry : zrange)
-                                                             (y : expr ℤ)
-                                                             (mask
-                                                              offset : Z) =>
-                                                           if
-                                                            (s11 =?
-                                                             2 ^ Z.log2 s11) &&
-                                                            (ZRange.normalize
-                                                               rland <<
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  offset) <=?
-                                                             ZRange.normalize
-                                                               rshiftl)%zrange &&
-                                                            (ZRange.normalize
-                                                               rshiftl <=?
-                                                             r[0 ~> s11 - 1])%zrange &&
-                                                            (ZRange.normalize
-                                                               ry &'
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  mask) <=?
-                                                             ZRange.normalize
-                                                               rland)%zrange &&
-                                                            (mask =?
-                                                             Z.ones
-                                                               (Z.log2 s11 -
-                                                                offset)) &&
-                                                            (0 <=? offset) &&
-                                                            (offset <=?
-                                                             Z.log2 s11)
-                                                           then
-                                                            Some
-                                                              (#(Z_cast2
-                                                                   (r1, r2))%expr @
-                                                               (#(fancy_subb
-                                                                    (Z.log2
-                                                                    s11)
-                                                                    offset)%expr @
-                                                                ((##bb)%expr,
-                                                                #(Z_cast rx)%expr @
-                                                                x12,
-                                                                #(Z_cast ry)%expr @
-                                                                y)))%expr_pat
-                                                           else None)
-                                                           (let (x12, _) :=
-                                                              xv in
-                                                            x12)
-                                                           (let (x12, _) :=
-                                                              xv0 in
-                                                            x12) args6
-                                                           (v
-                                                              (Compile.reflect
-                                                                 x4)) args5
-                                                           args3 args1
-                                                           (v0
-                                                              (Compile.reflect
-                                                                 x11))
-                                                           (let (x12, _) :=
-                                                              xv1 in
-                                                            x12)
-                                                           (let (x12, _) :=
-                                                              xv2 in
-                                                            x12);
-                                                  Some (Base x12));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
+                          match x7 with
+                          | @expr.App _ _ _ s7 _ (@expr.Ident _ _ _ t5 idc5)
+                            x8 =>
+                              match x6 with
+                              | (@expr.Ident _ _ _ t6 idc6 @ @expr.Ident _ _
+                                 _ t7 idc7)%expr_pat =>
+                                  args <- invert_bind_args idc7
+                                            Raw.ident.Literal;
+                                  args0 <- invert_bind_args idc6
+                                             Raw.ident.Z_cast;
+                                  args1 <- invert_bind_args idc5
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc4
+                                         Raw.ident.Z_shiftr;
+                                  args3 <- invert_bind_args idc3
+                                             Raw.ident.Z_cast;
+                                  args4 <- invert_bind_args idc2
+                                             Raw.ident.Z_cast;
+                                  args5 <- invert_bind_args idc1
+                                             Raw.ident.Literal;
+                                  args6 <- invert_bind_args idc0
+                                             Raw.ident.Z_cast;
+                                  _ <- invert_bind_args idc
+                                         Raw.ident.Z_sub_get_borrow;
+                                  match
+                                    pattern.type.unify_extracted
+                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                      (((projT1 args5) -> s3) ->
+                                       s7 -> (projT1 args))%ptype
+                                  with
+                                  | Some (_, _, (_, _))%zrange =>
+                                      if
+                                       type.type_beq base.type
+                                         base.type.type_beq
+                                         ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
+                                         (((projT1 args5) -> s3) ->
+                                          s7 -> (projT1 args))%ptype
+                                      then
+                                       xv <- ident.unify
+                                               pattern.ident.Literal
+                                               ##(projT2 args5);
+                                       v <- type.try_make_transport_cps s3 ℤ;
+                                       v0 <- type.try_make_transport_cps s7 ℤ;
+                                       xv0 <- ident.unify
+                                                pattern.ident.Literal
+                                                ##(projT2 args);
+                                       fv <- (x10 <- (let
+                                                      '(r1, r2)%zrange :=
+                                                       range in
+                                                       fun (rs : zrange)
+                                                         (s9 : Z)
+                                                         (rx : zrange)
+                                                         (x10 : expr ℤ)
+                                                         (rshiftr
+                                                          ry : zrange)
+                                                         (y : expr ℤ)
+                                                         (roffset : zrange)
+                                                         (offset : Z) =>
+                                                       if
+                                                        (s9 =? 2 ^ Z.log2 s9) &&
+                                                        (ZRange.normalize ry >>
+                                                         ZRange.normalize
+                                                           (ZRange.constant
+                                                              offset) <=?
+                                                         ZRange.normalize
+                                                           rshiftr)%zrange &&
+                                                        (ZRange.normalize
+                                                           rshiftr <=?
+                                                         r[0 ~> s9 - 1])%zrange &&
+                                                        is_bounded_by_bool s9
+                                                          (ZRange.normalize
+                                                             rs) &&
+                                                        is_bounded_by_bool
+                                                          offset
+                                                          (ZRange.normalize
+                                                             roffset)
+                                                       then
+                                                        Some
+                                                          (#(Z_cast2 (r1, r2))%expr @
+                                                           (#(fancy_sub
+                                                                (Z.log2 s9)
+                                                                (- offset))%expr @
+                                                            (#(Z_cast rx)%expr @
+                                                             x10,
+                                                            #(Z_cast ry)%expr @
+                                                            y)))%expr_pat
+                                                       else None) args6
+                                                       (let (x10, _) := xv in
+                                                        x10) args4
+                                                       (v
+                                                          (Compile.reflect x4))
+                                                       args3 args1
+                                                       (v0
+                                                          (Compile.reflect x8))
+                                                       args0
+                                                       (let (x10, _) :=
+                                                          xv0 in
+                                                        x10);
+                                              Some (Base x10));
+                                       Some (fv0 <-- fv;
+                                             Base fv0)%under_lets
+                                      else None
+                                  | None => None
                                   end
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  ($_)%expr))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  (_ @ _)))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ ($_)%expr _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (_ @ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
-                                  _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
-                              | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _
+                              | (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr)%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
                                  _ _ _)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (($_)%expr @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _
+                                (@expr.Ident _ _ _ t6 idc6 @ (_ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
                                  _ _ _ _ _)%expr_pat => None
                               | _ => None
-                              end;;
-                              match x7 with
-                              | @expr.App _ _ _ s7 _
-                                (@expr.Ident _ _ _ t5 idc5) x8 =>
-                                  match x6 with
-                                  | @expr.Ident _ _ _ t6 idc6 =>
-                                      args <- invert_bind_args idc6
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftr;
-                                      args2 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args3 <- invert_bind_args idc2
-                                                 Raw.ident.Z_cast;
-                                      args4 <- invert_bind_args idc1
-                                                 Raw.ident.Literal;
-                                      args5 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_sub_with_get_borrow;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                          ((((projT1 args5) -> (projT1 args4)) ->
-                                            s3) -> s7 -> (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                             ((((projT1 args5) ->
-                                                (projT1 args4)) -> s3) ->
-                                              s7 -> (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args5);
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args4);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           v0 <- type.try_make_transport_cps s7 ℤ;
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x9 <- (let
-                                                         '(r1, r2)%zrange :=
-                                                          range in
-                                                          fun (s8 bb : Z)
-                                                            (rx : zrange)
-                                                            (x9 : expr ℤ)
-                                                            (rshiftr
-                                                             ry : zrange)
-                                                            (y : expr ℤ)
-                                                            (offset : Z) =>
-                                                          if
-                                                           (s8 =?
-                                                            2 ^ Z.log2 s8) &&
-                                                           (ZRange.normalize
-                                                              ry >>
-                                                            ZRange.normalize
-                                                              (ZRange.constant
-                                                                 offset) <=?
-                                                            ZRange.normalize
-                                                              rshiftr)%zrange &&
-                                                           (ZRange.normalize
-                                                              rshiftr <=?
-                                                            r[0 ~> s8 - 1])%zrange
-                                                          then
-                                                           Some
-                                                             (#(Z_cast2
-                                                                  (r1, r2))%expr @
-                                                              (#(fancy_subb
-                                                                   (Z.log2 s8)
-                                                                   (- offset))%expr @
-                                                               ((##bb)%expr,
-                                                               #(Z_cast rx)%expr @
-                                                               x9,
-                                                               #(Z_cast ry)%expr @
-                                                               y)))%expr_pat
-                                                          else None)
-                                                          (let (x9, _) :=
-                                                             xv in
-                                                           x9)
-                                                          (let (x9, _) :=
-                                                             xv0 in
-                                                           x9) args3
-                                                          (v
-                                                             (Compile.reflect
-                                                                x4)) args2
-                                                          args0
-                                                          (v0
-                                                             (Compile.reflect
-                                                                x8))
-                                                          (let (x9, _) :=
-                                                             xv1 in
-                                                           x9);
-                                                  Some (Base x9));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App
-                                _ _ _ s7 _ (@expr.Abs _ _ _ _ _ _) _ |
-                                @expr.App _ _ _ s7 _ (_ @ _)%expr_pat _ |
-                                @expr.App _ _ _ s7 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
                               end
+                          | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _
+                            _ s7 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
+                            _ s7 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
+                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
                           | _ => None
-                          end;;
-                          args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args1 <- invert_bind_args idc1 Raw.ident.Literal;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_sub_with_get_borrow;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> (projT1 args1)) -> s3) ->
-                               s4)%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> (projT1 args1)) -> s3) ->
-                                  s4)%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args1);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               v0 <- type.try_make_transport_cps s4 ℤ;
-                               fv <- (x6 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s5 bb : Z) (rx : zrange)
-                                                (x6 : expr ℤ) (ry : zrange)
-                                                (y : expr ℤ) =>
-                                              if
-                                               (s5 =? 2 ^ Z.log2 s5) &&
-                                               (ZRange.normalize ry <=?
-                                                r[0 ~> s5 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_subb (Z.log2 s5) 0)%expr @
-                                                   ((##bb)%expr,
-                                                   #(Z_cast rx)%expr @ x6,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x6, _) := xv in x6)
-                                              (let (x6, _) := xv0 in x6)
-                                              args0 (v (Compile.reflect x4))
-                                              args (v0 (Compile.reflect x5));
-                                      Some (Base x6));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
                           end
-                      | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
                       | _ => None
+                      end;;
+                      args <- invert_bind_args idc3 Raw.ident.Z_cast;
+                      args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                      args1 <- invert_bind_args idc1 Raw.ident.Literal;
+                      args2 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                      _ <- invert_bind_args idc Raw.ident.Z_sub_get_borrow;
+                      match
+                        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
+                          (((projT1 args1) -> s3) -> s4)%ptype
+                      with
+                      | Some (_, _, _)%zrange =>
+                          if
+                           type.type_beq base.type base.type.type_beq
+                             ((ℤ -> ℤ) -> ℤ)%ptype
+                             (((projT1 args1) -> s3) -> s4)%ptype
+                          then
+                           xv <- ident.unify pattern.ident.Literal
+                                   ##(projT2 args1);
+                           v <- type.try_make_transport_cps s3 ℤ;
+                           v0 <- type.try_make_transport_cps s4 ℤ;
+                           fv <- (x6 <- (let
+                                         '(r1, r2)%zrange := range in
+                                          fun (rs : zrange) (s5 : Z)
+                                            (rx : zrange) (x6 : expr ℤ)
+                                            (ry : zrange) (y : expr ℤ) =>
+                                          if
+                                           (s5 =? 2 ^ Z.log2 s5) &&
+                                           (ZRange.normalize ry <=?
+                                            r[0 ~> s5 - 1])%zrange &&
+                                           is_bounded_by_bool s5
+                                             (ZRange.normalize rs)
+                                          then
+                                           Some
+                                             (#(Z_cast2 (r1, r2))%expr @
+                                              (#(fancy_sub (Z.log2 s5) 0)%expr @
+                                               (#(Z_cast rx)%expr @ x6,
+                                               #(Z_cast ry)%expr @ y)))%expr_pat
+                                          else None) args2
+                                          (let (x6, _) := xv in x6) args0
+                                          (v (Compile.reflect x4)) args
+                                          (v0 (Compile.reflect x5));
+                                  Some (Base x6));
+                           Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                          else None
+                      | None => None
                       end
-                  | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
+                  | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
+                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
+                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
                     (@expr.LetIn _ _ _ _ _ _ _) _ => None
                   | _ => None
                   end
-              | @expr.App _ _ _ s3 _ (@expr.Ident _ _ _ t1 idc1) x4 =>
+              | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
+                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
+                (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
+                (@expr.LetIn _ _ _ _ _ _ _) _ => None
+              | _ => None
+              end
+          | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+              None
+          | _ => None
+          end
+      | (@expr.Ident _ _ _ t idc @ x3 @ x2 @ x1 @ x0)%expr_pat =>
+          match x3 with
+          | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              match x2 with
+              | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5 =>
                   match x1 with
-                  | @expr.Ident _ _ _ t2 idc2 =>
+                  | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6 =>
                       match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args <- invert_bind_args idc3 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc2 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
+                      | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t4 idc4)
+                        x7 =>
+                          match x7 with
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ @expr.Ident _ _ _
+                              t12 idc12))%expr_pat =>
+                              args <- invert_bind_args idc12
+                                        Raw.ident.Literal;
+                              args0 <- invert_bind_args idc11
+                                         Raw.ident.Z_cast;
+                              args1 <- invert_bind_args idc10
+                                         Raw.ident.Literal;
+                              args2 <- invert_bind_args idc9 Raw.ident.Z_cast;
+                              args3 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc7 Raw.ident.Z_land;
+                              args5 <- invert_bind_args idc6 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc5 Raw.ident.Z_shiftl;
+                              args7 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                              args8 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                              args9 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                              args10 <- invert_bind_args idc1
+                                          Raw.ident.Literal;
+                              args11 <- invert_bind_args idc0
+                                          Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc
+                                     Raw.ident.Z_add_with_get_carry;
+                              match
+                                pattern.type.unify_extracted
+                                  (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
+                                  ((((projT1 args10) -> s4) -> s5) ->
+                                   (s12 -> (projT1 args1)) -> (projT1 args))%ptype
+                              with
+                              | Some (_, _, _, (_, _, _))%zrange =>
+                                  if
+                                   type.type_beq base.type base.type.type_beq
+                                     (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
+                                     ((((projT1 args10) -> s4) -> s5) ->
+                                      (s12 -> (projT1 args1)) ->
+                                      (projT1 args))%ptype
+                                  then
+                                   xv <- ident.unify pattern.ident.Literal
+                                           ##(projT2 args10);
+                                   v <- type.try_make_transport_cps s4 ℤ;
+                                   v0 <- type.try_make_transport_cps s5 ℤ;
+                                   v1 <- type.try_make_transport_cps s12 ℤ;
+                                   xv0 <- ident.unify pattern.ident.Literal
+                                            ##(projT2 args1);
+                                   xv1 <- ident.unify pattern.ident.Literal
+                                            ##(projT2 args);
+                                   fv <- (x16 <- (let
+                                                  '(r1, r2)%zrange := range
+                                                   in
+                                                   fun (rs : zrange)
+                                                     (s15 : Z) (rc : zrange)
+                                                     (c : expr ℤ)
+                                                     (rx : zrange)
+                                                     (x16 : expr ℤ)
+                                                     (rshiftl rland
+                                                      ry : zrange)
+                                                     (y : expr ℤ)
+                                                     (rmask : zrange)
+                                                     (mask : Z)
+                                                     (roffset : zrange)
+                                                     (offset : Z) =>
+                                                   if
+                                                    (s15 =? 2 ^ Z.log2 s15) &&
+                                                    (ZRange.normalize rland <<
+                                                     ZRange.normalize
+                                                       (ZRange.constant
+                                                          offset) <=?
+                                                     ZRange.normalize rshiftl)%zrange &&
+                                                    (ZRange.normalize ry &'
+                                                     ZRange.normalize
+                                                       (ZRange.constant mask) <=?
+                                                     ZRange.normalize rland)%zrange &&
+                                                    (ZRange.normalize rshiftl <=?
+                                                     r[0 ~> s15 - 1])%zrange &&
+                                                    (mask =?
+                                                     Z.ones
+                                                       (Z.log2 s15 - offset)) &&
+                                                    (0 <=? offset) &&
+                                                    (offset <=? Z.log2 s15) &&
+                                                    is_bounded_by_bool s15
+                                                      (ZRange.normalize rs) &&
+                                                    is_bounded_by_bool mask
+                                                      (ZRange.normalize rmask) &&
+                                                    is_bounded_by_bool offset
+                                                      (ZRange.normalize
+                                                         roffset)
+                                                   then
+                                                    Some
+                                                      (#(Z_cast2 (r1, r2))%expr @
+                                                       (#(fancy_addc
+                                                            (Z.log2 s15)
+                                                            offset)%expr @
+                                                        (#(Z_cast rc)%expr @
+                                                         c,
+                                                        #(Z_cast rx)%expr @
+                                                        x16,
+                                                        #(Z_cast ry)%expr @ y)))%expr_pat
+                                                   else None) args11
+                                                   (let (x16, _) := xv in x16)
+                                                   args9
+                                                   (v (Compile.reflect x5))
+                                                   args8
+                                                   (v0 (Compile.reflect x6))
+                                                   args7 args5 args3
+                                                   (v1 (Compile.reflect x13))
+                                                   args2
+                                                   (let (x16, _) := xv0 in
+                                                    x16) args0
+                                                   (let (x16, _) := xv1 in
+                                                    x16);
+                                          Some (Base x16));
+                                   Some (fv0 <-- fv;
+                                         Base fv0)%under_lets
+                                  else None
+                              | None => None
+                              end
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ ($_)%expr))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ @expr.Abs _ _ _ _
+                              _ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ (_ @ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ @expr.LetIn _ _ _
+                              _ _ _ _))%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ #(_))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ ($_)%expr)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ (($_)%expr @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ (_ @ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ ($_)%expr))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Abs _ _ _ _
+                                _ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ (_ @ _)))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.LetIn _ _ _
+                                _ _ _ _))) @ _)%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @ #
+                               (_))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               ($_)%expr)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               @expr.Abs _ _ _ _ _ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (($_)%expr @ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Abs _ _ _ _ _ _ @ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (_ @ _ @ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.LetIn _ _ _ _ _ _ _ @ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               @expr.LetIn _ _ _ _ _ _ _)) @ _)%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ ($_)%expr _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Abs _ _ _ _ _ _) _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (_ @ _) _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ #(_) @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr @ _)) @
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _ _ _ _
+                               _ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _
+                               _ _ _ _ @ _)) @ _)%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ #(_)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _
+                              _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ (#(_) @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ (($_)%expr @ _)) @
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Abs _ _ _ _ _ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ (($_)%expr @ _ @ _)) @
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Abs _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ (_ @ _ @ _ @ _)) @
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _
+                              _ _ _) @ _)%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
+                             _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
+                             _ _ _ @ _)%expr_pat => None
+                          | _ => None
+                          end;;
+                          match x6 with
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ @expr.Ident _ _ _
+                              t12 idc12))%expr_pat =>
+                              args <- invert_bind_args idc12
+                                        Raw.ident.Literal;
+                              args0 <- invert_bind_args idc11
+                                         Raw.ident.Z_cast;
+                              args1 <- invert_bind_args idc10
+                                         Raw.ident.Literal;
+                              args2 <- invert_bind_args idc9 Raw.ident.Z_cast;
+                              args3 <- invert_bind_args idc8 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc7 Raw.ident.Z_land;
+                              args5 <- invert_bind_args idc6 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc5 Raw.ident.Z_shiftl;
+                              args7 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                              args8 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                              args9 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                              args10 <- invert_bind_args idc1
+                                          Raw.ident.Literal;
+                              args11 <- invert_bind_args idc0
+                                          Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc
+                                     Raw.ident.Z_add_with_get_carry;
+                              match
+                                pattern.type.unify_extracted
+                                  (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                  ((((projT1 args10) -> s4) ->
+                                    (s12 -> (projT1 args1)) -> (projT1 args)) ->
+                                   s6)%ptype
+                              with
+                              | Some (_, _, (_, _, _), _)%zrange =>
+                                  if
+                                   type.type_beq base.type base.type.type_beq
+                                     (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
+                                     ((((projT1 args10) -> s4) ->
+                                       (s12 -> (projT1 args1)) ->
+                                       (projT1 args)) -> s6)%ptype
+                                  then
+                                   xv <- ident.unify pattern.ident.Literal
+                                           ##(projT2 args10);
+                                   v <- type.try_make_transport_cps s4 ℤ;
+                                   v0 <- type.try_make_transport_cps s12 ℤ;
+                                   xv0 <- ident.unify pattern.ident.Literal
+                                            ##(projT2 args1);
+                                   xv1 <- ident.unify pattern.ident.Literal
+                                            ##(projT2 args);
+                                   v1 <- type.try_make_transport_cps s6 ℤ;
+                                   fv <- (x16 <- (let
+                                                  '(r1, r2)%zrange := range
+                                                   in
+                                                   fun (rs : zrange)
+                                                     (s15 : Z) (rc : zrange)
+                                                     (c : expr ℤ)
+                                                     (rshiftl rland
+                                                      ry : zrange)
+                                                     (y : expr ℤ)
+                                                     (rmask : zrange)
+                                                     (mask : Z)
+                                                     (roffset : zrange)
+                                                     (offset : Z)
+                                                     (rx : zrange)
+                                                     (x16 : expr ℤ) =>
+                                                   if
+                                                    (s15 =? 2 ^ Z.log2 s15) &&
+                                                    (ZRange.normalize rland <<
+                                                     ZRange.normalize
+                                                       (ZRange.constant
+                                                          offset) <=?
+                                                     ZRange.normalize rshiftl)%zrange &&
+                                                    (ZRange.normalize rshiftl <=?
+                                                     r[0 ~> s15 - 1])%zrange &&
+                                                    (ZRange.normalize ry &'
+                                                     ZRange.normalize
+                                                       (ZRange.constant mask) <=?
+                                                     ZRange.normalize rland)%zrange &&
+                                                    (mask =?
+                                                     Z.ones
+                                                       (Z.log2 s15 - offset)) &&
+                                                    (0 <=? offset) &&
+                                                    (offset <=? Z.log2 s15) &&
+                                                    is_bounded_by_bool s15
+                                                      (ZRange.normalize rs) &&
+                                                    is_bounded_by_bool mask
+                                                      (ZRange.normalize rmask) &&
+                                                    is_bounded_by_bool offset
+                                                      (ZRange.normalize
+                                                         roffset)
+                                                   then
+                                                    Some
+                                                      (#(Z_cast2 (r1, r2))%expr @
+                                                       (#(fancy_addc
+                                                            (Z.log2 s15)
+                                                            offset)%expr @
+                                                        (#(Z_cast rc)%expr @
+                                                         c,
+                                                        #(Z_cast rx)%expr @
+                                                        x16,
+                                                        #(Z_cast ry)%expr @ y)))%expr_pat
+                                                   else None) args11
+                                                   (let (x16, _) := xv in x16)
+                                                   args9
+                                                   (v (Compile.reflect x5))
+                                                   args8 args5 args3
+                                                   (v0 (Compile.reflect x13))
+                                                   args2
+                                                   (let (x16, _) := xv0 in
+                                                    x16) args0
+                                                   (let (x16, _) := xv1 in
+                                                    x16) args7
+                                                   (v1 (Compile.reflect x7));
+                                          Some (Base x16));
+                                   Some (fv0 <-- fv;
+                                         Base fv0)%under_lets
+                                  else None
+                              | None => None
+                              end
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ ($_)%expr))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ @expr.Abs _ _ _ _
+                              _ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ (_ @ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.Ident _ _ _ t11 idc11 @ @expr.LetIn _ _ _
+                              _ _ _ _))%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ #(_))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ ($_)%expr)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ (($_)%expr @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ (_ @ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @
+                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
+                                t10 idc10))) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ ($_)%expr))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.Abs _ _ _ _
+                                _ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ (_ @ _)))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Ident _ _ _ t9 idc9 @ @expr.LetIn _ _ _
+                                _ _ _ _))) @ _)%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @ #
+                               (_))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               ($_)%expr)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               @expr.Abs _ _ _ _ _ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (($_)%expr @ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.Abs _ _ _ _ _ _ @ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (_ @ _ @ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               (@expr.LetIn _ _ _ _ _ _ _ @ _))) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                               @expr.LetIn _ _ _ _ _ _ _)) @ _)%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ ($_)%expr _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.Abs _ _ _ _ _ _) _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (_ @ _) _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                               s12 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ #(_) @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr @ _)) @
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _ _ _ _
+                               _ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _
+                               _ _ _ _ @ _)) @ _)%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ #(_)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _ _ _
+                              _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ (#(_) @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ (($_)%expr @ _)) @
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Abs _ _ _ _ _ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ (($_)%expr @ _ @ _)) @
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.Abs _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ (_ @ _ @ _ @ _)) @
+                             _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @
+                              (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _
+                              _ _ _) @ _)%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
+                             _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.Abs _ _ _ _ _ _ @ _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @
+                             (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
+                             _ _ _ @ _)%expr_pat => None
+                          | _ => None
+                          end;;
+                          match x7 with
+                          | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _
+                              t8 idc8))%expr_pat =>
+                              args <- invert_bind_args idc8 Raw.ident.Literal;
+                              args0 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                              args1 <- invert_bind_args idc6 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc5 Raw.ident.Z_shiftr;
+                              args3 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                              args4 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                              args5 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                              args6 <- invert_bind_args idc1
+                                         Raw.ident.Literal;
+                              args7 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc
+                                     Raw.ident.Z_add_with_get_carry;
+                              match
+                                pattern.type.unify_extracted
+                                  (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
+                                  ((((projT1 args6) -> s4) -> s5) ->
+                                   s9 -> (projT1 args))%ptype
+                              with
+                              | Some (_, _, _, (_, _))%zrange =>
+                                  if
+                                   type.type_beq base.type base.type.type_beq
+                                     (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
+                                     ((((projT1 args6) -> s4) -> s5) ->
+                                      s9 -> (projT1 args))%ptype
+                                  then
+                                   xv <- ident.unify pattern.ident.Literal
+                                           ##(projT2 args6);
+                                   v <- type.try_make_transport_cps s4 ℤ;
+                                   v0 <- type.try_make_transport_cps s5 ℤ;
+                                   v1 <- type.try_make_transport_cps s9 ℤ;
+                                   xv0 <- ident.unify pattern.ident.Literal
+                                            ##(projT2 args);
+                                   fv <- (x12 <- (let
+                                                  '(r1, r2)%zrange := range
+                                                   in
+                                                   fun (rs : zrange)
+                                                     (s11 : Z) (rc : zrange)
+                                                     (c : expr ℤ)
+                                                     (rx : zrange)
+                                                     (x12 : expr ℤ)
+                                                     (rshiftr ry : zrange)
+                                                     (y : expr ℤ)
+                                                     (roffset : zrange)
+                                                     (offset : Z) =>
+                                                   if
+                                                    (s11 =? 2 ^ Z.log2 s11) &&
+                                                    (ZRange.normalize ry >>
+                                                     ZRange.normalize
+                                                       (ZRange.constant
+                                                          offset) <=?
+                                                     ZRange.normalize rshiftr)%zrange &&
+                                                    (ZRange.normalize rshiftr <=?
+                                                     r[0 ~> s11 - 1])%zrange &&
+                                                    is_bounded_by_bool s11
+                                                      (ZRange.normalize rs) &&
+                                                    is_bounded_by_bool offset
+                                                      (ZRange.normalize
+                                                         roffset)
+                                                   then
+                                                    Some
+                                                      (#(Z_cast2 (r1, r2))%expr @
+                                                       (#(fancy_addc
+                                                            (Z.log2 s11)
+                                                            (- offset))%expr @
+                                                        (#(Z_cast rc)%expr @
+                                                         c,
+                                                        #(Z_cast rx)%expr @
+                                                        x12,
+                                                        #(Z_cast ry)%expr @ y)))%expr_pat
+                                                   else None) args7
+                                                   (let (x12, _) := xv in x12)
+                                                   args5
+                                                   (v (Compile.reflect x5))
+                                                   args4
+                                                   (v0 (Compile.reflect x6))
+                                                   args3 args1
+                                                   (v1 (Compile.reflect x10))
+                                                   args0
+                                                   (let (x12, _) := xv0 in
+                                                    x12);
+                                          Some (Base x12));
+                                   Some (fv0 <-- fv;
+                                         Base fv0)%under_lets
+                                  else None
+                              | None => None
+                              end
+                          | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _ _ _ _ _
+                              _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ (_ @ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _ _
+                              _ _ _))%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ #(_))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ ($_)%expr)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Abs _ _
+                             _ _ _ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (($_)%expr @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ (_ @ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.LetIn _
+                             _ _ _ _ _ _)%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             ($_)%expr _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (_ @ _) _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
+                             _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
+                             _ _ _ @ _)%expr_pat => None
+                          | _ => None
+                          end;;
+                          match x6 with
+                          | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _
+                              t8 idc8))%expr_pat =>
+                              args <- invert_bind_args idc8 Raw.ident.Literal;
+                              args0 <- invert_bind_args idc7 Raw.ident.Z_cast;
+                              args1 <- invert_bind_args idc6 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc5 Raw.ident.Z_shiftr;
+                              args3 <- invert_bind_args idc4 Raw.ident.Z_cast;
+                              args4 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                              args5 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                              args6 <- invert_bind_args idc1
+                                         Raw.ident.Literal;
+                              args7 <- invert_bind_args idc0 Raw.ident.Z_cast;
+                              _ <- invert_bind_args idc
+                                     Raw.ident.Z_add_with_get_carry;
+                              match
+                                pattern.type.unify_extracted
+                                  (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
+                                  ((((projT1 args6) -> s4) ->
+                                    s9 -> (projT1 args)) -> s6)%ptype
+                              with
+                              | Some (_, _, (_, _), _)%zrange =>
+                                  if
+                                   type.type_beq base.type base.type.type_beq
+                                     (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
+                                     ((((projT1 args6) -> s4) ->
+                                       s9 -> (projT1 args)) -> s6)%ptype
+                                  then
+                                   xv <- ident.unify pattern.ident.Literal
+                                           ##(projT2 args6);
+                                   v <- type.try_make_transport_cps s4 ℤ;
+                                   v0 <- type.try_make_transport_cps s9 ℤ;
+                                   xv0 <- ident.unify pattern.ident.Literal
+                                            ##(projT2 args);
+                                   v1 <- type.try_make_transport_cps s6 ℤ;
+                                   fv <- (x12 <- (let
+                                                  '(r1, r2)%zrange := range
+                                                   in
+                                                   fun (rs : zrange)
+                                                     (s11 : Z) (rc : zrange)
+                                                     (c : expr ℤ)
+                                                     (rshiftr ry : zrange)
+                                                     (y : expr ℤ)
+                                                     (roffset : zrange)
+                                                     (offset : Z)
+                                                     (rx : zrange)
+                                                     (x12 : expr ℤ) =>
+                                                   if
+                                                    (s11 =? 2 ^ Z.log2 s11) &&
+                                                    (ZRange.normalize ry >>
+                                                     ZRange.normalize
+                                                       (ZRange.constant
+                                                          offset) <=?
+                                                     ZRange.normalize rshiftr)%zrange &&
+                                                    (ZRange.normalize rshiftr <=?
+                                                     r[0 ~> s11 - 1])%zrange &&
+                                                    is_bounded_by_bool s11
+                                                      (ZRange.normalize rs) &&
+                                                    is_bounded_by_bool offset
+                                                      (ZRange.normalize
+                                                         roffset)
+                                                   then
+                                                    Some
+                                                      (#(Z_cast2 (r1, r2))%expr @
+                                                       (#(fancy_addc
+                                                            (Z.log2 s11)
+                                                            (- offset))%expr @
+                                                        (#(Z_cast rc)%expr @
+                                                         c,
+                                                        #(Z_cast rx)%expr @
+                                                        x12,
+                                                        #(Z_cast ry)%expr @ y)))%expr_pat
+                                                   else None) args7
+                                                   (let (x12, _) := xv in x12)
+                                                   args5
+                                                   (v (Compile.reflect x5))
+                                                   args4 args1
+                                                   (v0 (Compile.reflect x10))
+                                                   args0
+                                                   (let (x12, _) := xv0 in
+                                                    x12) args3
+                                                   (v1 (Compile.reflect x7));
+                                          Some (Base x12));
+                                   Some (fv0 <-- fv;
+                                         Base fv0)%under_lets
+                                  else None
+                              | None => None
+                              end
+                          | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _ _ _ _ _
+                              _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ (_ @ _)))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _ _
+                              _ _ _))%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ #(_))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ ($_)%expr)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.Abs _ _
+                             _ _ _ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (($_)%expr @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ (_ @ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @
+                             (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.LetIn _
+                             _ _ _ _ _ _)%expr_pat => None
+                          | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             ($_)%expr _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (_ @ _) _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
+                             (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+                              None
+                          | (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
+                             _ @ _)%expr_pat |
+                            (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
+                             _ _ _ @ _)%expr_pat => None
+                          | _ => None
+                          end;;
+                          args <- invert_bind_args idc4 Raw.ident.Z_cast;
+                          args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          args2 <- invert_bind_args idc1 Raw.ident.Literal;
+                          args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
                           _ <- invert_bind_args idc
-                                 Raw.ident.Z_sub_with_get_borrow;
+                                 Raw.ident.Z_add_with_get_carry;
                           match
                             pattern.type.unify_extracted
                               (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> s3) -> (projT1 args0)) ->
-                               (projT1 args))%ptype
+                              ((((projT1 args2) -> s4) -> s5) -> s6)%ptype
                           with
                           | Some (_, _, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> s3) -> (projT1 args0)) ->
-                                  (projT1 args))%ptype
+                                 ((((projT1 args2) -> s4) -> s5) -> s6)%ptype
                               then
                                xv <- ident.unify pattern.ident.Literal
                                        ##(projT2 args2);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
-                               xv1 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args);
-                               fv <- (x5 <- (let
+                               v <- type.try_make_transport_cps s4 ℤ;
+                               v0 <- type.try_make_transport_cps s5 ℤ;
+                               v1 <- type.try_make_transport_cps s6 ℤ;
+                               fv <- (x8 <- (let
                                              '(r1, r2)%zrange := range in
-                                              fun (s4 : Z) (rb : zrange)
-                                                (b2 : expr ℤ) (xx yy : Z) =>
+                                              fun (rs : zrange) (s7 : Z)
+                                                (rc : zrange) (c : expr ℤ)
+                                                (rx : zrange) (x8 : expr ℤ)
+                                                (ry : zrange) (y : expr ℤ) =>
                                               if
-                                               (s4 =? 2 ^ Z.log2 s4) &&
-                                               (ZRange.normalize
-                                                  (ZRange.constant yy) <=?
-                                                r[0 ~> s4 - 1])%zrange
+                                               (s7 =? 2 ^ Z.log2 s7) &&
+                                               (ZRange.normalize ry <=?
+                                                r[0 ~> s7 - 1])%zrange &&
+                                               is_bounded_by_bool s7
+                                                 (ZRange.normalize rs)
                                               then
                                                Some
                                                  (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_subb (Z.log2 s4) 0)%expr @
-                                                   (#(Z_cast rb)%expr @ b2,
-                                                   (##xx)%expr, (##yy)%expr)))%expr_pat
-                                              else None)
-                                              (let (x5, _) := xv in x5) args1
-                                              (v (Compile.reflect x4))
-                                              (let (x5, _) := xv0 in x5)
-                                              (let (x5, _) := xv1 in x5);
-                                      Some (Base x5));
+                                                  (#(fancy_addc (Z.log2 s7) 0)%expr @
+                                                   (#(Z_cast rc)%expr @ c,
+                                                   #(Z_cast rx)%expr @ x8,
+                                                   #(Z_cast ry)%expr @ y)))%expr_pat
+                                              else None) args3
+                                              (let (x8, _) := xv in x8) args1
+                                              (v (Compile.reflect x5)) args0
+                                              (v0 (Compile.reflect x6)) args
+                                              (v1 (Compile.reflect x7));
+                                      Some (Base x8));
                                Some (fv0 <-- fv;
                                      Base fv0)%under_lets
                               else None
                           | None => None
                           end
-                      | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t3 idc3)
-                        x5 =>
-                          match x5 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ x7 @ x6)%expr_pat =>
-                              match x7 with
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.Ident _ _ _ t8 idc8))%expr_pat =>
-                                  match x6 with
-                                  | @expr.Ident _ _ _ t9 idc9 =>
-                                      args <- invert_bind_args idc9
+                      | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6
+                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
+                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                      | _ => None
+                      end
+                  | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
+                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
+                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
+                  | _ => None
+                  end
+              | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
+                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
+                (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
+                (@expr.LetIn _ _ _ _ _ _ _) _ => None
+              | _ => None
+              end
+          | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+              None
+          | _ => None
+          end;;
+          match x3 with
+          | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
+              match x2 with
+              | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5 =>
+                  match x1 with
+                  | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6 =>
+                      match x0 with
+                      | @expr.App _ _ _ s6 _ (@expr.Ident _ _ _ t4 idc4)
+                        x7 =>
+                          match x7 with
+                          | (@expr.Ident _ _ _ t5 idc5 @ x9 @ x8)%expr_pat =>
+                              match x9 with
+                              | (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _
+                                   _ _ t10 idc10)))%expr_pat =>
+                                  match x8 with
+                                  | (@expr.Ident _ _ _ t11 idc11 @
+                                     @expr.Ident _ _ _ t12 idc12)%expr_pat =>
+                                      args <- invert_bind_args idc12
                                                 Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc8
-                                                 Raw.ident.Literal;
-                                      args1 <- invert_bind_args idc7
+                                      args0 <- invert_bind_args idc11
                                                  Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc6
+                                      args1 <- invert_bind_args idc10
+                                                 Raw.ident.Literal;
+                                      args2 <- invert_bind_args idc9
+                                                 Raw.ident.Z_cast;
+                                      args3 <- invert_bind_args idc8
+                                                 Raw.ident.Z_cast;
+                                      _ <- invert_bind_args idc7
                                              Raw.ident.Z_land;
-                                      args3 <- invert_bind_args idc5
+                                      args5 <- invert_bind_args idc6
                                                  Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
+                                      _ <- invert_bind_args idc5
                                              Raw.ident.Z_shiftl;
-                                      args5 <- invert_bind_args idc3
+                                      args7 <- invert_bind_args idc4
                                                  Raw.ident.Z_cast;
-                                      args6 <- invert_bind_args idc2
-                                                 Raw.ident.Literal;
-                                      args7 <- invert_bind_args idc1
+                                      args8 <- invert_bind_args idc3
                                                  Raw.ident.Z_cast;
-                                      args8 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
+                                      args9 <- invert_bind_args idc2
+                                                 Raw.ident.Z_cast;
+                                      args10 <- invert_bind_args idc1
+                                                  Raw.ident.Literal;
+                                      args11 <- invert_bind_args idc0
+                                                  Raw.ident.Z_cast;
                                       _ <- invert_bind_args idc
                                              Raw.ident.Z_sub_with_get_borrow;
                                       match
                                         pattern.type.unify_extracted
                                           (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args8) -> s3) ->
-                                            (projT1 args6)) ->
-                                           (s10 -> (projT1 args0)) ->
+                                          ((((projT1 args10) -> s4) -> s5) ->
+                                           (s12 -> (projT1 args1)) ->
                                            (projT1 args))%ptype
                                       with
                                       | Some (_, _, _, (_, _, _))%zrange =>
@@ -9036,664 +5759,288 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                              base.type.type_beq
                                              (((ℤ -> ℤ) -> ℤ) ->
                                               (ℤ -> ℤ) -> ℤ)%ptype
-                                             ((((projT1 args8) -> s3) ->
-                                               (projT1 args6)) ->
-                                              (s10 -> (projT1 args0)) ->
+                                             ((((projT1 args10) -> s4) -> s5) ->
+                                              (s12 -> (projT1 args1)) ->
                                               (projT1 args))%ptype
                                           then
                                            xv <- ident.unify
                                                    pattern.ident.Literal
-                                                   ##(projT2 args8);
-                                           v <- type.try_make_transport_cps s3 ℤ;
+                                                   ##(projT2 args10);
+                                           v <- type.try_make_transport_cps s4 ℤ;
+                                           v0 <- type.try_make_transport_cps s5 ℤ;
+                                           v1 <- type.try_make_transport_cps s12 ℤ;
                                            xv0 <- ident.unify
                                                     pattern.ident.Literal
-                                                    ##(projT2 args6);
-                                           v0 <- type.try_make_transport_cps s10 ℤ;
+                                                    ##(projT2 args1);
                                            xv1 <- ident.unify
                                                     pattern.ident.Literal
-                                                    ##(projT2 args0);
-                                           xv2 <- ident.unify
+                                                    ##(projT2 args);
+                                           fv <- (x16 <- (let
+                                                          '(r1, r2)%zrange :=
+                                                           range in
+                                                           fun (rs : zrange)
+                                                             (s15 : Z)
+                                                             (rb : zrange)
+                                                             (b4 : expr ℤ)
+                                                             (rx : zrange)
+                                                             (x16 : expr ℤ)
+                                                             (rshiftl rland
+                                                              ry : zrange)
+                                                             (y : expr ℤ)
+                                                             (rmask : zrange)
+                                                             (mask : Z)
+                                                             (roffset : zrange)
+                                                             (offset : Z) =>
+                                                           if
+                                                            (s15 =?
+                                                             2 ^ Z.log2 s15) &&
+                                                            (ZRange.normalize
+                                                               rland <<
+                                                             ZRange.normalize
+                                                               (ZRange.constant
+                                                                  offset) <=?
+                                                             ZRange.normalize
+                                                               rshiftl)%zrange &&
+                                                            (ZRange.normalize
+                                                               rshiftl <=?
+                                                             r[0 ~> s15 - 1])%zrange &&
+                                                            (ZRange.normalize
+                                                               ry &'
+                                                             ZRange.normalize
+                                                               (ZRange.constant
+                                                                  mask) <=?
+                                                             ZRange.normalize
+                                                               rland)%zrange &&
+                                                            (mask =?
+                                                             Z.ones
+                                                               (Z.log2 s15 -
+                                                                offset)) &&
+                                                            (0 <=? offset) &&
+                                                            (offset <=?
+                                                             Z.log2 s15) &&
+                                                            is_bounded_by_bool
+                                                              s15
+                                                              (ZRange.normalize
+                                                                 rs) &&
+                                                            is_bounded_by_bool
+                                                              mask
+                                                              (ZRange.normalize
+                                                                 rmask) &&
+                                                            is_bounded_by_bool
+                                                              offset
+                                                              (ZRange.normalize
+                                                                 roffset)
+                                                           then
+                                                            Some
+                                                              (#(Z_cast2
+                                                                   (r1, r2))%expr @
+                                                               (#(fancy_subb
+                                                                    (Z.log2
+                                                                    s15)
+                                                                    offset)%expr @
+                                                                (#(Z_cast rb)%expr @
+                                                                 b4,
+                                                                #(Z_cast rx)%expr @
+                                                                x16,
+                                                                #(Z_cast ry)%expr @
+                                                                y)))%expr_pat
+                                                           else None) args11
+                                                           (let (x16, _) :=
+                                                              xv in
+                                                            x16) args9
+                                                           (v
+                                                              (Compile.reflect
+                                                                 x5)) args8
+                                                           (v0
+                                                              (Compile.reflect
+                                                                 x6)) args7
+                                                           args5 args3
+                                                           (v1
+                                                              (Compile.reflect
+                                                                 x13)) args2
+                                                           (let (x16, _) :=
+                                                              xv0 in
+                                                            x16) args0
+                                                           (let (x16, _) :=
+                                                              xv1 in
+                                                            x16);
+                                                  Some (Base x16));
+                                           Some
+                                             (fv0 <-- fv;
+                                              Base fv0)%under_lets
+                                          else None
+                                      | None => None
+                                      end
+                                  | (@expr.Ident _ _ _ t11 idc11 @ ($_)%expr)%expr_pat |
+                                    (@expr.Ident _ _ _ t11 idc11 @ @expr.Abs
+                                     _ _ _ _ _ _)%expr_pat |
+                                    (@expr.Ident _ _ _ t11 idc11 @ (_ @ _))%expr_pat |
+                                    (@expr.Ident _ _ _ t11 idc11 @
+                                     @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+                                      None
+                                  | _ => None
+                                  end
+                              | (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (@expr.Ident _ _ _ t9 idc9 @ ($_)%expr)))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (@expr.Ident _ _ _ t9 idc9 @ @expr.Abs _ _
+                                   _ _ _ _)))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (@expr.Ident _ _ _ t9 idc9 @ (_ @ _))))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (@expr.Ident _ _ _ t9 idc9 @ @expr.LetIn _
+                                   _ _ _ _ _ _)))%expr_pat => None
+                              | (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  #(_)))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  ($_)%expr))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (($_)%expr @ _)))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (@expr.Abs _ _ _ _ _ _ @ _)))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (_ @ _ @ _)))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  (@expr.LetIn _ _ _ _ _ _ _ @ _)))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
+                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
+                                  None
+                              | (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ ($_)%expr _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (_ @ _) _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
+                                  s12 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
+                                  None
+                              | (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ #(_) @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _ _ _
+                                  _ _ _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _
+                                  _ _ _ _ _ @ _))%expr_pat => None
+                              | (@expr.Ident _ _ _ t6 idc6 @ #(_))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr)%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
+                                 _ _ _)%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @ (#(_) @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @ (($_)%expr @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (($_)%expr @ _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @ (_ @ _ @ _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @
+                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
+                                (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
+                                 _ _ _ _ _)%expr_pat => None
+                              | _ => None
+                              end;;
+                              match x9 with
+                              | @expr.App _ _ _ s9 _
+                                (@expr.Ident _ _ _ t6 idc6) x10 =>
+                                  match x8 with
+                                  | (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident
+                                     _ _ _ t8 idc8)%expr_pat =>
+                                      args <- invert_bind_args idc8
+                                                Raw.ident.Literal;
+                                      args0 <- invert_bind_args idc7
+                                                 Raw.ident.Z_cast;
+                                      args1 <- invert_bind_args idc6
+                                                 Raw.ident.Z_cast;
+                                      _ <- invert_bind_args idc5
+                                             Raw.ident.Z_shiftr;
+                                      args3 <- invert_bind_args idc4
+                                                 Raw.ident.Z_cast;
+                                      args4 <- invert_bind_args idc3
+                                                 Raw.ident.Z_cast;
+                                      args5 <- invert_bind_args idc2
+                                                 Raw.ident.Z_cast;
+                                      args6 <- invert_bind_args idc1
+                                                 Raw.ident.Literal;
+                                      args7 <- invert_bind_args idc0
+                                                 Raw.ident.Z_cast;
+                                      _ <- invert_bind_args idc
+                                             Raw.ident.Z_sub_with_get_borrow;
+                                      match
+                                        pattern.type.unify_extracted
+                                          (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
+                                          ((((projT1 args6) -> s4) -> s5) ->
+                                           s9 -> (projT1 args))%ptype
+                                      with
+                                      | Some (_, _, _, (_, _))%zrange =>
+                                          if
+                                           type.type_beq base.type
+                                             base.type.type_beq
+                                             (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
+                                             ((((projT1 args6) -> s4) -> s5) ->
+                                              s9 -> (projT1 args))%ptype
+                                          then
+                                           xv <- ident.unify
+                                                   pattern.ident.Literal
+                                                   ##(projT2 args6);
+                                           v <- type.try_make_transport_cps s4 ℤ;
+                                           v0 <- type.try_make_transport_cps s5 ℤ;
+                                           v1 <- type.try_make_transport_cps s9 ℤ;
+                                           xv0 <- ident.unify
                                                     pattern.ident.Literal
                                                     ##(projT2 args);
                                            fv <- (x12 <- (let
                                                           '(r1, r2)%zrange :=
                                                            range in
-                                                           fun (s11 : Z)
-                                                             (rb : zrange)
-                                                             (b4 : expr ℤ)
-                                                             (xx : Z)
-                                                             (rshiftl rland
-                                                              ry : zrange)
-                                                             (y : expr ℤ)
-                                                             (mask
-                                                              offset : Z) =>
-                                                           if
-                                                            (s11 =?
-                                                             2 ^ Z.log2 s11) &&
-                                                            (ZRange.normalize
-                                                               rland <<
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  offset) <=?
-                                                             ZRange.normalize
-                                                               rshiftl)%zrange &&
-                                                            (ZRange.normalize
-                                                               rshiftl <=?
-                                                             r[0 ~> s11 - 1])%zrange &&
-                                                            (ZRange.normalize
-                                                               ry &'
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  mask) <=?
-                                                             ZRange.normalize
-                                                               rland)%zrange &&
-                                                            (mask =?
-                                                             Z.ones
-                                                               (Z.log2 s11 -
-                                                                offset)) &&
-                                                            (0 <=? offset) &&
-                                                            (offset <=?
-                                                             Z.log2 s11)
-                                                           then
-                                                            Some
-                                                              (#(Z_cast2
-                                                                   (r1, r2))%expr @
-                                                               (#(fancy_subb
-                                                                    (Z.log2
-                                                                    s11)
-                                                                    offset)%expr @
-                                                                (#(Z_cast rb)%expr @
-                                                                 b4,
-                                                                (##xx)%expr,
-                                                                #(Z_cast ry)%expr @
-                                                                y)))%expr_pat
-                                                           else None)
-                                                           (let (x12, _) :=
-                                                              xv in
-                                                            x12) args7
-                                                           (v
-                                                              (Compile.reflect
-                                                                 x4))
-                                                           (let (x12, _) :=
-                                                              xv0 in
-                                                            x12) args5 args3
-                                                           args1
-                                                           (v0
-                                                              (Compile.reflect
-                                                                 x11))
-                                                           (let (x12, _) :=
-                                                              xv1 in
-                                                            x12)
-                                                           (let (x12, _) :=
-                                                              xv2 in
-                                                            x12);
-                                                  Some (Base x12));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  ($_)%expr))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  (_ @ _)))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Ident _ _ _ t7 idc7) x11 @
-                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ ($_)%expr _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (_ @ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s10 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
-                                  _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
-                              | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _
-                                 _ _ _)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (($_)%expr @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
-                              end;;
-                              match x7 with
-                              | @expr.App _ _ _ s7 _
-                                (@expr.Ident _ _ _ t5 idc5) x8 =>
-                                  match x6 with
-                                  | @expr.Ident _ _ _ t6 idc6 =>
-                                      args <- invert_bind_args idc6
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftr;
-                                      args2 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args3 <- invert_bind_args idc2
-                                                 Raw.ident.Literal;
-                                      args4 <- invert_bind_args idc1
-                                                 Raw.ident.Z_cast;
-                                      args5 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_sub_with_get_borrow;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                          ((((projT1 args5) -> s3) ->
-                                            (projT1 args3)) ->
-                                           s7 -> (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                             ((((projT1 args5) -> s3) ->
-                                               (projT1 args3)) ->
-                                              s7 -> (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args5);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args3);
-                                           v0 <- type.try_make_transport_cps s7 ℤ;
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x9 <- (let
-                                                         '(r1, r2)%zrange :=
-                                                          range in
-                                                          fun (s8 : Z)
-                                                            (rb : zrange)
-                                                            (b3 : expr ℤ)
-                                                            (xx : Z)
-                                                            (rshiftr
-                                                             ry : zrange)
-                                                            (y : expr ℤ)
-                                                            (offset : Z) =>
-                                                          if
-                                                           (s8 =?
-                                                            2 ^ Z.log2 s8) &&
-                                                           (ZRange.normalize
-                                                              ry >>
-                                                            ZRange.normalize
-                                                              (ZRange.constant
-                                                                 offset) <=?
-                                                            ZRange.normalize
-                                                              rshiftr)%zrange &&
-                                                           (ZRange.normalize
-                                                              rshiftr <=?
-                                                            r[0 ~> s8 - 1])%zrange
-                                                          then
-                                                           Some
-                                                             (#(Z_cast2
-                                                                  (r1, r2))%expr @
-                                                              (#(fancy_subb
-                                                                   (Z.log2 s8)
-                                                                   (- offset))%expr @
-                                                               (#(Z_cast rb)%expr @
-                                                                b3,
-                                                               (##xx)%expr,
-                                                               #(Z_cast ry)%expr @
-                                                               y)))%expr_pat
-                                                          else None)
-                                                          (let (x9, _) :=
-                                                             xv in
-                                                           x9) args4
-                                                          (v
-                                                             (Compile.reflect
-                                                                x4))
-                                                          (let (x9, _) :=
-                                                             xv0 in
-                                                           x9) args2 args0
-                                                          (v0
-                                                             (Compile.reflect
-                                                                x8))
-                                                          (let (x9, _) :=
-                                                             xv1 in
-                                                           x9);
-                                                  Some (Base x9));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App
-                                _ _ _ s7 _ (@expr.Abs _ _ _ _ _ _) _ |
-                                @expr.App _ _ _ s7 _ (_ @ _)%expr_pat _ |
-                                @expr.App _ _ _ s7 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
-                              end
-                          | _ => None
-                          end;;
-                          args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                          args0 <- invert_bind_args idc2 Raw.ident.Literal;
-                          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_sub_with_get_borrow;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> s3) -> (projT1 args0)) ->
-                               s4)%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> s3) -> (projT1 args0)) ->
-                                  s4)%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args0);
-                               v0 <- type.try_make_transport_cps s4 ℤ;
-                               fv <- (x6 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s5 : Z) (rb : zrange)
-                                                (b2 : expr ℤ) (xx : Z)
-                                                (ry : zrange) (y : expr ℤ) =>
-                                              if
-                                               (s5 =? 2 ^ Z.log2 s5) &&
-                                               (ZRange.normalize ry <=?
-                                                r[0 ~> s5 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_subb (Z.log2 s5) 0)%expr @
-                                                   (#(Z_cast rb)%expr @ b2,
-                                                   (##xx)%expr,
-                                                   #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x6, _) := xv in x6) args1
-                                              (v (Compile.reflect x4))
-                                              (let (x6, _) := xv0 in x6) args
-                                              (v0 (Compile.reflect x5));
-                                      Some (Base x6));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
-                      end
-                  | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5 =>
-                      match x0 with
-                      | @expr.Ident _ _ _ t3 idc3 =>
-                          args <- invert_bind_args idc3 Raw.ident.Literal;
-                          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
-                          _ <- invert_bind_args idc
-                                 Raw.ident.Z_sub_with_get_borrow;
-                          match
-                            pattern.type.unify_extracted
-                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> s3) -> s4) ->
-                               (projT1 args))%ptype
-                          with
-                          | Some (_, _, _, _)%zrange =>
-                              if
-                               type.type_beq base.type base.type.type_beq
-                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> s3) -> s4) ->
-                                  (projT1 args))%ptype
-                              then
-                               xv <- ident.unify pattern.ident.Literal
-                                       ##(projT2 args2);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               v0 <- type.try_make_transport_cps s4 ℤ;
-                               xv0 <- ident.unify pattern.ident.Literal
-                                        ##(projT2 args);
-                               fv <- (x6 <- (let
-                                             '(r1, r2)%zrange := range in
-                                              fun (s5 : Z) (rb : zrange)
-                                                (b2 : expr ℤ) (rx : zrange)
-                                                (x6 : expr ℤ) (yy : Z) =>
-                                              if
-                                               (s5 =? 2 ^ Z.log2 s5) &&
-                                               (ZRange.normalize
-                                                  (ZRange.constant yy) <=?
-                                                r[0 ~> s5 - 1])%zrange
-                                              then
-                                               Some
-                                                 (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_subb (Z.log2 s5) 0)%expr @
-                                                   (#(Z_cast rb)%expr @ b2,
-                                                   #(Z_cast rx)%expr @ x6,
-                                                   (##yy)%expr)))%expr_pat
-                                              else None)
-                                              (let (x6, _) := xv in x6) args1
-                                              (v (Compile.reflect x4)) args0
-                                              (v0 (Compile.reflect x5))
-                                              (let (x6, _) := xv0 in x6);
-                                      Some (Base x6));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
-                          end
-                      | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3)
-                        x6 =>
-                          match x6 with
-                          | (@expr.Ident _ _ _ t4 idc4 @ x8 @ x7)%expr_pat =>
-                              match x8 with
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                                  @expr.Ident _ _ _ t8 idc8))%expr_pat =>
-                                  match x7 with
-                                  | @expr.Ident _ _ _ t9 idc9 =>
-                                      args <- invert_bind_args idc9
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc8
-                                                 Raw.ident.Literal;
-                                      args1 <- invert_bind_args idc7
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc6
-                                             Raw.ident.Z_land;
-                                      args3 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftl;
-                                      args5 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args6 <- invert_bind_args idc2
-                                                 Raw.ident.Z_cast;
-                                      args7 <- invert_bind_args idc1
-                                                 Raw.ident.Z_cast;
-                                      args8 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_sub_with_get_borrow;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
-                                          ((((projT1 args8) -> s3) -> s4) ->
-                                           (s11 -> (projT1 args0)) ->
-                                           (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) ->
-                                              (ℤ -> ℤ) -> ℤ)%ptype
-                                             ((((projT1 args8) -> s3) -> s4) ->
-                                              (s11 -> (projT1 args0)) ->
-                                              (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args8);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           v0 <- type.try_make_transport_cps s4 ℤ;
-                                           v1 <- type.try_make_transport_cps s11 ℤ;
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args0);
-                                           xv1 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x13 <- (let
-                                                          '(r1, r2)%zrange :=
-                                                           range in
-                                                           fun (s12 : Z)
-                                                             (rb : zrange)
-                                                             (b4 : expr ℤ)
-                                                             (rx : zrange)
-                                                             (x13 : expr ℤ)
-                                                             (rshiftl rland
-                                                              ry : zrange)
-                                                             (y : expr ℤ)
-                                                             (mask
-                                                              offset : Z) =>
-                                                           if
-                                                            (s12 =?
-                                                             2 ^ Z.log2 s12) &&
-                                                            (ZRange.normalize
-                                                               rland <<
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  offset) <=?
-                                                             ZRange.normalize
-                                                               rshiftl)%zrange &&
-                                                            (ZRange.normalize
-                                                               rshiftl <=?
-                                                             r[0 ~> s12 - 1])%zrange &&
-                                                            (ZRange.normalize
-                                                               ry &'
-                                                             ZRange.normalize
-                                                               (ZRange.constant
-                                                                  mask) <=?
-                                                             ZRange.normalize
-                                                               rland)%zrange &&
-                                                            (mask =?
-                                                             Z.ones
-                                                               (Z.log2 s12 -
-                                                                offset)) &&
-                                                            (0 <=? offset) &&
-                                                            (offset <=?
-                                                             Z.log2 s12)
-                                                           then
-                                                            Some
-                                                              (#(Z_cast2
-                                                                   (r1, r2))%expr @
-                                                               (#(fancy_subb
-                                                                    (Z.log2
-                                                                    s12)
-                                                                    offset)%expr @
-                                                                (#(Z_cast rb)%expr @
-                                                                 b4,
-                                                                #(Z_cast rx)%expr @
-                                                                x13,
-                                                                #(Z_cast ry)%expr @
-                                                                y)))%expr_pat
-                                                           else None)
-                                                           (let (x13, _) :=
-                                                              xv in
-                                                            x13) args7
-                                                           (v
-                                                              (Compile.reflect
-                                                                 x4)) args6
-                                                           (v0
-                                                              (Compile.reflect
-                                                                 x5)) args5
-                                                           args3 args1
-                                                           (v1
-                                                              (Compile.reflect
-                                                                 x12))
-                                                           (let (x13, _) :=
-                                                              xv0 in
-                                                            x13)
-                                                           (let (x13, _) :=
-                                                              xv1 in
-                                                            x13);
-                                                  Some (Base x13));
-                                           Some
-                                             (fv0 <-- fv;
-                                              Base fv0)%under_lets
-                                          else None
-                                      | None => None
-                                      end
-                                  | _ => None
-                                  end
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                                  ($_)%expr))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                                  @expr.Abs _ _ _ _ _ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                                  (_ @ _)))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ (@expr.Ident _ _ _ t7 idc7) x12 @
-                                  @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ ($_)%expr _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ (@expr.Abs _ _ _ _ _ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ (_ @ _) _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _
-                                  s11 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
-                              | (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
-                                  _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
-                              | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _
-                                 _ _ _)%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (#(_) @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (($_)%expr @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (($_)%expr @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.Abs _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ (_ @ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @
-                                 (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
-                                (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
-                              end;;
-                              match x8 with
-                              | @expr.App _ _ _ s8 _
-                                (@expr.Ident _ _ _ t5 idc5) x9 =>
-                                  match x7 with
-                                  | @expr.Ident _ _ _ t6 idc6 =>
-                                      args <- invert_bind_args idc6
-                                                Raw.ident.Literal;
-                                      args0 <- invert_bind_args idc5
-                                                 Raw.ident.Z_cast;
-                                      _ <- invert_bind_args idc4
-                                             Raw.ident.Z_shiftr;
-                                      args2 <- invert_bind_args idc3
-                                                 Raw.ident.Z_cast;
-                                      args3 <- invert_bind_args idc2
-                                                 Raw.ident.Z_cast;
-                                      args4 <- invert_bind_args idc1
-                                                 Raw.ident.Z_cast;
-                                      args5 <- invert_bind_args idc0
-                                                 Raw.ident.Literal;
-                                      _ <- invert_bind_args idc
-                                             Raw.ident.Z_sub_with_get_borrow;
-                                      match
-                                        pattern.type.unify_extracted
-                                          (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                          ((((projT1 args5) -> s3) -> s4) ->
-                                           s8 -> (projT1 args))%ptype
-                                      with
-                                      | Some (_, _, _, (_, _))%zrange =>
-                                          if
-                                           type.type_beq base.type
-                                             base.type.type_beq
-                                             (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
-                                             ((((projT1 args5) -> s3) -> s4) ->
-                                              s8 -> (projT1 args))%ptype
-                                          then
-                                           xv <- ident.unify
-                                                   pattern.ident.Literal
-                                                   ##(projT2 args5);
-                                           v <- type.try_make_transport_cps s3 ℤ;
-                                           v0 <- type.try_make_transport_cps s4 ℤ;
-                                           v1 <- type.try_make_transport_cps s8 ℤ;
-                                           xv0 <- ident.unify
-                                                    pattern.ident.Literal
-                                                    ##(projT2 args);
-                                           fv <- (x10 <- (let
-                                                          '(r1, r2)%zrange :=
-                                                           range in
-                                                           fun (s9 : Z)
+                                                           fun (rs : zrange)
+                                                             (s11 : Z)
                                                              (rb : zrange)
                                                              (b3 : expr ℤ)
                                                              (rx : zrange)
-                                                             (x10 : expr ℤ)
+                                                             (x12 : expr ℤ)
                                                              (rshiftr
                                                               ry : zrange)
                                                              (y : expr ℤ)
+                                                             (roffset : zrange)
                                                              (offset : Z) =>
                                                            if
-                                                            (s9 =?
-                                                             2 ^ Z.log2 s9) &&
+                                                            (s11 =?
+                                                             2 ^ Z.log2 s11) &&
                                                             (ZRange.normalize
                                                                ry >>
                                                              ZRange.normalize
@@ -9703,124 +6050,146 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                                rshiftr)%zrange &&
                                                             (ZRange.normalize
                                                                rshiftr <=?
-                                                             r[0 ~> s9 - 1])%zrange
+                                                             r[0 ~> s11 - 1])%zrange &&
+                                                            is_bounded_by_bool
+                                                              s11
+                                                              (ZRange.normalize
+                                                                 rs) &&
+                                                            is_bounded_by_bool
+                                                              offset
+                                                              (ZRange.normalize
+                                                                 roffset)
                                                            then
                                                             Some
                                                               (#(Z_cast2
                                                                    (r1, r2))%expr @
                                                                (#(fancy_subb
                                                                     (Z.log2
-                                                                    s9)
+                                                                    s11)
                                                                     (- offset))%expr @
                                                                 (#(Z_cast rb)%expr @
                                                                  b3,
                                                                 #(Z_cast rx)%expr @
-                                                                x10,
+                                                                x12,
                                                                 #(Z_cast ry)%expr @
                                                                 y)))%expr_pat
-                                                           else None)
-                                                           (let (x10, _) :=
+                                                           else None) args7
+                                                           (let (x12, _) :=
                                                               xv in
-                                                            x10) args4
+                                                            x12) args5
                                                            (v
                                                               (Compile.reflect
-                                                                 x4)) args3
+                                                                 x5)) args4
                                                            (v0
                                                               (Compile.reflect
-                                                                 x5)) args2
-                                                           args0
+                                                                 x6)) args3
+                                                           args1
                                                            (v1
                                                               (Compile.reflect
-                                                                 x9))
-                                                           (let (x10, _) :=
+                                                                 x10)) args0
+                                                           (let (x12, _) :=
                                                               xv0 in
-                                                            x10);
-                                                  Some (Base x10));
+                                                            x12);
+                                                  Some (Base x12));
                                            Some
                                              (fv0 <-- fv;
                                               Base fv0)%under_lets
                                           else None
                                       | None => None
                                       end
+                                  | (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr)%expr_pat |
+                                    (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _
+                                     _ _ _ _ _)%expr_pat |
+                                    (@expr.Ident _ _ _ t7 idc7 @ (_ @ _))%expr_pat |
+                                    (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn
+                                     _ _ _ _ _ _ _)%expr_pat => None
                                   | _ => None
                                   end
-                              | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App
-                                _ _ _ s8 _ (@expr.Abs _ _ _ _ _ _) _ |
-                                @expr.App _ _ _ s8 _ (_ @ _)%expr_pat _ |
-                                @expr.App _ _ _ s8 _
+                              | @expr.App _ _ _ s9 _ ($_)%expr _ | @expr.App
+                                _ _ _ s9 _ (@expr.Abs _ _ _ _ _ _) _ |
+                                @expr.App _ _ _ s9 _ (_ @ _)%expr_pat _ |
+                                @expr.App _ _ _ s9 _
                                 (@expr.LetIn _ _ _ _ _ _ _) _ => None
                               | _ => None
                               end
                           | _ => None
                           end;;
-                          args <- invert_bind_args idc3 Raw.ident.Z_cast;
-                          args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
-                          args1 <- invert_bind_args idc1 Raw.ident.Z_cast;
-                          args2 <- invert_bind_args idc0 Raw.ident.Literal;
+                          args <- invert_bind_args idc4 Raw.ident.Z_cast;
+                          args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
+                          args1 <- invert_bind_args idc2 Raw.ident.Z_cast;
+                          args2 <- invert_bind_args idc1 Raw.ident.Literal;
+                          args3 <- invert_bind_args idc0 Raw.ident.Z_cast;
                           _ <- invert_bind_args idc
                                  Raw.ident.Z_sub_with_get_borrow;
                           match
                             pattern.type.unify_extracted
                               (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                              ((((projT1 args2) -> s3) -> s4) -> s5)%ptype
+                              ((((projT1 args2) -> s4) -> s5) -> s6)%ptype
                           with
                           | Some (_, _, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
-                                 ((((projT1 args2) -> s3) -> s4) -> s5)%ptype
+                                 ((((projT1 args2) -> s4) -> s5) -> s6)%ptype
                               then
                                xv <- ident.unify pattern.ident.Literal
                                        ##(projT2 args2);
-                               v <- type.try_make_transport_cps s3 ℤ;
-                               v0 <- type.try_make_transport_cps s4 ℤ;
-                               v1 <- type.try_make_transport_cps s5 ℤ;
-                               fv <- (x7 <- (let
+                               v <- type.try_make_transport_cps s4 ℤ;
+                               v0 <- type.try_make_transport_cps s5 ℤ;
+                               v1 <- type.try_make_transport_cps s6 ℤ;
+                               fv <- (x8 <- (let
                                              '(r1, r2)%zrange := range in
-                                              fun (s6 : Z) (rb : zrange)
-                                                (b2 : expr ℤ) (rx : zrange)
-                                                (x7 : expr ℤ) (ry : zrange)
-                                                (y : expr ℤ) =>
+                                              fun (rs : zrange) (s7 : Z)
+                                                (rb : zrange) (b2 : expr ℤ)
+                                                (rx : zrange) (x8 : expr ℤ)
+                                                (ry : zrange) (y : expr ℤ) =>
                                               if
-                                               (s6 =? 2 ^ Z.log2 s6) &&
+                                               (s7 =? 2 ^ Z.log2 s7) &&
                                                (ZRange.normalize ry <=?
-                                                r[0 ~> s6 - 1])%zrange
+                                                r[0 ~> s7 - 1])%zrange &&
+                                               is_bounded_by_bool s7
+                                                 (ZRange.normalize rs)
                                               then
                                                Some
                                                  (#(Z_cast2 (r1, r2))%expr @
-                                                  (#(fancy_subb (Z.log2 s6) 0)%expr @
+                                                  (#(fancy_subb (Z.log2 s7) 0)%expr @
                                                    (#(Z_cast rb)%expr @ b2,
-                                                   #(Z_cast rx)%expr @ x7,
+                                                   #(Z_cast rx)%expr @ x8,
                                                    #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None)
-                                              (let (x7, _) := xv in x7) args1
-                                              (v (Compile.reflect x4)) args0
-                                              (v0 (Compile.reflect x5)) args
-                                              (v1 (Compile.reflect x6));
-                                      Some (Base x7));
+                                              else None) args3
+                                              (let (x8, _) := xv in x8) args1
+                                              (v (Compile.reflect x5)) args0
+                                              (v0 (Compile.reflect x6)) args
+                                              (v1 (Compile.reflect x7));
+                                      Some (Base x8));
                                Some (fv0 <-- fv;
                                      Base fv0)%under_lets
                               else None
                           | None => None
                           end
-                      | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5
-                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
-                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
+                      | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6
+                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
+                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
                         (@expr.LetIn _ _ _ _ _ _ _) _ => None
                       | _ => None
                       end
-                  | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
-                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
-                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
+                  | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
+                    (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
+                    (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
                     (@expr.LetIn _ _ _ _ _ _ _) _ => None
                   | _ => None
                   end
-              | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
-                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
-                (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
+              | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
+                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
+                (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
                 (@expr.LetIn _ _ _ _ _ _ _) _ => None
               | _ => None
               end
+          | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
+            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+              None
           | _ => None
           end
       | _ => None

--- a/src/strip_literal_casts_rewrite_head.out
+++ b/src/strip_literal_casts_rewrite_head.out
@@ -1,0 +1,227 @@
+strip_literal_casts_rewrite_head = 
+match idc in (Compilers.ident t) return (Compile.value' true t) with
+| @Literal t v => Base (##v)%expr
+| Nat_succ => fun x : expr ℕ => Base (#(Nat_succ)%expr @ x)%expr_pat
+| Nat_pred => fun x : expr ℕ => Base (#(Nat_pred)%expr @ x)%expr_pat
+| Nat_max => fun x x0 : expr ℕ => Base (#(Nat_max)%expr @ x @ x0)%expr_pat
+| Nat_mul => fun x x0 : expr ℕ => Base (#(Nat_mul)%expr @ x @ x0)%expr_pat
+| Nat_add => fun x x0 : expr ℕ => Base (#(Nat_add)%expr @ x @ x0)%expr_pat
+| Nat_sub => fun x x0 : expr ℕ => Base (#(Nat_sub)%expr @ x @ x0)%expr_pat
+| Nat_eqb => fun x x0 : expr ℕ => Base (#(Nat_eqb)%expr @ x @ x0)%expr_pat
+| @nil t => Base []%expr_pat
+| @cons t => fun (x : expr t) (x0 : expr (list t)) => Base (x :: x0)%expr_pat
+| @pair A B => fun (x : expr A) (x0 : expr B) => Base (x, x0)%expr_pat
+| @fst A B => fun x : expr (A * B)%etype => Base (#(fst)%expr @ x)%expr_pat
+| @snd A B => fun x : expr (A * B)%etype => Base (#(snd)%expr @ x)%expr_pat
+| @prod_rect A B T =>
+    fun (x : expr A -> expr B -> UnderLets (expr T))
+      (x0 : expr (A * B)%etype) =>
+    Base
+      (#(prod_rect)%expr @
+       (λ (x1 : var A)(x2 : var B),
+        to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
+| @bool_rect T =>
+    fun (x x0 : expr unit -> UnderLets (expr T)) (x1 : expr bool) =>
+    Base
+      (#(bool_rect)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| @nat_rect P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr ℕ -> expr P -> UnderLets (expr P)) (x1 : expr ℕ) =>
+    Base
+      (#(nat_rect)%expr @ (λ x2 : var unit,
+                           to_expr (x ($x2)))%expr @
+       (λ (x2 : var ℕ)(x3 : var P),
+        to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
+| @nat_rect_arrow P Q =>
+    fun (x : expr P -> UnderLets (expr Q))
+      (x0 : expr ℕ ->
+            (expr P -> UnderLets (expr Q)) -> expr P -> UnderLets (expr Q))
+      (x1 : expr ℕ) (x2 : expr P) =>
+    Base
+      (#(nat_rect_arrow)%expr @ (λ x3 : var P,
+                                 to_expr (x ($x3)))%expr @
+       (λ (x3 : var ℕ)(x4 : var (P -> Q)%ptype)(x5 : var P),
+        to_expr
+          (x0 ($x3) (fun x6 : expr P => Base ($x4 @ x6)%expr_pat) ($x5)))%expr @
+       x1 @ x2)%expr_pat
+| @list_rect A P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr A -> expr (list A) -> expr P -> UnderLets (expr P))
+      (x1 : expr (list A)) =>
+    Base
+      (#(list_rect)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ (x2 : var A)(x3 : var (list A))(x4 : var P),
+        to_expr (x0 ($x2) ($x3) ($x4)))%expr @ x1)%expr_pat
+| @list_case A P =>
+    fun (x : expr unit -> UnderLets (expr P))
+      (x0 : expr A -> expr (list A) -> UnderLets (expr P))
+      (x1 : expr (list A)) =>
+    Base
+      (#(list_case)%expr @ (λ x2 : var unit,
+                            to_expr (x ($x2)))%expr @
+       (λ (x2 : var A)(x3 : var (list A)),
+        to_expr (x0 ($x2) ($x3)))%expr @ x1)%expr_pat
+| @List_length T =>
+    fun x : expr (list T) => Base (#(List_length)%expr @ x)%expr_pat
+| List_seq => fun x x0 : expr ℕ => Base (#(List_seq)%expr @ x @ x0)%expr_pat
+| @List_firstn A =>
+    fun (x : expr ℕ) (x0 : expr (list A)) =>
+    Base (#(List_firstn)%expr @ x @ x0)%expr_pat
+| @List_skipn A =>
+    fun (x : expr ℕ) (x0 : expr (list A)) =>
+    Base (#(List_skipn)%expr @ x @ x0)%expr_pat
+| @List_repeat A =>
+    fun (x : expr A) (x0 : expr ℕ) =>
+    Base (#(List_repeat)%expr @ x @ x0)%expr_pat
+| @List_combine A B =>
+    fun (x : expr (list A)) (x0 : expr (list B)) =>
+    Base (#(List_combine)%expr @ x @ x0)%expr_pat
+| @List_map A B =>
+    fun (x : expr A -> UnderLets (expr B)) (x0 : expr (list A)) =>
+    Base
+      (#(List_map)%expr @ (λ x1 : var A,
+                           to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_app A => fun x x0 : expr (list A) => Base (x ++ x0)%expr
+| @List_rev A =>
+    fun x : expr (list A) => Base (#(List_rev)%expr @ x)%expr_pat
+| @List_flat_map A B =>
+    fun (x : expr A -> UnderLets (expr (list B))) (x0 : expr (list A)) =>
+    Base
+      (#(List_flat_map)%expr @ (λ x1 : var A,
+                                to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_partition A =>
+    fun (x : expr A -> UnderLets (expr bool)) (x0 : expr (list A)) =>
+    Base
+      (#(List_partition)%expr @ (λ x1 : var A,
+                                 to_expr (x ($x1)))%expr @ x0)%expr_pat
+| @List_fold_right A B =>
+    fun (x : expr B -> expr A -> UnderLets (expr A)) (x0 : expr A)
+      (x1 : expr (list B)) =>
+    Base
+      (#(List_fold_right)%expr @
+       (λ (x2 : var B)(x3 : var A),
+        to_expr (x ($x2) ($x3)))%expr @ x0 @ x1)%expr_pat
+| @List_update_nth T =>
+    fun (x : expr ℕ) (x0 : expr T -> UnderLets (expr T)) (x1 : expr (list T))
+    =>
+    Base
+      (#(List_update_nth)%expr @ x @ (λ x2 : var T,
+                                      to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| @List_nth_default T =>
+    fun (x : expr T) (x0 : expr (list T)) (x1 : expr ℕ) =>
+    Base (#(List_nth_default)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add => fun x x0 : expr ℤ => Base (x + x0)%expr
+| Z_mul => fun x x0 : expr ℤ => Base (x * x0)%expr
+| Z_pow => fun x x0 : expr ℤ => Base (#(Z_pow)%expr @ x @ x0)%expr_pat
+| Z_sub => fun x x0 : expr ℤ => Base (x - x0)%expr
+| Z_opp => fun x : expr ℤ => Base (- x)%expr
+| Z_div => fun x x0 : expr ℤ => Base (x / x0)%expr
+| Z_modulo => fun x x0 : expr ℤ => Base (x mod x0)%expr
+| Z_log2 => fun x : expr ℤ => Base (#(Z_log2)%expr @ x)%expr_pat
+| Z_log2_up => fun x : expr ℤ => Base (#(Z_log2_up)%expr @ x)%expr_pat
+| Z_eqb => fun x x0 : expr ℤ => Base (#(Z_eqb)%expr @ x @ x0)%expr_pat
+| Z_leb => fun x x0 : expr ℤ => Base (#(Z_leb)%expr @ x @ x0)%expr_pat
+| Z_geb => fun x x0 : expr ℤ => Base (#(Z_geb)%expr @ x @ x0)%expr_pat
+| Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
+| Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
+| Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
+| Z_shiftl => fun x x0 : expr ℤ => Base (x << x0)%expr
+| Z_land => fun x x0 : expr ℤ => Base (x &' x0)%expr
+| Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
+| Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
+| Z_lnot_modulo =>
+    fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
+| Z_mul_split =>
+    fun x x0 x1 : expr ℤ => Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add_get_carry =>
+    fun x x0 x1 : expr ℤ =>
+    Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add_with_carry =>
+    fun x x0 x1 : expr ℤ =>
+    Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add_with_get_carry =>
+    fun x x0 x1 x2 : expr ℤ =>
+    Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+| Z_sub_get_borrow =>
+    fun x x0 x1 : expr ℤ =>
+    Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat
+| Z_sub_with_get_borrow =>
+    fun x x0 x1 x2 : expr ℤ =>
+    Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+| Z_zselect =>
+    fun x x0 x1 : expr ℤ => Base (#(Z_zselect)%expr @ x @ x0 @ x1)%expr_pat
+| Z_add_modulo =>
+    fun x x0 x1 : expr ℤ =>
+    Base (#(Z_add_modulo)%expr @ x @ x0 @ x1)%expr_pat
+| Z_rshi =>
+    fun x x0 x1 x2 : expr ℤ =>
+    Base (#(Z_rshi)%expr @ x @ x0 @ x1 @ x2)%expr_pat
+| Z_cc_m => fun x x0 : expr ℤ => Base (#(Z_cc_m)%expr @ x @ x0)%expr_pat
+| Z_cast range =>
+    fun x : expr ℤ =>
+    (match x with
+     | @expr.Ident _ _ _ t idc =>
+         args <- invert_bind_args idc Raw.ident.Literal;
+         match pattern.type.unify_extracted ℤ (projT1 args) with
+         | Some _ =>
+             if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
+             then
+              xv <- ident.unify pattern.ident.Literal ##(projT2 args);
+              fv <- (x0 <- (if
+                             is_bounded_by_bool (let (x0, _) := xv in x0)
+                               (ZRange.normalize range)
+                            then Some (##(let (x0, _) := xv in x0))%expr
+                            else None);
+                     Some (Base x0));
+              Some (fv0 <-- fv;
+                    Base fv0)%under_lets
+             else None
+         | None => None
+         end
+     | _ => None
+     end;;;
+     Base (#(Z_cast range)%expr @ x)%expr_pat)%option
+| Z_cast2 range =>
+    fun x : expr (ℤ * ℤ)%etype => Base (#(Z_cast2 range)%expr @ x)%expr_pat
+| fancy_add log2wordmax imm =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat
+| fancy_addc log2wordmax imm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_addc log2wordmax imm)%expr @ x)%expr_pat
+| fancy_sub log2wordmax imm =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_sub log2wordmax imm)%expr @ x)%expr_pat
+| fancy_subb log2wordmax imm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_subb log2wordmax imm)%expr @ x)%expr_pat
+| fancy_mulll log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulll log2wordmax)%expr @ x)%expr_pat
+| fancy_mullh log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mullh log2wordmax)%expr @ x)%expr_pat
+| fancy_mulhl log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulhl log2wordmax)%expr @ x)%expr_pat
+| fancy_mulhh log2wordmax =>
+    fun x : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_mulhh log2wordmax)%expr @ x)%expr_pat
+| fancy_rshi log2wordmax x =>
+    fun x0 : expr (ℤ * ℤ)%etype =>
+    Base (#(fancy_rshi log2wordmax x)%expr @ x0)%expr_pat
+| fancy_selc =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_selc)%expr @ x)%expr_pat
+| fancy_selm log2wordmax =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype =>
+    Base (#(fancy_selm log2wordmax)%expr @ x)%expr_pat
+| fancy_sell =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_sell)%expr @ x)%expr_pat
+| fancy_addm =>
+    fun x : expr (ℤ * ℤ * ℤ)%etype => Base (#(fancy_addm)%expr @ x)%expr_pat
+end
+     : Compile.value' true t


### PR DESCRIPTION
Unless we explicitly say not to.  The ability to explicitly say not to
is required for, e.g., eta-expansion where we want to replace variable
lists of known length with with cons cells indexing into the variable
list, but don't want to pollute the code with casts.

Uniformity in this way allows rewrite rules to not blow up exponentially
(in the number of wildcards); we previously required a separate rewrite
rule for each way of choosing between wildcard and literal.

To preserve output of the pipeline, we add another pass that just strips
the casts off of literals at the end.

@jadephilipoom Is there anything I have to check (other than that things compile) to ensure I haven't broken the fancy-machine stuff?

```
After     | File Name                                    | Before    || Change    | % Change
--------------------------------------------------------------------------------------------
20m27.24s | Total                                        | 22m39.70s || -2m12.46s | -9.74%
--------------------------------------------------------------------------------------------
0m44.27s  | Rewriter.vo                                  | 2m11.58s  || -1m27.31s | -66.35%
1m15.23s  | RewriterRulesInterpGood.vo                   | 1m50.28s  || -0m35.04s | -31.78%
1m40.19s  | RewriterRulesGood.vo                         | 1m58.05s  || -0m17.85s | -15.12%
0m26.99s  | AbstractInterpretationProofs.vo              | 0m16.91s  || +0m10.07s | +59.60%
3m15.98s  | p384_32.c                                    | 3m07.78s  || +0m08.19s | +4.36%
0m42.52s  | ExtractionHaskell/word_by_word_montgomery    | 0m44.60s  || -0m02.07s | -4.66%
0m28.63s  | ExtractionHaskell/unsaturated_solinas        | 0m31.38s  || -0m02.75s | -8.76%
0m21.76s  | ExtractionHaskell/saturated_solinas          | 0m24.56s  || -0m02.79s | -11.40%
0m09.87s  | ExtractionOCaml/unsaturated_solinas          | 0m11.28s  || -0m01.41s | -12.50%
1m59.22s  | RewriterWf2.vo                               | 2m00.09s  || -0m00.87s | -0.72%
1m07.03s  | Fancy/Montgomery256.vo                       | 1m07.31s  || -0m00.28s | -0.41%
0m52.60s  | Fancy/Barrett256.vo                          | 0m53.16s  || -0m00.55s | -1.05%
0m48.17s  | RewriterInterpProofs1.vo                     | 0m48.72s  || -0m00.54s | -1.12%
0m40.16s  | AbstractInterpretationWf.vo                  | 0m40.23s  || -0m00.07s | -0.17%
0m38.35s  | p521_32.c                                    | 0m38.26s  || +0m00.09s | +0.23%
0m31.56s  | p521_64.c                                    | 0m31.53s  || +0m00.02s | +0.09%
0m24.64s  | RewriterWf1.vo                               | 0m24.01s  || +0m00.62s | +2.62%
0m23.54s  | AbstractInterpretationZRangeProofs.vo        | 0m23.64s  || -0m00.10s | -0.42%
0m23.48s  | PushButtonSynthesis/WordByWordMontgomery.vo  | 0m23.26s  || +0m00.21s | +0.94%
0m20.92s  | SlowPrimeSynthesisExamples.vo                | 0m20.62s  || +0m00.30s | +1.45%
0m19.92s  | PushButtonSynthesis/UnsaturatedSolinas.vo    | 0m19.80s  || +0m00.12s | +0.60%
0m16.60s  | ExtractionOCaml/word_by_word_montgomery      | 0m17.56s  || -0m00.95s | -5.46%
0m14.72s  | p448_solinas_64.c                            | 0m14.66s  || +0m00.06s | +0.40%
0m13.70s  | secp256k1_32.c                               | 0m13.45s  || +0m00.25s | +1.85%
0m13.68s  | p256_32.c                                    | 0m13.33s  || +0m00.34s | +2.62%
0m13.28s  | CStringification.vo                          | 0m13.26s  || +0m00.01s | +0.15%
0m11.88s  | p484_64.c                                    | 0m11.74s  || +0m00.14s | +1.19%
0m09.96s  | ExtractionOCaml/word_by_word_montgomery.ml   | 0m10.24s  || -0m00.27s | -2.73%
0m07.47s  | ExtractionOCaml/saturated_solinas            | 0m07.93s  || -0m00.46s | -5.80%
0m06.78s  | BoundsPipeline.vo                            | 0m05.96s  || +0m00.82s | +13.75%
0m06.72s  | ExtractionOCaml/unsaturated_solinas.ml       | 0m07.03s  || -0m00.31s | -4.40%
0m06.38s  | p224_32.c                                    | 0m06.54s  || -0m00.16s | -2.44%
0m06.21s  | ExtractionHaskell/word_by_word_montgomery.hs | 0m06.34s  || -0m00.12s | -2.05%
0m05.45s  | p384_64.c                                    | 0m05.18s  || +0m00.27s | +5.21%
0m04.82s  | ExtractionHaskell/unsaturated_solinas.hs     | 0m04.84s  || -0m00.01s | -0.41%
0m04.80s  | ExtractionOCaml/saturated_solinas.ml         | 0m05.07s  || -0m00.27s | -5.32%
0m03.83s  | ExtractionHaskell/saturated_solinas.hs       | 0m04.07s  || -0m00.24s | -5.89%
0m03.30s  | PushButtonSynthesis/Primitives.vo            | 0m03.31s  || -0m00.01s | -0.30%
0m03.26s  | PushButtonSynthesis/SmallExamples.vo         | 0m03.24s  || +0m00.01s | +0.61%
0m03.08s  | PushButtonSynthesis/SaturatedSolinas.vo      | 0m02.96s  || +0m00.12s | +4.05%
0m02.16s  | curve25519_32.c                              | 0m02.16s  || +0m00.00s | +0.00%
0m01.57s  | curve25519_64.c                              | 0m01.47s  || +0m00.10s | +6.80%
0m01.40s  | CLI.vo                                       | 0m01.32s  || +0m00.07s | +6.06%
0m01.27s  | PushButtonSynthesis/MontgomeryReduction.vo   | 0m01.19s  || +0m00.08s | +6.72%
0m01.26s  | StandaloneHaskellMain.vo                     | 0m01.18s  || +0m00.08s | +6.77%
0m01.22s  | PushButtonSynthesis/BarrettReduction.vo      | 0m01.29s  || -0m00.07s | -5.42%
0m01.13s  | RewriterProofs.vo                            | 0m01.10s  || +0m00.02s | +2.72%
0m01.10s  | secp256k1_64.c                               | 0m01.01s  || +0m00.09s | +8.91%
0m01.08s  | StandaloneOCamlMain.vo                       | 0m01.13s  || -0m00.04s | -4.42%
0m01.06s  | p256_64.c                                    | 0m01.02s  || +0m00.04s | +3.92%
0m01.05s  | AbstractInterpretation.vo                    | 0m01.00s  || +0m00.05s | +5.00%
0m01.00s  | CompilersTestCases.vo                        | 0m01.08s  || -0m00.08s | -7.40%
0m01.00s  | p224_64.c                                    | 0m01.00s  || +0m00.00s | +0.00%
```

