### PR TITLE
 Add support for reifying `zrange` and `option`

### DIFF
--- a/src/AbstractInterpretationWf.v
+++ b/src/AbstractInterpretationWf.v
@@ -305,6 +305,7 @@ Module Compilers.
                 (bottom' : forall A, abstract_domain' A)
                 (abstract_interp_ident : forall t, ident t -> type.interp abstract_domain' t)
                 (extract_list_state : forall A, abstract_domain' (base.type.list A) -> option (list (abstract_domain' A)))
+                (extract_option_state : forall A, abstract_domain' (base.type.option A) -> option (option (abstract_domain' A)))
                 (is_annotated_for : forall t t', ident t -> abstract_domain' t' -> bool).
         Context (abstract_domain'_R : forall t, abstract_domain' t -> abstract_domain' t -> Prop).
         Local Notation abstract_domain_R := (@abstract_domain_R base.type abstract_domain' abstract_domain'_R).
@@ -313,7 +314,8 @@ Module Compilers.
                 {bottom'_Proper : forall t, Proper (abstract_domain'_R t) (bottom' t)}
                 {is_annotated_for_Proper : forall t t', Proper (eq ==> abstract_domain'_R _ ==> eq) (@is_annotated_for t t')}
                 (extract_list_state_length : forall t v1 v2, abstract_domain'_R _ v1 v2 -> option_map (@length _) (extract_list_state t v1) = option_map (@length _) (extract_list_state t v2))
-                (extract_list_state_rel : forall t v1 v2, abstract_domain'_R _ v1 v2 -> forall l1 l2, extract_list_state t v1 = Some l1 -> extract_list_state t v2 = Some l2 -> forall vv1 vv2, List.In (vv1, vv2) (List.combine l1 l2) -> @abstract_domain'_R t vv1 vv2).
+                (extract_list_state_rel : forall t v1 v2, abstract_domain'_R _ v1 v2 -> forall l1 l2, extract_list_state t v1 = Some l1 -> extract_list_state t v2 = Some l2 -> forall vv1 vv2, List.In (vv1, vv2) (List.combine l1 l2) -> @abstract_domain'_R t vv1 vv2)
+                (extract_option_state_rel : forall t v1 v2, abstract_domain'_R _ v1 v2 -> option_eq (option_eq (abstract_domain'_R _)) (extract_option_state t v1) (extract_option_state t v2)).
 
         Local Instance abstract_interp_ident_Proper_arrow s d
           : Proper (eq ==> abstract_domain'_R s ==> abstract_domain'_R d) (abstract_interp_ident (type.arrow s d))
@@ -324,14 +326,14 @@ Module Compilers.
 
           Local Notation update_annotation1 := (@ident.update_annotation var1 abstract_domain' annotate_ident is_annotated_for).
           Local Notation update_annotation2 := (@ident.update_annotation var2 abstract_domain' annotate_ident is_annotated_for).
-          Local Notation annotate1 := (@ident.annotate var1 abstract_domain' annotate_ident abstract_interp_ident extract_list_state is_annotated_for).
-          Local Notation annotate2 := (@ident.annotate var2 abstract_domain' annotate_ident abstract_interp_ident extract_list_state is_annotated_for).
+          Local Notation annotate1 := (@ident.annotate var1 abstract_domain' annotate_ident abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
+          Local Notation annotate2 := (@ident.annotate var2 abstract_domain' annotate_ident abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
           Local Notation annotate_base1 := (@ident.annotate_base var1 abstract_domain' annotate_ident is_annotated_for).
           Local Notation annotate_base2 := (@ident.annotate_base var2 abstract_domain' annotate_ident is_annotated_for).
           Local Notation annotate_with_ident1 := (@ident.annotate_with_ident var1 abstract_domain' annotate_ident is_annotated_for).
           Local Notation annotate_with_ident2 := (@ident.annotate_with_ident var2 abstract_domain' annotate_ident is_annotated_for).
-          Local Notation interp_ident1 := (@ident.interp_ident var1 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state is_annotated_for).
-          Local Notation interp_ident2 := (@ident.interp_ident var2 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state is_annotated_for).
+          Local Notation interp_ident1 := (@ident.interp_ident var1 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
+          Local Notation interp_ident2 := (@ident.interp_ident var2 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
           Local Notation reflect1 := (@reflect base.type ident var1 abstract_domain' annotate1 bottom').
           Local Notation reflect2 := (@reflect base.type ident var2 abstract_domain' annotate2 bottom').
 
@@ -408,7 +410,7 @@ Module Compilers.
                 v1 v2 (Hv : abstract_domain'_R t v1 v2)
                 e1 e2 (He : expr.wf G e1 e2)
             : UnderLets.wf (fun G' => expr.wf G') G (@annotate1 is_let_bound t v1 e1) (@annotate2 is_let_bound t v2 e2).
-          Proof using abstract_interp_ident_Proper annotate_ident_Proper extract_list_state_length extract_list_state_rel is_annotated_for_Proper.
+          Proof using abstract_interp_ident_Proper annotate_ident_Proper extract_list_state_length extract_list_state_rel extract_option_state_rel is_annotated_for_Proper.
             revert dependent G; induction t; intros;
               cbn [ident.annotate]; try apply wf_annotate_base; trivial.
             all: repeat first [ lazymatch goal with
@@ -430,6 +432,13 @@ Module Compilers.
                                      pose proof (extract_list_state_length _ v1 v2 Hv) as Hl;
                                      pose proof (extract_list_state_rel _ v1 v2 Hv) as Hl';
                                      rewrite H, H' in Hl, Hl'; cbv [option_eq option_map] in Hl, Hl'; clear H H'
+                                | [ H : abstract_domain'_R _ ?v1 ?v2, H1 : extract_option_state _ ?v1 = _, H2 : extract_option_state _ ?v2 = _ |- _ ]
+                                  => let H' := fresh in
+                                     pose proof H as H';
+                                     apply extract_option_state_rel in H';
+                                     rewrite H1, H2 in H';
+                                     cbv [option_eq] in H';
+                                     clear H1 H2
                                 | [ H : ?x = ?x |- _ ] => clear H
                                 | [ H : length ?l1 = length ?l2, H' : context[length ?l1] |- _ ] => rewrite H in H'
                                 end
@@ -476,6 +485,9 @@ Module Compilers.
                               | progress rewrite_type_transport_correct
                               | apply conj
                               | congruence
+                              | progress destruct_head' option
+                              | progress cbn [Option.combine option_map UnderLets.splice_option reify_option option_rect] in *
+                              | progress cbn [type.decode f_equal eq_rect fst snd] in *
                               | solve [ wf_t ] ].
           Qed.
 
@@ -492,7 +504,7 @@ Module Compilers.
             end.
           Lemma wf_interp_ident_nth_default (annotate_with_state : bool) G T
             : wf_value_with_lets G (@interp_ident1 annotate_with_state _ (@ident.List_nth_default T)) (@interp_ident2 annotate_with_state _ (@ident.List_nth_default T)).
-          Proof using abstract_interp_ident_Proper annotate_ident_Proper extract_list_state_length extract_list_state_rel is_annotated_for_Proper.
+          Proof using abstract_interp_ident_Proper annotate_ident_Proper extract_list_state_length extract_list_state_rel extract_option_state_rel is_annotated_for_Proper.
             cbv [wf_value_with_lets wf_value ident.interp_ident]; constructor; cbn -[abstract_domain_R abstract_domain].
             { intros; subst.
               destruct_head'_prod; destruct_head'_and; cbn [fst snd] in *.
@@ -600,7 +612,7 @@ Module Compilers.
 
           Lemma wf_interp_ident_not_nth_default (annotate_with_state : bool) G {t} (idc : ident t)
             : wf_value_with_lets G (Base (reflect1 annotate_with_state (###idc)%expr (abstract_interp_ident _ idc))) (Base (reflect2 annotate_with_state (###idc)%expr (abstract_interp_ident _ idc))).
-          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel is_annotated_for_Proper.
+          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel extract_option_state_rel is_annotated_for_Proper.
             constructor; eapply wf_reflect;
               solve [ apply bottom'_Proper
                     | apply wf_annotate
@@ -610,41 +622,41 @@ Module Compilers.
 
           Lemma wf_interp_ident (annotate_with_state : bool) G {t} idc1 idc2 (Hidc : idc1 = idc2)
             : wf_value_with_lets G (@interp_ident1 annotate_with_state t idc1) (@interp_ident2 annotate_with_state t idc2).
-          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel is_annotated_for_Proper.
+          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel extract_option_state_rel is_annotated_for_Proper.
             cbv [wf_value_with_lets ident.interp_ident]; subst idc2; destruct idc1;
               first [ apply wf_interp_ident_nth_default
                     | apply wf_interp_ident_not_nth_default ].
           Qed.
 
-          Local Notation eval_with_bound1 := (@partial.ident.eval_with_bound var1 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state is_annotated_for).
-          Local Notation eval_with_bound2 := (@partial.ident.eval_with_bound var2 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state is_annotated_for).
+          Local Notation eval_with_bound1 := (@partial.ident.eval_with_bound var1 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
+          Local Notation eval_with_bound2 := (@partial.ident.eval_with_bound var2 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
           Lemma wf_eval_with_bound (annotate_with_state : bool) {t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
                 (HGG' : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> wf_value_with_lets G' v1 v2)
             : expr.wf G' (@eval_with_bound1 annotate_with_state t e1 st1) (@eval_with_bound2 annotate_with_state t e2 st2).
-          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel is_annotated_for_Proper.
+          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel extract_option_state_rel is_annotated_for_Proper.
             eapply wf_eval_with_bound';
               solve [ eassumption
                     | eapply wf_annotate
                     | eapply wf_interp_ident ].
           Qed.
 
-          Local Notation eval1 := (@partial.ident.eval var1 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state is_annotated_for).
-          Local Notation eval2 := (@partial.ident.eval var2 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state is_annotated_for).
+          Local Notation eval1 := (@partial.ident.eval var1 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
+          Local Notation eval2 := (@partial.ident.eval var2 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
           Lemma wf_eval {t} G G' e1 e2 (Hwf : expr.wf G e1 e2)
                 (HGG' : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> wf_value_with_lets G' v1 v2)
             : expr.wf G' (@eval1 t e1) (@eval2 t e2).
-          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel is_annotated_for_Proper.
+          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel extract_option_state_rel is_annotated_for_Proper.
             eapply wf_eval';
               solve [ eassumption
                     | eapply wf_annotate
                     | eapply wf_interp_ident ].
           Qed.
 
-          Local Notation eta_expand_with_bound1 := (@partial.ident.eta_expand_with_bound var1 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state is_annotated_for).
-          Local Notation eta_expand_with_bound2 := (@partial.ident.eta_expand_with_bound var2 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state is_annotated_for).
+          Local Notation eta_expand_with_bound1 := (@partial.ident.eta_expand_with_bound var1 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
+          Local Notation eta_expand_with_bound2 := (@partial.ident.eta_expand_with_bound var2 abstract_domain' annotate_ident bottom' abstract_interp_ident extract_list_state extract_option_state is_annotated_for).
           Lemma wf_eta_expand_with_bound {t} G e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
             : expr.wf G (@eta_expand_with_bound1 t e1 st1) (@eta_expand_with_bound2 t e2 st2).
-          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel is_annotated_for_Proper.
+          Proof using abstract_interp_ident_Proper annotate_ident_Proper bottom'_Proper extract_list_state_length extract_list_state_rel extract_option_state_rel is_annotated_for_Proper.
             eapply wf_eta_expand_with_bound';
               solve [ eassumption
                     | eapply wf_annotate
@@ -682,6 +694,8 @@ Module Compilers.
                        | progress destruct_head'_prod
                        | progress destruct_head'_bool
                        | progress destruct_head' option
+                       | progress inversion_option
+                       | discriminate
                        | solve [ eauto ]
                        | apply NatUtil.nat_rect_Proper_nondep
                        | apply ListUtil.list_rect_Proper
@@ -691,8 +705,15 @@ Module Compilers.
                        | apply ListUtil.update_nth_Proper
                        | apply (@nat_rect_Proper_nondep_gen (_ -> _) (eq ==> eq)%signature)
                        | cbn; apply (f_equal (@Some _))
+                       | progress cbn [ZRange.ident.option.interp]
+                       | progress cbv [zrange_rect]
+                       | apply (f_equal2 pair)
+                       | break_innermost_match_step
                        | match goal with
                          | [ H : _ |- _ ] => erewrite H by (eauto; (eassumption || reflexivity))
+                         | [ H : forall x y, x = y -> _ |- _ ] => specialize (fun x => H x x eq_refl)
+                         | [ H : forall x, ?f x = ?g x, H1 : ?f ?y = _, H2 : ?g ?y = _ |- _ ]
+                           => specialize (H y); rewrite H1, H2 in H
                          end ].
       Qed.
 
@@ -719,6 +740,12 @@ Module Compilers.
         destruct_head'_ex; destruct_head'_and; inversion_prod; subst; reflexivity.
       Qed.
 
+      Lemma extract_option_state_rel
+        : forall t v1 v2, abstract_domain'_R _ v1 v2 -> option_eq (option_eq (abstract_domain'_R _)) (extract_option_state t v1) (extract_option_state t v2).
+      Proof.
+        cbv [extract_option_state option_eq]; intros; subst; break_match; reflexivity.
+      Qed.
+
       Section with_var2.
         Context {var1 var2 : type -> Type}.
         Local Notation wf_value_with_lets := (@wf_value_with_lets base.type ident abstract_domain' (fun t => abstract_domain'_R t) var1 var2).
@@ -731,7 +758,8 @@ Module Compilers.
             solve [ eassumption
                   | exact _
                   | apply extract_list_state_length
-                  | apply extract_list_state_rel ].
+                  | apply extract_list_state_rel
+                  | apply extract_option_state_rel ].
         Qed.
 
         Lemma wf_eval_with_bound {relax_zrange t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
@@ -742,7 +770,8 @@ Module Compilers.
             solve [ eassumption
                   | exact _
                   | apply extract_list_state_length
-                  | apply extract_list_state_rel ].
+                  | apply extract_list_state_rel
+                  | apply extract_option_state_rel ].
         Qed.
 
 
@@ -753,7 +782,8 @@ Module Compilers.
             solve [ eassumption
                   | exact _
                   | apply extract_list_state_length
-                  | apply extract_list_state_rel ].
+                  | apply extract_list_state_rel
+                  | apply extract_option_state_rel ].
         Qed.
       End with_var2.
 

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -141,6 +141,7 @@ Module Pipeline.
            => fun 'tt 'tt => (false, nil, nil)
          | base.type.nat
          | base.type.bool
+         | base.type.zrange
            => fun _ _ => (false, nil, nil)
          | base.type.Z
            => fun a b
@@ -152,6 +153,19 @@ Module Pipeline.
                    => if is_tighter_than_bool a b
                       then (false, nil, nil)
                       else (false, nil, ((a, b)::nil))
+                 end
+         | base.type.option A
+           => fun a b
+              => match a, b with
+                 | None, None => (false, nil, nil)
+                 | Some _, None => (false, nil, nil)
+                 | None, Some _ => (true, nil, nil)
+                 | Some None, Some None
+                 | Some (Some _), Some None
+                 | Some None, Some (Some _)
+                   => (false, nil, nil)
+                 | Some (Some a), Some (Some b)
+                   => @find_too_loose_base_bounds A a b
                  end
          | base.type.prod A B
            => fun '(ra, rb) '(ra', rb')

--- a/src/CompilersTestCases.v
+++ b/src/CompilersTestCases.v
@@ -61,7 +61,7 @@ Module testrewrite.
                                       (RewriteRules.RewriteNBE (fun var =>
                 (\z , ((\ x , expr_let y := ##5 in $y + ($z + (#ident.fst @ $x + #ident.snd @ $x)))
                          @ (##1, ##7)))%expr) _)
-                (Some r[0~>100]%zrange, tt).
+                (Datatypes.Some r[0~>100]%zrange, tt).
 End testrewrite.
 Module testpartial.
   Import expr.
@@ -85,7 +85,7 @@ Module testpartial.
                 partial.default_relax_zrange
                 (\z , ((\ x , expr_let y := ##5 in $y + ($z + (#ident.fst @ $x + #ident.snd @ $x)))
                          @ (##1, ##7)))%expr
-                (Some r[0~>100]%zrange, tt).
+                (Datatypes.Some r[0~>100]%zrange, tt).
 End testpartial.
 
 Module test2.

--- a/src/GENERATEDIdentifiersWithoutTypesProofs.v
+++ b/src/GENERATEDIdentifiersWithoutTypesProofs.v
@@ -21,6 +21,7 @@ Module Compilers.
 
   Module pattern.
     Import GENERATEDIdentifiersWithoutTypes.Compilers.pattern.
+    Import Datatypes. (* for Some, None, option *)
 
     Local Lemma quick_invert_eq_option {A} (P : Type) (x y : option A) (H : x = y)
       : match x, y return Type with
@@ -81,6 +82,7 @@ Module Compilers.
     Module Raw.
       Module ident.
         Import GENERATEDIdentifiersWithoutTypes.Compilers.pattern.Raw.ident.
+        Import Datatypes. (* for Some, None, option *)
 
         Global Instance eq_ident_Decidable : DecidableRel (@eq ident) := ident_eq_dec.
 
@@ -144,6 +146,7 @@ Module Compilers.
 
     Module ident.
       Import GENERATEDIdentifiersWithoutTypes.Compilers.pattern.ident.
+      Import Datatypes. (* for Some, None, option *)
 
       Lemma eta_ident_cps_correct T t idc f
         : @eta_ident_cps T t idc f = f t idc.
@@ -201,35 +204,6 @@ Module Compilers.
                             end
                           | progress Compilers.type.inversion_type ].
       Qed.
-
-      (*
-      Local Ltac solve_ex_or_eq :=
-        lazymatch goal with
-        | [ |- ex _ ] => eexists; solve_ex_or_eq
-        | [ |- _ /\ _ ] => split; solve_ex_or_eq
-        | [ |- _ \/ _ ] => (left + right); solve_ex_or_eq
-        | [ |- _ = _ ] => reflexivity || eassumption
-        end.
-      Lemma type_vars_enough
-        : forall t idc k,
-          PositiveSet.mem k (pattern.type.collect_vars t) = true
-          -> exists v, List.In v (@pattern.ident.type_vars t idc) /\ PositiveSet.mem k (pattern.type.collect_vars v) = true.
-      Proof using Type.
-        destruct idc; cbn [type.collect_vars ident.type_vars List.In base.collect_vars PositiveSet.mem PositiveSet.empty PositiveSet.union] in *.
-        all: repeat first [ match goal with
-                            | [ H : true = false |- _ ] => exfalso; apply Bool.diff_true_false, H
-                            | [ H : false = true |- _ ] => exfalso; apply Bool.diff_false_true, H
-                            | [ H : context[PositiveSet.mem _ (PositiveSet.union _ _)] |- _ ]
-                              => rewrite PositiveSetFacts.union_b in H
-                            | [ H : context[orb _ _ = true] |- _ ]
-                              => rewrite Bool.orb_true_iff in H
-                            end
-                          | progress cbn [PositiveSet.mem PositiveSet.empty] in *
-                          | progress intros
-                          | progress destruct_head'_or
-                          | solve_ex_or_eq ].
-      Qed.
-       *)
     End ident.
   End pattern.
 End Compilers.

--- a/src/RewriterWf1.v
+++ b/src/RewriterWf1.v
@@ -71,6 +71,7 @@ Module Compilers.
                          | progress intros
                          | reflexivity
                          | apply (f_equal base.type.list)
+                         | apply (f_equal base.type.option)
                          | apply (f_equal2 base.type.prod)
                          | break_innermost_match_step
                          | break_innermost_match_hyps_step
@@ -126,6 +127,7 @@ Module Compilers.
                          | [ |- iff _ _ ] => split
                          | [ H : base.type.prod _ _ = base.type.prod _ _ |- _ ] => inversion H; clear H
                          | [ H : base.type.list _ = base.type.list _ |- _ ] => inversion H; clear H
+                         | [ H : base.type.option _ = base.type.option _ |- _ ] => inversion H; clear H
                          | [ H : Some _ = _ |- _ ] => symmetry in H
                          | [ H : None = _ |- _ ] => symmetry in H
                          | [ H : ?x = Some _ |- context[?x] ] => rewrite H

--- a/src/UnderLetsProofs.v
+++ b/src/UnderLetsProofs.v
@@ -652,8 +652,9 @@ Module Compilers.
           : wf P G (reify_and_let_binds_base_cps e1 T1 k1) (reify_and_let_binds_base_cps e2 T2 k2).
         Proof.
           revert dependent G; induction t; cbn [reify_and_let_binds_base_cps]; intros;
+            cbv [option_rect];
             try (cbv [SubstVarLike.is_var_fst_snd_pair_opp_cast] in *; erewrite !SubstVarLike.wfT_is_recursively_var_or_ident by eassumption);
-            break_innermost_match; wf_reify_and_let_binds_base_cps_t Hk.
+            break_innermost_match; wf_reify_and_let_binds_base_cps_t Hk; eauto.
           all: repeat match goal with H : list (sigT _) |- _ => revert dependent H end.
           all: revert dependent k1; revert dependent k2.
           all: lazymatch goal with
@@ -719,13 +720,14 @@ Module Compilers.
           : P (UnderLets.interp (@ident_interp) (@reify_and_let_binds_base_cps _ t e T k)).
         Proof.
           revert T k P Hk; induction t; cbn [reify_and_let_binds_base_cps]; intros;
-            break_innermost_match;
+            cbv [option_rect]; break_innermost_match;
             expr.invert_subst; cbn [type.related UnderLets.interp fst snd expr.interp ident_interp] in *; subst; eauto;
               repeat first [ progress intros
                            | reflexivity
                            | progress cbn [expr.interp ident_interp List.map]
                            | apply (f_equal2 (@pair _ _))
                            | apply (f_equal2 (@cons _))
+                           | apply (f_equal (@Some _))
                            | match goal with
                              | [ H : _ |- _ ] => apply H; clear H
                              | [ H : SubstVarLike.is_var_fst_snd_pair_opp_cast (reify_list _) = _ |- _ ] => clear H
@@ -823,6 +825,7 @@ Module Compilers.
           : interp (to_expr (reify_and_let_binds_base_cps e1 _ k1)) == k2 (interp e2).
         Proof.
           revert dependent G; revert dependent t'; induction t; cbn [reify_and_let_binds_base_cps]; intros;
+            cbv [option_rect];
             try (cbv [SubstVarLike.is_var_fst_snd_pair_opp_cast] in *; erewrite !SubstVarLike.wfT_is_recursively_var_or_ident by eassumption);
             break_innermost_match; interp_to_expr_reify_and_let_binds_base_cps_t Hk.
           all: repeat match goal with H : list (sigT _) |- _ => revert dependent H end.
@@ -950,7 +953,7 @@ Module Compilers.
         Proof using Type.
           cbv [expr.interp_related]; revert T T' k R v; induction t.
           all: repeat first [ progress cbn [expr.interp_related_gen interp_related reify_and_let_binds_base_cps fst snd] in *
-                            | progress cbv [expr.interp_related] in *
+                            | progress cbv [expr.interp_related option_rect] in *
                             | progress intros
                             | assumption
                             | progress destruct_head'_ex

--- a/src/arith_rewrite_head.out
+++ b/src/arith_rewrite_head.out
@@ -28,7 +28,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Datatypes.Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b3) ->
@@ -47,21 +47,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                _ <- base.try_make_transport_cps b2 b2;
                v3 <- base.try_make_transport_cps b3 A;
                v4 <- base.try_make_transport_cps A A;
-               Some (Base (v4 (v3 (v1 (v (Compile.reflect x1))))))
-              else None
-          | None => None
+               Datatypes.Some (Base (v4 (v3 (v1 (v (Compile.reflect x1))))))
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(fst)%expr @ x)%expr_pat)%option
 | @snd A B =>
     fun x : expr (A * B)%etype =>
@@ -80,7 +81,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Datatypes.Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b2) ->
@@ -99,21 +100,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v2 <- base.try_make_transport_cps b2 b2;
                v3 <- base.try_make_transport_cps b2 B;
                v4 <- base.try_make_transport_cps B B;
-               Some (Base (v4 (v3 (v2 (v0 (Compile.reflect x0))))))
-              else None
-          | None => None
+               Datatypes.Some (Base (v4 (v3 (v2 (v0 (Compile.reflect x0))))))
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(snd)%expr @ x)%expr_pat)%option
 | @prod_rect A B T =>
     fun (x : expr A -> expr B -> UnderLets (expr T))
@@ -225,22 +227,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
-                              then Some x0
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some x0
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
@@ -249,20 +251,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype
             with
-            | Some (_, _)%zrange =>
+            | Datatypes.Some (_, _)%zrange =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    (ℤ -> (projT1 args))%ptype
                 then
                  xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                  fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
-                               then Some x
-                               else None);
-                        Some (Base x1));
-                 Some (fv0 <-- fv;
-                       Base fv0)%under_lets
-                else None
-            | None => None
+                               then Datatypes.Some x
+                               else Datatypes.None);
+                        Datatypes.Some (Base x1));
+                 Datatypes.Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                else Datatypes.None
+            | Datatypes.None => Datatypes.None
             end);;
            match x with
            | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x1 =>
@@ -272,7 +274,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                     (s -> (projT1 args0))%ptype
                 with
-                | Some (_, _)%zrange =>
+                | Datatypes.Some (_, _)%zrange =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype (s -> (projT1 args0))%ptype
@@ -281,15 +283,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                      fv <- (x2 <- (if (let (x2, _) := xv in x2) >? 0
                                    then
-                                    Some
+                                    Datatypes.Some
                                       (##(let (x2, _) := xv in x2) -
                                        v (Compile.reflect x1))%expr
-                                   else None);
-                            Some (Base x2));
-                     Some (fv0 <-- fv;
-                           Base fv0)%under_lets
-                    else None
-                | None => None
+                                   else Datatypes.None);
+                            Datatypes.Some (Base x2));
+                     Datatypes.Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                    else Datatypes.None
+                | Datatypes.None => Datatypes.None
                 end);;
                _ <- invert_bind_args idc0 Raw.ident.Z_opp;
                args0 <- invert_bind_args idc Raw.ident.Literal;
@@ -297,7 +299,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                    (s -> (projT1 args0))%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args0))%ptype
@@ -306,21 +308,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                     fv <- (x2 <- (if (let (x2, _) := xv in x2) <? 0
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (-
                                       (v (Compile.reflect x1) +
                                        ##(- (let (x2, _) := xv in x2))%Z))%expr
-                                  else None);
-                           Some (Base x2));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x2));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
            | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
+             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+               Datatypes.None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
            match x with
@@ -331,7 +334,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                     ((projT1 args) -> s)%ptype
                 with
-                | Some (_, _)%zrange =>
+                | Datatypes.Some (_, _)%zrange =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype ((projT1 args) -> s)%ptype
@@ -340,15 +343,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      v <- type.try_make_transport_cps s ℤ;
                      fv <- (x2 <- (if (let (x2, _) := xv in x2) >? 0
                                    then
-                                    Some
+                                    Datatypes.Some
                                       (##(let (x2, _) := xv in x2) -
                                        v (Compile.reflect x1))%expr
-                                   else None);
-                            Some (Base x2));
-                     Some (fv0 <-- fv;
-                           Base fv0)%under_lets
-                    else None
-                | None => None
+                                   else Datatypes.None);
+                            Datatypes.Some (Base x2));
+                     Datatypes.Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                    else Datatypes.None
+                | Datatypes.None => Datatypes.None
                 end);;
                args <- invert_bind_args idc0 Raw.ident.Literal;
                _ <- invert_bind_args idc Raw.ident.Z_opp;
@@ -356,7 +359,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -365,16 +368,16 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     v <- type.try_make_transport_cps s ℤ;
                     fv <- (x2 <- (if (let (x2, _) := xv in x2) <? 0
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (-
                                       (##(- (let (x2, _) := xv in x2))%Z +
                                        v (Compile.reflect x1)))%expr
-                                  else None);
-                           Some (Base x2));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x2));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
            | @expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t0 idc0) x2 =>
                _ <- invert_bind_args idc0 Raw.ident.Z_opp;
@@ -382,30 +385,30 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                match
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype (s0 -> s)%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
                    then
                     v <- type.try_make_transport_cps s0 ℤ;
                     v0 <- type.try_make_transport_cps s ℤ;
-                    Some
+                    Datatypes.Some
                       (Base
                          (-
                           (v (Compile.reflect x2) + v0 (Compile.reflect x1)))%expr)
-                   else None
-               | None => None
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
            | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
              (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
-             (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
+             (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
@@ -413,20 +416,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
                then
                 v <- type.try_make_transport_cps s ℤ;
-                Some (Base (x0 - v (Compile.reflect x1))%expr)
-               else None
-           | None => None
+                Datatypes.Some (Base (x0 - v (Compile.reflect x1))%expr)
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
@@ -434,22 +437,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
                then
                 v <- type.try_make_transport_cps s ℤ;
-                Some (Base (x - v (Compile.reflect x1))%expr)
-               else None
-           | None => None
+                Datatypes.Some (Base (x - v (Compile.reflect x1))%expr)
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end);;
-      None);;;
+      Datatypes.None);;;
      Base (x + x0)%expr)%option
 | Z_mul =>
     fun x x0 : expr ℤ =>
@@ -463,43 +466,43 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                    ((projT1 args0) -> (projT1 args))%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args0) -> (projT1 args))%ptype
                    then
                     xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                     xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                    Some
+                    Datatypes.Some
                       (Base
                          (##((let (x1, _) := xv in x1) *
                              (let (x1, _) := xv0 in x1))%Z)%expr)
-                   else None
-               | None => None
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
-           | _ => None
+           | _ => Datatypes.None
            end;;
            args <- invert_bind_args idc Raw.ident.Literal;
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
-                              then Some (##0)%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some (##0)%expr
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
@@ -508,22 +511,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
-                              then Some (##0)%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some (##0)%expr
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
@@ -532,22 +535,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 1
-                              then Some x0
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some x0
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
@@ -556,20 +559,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype
             with
-            | Some (_, _)%zrange =>
+            | Datatypes.Some (_, _)%zrange =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    (ℤ -> (projT1 args))%ptype
                 then
                  xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                  fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 1
-                               then Some x
-                               else None);
-                        Some (Base x1));
-                 Some (fv0 <-- fv;
-                       Base fv0)%under_lets
-                else None
-            | None => None
+                               then Datatypes.Some x
+                               else Datatypes.None);
+                        Datatypes.Some (Base x1));
+                 Datatypes.Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                else Datatypes.None
+            | Datatypes.None => Datatypes.None
             end);;
            match x with
            | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t0 idc0) x1 =>
@@ -579,7 +582,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                    (s -> (projT1 args0))%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args0))%ptype
@@ -587,18 +590,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     v <- type.try_make_transport_cps s ℤ;
                     xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                     fv <- (x2 <- (if (let (x2, _) := xv in x2) =? -1
-                                  then Some (v (Compile.reflect x1))
-                                  else None);
-                           Some (Base x2));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  then
+                                   Datatypes.Some (v (Compile.reflect x1))
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x2));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
            | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
+             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+               Datatypes.None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
            match x with
@@ -609,7 +614,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -617,20 +622,21 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                     v <- type.try_make_transport_cps s ℤ;
                     fv <- (x2 <- (if (let (x2, _) := xv in x2) =? -1
-                                  then Some (v (Compile.reflect x1))
-                                  else None);
-                           Some (Base x2));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  then
+                                   Datatypes.Some (v (Compile.reflect x1))
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x2));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
-           | _ => None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
@@ -639,22 +645,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? -1
-                              then Some (- x0)%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some (- x0)%expr
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
@@ -663,22 +669,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? -1
-                              then Some (- x)%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some (- x)%expr
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
@@ -687,7 +693,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -695,16 +701,16 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) <? 0
                               then
-                               Some
+                               Datatypes.Some
                                  (- (##(- (let (x1, _) := xv in x1))%Z * x0))%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
@@ -713,7 +719,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -721,14 +727,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) <? 0
                               then
-                               Some
+                               Datatypes.Some
                                  (- (x * ##(- (let (x1, _) := xv in x1))%Z))%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
            match x with
@@ -738,29 +744,29 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                match
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype (s0 -> s)%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
                    then
                     v <- type.try_make_transport_cps s0 ℤ;
                     v0 <- type.try_make_transport_cps s ℤ;
-                    Some
+                    Datatypes.Some
                       (Base
                          (v (Compile.reflect x2) * v0 (Compile.reflect x1))%expr)
-                   else None
-               | None => None
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
            | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
              (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
-             (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
+             (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
@@ -768,20 +774,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
                then
                 v <- type.try_make_transport_cps s ℤ;
-                Some (Base (- (v (Compile.reflect x1) * x0))%expr)
-               else None
-           | None => None
+                Datatypes.Some (Base (- (v (Compile.reflect x1) * x0))%expr)
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
@@ -790,7 +796,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -801,34 +807,34 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 2 ^ Z.log2 (let (x1, _) := xv in x1)) &&
                                negb ((let (x1, _) := xv in x1) =? 2)
                               then
-                               Some
+                               Datatypes.Some
                                  (x << ##(Z.log2 (let (x1, _) := xv in x1)))%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
            _ <- invert_bind_args idc Raw.ident.Z_opp;
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
                then
                 v <- type.try_make_transport_cps s ℤ;
-                Some (Base (- (x * v (Compile.reflect x1)))%expr)
-               else None
-           | None => None
+                Datatypes.Some (Base (- (x * v (Compile.reflect x1)))%expr)
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
@@ -837,7 +843,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                 ((projT1 args) -> ℤ)%ptype
             with
-            | Some (_, _)%zrange =>
+            | Datatypes.Some (_, _)%zrange =>
                 if
                  type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                    ((projT1 args) -> ℤ)%ptype
@@ -848,14 +854,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                  2 ^ Z.log2 (let (x1, _) := xv in x1)) &&
                                 negb ((let (x1, _) := xv in x1) =? 2)
                                then
-                                Some
+                                Datatypes.Some
                                   (x0 << ##(Z.log2 (let (x1, _) := xv in x1)))%expr
-                               else None);
-                        Some (Base x1));
-                 Some (fv0 <-- fv;
-                       Base fv0)%under_lets
-                else None
-            | None => None
+                               else Datatypes.None);
+                        Datatypes.Some (Base x1));
+                 Datatypes.Some (fv0 <-- fv;
+                                 Base fv0)%under_lets
+                else Datatypes.None
+            | Datatypes.None => Datatypes.None
             end);;
            match x0 with
            | @expr.App _ _ _ s _
@@ -875,7 +881,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (ℤ -> ℤ -> ℤ -> ℤ)%ptype
                            ((projT1 args2) -> (projT1 args0) -> s2 -> s1)%ptype
                        with
-                       | Some (_, (_, (_, _)))%zrange =>
+                       | Datatypes.Some (_, (_, (_, _)))%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               (ℤ -> ℤ -> ℤ -> ℤ)%ptype
@@ -893,17 +899,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                            (Z.abs (let (x5, _) := xv0 in x5) <=?
                                             Z.abs max_const_val)
                                           then
-                                           Some
+                                           Datatypes.Some
                                              (v (Compile.reflect x4) *
                                               (v0 (Compile.reflect x3) *
                                                (##(let (x5, _) := xv in x5) *
                                                 ##(let (x5, _) := xv0 in x5))))%expr
-                                          else None);
-                                   Some (Base x5));
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
+                                          else Datatypes.None);
+                                   Datatypes.Some (Base x5));
+                            Datatypes.Some (fv0 <-- fv;
+                                            Base fv0)%under_lets
+                           else Datatypes.None
+                       | Datatypes.None => Datatypes.None
                        end
                    | @expr.App _ _ _ s1 _ (@expr.App _ _ _ s2 _ ($_)%expr _)
                      _ | @expr.App _ _ _ s1 _
@@ -912,14 +918,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      (@expr.App _ _ _ s2 _ (_ @ _)%expr_pat _) _ | @expr.App
                      _ _ _ s1 _
                      (@expr.App _ _ _ s2 _ (@expr.LetIn _ _ _ _ _ _ _) _)
-                     _ => None
+                     _ => Datatypes.None
                    | @expr.App _ _ _ s1 _ #(_)%expr_pat _ | @expr.App _ _ _
                      s1 _ ($_)%expr _ | @expr.App _ _ _ s1 _
                      (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s1 _
-                     (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                   | _ => None
+                     (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                   | _ => Datatypes.None
                    end
-               | _ => None
+               | _ => Datatypes.None
                end;;
                match x1 with
                | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
@@ -932,7 +938,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      pattern.type.unify_extracted (ℤ -> ℤ -> ℤ -> ℤ)%ptype
                        ((projT1 args2) -> s0 -> s2 -> (projT1 args))%ptype
                    with
-                   | Some (_, (_, (_, _)))%zrange =>
+                   | Datatypes.Some (_, (_, (_, _)))%zrange =>
                        if
                         type.type_beq base.type base.type.type_beq
                           (ℤ -> ℤ -> ℤ -> ℤ)%ptype
@@ -950,17 +956,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                        (Z.abs (let (x5, _) := xv0 in x5) <=?
                                         Z.abs max_const_val)
                                       then
-                                       Some
+                                       Datatypes.Some
                                          (v (Compile.reflect x2) *
                                           (v0 (Compile.reflect x4) *
                                            (##(let (x5, _) := xv in x5) *
                                             ##(let (x5, _) := xv0 in x5))))%expr
-                                      else None);
-                               Some (Base x5));
-                        Some (fv0 <-- fv;
-                              Base fv0)%under_lets
-                       else None
-                   | None => None
+                                      else Datatypes.None);
+                               Datatypes.Some (Base x5));
+                        Datatypes.Some (fv0 <-- fv;
+                                        Base fv0)%under_lets
+                       else Datatypes.None
+                   | Datatypes.None => Datatypes.None
                    end
                | (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
                   ($_)%expr)%expr_pat |
@@ -969,13 +975,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
                   (_ @ _))%expr_pat |
                  (@expr.App _ _ _ s2 _ (@expr.Ident _ _ _ t1 idc1) x4 @
-                  @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+                  @expr.LetIn _ _ _ _ _ _ _)%expr_pat => Datatypes.None
                | (@expr.App _ _ _ s2 _ ($_)%expr _ @ _)%expr_pat |
                  (@expr.App _ _ _ s2 _ (@expr.Abs _ _ _ _ _ _) _ @ _)%expr_pat |
                  (@expr.App _ _ _ s2 _ (_ @ _) _ @ _)%expr_pat |
                  (@expr.App _ _ _ s2 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-                   None
-               | _ => None
+                   Datatypes.None
+               | _ => Datatypes.None
                end;;
                _ <- invert_bind_args idc0 Raw.ident.Z_mul;
                args0 <- invert_bind_args idc Raw.ident.Literal;
@@ -983,7 +989,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
                    ((projT1 args0) -> s0 -> s)%ptype
                with
-               | Some (_, (_, _))%zrange =>
+               | Datatypes.Some (_, (_, _))%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq
                       (ℤ -> ℤ -> ℤ)%ptype ((projT1 args0) -> s0 -> s)%ptype
@@ -995,34 +1001,35 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                    Z.abs (let (x3, _) := xv in x3) <=?
                                    Z.abs max_const_val
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (v (Compile.reflect x2) *
                                       (v0 (Compile.reflect x1) *
                                        ##(let (x3, _) := xv in x3)))%expr
-                                  else None);
-                           Some (Base x3));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x3));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
            | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ |
              @expr.App _ _ _ s _
              (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ | @expr.App _
              _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ | @expr.App
              _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _)
-             _ => None
+             _ => Datatypes.None
            | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _
              ($_)%expr _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ |
-             @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
+             @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+               Datatypes.None
+           | _ => Datatypes.None
            end;;
            args <- invert_bind_args idc Raw.ident.Literal;
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1032,17 +1039,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                Z.abs (let (x1, _) := xv in x1) <=?
                                Z.abs max_const_val
                               then
-                               Some (x0 * ##(let (x1, _) := xv in x1))%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                               Datatypes.Some
+                                 (x0 * ##(let (x1, _) := xv in x1))%expr
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end);;
-      None);;;
+      Datatypes.None);;;
      Base (x * x0)%expr)%option
 | Z_pow => fun x x0 : expr ℤ => Base (#(Z_pow)%expr @ x @ x0)%expr_pat
 | Z_sub =>
@@ -1057,7 +1065,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                    ((projT1 args0) -> s)%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args0) -> s)%ptype
@@ -1065,40 +1073,42 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                     v <- type.try_make_transport_cps s ℤ;
                     fv <- (x2 <- (if (let (x2, _) := xv in x2) =? 0
-                                  then Some (v (Compile.reflect x1))
-                                  else None);
-                           Some (Base x2));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  then
+                                   Datatypes.Some (v (Compile.reflect x1))
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x2));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
            | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat
-             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
+             _ | @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+               Datatypes.None
+           | _ => Datatypes.None
            end;;
            args <- invert_bind_args idc Raw.ident.Literal;
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
-                              then Some (- x0)%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some (- x0)%expr
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
@@ -1107,20 +1117,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
-                              then Some x
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some x
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
            match x with
@@ -1131,7 +1141,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                     ((projT1 args) -> s)%ptype
                 with
-                | Some (_, _)%zrange =>
+                | Datatypes.Some (_, _)%zrange =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype ((projT1 args) -> s)%ptype
@@ -1140,15 +1150,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      v <- type.try_make_transport_cps s ℤ;
                      fv <- (x2 <- (if (let (x2, _) := xv in x2) >? 0
                                    then
-                                    Some
+                                    Datatypes.Some
                                       (##(let (x2, _) := xv in x2) +
                                        v (Compile.reflect x1))%expr
-                                   else None);
-                            Some (Base x2));
-                     Some (fv0 <-- fv;
-                           Base fv0)%under_lets
-                    else None
-                | None => None
+                                   else Datatypes.None);
+                            Datatypes.Some (Base x2));
+                     Datatypes.Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                    else Datatypes.None
+                | Datatypes.None => Datatypes.None
                 end);;
                args <- invert_bind_args idc0 Raw.ident.Literal;
                _ <- invert_bind_args idc Raw.ident.Z_opp;
@@ -1156,7 +1166,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                    ((projT1 args) -> s)%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       ((projT1 args) -> s)%ptype
@@ -1165,22 +1175,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     v <- type.try_make_transport_cps s ℤ;
                     fv <- (x2 <- (if (let (x2, _) := xv in x2) <? 0
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (v (Compile.reflect x1) -
                                       ##(- (let (x2, _) := xv in x2))%Z)%expr
-                                  else None);
-                           Some (Base x2));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x2));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
-           | _ => None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
@@ -1189,7 +1199,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -1197,14 +1207,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) <? 0
                               then
-                               Some
+                               Datatypes.Some
                                  (- (##(- (let (x1, _) := xv in x1))%Z + x0))%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
            match x0 with
@@ -1215,7 +1225,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                     (s -> (projT1 args))%ptype
                 with
-                | Some (_, _)%zrange =>
+                | Datatypes.Some (_, _)%zrange =>
                     if
                      type.type_beq base.type base.type.type_beq
                        (ℤ -> ℤ)%ptype (s -> (projT1 args))%ptype
@@ -1224,16 +1234,16 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                      fv <- (x2 <- (if (let (x2, _) := xv in x2) >? 0
                                    then
-                                    Some
+                                    Datatypes.Some
                                       (-
                                        (v (Compile.reflect x1) +
                                         ##(let (x2, _) := xv in x2)))%expr
-                                   else None);
-                            Some (Base x2));
-                     Some (fv0 <-- fv;
-                           Base fv0)%under_lets
-                    else None
-                | None => None
+                                   else Datatypes.None);
+                            Datatypes.Some (Base x2));
+                     Datatypes.Some (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                    else Datatypes.None
+                | Datatypes.None => Datatypes.None
                 end);;
                args <- invert_bind_args idc0 Raw.ident.Literal;
                _ <- invert_bind_args idc Raw.ident.Z_opp;
@@ -1241,7 +1251,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                    (s -> (projT1 args))%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s -> (projT1 args))%ptype
@@ -1250,22 +1260,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                     fv <- (x2 <- (if (let (x2, _) := xv in x2) <? 0
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (##(- (let (x2, _) := xv in x2))%Z -
                                       v (Compile.reflect x1))%expr
-                                  else None);
-                           Some (Base x2));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x2));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
-           | _ => None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.Ident _ _ _ t idc =>
@@ -1274,7 +1284,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -1282,14 +1292,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) <? 0
                               then
-                               Some
+                               Datatypes.Some
                                  (x + ##(- (let (x1, _) := xv in x1))%Z)%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
            match x with
@@ -1299,29 +1309,29 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                match
                  pattern.type.unify_extracted (ℤ -> ℤ)%ptype (s0 -> s)%ptype
                with
-               | Some (_, _)%zrange =>
+               | Datatypes.Some (_, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                       (s0 -> s)%ptype
                    then
                     v <- type.try_make_transport_cps s0 ℤ;
                     v0 <- type.try_make_transport_cps s ℤ;
-                    Some
+                    Datatypes.Some
                       (Base
                          (v0 (Compile.reflect x1) - v (Compile.reflect x2))%expr)
-                   else None
-               | None => None
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
            | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
              (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _
              (_ @ _)%expr_pat _ | @expr.App _ _ _ s0 _
-             (@expr.LetIn _ _ _ _ _ _ _) _ => None
-           | _ => None
+             (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
@@ -1329,20 +1339,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype (s -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (s -> ℤ)%ptype
                then
                 v <- type.try_make_transport_cps s ℤ;
-                Some (Base (- (v (Compile.reflect x1) + x0))%expr)
-               else None
-           | None => None
+                Datatypes.Some (Base (- (v (Compile.reflect x1) + x0))%expr)
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x1 =>
@@ -1350,22 +1360,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            match
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype (ℤ -> s)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> s)%ptype
                then
                 v <- type.try_make_transport_cps s ℤ;
-                Some (Base (x + v (Compile.reflect x1))%expr)
-               else None
-           | None => None
+                Datatypes.Some (Base (x + v (Compile.reflect x1))%expr)
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end);;
-      None);;;
+      Datatypes.None);;;
      Base (x - x0)%expr)%option
 | Z_opp =>
     fun x : expr ℤ =>
@@ -1373,32 +1383,34 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x0 =>
            _ <- invert_bind_args idc Raw.ident.Z_opp;
            match pattern.type.unify_extracted ℤ s with
-           | Some _ =>
+           | Datatypes.Some _ =>
                if type.type_beq base.type base.type.type_beq ℤ s
                then
                 v <- type.try_make_transport_cps s ℤ;
-                Some (Base (v (Compile.reflect x0)))
-               else None
-           | None => None
+                Datatypes.Some (Base (v (Compile.reflect x0)))
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end;;
        match pattern.type.unify_extracted ℤ ℤ with
-       | Some _ =>
+       | Datatypes.Some _ =>
            if type.type_beq base.type base.type.type_beq ℤ ℤ
            then
             fv <- (if negb (SubstVarLike.is_var_fst_snd_pair_opp_cast x)
-                   then Some (UnderLet x (fun v : var ℤ => Base (- $v)%expr))
-                   else None);
-            Some (fv0 <-- fv;
-                  Base fv0)%under_lets
-           else None
-       | None => None
+                   then
+                    Datatypes.Some
+                      (UnderLet x (fun v : var ℤ => Base (- $v)%expr))
+                   else Datatypes.None);
+            Datatypes.Some (fv0 <-- fv;
+                            Base fv0)%under_lets
+           else Datatypes.None
+       | Datatypes.None => Datatypes.None
        end);;
-      None);;;
+      Datatypes.None);;;
      Base (- x)%expr)%option
 | Z_div =>
     fun x x0 : expr ℤ =>
@@ -1409,27 +1421,27 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 1
-                              then Some x
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some x
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end);;
           args <- invert_bind_args idc Raw.ident.Literal;
           match
             pattern.type.unify_extracted (ℤ -> ℤ)%ptype
               (ℤ -> (projT1 args))%ptype
           with
-          | Some (_, _)%zrange =>
+          | Datatypes.Some (_, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                  (ℤ -> (projT1 args))%ptype
@@ -1439,18 +1451,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (let (x1, _) := xv in x1) =?
                               2 ^ Z.log2 (let (x1, _) := xv in x1)
                              then
-                              Some
+                              Datatypes.Some
                                 (x >> ##(Z.log2 (let (x1, _) := xv in x1)))%expr
-                             else None);
-                      Some (Base x1));
-               Some (fv0 <-- fv;
-                     Base fv0)%under_lets
-              else None
-          | None => None
+                             else Datatypes.None);
+                      Datatypes.Some (Base x1));
+               Datatypes.Some (fv0 <-- fv;
+                               Base fv0)%under_lets
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x / x0)%expr)%option
 | Z_modulo =>
     fun x x0 : expr ℤ =>
@@ -1461,27 +1473,27 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             pattern.type.unify_extracted (ℤ -> ℤ)%ptype
               (ℤ -> (projT1 args))%ptype
           with
-          | Some (_, _)%zrange =>
+          | Datatypes.Some (_, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                  (ℤ -> (projT1 args))%ptype
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 1
-                             then Some (##0)%expr
-                             else None);
-                      Some (Base x1));
-               Some (fv0 <-- fv;
-                     Base fv0)%under_lets
-              else None
-          | None => None
+                             then Datatypes.Some (##0)%expr
+                             else Datatypes.None);
+                      Datatypes.Some (Base x1));
+               Datatypes.Some (fv0 <-- fv;
+                               Base fv0)%under_lets
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end);;
          args <- invert_bind_args idc Raw.ident.Literal;
          match
            pattern.type.unify_extracted (ℤ -> ℤ)%ptype
              (ℤ -> (projT1 args))%ptype
          with
-         | Some (_, _)%zrange =>
+         | Datatypes.Some (_, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                 (ℤ -> (projT1 args))%ptype
@@ -1491,23 +1503,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (let (x1, _) := xv in x1) =?
                              2 ^ Z.log2 (let (x1, _) := xv in x1)
                             then
-                             Some
+                             Datatypes.Some
                                (x &' ##((let (x1, _) := xv in x1) - 1)%Z)%expr
-                            else None);
-                     Some (Base x1));
-              Some (fv0 <-- fv;
-                    Base fv0)%under_lets
-             else None
-         | None => None
+                            else Datatypes.None);
+                     Datatypes.Some (Base x1));
+              Datatypes.Some (fv0 <-- fv;
+                              Base fv0)%under_lets
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
-     | _ => None
+     | _ => Datatypes.None
      end;;;
      Base (x mod x0)%expr)%option
 | Z_log2 => fun x : expr ℤ => Base (#(Z_log2)%expr @ x)%expr_pat
 | Z_log2_up => fun x : expr ℤ => Base (#(Z_log2_up)%expr @ x)%expr_pat
 | Z_eqb => fun x x0 : expr ℤ => Base (#(Z_eqb)%expr @ x @ x0)%expr_pat
 | Z_leb => fun x x0 : expr ℤ => Base (#(Z_leb)%expr @ x @ x0)%expr_pat
+| Z_ltb => fun x x0 : expr ℤ => Base (#(Z_ltb)%expr @ x @ x0)%expr_pat
 | Z_geb => fun x x0 : expr ℤ => Base (#(Z_geb)%expr @ x @ x0)%expr_pat
+| Z_gtb => fun x x0 : expr ℤ => Base (#(Z_gtb)%expr @ x @ x0)%expr_pat
 | Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
 | Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
 | Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
@@ -1521,22 +1535,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
-                              then Some (##0)%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some (##0)%expr
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end;;
        match x with
        | @expr.Ident _ _ _ t idc =>
@@ -1545,26 +1559,28 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
                then
                 xv <- ident.unify pattern.ident.Literal ##(projT2 args);
                 fv <- (x1 <- (if (let (x1, _) := xv in x1) =? 0
-                              then Some (##0)%expr
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some (##0)%expr
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
-       | _ => None
+       | _ => Datatypes.None
        end);;
-      None);;;
+      Datatypes.None);;;
      Base (x &' x0)%expr)%option
 | Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
+| Z_min => fun x x0 : expr ℤ => Base (#(Z_min)%expr @ x @ x0)%expr_pat
+| Z_max => fun x x0 : expr ℤ => Base (#(Z_max)%expr @ x @ x0)%expr_pat
 | Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
 | Z_lnot_modulo =>
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
@@ -1609,7 +1625,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                s0) -> s)%ptype
          with
-         | Some (_, (_, (_, _)), _, _)%zrange =>
+         | Datatypes.Some (_, (_, (_, _)), _, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq
                 (((ℤ -> ℤ -> (ℤ * ℤ)%etype) -> ℤ) -> ℤ)%ptype
@@ -1621,26 +1637,46 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               _ <- ident.unify pattern.ident.pair pair;
               v <- type.try_make_transport_cps s0 ℤ;
               v0 <- type.try_make_transport_cps s ℤ;
-              Some
+              Datatypes.Some
                 (fv0 <-- do_again (ℤ * ℤ)
                            (#(Z_cast (Datatypes.fst range))%expr @
                             ($(v (Compile.reflect x1)))%expr,
                            #(Z_cast (Datatypes.snd range))%expr @
                            ($(v0 (Compile.reflect x0)))%expr)%expr_pat;
                  Base fv0)%under_lets
-             else None
-         | None => None
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
      | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App _
        _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ | @expr.App
        _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ | @expr.App _ _
-       _ s _ (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+       _ s _ (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+         Datatypes.None
      | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
        _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-       _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-     | _ => None
+       _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+     | _ => Datatypes.None
      end;;;
      Base (#(Z_cast2 range)%expr @ x)%expr_pat)%option
+| Some A => fun x : expr A => Base (#(Some)%expr @ x)%expr_pat
+| None A => Base #(None)%expr
+| @option_rect A P =>
+    fun (x : expr A -> UnderLets (expr P))
+      (x0 : expr unit -> UnderLets (expr P)) (x1 : expr (base.type.option A))
+    =>
+    Base
+      (#(option_rect)%expr @ (λ x2 : var A,
+                              to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| Build_zrange =>
+    fun x x0 : expr ℤ => Base (#(Build_zrange)%expr @ x @ x0)%expr_pat
+| @zrange_rect P =>
+    fun (x : expr ℤ -> expr ℤ -> UnderLets (expr P))
+      (x0 : expr base.type.zrange) =>
+    Base
+      (#(zrange_rect)%expr @ (λ x1 x2 : var ℤ,
+                              to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
 | fancy_add log2wordmax imm =>
     fun x : expr (ℤ * ℤ)%etype =>
     Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat

--- a/src/arith_with_casts_rewrite_head.out
+++ b/src/arith_with_casts_rewrite_head.out
@@ -28,7 +28,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Datatypes.Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b3) ->
@@ -47,21 +47,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                _ <- base.try_make_transport_cps b2 b2;
                v3 <- base.try_make_transport_cps b3 A;
                v4 <- base.try_make_transport_cps A A;
-               Some (Base (v4 (v3 (v1 (v (Compile.reflect x1))))))
-              else None
-          | None => None
+               Datatypes.Some (Base (v4 (v3 (v1 (v (Compile.reflect x1))))))
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(fst)%expr @ x)%expr_pat)%option
 | @snd A B =>
     fun x : expr (A * B)%etype =>
@@ -80,7 +81,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Datatypes.Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b2) ->
@@ -99,21 +100,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v2 <- base.try_make_transport_cps b2 b2;
                v3 <- base.try_make_transport_cps b2 B;
                v4 <- base.try_make_transport_cps B B;
-               Some (Base (v4 (v3 (v2 (v0 (Compile.reflect x0))))))
-              else None
-          | None => None
+               Datatypes.Some (Base (v4 (v3 (v2 (v0 (Compile.reflect x0))))))
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(snd)%expr @ x)%expr_pat)%option
 | @prod_rect A B T =>
     fun (x : expr A -> expr B -> UnderLets (expr T))
@@ -226,7 +228,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                ((projT1 args) -> ℤ)%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   ((projT1 args) -> ℤ)%ptype
@@ -236,20 +238,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                ((let (x2, _) := xv in x2) =? 0) &&
                                is_bounded_by_bool (let (x2, _) := xv in x2)
                                  (ZRange.normalize args0)
-                              then Some x0
-                              else None);
-                       Some (Base x2));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some x0
+                              else Datatypes.None);
+                       Datatypes.Some (Base x2));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
          (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
          (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
          (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-           None
-       | _ => None
+           Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x0 with
        | (@expr.Ident _ _ _ t idc @ @expr.Ident _ _ _ t0 idc0)%expr_pat =>
@@ -259,7 +261,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                (ℤ -> (projT1 args))%ptype
            with
-           | Some (_, _)%zrange =>
+           | Datatypes.Some (_, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                   (ℤ -> (projT1 args))%ptype
@@ -269,22 +271,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                ((let (x2, _) := xv in x2) =? 0) &&
                                is_bounded_by_bool (let (x2, _) := xv in x2)
                                  (ZRange.normalize args0)
-                              then Some x
-                              else None);
-                       Some (Base x2));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              then Datatypes.Some x
+                              else Datatypes.None);
+                       Datatypes.Some (Base x2));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
          (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
          (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
          (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-           None
-       | _ => None
+           Datatypes.None
+       | _ => Datatypes.None
        end);;
-      None);;;
+      Datatypes.None);;;
      Base (x + x0)%expr)%option
 | Z_mul => fun x x0 : expr ℤ => Base (x * x0)%expr
 | Z_pow => fun x x0 : expr ℤ => Base (#(Z_pow)%expr @ x @ x0)%expr_pat
@@ -305,7 +307,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args2) -> s2)%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args2) -> s2)%ptype
@@ -319,15 +321,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   is_bounded_by_bool
                                     (let (x5, _) := xv in x5) args3
                                  then
-                                  Some
+                                  Datatypes.Some
                                     (#(Z_cast args)%expr @
                                      v (Compile.reflect x4))%expr_pat
-                                 else None);
-                          Some (Base x5));
-                   Some (fv0 <-- fv;
-                         Base fv0)%under_lets
-                  else None
-              | None => None
+                                 else Datatypes.None);
+                          Datatypes.Some (Base x5));
+                   Datatypes.Some (fv0 <-- fv;
+                                   Base fv0)%under_lets
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
           | (@expr.Ident _ _ _ t1 idc1 @
              (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s2 _ ($_)%expr _))%expr_pat |
@@ -338,7 +340,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s2 _ (_ @ _) _))%expr_pat |
             (@expr.Ident _ _ _ t1 idc1 @
              (@expr.Ident _ _ _ t2 idc2 @ @expr.App _ _ _ s2 _
-              (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+              (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => Datatypes.None
           | (@expr.Ident _ _ _ t1 idc1 @ (@expr.Ident _ _ _ t2 idc2 @ #(_)))%expr_pat |
             (@expr.Ident _ _ _ t1 idc1 @
              (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr))%expr_pat |
@@ -346,7 +348,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
             (@expr.Ident _ _ _ t1 idc1 @
              (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-              None
+              Datatypes.None
           | (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat |
             (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -355,8 +357,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             (@expr.Ident _ _ _ t1 idc1 @ (_ @ _ @ _))%expr_pat |
             (@expr.Ident _ _ _ t1 idc1 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
             (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           args <- invert_bind_args idc0 Raw.ident.Literal;
           args0 <- invert_bind_args idc Raw.ident.Z_cast;
@@ -364,7 +366,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             pattern.type.unify_extracted (ℤ -> ℤ)%ptype
               ((projT1 args) -> ℤ)%ptype
           with
-          | Some (_, _)%zrange =>
+          | Datatypes.Some (_, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                  ((projT1 args) -> ℤ)%ptype
@@ -374,22 +376,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((let (x2, _) := xv in x2) =? 0) &&
                               is_bounded_by_bool (let (x2, _) := xv in x2)
                                 (ZRange.normalize args0)
-                             then Some (- x0)%expr
-                             else None);
-                      Some (Base x2));
-               Some (fv0 <-- fv;
-                     Base fv0)%under_lets
-              else None
-          | None => None
+                             then Datatypes.Some (- x0)%expr
+                             else Datatypes.None);
+                      Datatypes.Some (Base x2));
+               Datatypes.Some (fv0 <-- fv;
+                               Base fv0)%under_lets
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-          None
-      | _ => None
+          Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x - x0)%expr)%option
 | Z_opp =>
     fun x : expr ℤ =>
@@ -401,7 +403,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           _ <- invert_bind_args idc0 Raw.ident.Z_opp;
           args1 <- invert_bind_args idc Raw.ident.Z_cast;
           match pattern.type.unify_extracted ℤ s1 with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℤ s1
               then
                v <- type.try_make_transport_cps s1 ℤ;
@@ -409,14 +411,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (ZRange.normalize args <=?
                                - ZRange.normalize args1)%zrange
                              then
-                              Some
+                              Datatypes.Some
                                 (#(Z_cast args)%expr @ v (Compile.reflect x2))%expr_pat
-                             else None);
-                      Some (Base x3));
-               Some (fv0 <-- fv;
-                     Base fv0)%under_lets
-              else None
-          | None => None
+                             else Datatypes.None);
+                      Datatypes.Some (Base x3));
+               Datatypes.Some (fv0 <-- fv;
+                               Base fv0)%under_lets
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.App _ _ _ s1 _ ($_)%expr _))%expr_pat |
@@ -427,14 +429,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          (@expr.Ident _ _ _ t0 idc0 @ @expr.App _ _ _ s1 _ (_ @ _) _))%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.App _ _ _ s1 _
-          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => Datatypes.None
       | (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ #(_)))%expr_pat |
         (@expr.Ident _ _ _ t idc @ (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr))%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-          None
+          Datatypes.None
       | (@expr.Ident _ _ _ t idc @ #(_))%expr_pat |
         (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -443,10 +445,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.Ident _ _ _ t idc @ (_ @ _ @ _))%expr_pat |
         (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-          None
-      | _ => None
+          Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (- x)%expr)%option
 | Z_div => fun x x0 : expr ℤ => Base (x / x0)%expr
 | Z_modulo => fun x x0 : expr ℤ => Base (x mod x0)%expr
@@ -454,7 +456,9 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_log2_up => fun x : expr ℤ => Base (#(Z_log2_up)%expr @ x)%expr_pat
 | Z_eqb => fun x x0 : expr ℤ => Base (#(Z_eqb)%expr @ x @ x0)%expr_pat
 | Z_leb => fun x x0 : expr ℤ => Base (#(Z_leb)%expr @ x @ x0)%expr_pat
+| Z_ltb => fun x x0 : expr ℤ => Base (#(Z_ltb)%expr @ x @ x0)%expr_pat
 | Z_geb => fun x x0 : expr ℤ => Base (#(Z_geb)%expr @ x @ x0)%expr_pat
+| Z_gtb => fun x x0 : expr ℤ => Base (#(Z_gtb)%expr @ x @ x0)%expr_pat
 | Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
 | Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
 | Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
@@ -468,7 +472,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            pattern.type.unify_extracted (ℤ -> ℤ)%ptype
              ((projT1 args) -> ℤ)%ptype
          with
-         | Some (_, _)%zrange =>
+         | Datatypes.Some (_, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                 ((projT1 args) -> ℤ)%ptype
@@ -478,23 +482,26 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              ((let (x2, _) := xv in x2) =? 0) &&
                              is_bounded_by_bool (let (x2, _) := xv in x2)
                                (ZRange.normalize args0)
-                            then Some (##0)%expr
-                            else None);
-                     Some (Base x2));
-              Some (fv0 <-- fv;
-                    Base fv0)%under_lets
-             else None
-         | None => None
+                            then Datatypes.Some (##0)%expr
+                            else Datatypes.None);
+                     Datatypes.Some (Base x2));
+              Datatypes.Some (fv0 <-- fv;
+                              Base fv0)%under_lets
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
      | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
        (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
-       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
-     | _ => None
+       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+         Datatypes.None
+     | _ => Datatypes.None
      end;;;
      Base (x << x0)%expr)%option
 | Z_land => fun x x0 : expr ℤ => Base (x &' x0)%expr
 | Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
+| Z_min => fun x x0 : expr ℤ => Base (#(Z_min)%expr @ x @ x0)%expr_pat
+| Z_max => fun x x0 : expr ℤ => Base (#(Z_max)%expr @ x @ x0)%expr_pat
 | Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
 | Z_lnot_modulo =>
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
@@ -508,7 +515,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                ((ℤ -> (projT1 args)) -> ℤ)%ptype
            with
-           | Some (_, _, _)%zrange =>
+           | Datatypes.Some (_, _, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq
                   ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> (projT1 args)) -> ℤ)%ptype
@@ -519,22 +526,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                is_bounded_by_bool (let (x3, _) := xv in x3)
                                  (ZRange.normalize args0)
                               then
-                               Some
+                               Datatypes.Some
                                  (#(Z_cast r[0 ~> 0])%expr @ (##0)%expr,
                                  #(Z_cast r[0 ~> 0])%expr @ (##0)%expr)%expr_pat
-                              else None);
-                       Some (Base x3));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              else Datatypes.None);
+                       Datatypes.Some (Base x3));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
          (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
          (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
          (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-           None
-       | _ => None
+           Datatypes.None
+       | _ => Datatypes.None
        end;;
        match x1 with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x2 =>
@@ -546,7 +553,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                    ((ℤ -> ℤ) -> (projT1 args))%ptype
                with
-               | Some (_, _, _)%zrange =>
+               | Datatypes.Some (_, _, _)%zrange =>
                    if
                     type.type_beq base.type base.type.type_beq
                       ((ℤ -> ℤ) -> ℤ)%ptype ((ℤ -> ℤ) -> (projT1 args))%ptype
@@ -558,17 +565,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                      (let (x3, _) := xv in x3)
                                      (ZRange.normalize args0)
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (#(Z_cast r[0 ~> 0])%expr @ (##0)%expr,
                                      #(Z_cast r[0 ~> 0])%expr @ (##0)%expr)%expr_pat
-                                  else None);
-                           Some (Base x3));
-                    Some (fv0 <-- fv;
-                          Base fv0)%under_lets
-                   else None
-               | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (Base x3));
+                    Datatypes.Some (fv0 <-- fv;
+                                    Base fv0)%under_lets
+                   else Datatypes.None
+               | Datatypes.None => Datatypes.None
                end
-           | _ => None
+           | _ => Datatypes.None
            end;;
            match x with
            | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
@@ -585,7 +592,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                            (((projT1 args1) -> (projT1 args)) -> s)%ptype
                        with
-                       | Some (_, _, _)%zrange =>
+                       | Datatypes.Some (_, _, _)%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               ((ℤ -> ℤ) -> ℤ)%ptype
@@ -608,19 +615,19 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                              (let (x5, _) := xv0 in x5)
                                              (ZRange.normalize args0)
                                           then
-                                           Some
+                                           Datatypes.Some
                                              (#(Z_cast args3)%expr @
                                               v (Compile.reflect x2),
                                              #(Z_cast r[0 ~> 0])%expr @
                                              (##0)%expr)%expr_pat
-                                          else None);
-                                   Some (Base x5));
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
+                                          else Datatypes.None);
+                                   Datatypes.Some (Base x5));
+                            Datatypes.Some (fv0 <-- fv;
+                                            Base fv0)%under_lets
+                           else Datatypes.None
+                       | Datatypes.None => Datatypes.None
                        end
-                   | _ => None
+                   | _ => Datatypes.None
                    end;;
                    match x2 with
                    | @expr.Ident _ _ _ t3 idc3 =>
@@ -633,7 +640,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                            (((projT1 args1) -> s1) -> (projT1 args))%ptype
                        with
-                       | Some (_, _, _)%zrange =>
+                       | Datatypes.Some (_, _, _)%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               ((ℤ -> ℤ) -> ℤ)%ptype
@@ -656,39 +663,39 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                              (let (x5, _) := xv0 in x5)
                                              (ZRange.normalize args3)
                                           then
-                                           Some
+                                           Datatypes.Some
                                              (#(Z_cast args0)%expr @
                                               v (Compile.reflect x4),
                                              #(Z_cast r[0 ~> 0])%expr @
                                              (##0)%expr)%expr_pat
-                                          else None);
-                                   Some (Base x5));
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
+                                          else Datatypes.None);
+                                   Datatypes.Some (Base x5));
+                            Datatypes.Some (fv0 <-- fv;
+                                            Base fv0)%under_lets
+                           else Datatypes.None
+                       | Datatypes.None => Datatypes.None
                        end
-                   | _ => None
+                   | _ => Datatypes.None
                    end
                | @expr.App _ _ _ s1 _ ($_)%expr _ | @expr.App _ _ _ s1 _
                  (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s1 _
                  (_ @ _)%expr_pat _ | @expr.App _ _ _ s1 _
-                 (@expr.LetIn _ _ _ _ _ _ _) _ => None
-               | _ => None
+                 (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+               | _ => Datatypes.None
                end
            | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
              (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
              (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
              (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-               None
-           | _ => None
+               Datatypes.None
+           | _ => Datatypes.None
            end
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _ (_ @ _)%expr_pat _ |
-         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         @expr.App _ _ _ s _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end);;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_get_carry =>
     fun x x0 x1 : expr ℤ =>
@@ -714,7 +721,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (((projT1 args3) -> (projT1 args1)) ->
                                (projT1 args))%ptype
                           with
-                          | Some (_, _, _)%zrange =>
+                          | Datatypes.Some (_, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ)%ptype
@@ -738,7 +745,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                 (let (x5, _) := xv1 in x5)
                                                 (ZRange.normalize args0)
                                              then
-                                              Some
+                                              Datatypes.Some
                                                 (let
                                                  '(a1, b1)%zrange :=
                                                   Z.add_get_carry_full
@@ -747,14 +754,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     (let (x5, _) := xv1 in x5)
                                                   in
                                                   ((##a1)%expr, (##b1)%expr)%expr_pat)
-                                             else None);
-                                      Some (Base x5));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                             else Datatypes.None);
+                                      Datatypes.Some (Base x5));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
-                      | _ => None
+                      | _ => Datatypes.None
                       end;;
                       args <- invert_bind_args idc3 Raw.ident.Z_cast;
                       args0 <- invert_bind_args idc2 Raw.ident.Literal;
@@ -765,7 +773,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                           (((projT1 args2) -> (projT1 args0)) -> s1)%ptype
                       with
-                      | Some (_, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              ((ℤ -> ℤ) -> ℤ)%ptype
@@ -788,25 +796,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                             (let (x5, _) := xv in x5)
                                             (ZRange.normalize args3)
                                          then
-                                          Some
+                                          Datatypes.Some
                                             (#(Z_cast args)%expr @
                                              v (Compile.reflect x4),
                                             #(Z_cast r[0 ~> 0])%expr @
                                             (##0)%expr)%expr_pat
-                                         else None);
-                                  Some (Base x5));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                         else Datatypes.None);
+                                  Datatypes.Some (Base x5));
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | @expr.App _ _ _ s1 _ ($_)%expr _ | @expr.App _ _ _ s1 _
                     (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s1 _
                     (_ @ _)%expr_pat _ | @expr.App _ _ _ s1 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                  | _ => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end;;
               match x1 with
               | (@expr.Ident _ _ _ t2 idc2 @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
@@ -819,7 +827,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                       (((projT1 args2) -> s0) -> (projT1 args))%ptype
                   with
-                  | Some (_, _, _)%zrange =>
+                  | Datatypes.Some (_, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          ((ℤ -> ℤ) -> ℤ)%ptype
@@ -841,37 +849,38 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                         (let (x5, _) := xv in x5)
                                         (ZRange.normalize args3)
                                      then
-                                      Some
+                                      Datatypes.Some
                                         (#(Z_cast args1)%expr @
                                          v (Compile.reflect x3),
                                         #(Z_cast r[0 ~> 0])%expr @ (##0)%expr)%expr_pat
-                                     else None);
-                              Some (Base x5));
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
+                                     else Datatypes.None);
+                              Datatypes.Some (Base x5));
+                       Datatypes.Some (fv0 <-- fv;
+                                       Base fv0)%under_lets
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
               | (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
                 (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                 (@expr.Ident _ _ _ t2 idc2 @ (_ @ _))%expr_pat |
                 (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                  None
-              | _ => None
+                  Datatypes.None
+              | _ => Datatypes.None
               end
           | @expr.App _ _ _ s0 _ ($_)%expr _ | @expr.App _ _ _ s0 _
             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s0 _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-          | _ => None
+            _ | @expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+              Datatypes.None
+          | _ => Datatypes.None
           end
       | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-          None
-      | _ => None
+          Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_carry =>
     fun x x0 x1 : expr ℤ =>
@@ -883,7 +892,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
              (((projT1 args) -> ℤ) -> ℤ)%ptype
          with
-         | Some (_, _, _)%zrange =>
+         | Datatypes.Some (_, _, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq
                 ((ℤ -> ℤ) -> ℤ)%ptype (((projT1 args) -> ℤ) -> ℤ)%ptype
@@ -893,19 +902,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              ((let (x3, _) := xv in x3) =? 0) &&
                              is_bounded_by_bool (let (x3, _) := xv in x3)
                                (ZRange.normalize args0)
-                            then Some (x0 + x1)%expr
-                            else None);
-                     Some (Base x3));
-              Some (fv0 <-- fv;
-                    Base fv0)%under_lets
-             else None
-         | None => None
+                            then Datatypes.Some (x0 + x1)%expr
+                            else Datatypes.None);
+                     Datatypes.Some (Base x3));
+              Datatypes.Some (fv0 <-- fv;
+                              Base fv0)%under_lets
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
      | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
        (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
-       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
-     | _ => None
+       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+         Datatypes.None
+     | _ => Datatypes.None
      end;;;
      Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_get_carry =>
@@ -936,7 +946,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                  ((((projT1 args5) -> (projT1 args3)) ->
                                    (projT1 args1)) -> (projT1 args))%ptype
                              with
-                             | Some (_, _, _, _)%zrange =>
+                             | Datatypes.Some (_, _, _, _)%zrange =>
                                  if
                                   type.type_beq base.type base.type.type_beq
                                     (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -965,7 +975,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (let (x7, _) := xv2 in x7)
                                                    (ZRange.normalize args0)
                                                 then
-                                                 Some
+                                                 Datatypes.Some
                                                    (let
                                                     '(a2, b2)%zrange :=
                                                      Z.add_with_get_carry_full
@@ -979,14 +989,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                         x7) in
                                                      ((##a2)%expr,
                                                      (##b2)%expr)%expr_pat)
-                                                else None);
-                                         Some (Base x7));
-                                  Some (fv0 <-- fv;
-                                        Base fv0)%under_lets
-                                 else None
-                             | None => None
+                                                else Datatypes.None);
+                                         Datatypes.Some (Base x7));
+                                  Datatypes.Some
+                                    (fv0 <-- fv;
+                                     Base fv0)%under_lets
+                                 else Datatypes.None
+                             | Datatypes.None => Datatypes.None
                              end
-                         | _ => None
+                         | _ => Datatypes.None
                          end;;
                          args <- invert_bind_args idc5 Raw.ident.Z_cast;
                          args0 <- invert_bind_args idc4 Raw.ident.Literal;
@@ -1001,7 +1012,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              ((((projT1 args4) -> (projT1 args2)) ->
                                (projT1 args0)) -> s2)%ptype
                          with
-                         | Some (_, _, _, _)%zrange =>
+                         | Datatypes.Some (_, _, _, _)%zrange =>
                              if
                               type.type_beq base.type base.type.type_beq
                                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -1031,25 +1042,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                (let (x7, _) := xv1 in x7)
                                                (ZRange.normalize args1)
                                             then
-                                             Some
+                                             Datatypes.Some
                                                (#(Z_cast args)%expr @
                                                 v (Compile.reflect x6),
                                                #(Z_cast r[0 ~> 0])%expr @
                                                (##0)%expr)%expr_pat
-                                            else None);
-                                     Some (Base x7));
-                              Some (fv0 <-- fv;
-                                    Base fv0)%under_lets
-                             else None
-                         | None => None
+                                            else Datatypes.None);
+                                     Datatypes.Some (Base x7));
+                              Datatypes.Some (fv0 <-- fv;
+                                              Base fv0)%under_lets
+                             else Datatypes.None
+                         | Datatypes.None => Datatypes.None
                          end
                      | @expr.App _ _ _ s2 _ ($_)%expr _ | @expr.App _ _ _ s2
                        _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s2 _
                        (_ @ _)%expr_pat _ | @expr.App _ _ _ s2 _
-                       (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                     | _ => None
+                       (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                     | _ => Datatypes.None
                      end
-                 | _ => None
+                 | _ => Datatypes.None
                  end;;
                  match x2 with
                  | (@expr.Ident _ _ _ t4 idc4 @ @expr.Ident _ _ _ t5 idc5)%expr_pat =>
@@ -1066,7 +1077,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          ((((projT1 args4) -> (projT1 args2)) -> s1) ->
                           (projT1 args))%ptype
                      with
-                     | Some (_, _, _, _)%zrange =>
+                     | Datatypes.Some (_, _, _, _)%zrange =>
                          if
                           type.type_beq base.type base.type.type_beq
                             (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -1096,43 +1107,44 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                            (let (x7, _) := xv1 in x7)
                                            (ZRange.normalize args0)
                                         then
-                                         Some
+                                         Datatypes.Some
                                            (#(Z_cast args1)%expr @
                                             v (Compile.reflect x5),
                                            #(Z_cast r[0 ~> 0])%expr @
                                            (##0)%expr)%expr_pat
-                                        else None);
-                                 Some (Base x7));
-                          Some (fv0 <-- fv;
-                                Base fv0)%under_lets
-                         else None
-                     | None => None
+                                        else Datatypes.None);
+                                 Datatypes.Some (Base x7));
+                          Datatypes.Some (fv0 <-- fv;
+                                          Base fv0)%under_lets
+                         else Datatypes.None
+                     | Datatypes.None => Datatypes.None
                      end
                  | (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr)%expr_pat |
                    (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                    (@expr.Ident _ _ _ t4 idc4 @ (_ @ _))%expr_pat |
                    (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                     None
-                 | _ => None
+                     Datatypes.None
+                 | _ => Datatypes.None
                  end
              | @expr.App _ _ _ s1 _ ($_)%expr _ | @expr.App _ _ _ s1 _
                (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s1 _
                (_ @ _)%expr_pat _ | @expr.App _ _ _ s1 _
-               (@expr.LetIn _ _ _ _ _ _ _) _ => None
-             | _ => None
+               (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+             | _ => Datatypes.None
              end
          | (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
            (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
            (@expr.Ident _ _ _ t1 idc1 @ (_ @ _))%expr_pat |
            (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-             None
-         | _ => None
+             Datatypes.None
+         | _ => Datatypes.None
          end
      | (@expr.Ident _ _ _ t idc @ ($_)%expr)%expr_pat |
        (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _)%expr_pat |
        (@expr.Ident _ _ _ t idc @ (_ @ _))%expr_pat |
-       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
-     | _ => None
+       (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+         Datatypes.None
+     | _ => Datatypes.None
      end;;;
      Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
 | Z_sub_get_borrow =>
@@ -1153,25 +1165,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_cast range =>
     fun x : expr ℤ =>
     (((match pattern.type.unify_extracted ℤ ℤ with
-       | Some _ =>
+       | Datatypes.Some _ =>
            if type.type_beq base.type base.type.type_beq ℤ ℤ
            then
             fv <- (x0 <- (if lower range =? upper range
                           then
-                           Some
+                           Datatypes.Some
                              (#(Z_cast range)%expr @ (##(lower range))%expr)%expr_pat
-                          else None);
-                   Some (Base x0));
-            Some (fv0 <-- fv;
-                  Base fv0)%under_lets
-           else None
-       | None => None
+                          else Datatypes.None);
+                   Datatypes.Some (Base x0));
+            Datatypes.Some (fv0 <-- fv;
+                            Base fv0)%under_lets
+           else Datatypes.None
+       | Datatypes.None => Datatypes.None
        end;;
        match x with
        | @expr.App _ _ _ s _ (@expr.Ident _ _ _ t idc) x0 =>
            args <- invert_bind_args idc Raw.ident.Z_cast;
            match pattern.type.unify_extracted ℤ s with
-           | Some _ =>
+           | Datatypes.Some _ =>
                if type.type_beq base.type base.type.type_beq ℤ s
                then
                 v <- type.try_make_transport_cps s ℤ;
@@ -1179,15 +1191,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                (ZRange.normalize args <=?
                                 ZRange.normalize range)%zrange
                               then
-                               Some
+                               Datatypes.Some
                                  (#(Z_cast args)%expr @
                                   v (Compile.reflect x0))%expr_pat
-                              else None);
-                       Some (Base x1));
-                Some (fv0 <-- fv;
-                      Base fv0)%under_lets
-               else None
-           | None => None
+                              else Datatypes.None);
+                       Datatypes.Some (Base x1));
+                Datatypes.Some (fv0 <-- fv;
+                                Base fv0)%under_lets
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _
          (@expr.App _ _ _ s0 _
@@ -1197,7 +1209,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                ((s1 -> s0) -> s)%ptype
            with
-           | Some (_, _, _)%zrange =>
+           | Datatypes.Some (_, _, _)%zrange =>
                if
                 type.type_beq base.type base.type.type_beq
                   ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
@@ -1205,15 +1217,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 v <- type.try_make_transport_cps s1 ℤ;
                 v0 <- type.try_make_transport_cps s0 ℤ;
                 v1 <- type.try_make_transport_cps s ℤ;
-                Some
+                Datatypes.Some
                   (UnderLet
                      (#(Z_cast range)%expr @
                       (#(Z_add_with_carry)%expr @ v (Compile.reflect x2) @
                        v0 (Compile.reflect x1) @ v1 (Compile.reflect x0)))%expr_pat
                      (fun v2 : var ℤ =>
                       Base (#(Z_cast range)%expr @ ($v2)%expr)%expr_pat))
-               else None
-           | None => None
+               else Datatypes.None
+           | Datatypes.None => Datatypes.None
            end
        | @expr.App _ _ _ s _
          (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ ($_)%expr _) _) _ |
@@ -1224,18 +1236,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ (_ @ _)%expr_pat _) _)
          _ | @expr.App _ _ _ s _
          (@expr.App _ _ _ s0 _
-          (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ => None
+          (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ =>
+           Datatypes.None
        | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ #(_)%expr_pat _) _ |
          @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
          _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
          @expr.App _ _ _ s _
-         (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+         (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+           Datatypes.None
        | @expr.App _ _ _ s _ ($_)%expr _ | @expr.App _ _ _ s _
          (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s _
-         (@expr.LetIn _ _ _ _ _ _ _) _ => None
-       | _ => None
+         (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+       | _ => Datatypes.None
        end);;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_cast range)%expr @ x)%expr_pat)%option
 | Z_cast2 range =>
     fun x : expr (ℤ * ℤ)%etype =>
@@ -1251,7 +1265,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                s0) -> s)%ptype
          with
-         | Some (_, (_, (_, _)), _, _)%zrange =>
+         | Datatypes.Some (_, (_, (_, _)), _, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq
                 (((ℤ -> ℤ -> (ℤ * ℤ)%etype) -> ℤ) -> ℤ)%ptype
@@ -1263,15 +1277,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               _ <- ident.unify pattern.ident.pair pair;
               v <- type.try_make_transport_cps s0 ℤ;
               v0 <- type.try_make_transport_cps s ℤ;
-              Some
+              Datatypes.Some
                 (fv0 <-- do_again (ℤ * ℤ)
                            (#(Z_cast (Datatypes.fst range))%expr @
                             ($(v (Compile.reflect x1)))%expr,
                            #(Z_cast (Datatypes.snd range))%expr @
                            ($(v0 (Compile.reflect x0)))%expr)%expr_pat;
                  Base fv0)%under_lets
-             else None
-         | None => None
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
      | @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _
@@ -1288,7 +1302,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                   ((s1 -> s4) -> s)%ptype
               with
-              | Some (_, _, _)%zrange =>
+              | Datatypes.Some (_, _, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq
                      ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s4) -> s)%ptype
@@ -1300,7 +1314,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (ZRange.normalize args <=?
                             - ZRange.normalize args1)%zrange
                           then
-                           Some
+                           Datatypes.Some
                              (UnderLet
                                 (#(Z_cast2
                                      (Datatypes.fst range,
@@ -1325,11 +1339,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       (#(Z_cast2
                                            (Datatypes.fst range,
                                            - Datatypes.snd range))%expr @ $vc)))%expr_pat)%expr)%expr_pat))
-                          else None);
-                   Some (fv0 <-- fv;
-                         Base fv0)%under_lets
-                  else None
-              | None => None
+                          else Datatypes.None);
+                   Datatypes.Some (fv0 <-- fv;
+                                   Base fv0)%under_lets
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _ ($_)%expr _))%expr_pat |
@@ -1340,7 +1354,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _ (_ @ _) _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _
-              (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+              (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => Datatypes.None
           | (@expr.Ident _ _ _ t0 idc0 @ (@expr.Ident _ _ _ t1 idc1 @ #(_)))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr))%expr_pat |
@@ -1348,7 +1362,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-              None
+              Datatypes.None
           | (@expr.Ident _ _ _ t0 idc0 @ #(_))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1357,8 +1371,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           match x0 with
           | (@expr.Ident _ _ _ t0 idc0 @
@@ -1372,7 +1386,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                   ((s1 -> s0) -> s4)%ptype
               with
-              | Some (_, _, _)%zrange =>
+              | Datatypes.Some (_, _, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq
                      ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s4)%ptype
@@ -1384,7 +1398,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (ZRange.normalize args <=?
                             - ZRange.normalize args1)%zrange
                           then
-                           Some
+                           Datatypes.Some
                              (UnderLet
                                 (#(Z_cast2
                                      (Datatypes.fst range,
@@ -1409,11 +1423,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       (#(Z_cast2
                                            (Datatypes.fst range,
                                            - Datatypes.snd range))%expr @ $vc)))%expr_pat)%expr)%expr_pat))
-                          else None);
-                   Some (fv0 <-- fv;
-                         Base fv0)%under_lets
-                  else None
-              | None => None
+                          else Datatypes.None);
+                   Datatypes.Some (fv0 <-- fv;
+                                   Base fv0)%under_lets
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _ ($_)%expr _))%expr_pat |
@@ -1424,7 +1438,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _ (_ @ _) _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s4 _
-              (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+              (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => Datatypes.None
           | (@expr.Ident _ _ _ t0 idc0 @ (@expr.Ident _ _ _ t1 idc1 @ #(_)))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr))%expr_pat |
@@ -1432,7 +1446,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @
              (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-              None
+              Datatypes.None
           | (@expr.Ident _ _ _ t0 idc0 @ #(_))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1441,8 +1455,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           match x1 with
           | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
@@ -1453,7 +1467,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                   ((s1 -> (projT1 args)) -> s)%ptype
               with
-              | Some (_, _, _)%zrange =>
+              | Datatypes.Some (_, _, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq
                      ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> (projT1 args)) -> s)%ptype
@@ -1466,7 +1480,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            is_bounded_by_bool (let (x4, _) := xv in x4)
                              (ZRange.normalize args0)
                           then
-                           Some
+                           Datatypes.Some
                              (UnderLet
                                 (#(Z_cast2
                                      (Datatypes.fst range,
@@ -1491,18 +1505,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       (#(Z_cast2
                                            (Datatypes.fst range,
                                            - Datatypes.snd range))%expr @ $vc)))%expr_pat)%expr)%expr_pat))
-                          else None);
-                   Some (fv0 <-- fv;
-                         Base fv0)%under_lets
-                  else None
-              | None => None
+                          else Datatypes.None);
+                   Datatypes.Some (fv0 <-- fv;
+                                   Base fv0)%under_lets
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           match x0 with
           | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
@@ -1513,7 +1527,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                   ((s1 -> s0) -> (projT1 args))%ptype
               with
-              | Some (_, _, _)%zrange =>
+              | Datatypes.Some (_, _, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq
                      ((ℤ -> ℤ) -> ℤ)%ptype
@@ -1527,7 +1541,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            is_bounded_by_bool (let (x4, _) := xv in x4)
                              (ZRange.normalize args0)
                           then
-                           Some
+                           Datatypes.Some
                              (UnderLet
                                 (#(Z_cast2
                                      (Datatypes.fst range,
@@ -1552,25 +1566,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       (#(Z_cast2
                                            (Datatypes.fst range,
                                            - Datatypes.snd range))%expr @ $vc)))%expr_pat)%expr)%expr_pat))
-                          else None);
-                   Some (fv0 <-- fv;
-                         Base fv0)%under_lets
-                  else None
-              | None => None
+                          else Datatypes.None);
+                   Datatypes.Some (fv0 <-- fv;
+                                   Base fv0)%under_lets
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           _ <- invert_bind_args idc Raw.ident.Z_add_get_carry;
           match
             pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
               ((s1 -> s0) -> s)%ptype
           with
-          | Some (_, _, _)%zrange =>
+          | Datatypes.Some (_, _, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
@@ -1578,7 +1592,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v <- type.try_make_transport_cps s1 ℤ;
                v0 <- type.try_make_transport_cps s0 ℤ;
                v1 <- type.try_make_transport_cps s ℤ;
-               Some
+               Datatypes.Some
                  (UnderLet
                     (#(Z_cast2 range)%expr @
                      (#(Z_add_get_carry)%expr @ v (Compile.reflect x2) @
@@ -1589,15 +1603,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)),
                        #(Z_cast (Datatypes.snd range))%expr @
                        (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)))%expr_pat))
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end);;
          (_ <- invert_bind_args idc Raw.ident.Z_sub_get_borrow;
           match
             pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
               ((s1 -> s0) -> s)%ptype
           with
-          | Some (_, _, _)%zrange =>
+          | Datatypes.Some (_, _, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
@@ -1605,7 +1619,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v <- type.try_make_transport_cps s1 ℤ;
                v0 <- type.try_make_transport_cps s0 ℤ;
                v1 <- type.try_make_transport_cps s ℤ;
-               Some
+               Datatypes.Some
                  (UnderLet
                     (#(Z_cast2 range)%expr @
                      (#(Z_sub_get_borrow)%expr @ v (Compile.reflect x2) @
@@ -1616,15 +1630,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)),
                        #(Z_cast (Datatypes.snd range))%expr @
                        (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)))%expr_pat))
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end);;
          _ <- invert_bind_args idc Raw.ident.Z_mul_split;
          match
            pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
              ((s1 -> s0) -> s)%ptype
          with
-         | Some (_, _, _)%zrange =>
+         | Datatypes.Some (_, _, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq
                 ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
@@ -1632,7 +1646,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               v <- type.try_make_transport_cps s1 ℤ;
               v0 <- type.try_make_transport_cps s0 ℤ;
               v1 <- type.try_make_transport_cps s ℤ;
-              Some
+              Datatypes.Some
                 (UnderLet
                    (#(Z_cast2 range)%expr @
                     (#(Z_mul_split)%expr @ v (Compile.reflect x2) @
@@ -1643,8 +1657,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                        (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)),
                       #(Z_cast (Datatypes.snd range))%expr @
                       (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v2)%expr)))%expr_pat))
-             else None
-         | None => None
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
      | @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _
@@ -1670,7 +1684,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                            (((s2 -> (projT1 args2)) -> s6) -> s)%ptype
                        with
-                       | Some (_, _, _, _)%zrange =>
+                       | Datatypes.Some (_, _, _, _)%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -1689,7 +1703,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       (let (x8, _) := xv in x8)
                                       (ZRange.normalize args3)
                                    then
-                                    Some
+                                    Datatypes.Some
                                       (UnderLet
                                          (#(Z_cast2
                                               (Datatypes.fst range,
@@ -1716,11 +1730,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     (Datatypes.fst range,
                                                     - Datatypes.snd range))%expr @
                                                 $vc)))%expr_pat)%expr)%expr_pat))
-                                   else None);
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
+                                   else Datatypes.None);
+                            Datatypes.Some (fv0 <-- fv;
+                                            Base fv0)%under_lets
+                           else Datatypes.None
+                       | Datatypes.None => Datatypes.None
                        end);;
                       args <- invert_bind_args idc4 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc3 Raw.ident.Z_opp;
@@ -1734,7 +1748,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                           (((s2 -> (projT1 args2)) -> s6) -> s)%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -1753,7 +1767,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                      (let (x8, _) := xv in x8)
                                      (ZRange.normalize args3)
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (UnderLet
                                         (#(Z_cast2
                                              (Datatypes.fst range,
@@ -1781,11 +1795,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (Datatypes.fst range,
                                                    - Datatypes.snd range))%expr @
                                                $vc)))%expr_pat)%expr)%expr_pat))
-                                  else None);
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
@@ -1798,7 +1812,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                       (_ @ _) _))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat =>
+                      Datatypes.None
                   | (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.Ident _ _ _ t3 idc3 @ #(_)))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @
@@ -1807,7 +1822,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                      None
+                      Datatypes.None
                   | (@expr.Ident _ _ _ t2 idc2 @ #(_))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1817,8 +1832,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end;;
                   match x0 with
                   | (@expr.Ident _ _ _ t2 idc2 @
@@ -1836,7 +1851,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                            (((s2 -> (projT1 args2)) -> s0) -> s6)%ptype
                        with
-                       | Some (_, _, _, _)%zrange =>
+                       | Datatypes.Some (_, _, _, _)%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -1855,7 +1870,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       (let (x8, _) := xv in x8)
                                       (ZRange.normalize args3)
                                    then
-                                    Some
+                                    Datatypes.Some
                                       (UnderLet
                                          (#(Z_cast2
                                               (Datatypes.fst range,
@@ -1882,11 +1897,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     (Datatypes.fst range,
                                                     - Datatypes.snd range))%expr @
                                                 $vc)))%expr_pat)%expr)%expr_pat))
-                                   else None);
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
+                                   else Datatypes.None);
+                            Datatypes.Some (fv0 <-- fv;
+                                            Base fv0)%under_lets
+                           else Datatypes.None
+                       | Datatypes.None => Datatypes.None
                        end);;
                       args <- invert_bind_args idc4 Raw.ident.Z_cast;
                       _ <- invert_bind_args idc3 Raw.ident.Z_opp;
@@ -1900,7 +1915,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                           (((s2 -> (projT1 args2)) -> s0) -> s6)%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -1919,7 +1934,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                      (let (x8, _) := xv in x8)
                                      (ZRange.normalize args3)
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (UnderLet
                                         (#(Z_cast2
                                              (Datatypes.fst range,
@@ -1947,11 +1962,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (Datatypes.fst range,
                                                    - Datatypes.snd range))%expr @
                                                $vc)))%expr_pat)%expr)%expr_pat))
-                                  else None);
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
@@ -1964,7 +1979,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                       (_ @ _) _))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.Ident _ _ _ t3 idc3 @ @expr.App _ _ _ s6 _
-                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat =>
+                      Datatypes.None
                   | (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.Ident _ _ _ t3 idc3 @ #(_)))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @
@@ -1973,7 +1989,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                      None
+                      Datatypes.None
                   | (@expr.Ident _ _ _ t2 idc2 @ #(_))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1983,8 +1999,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     (@expr.Ident _ _ _ t2 idc2 @
                      (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end;;
                   match x1 with
                   | (@expr.Ident _ _ _ t2 idc2 @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
@@ -1999,7 +2015,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                           (((s2 -> (projT1 args1)) -> (projT1 args)) -> s)%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2023,7 +2039,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                      (let (x6, _) := xv in x6)
                                      (ZRange.normalize args2)
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (UnderLet
                                         (#(Z_cast2
                                              (Datatypes.fst range,
@@ -2051,18 +2067,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (Datatypes.fst range,
                                                    - Datatypes.snd range))%expr @
                                                $vc)))%expr_pat)%expr)%expr_pat))
-                                  else None);
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ (_ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end;;
                   match x0 with
                   | (@expr.Ident _ _ _ t2 idc2 @ @expr.Ident _ _ _ t3 idc3)%expr_pat =>
@@ -2077,7 +2093,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                           (((s2 -> (projT1 args1)) -> s0) -> (projT1 args))%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2101,7 +2117,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                      (let (x6, _) := xv in x6)
                                      (ZRange.normalize args2)
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (UnderLet
                                         (#(Z_cast2
                                              (Datatypes.fst range,
@@ -2129,18 +2145,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (Datatypes.fst range,
                                                    - Datatypes.snd range))%expr @
                                                $vc)))%expr_pat)%expr)%expr_pat))
-                                  else None);
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ (_ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end;;
                   args <- invert_bind_args idc1 Raw.ident.Literal;
                   args0 <- invert_bind_args idc0 Raw.ident.Z_cast;
@@ -2149,7 +2165,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                       (((s2 -> (projT1 args)) -> s0) -> s)%ptype
                   with
-                  | Some (_, _, _, _)%zrange =>
+                  | Datatypes.Some (_, _, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2165,7 +2181,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                is_bounded_by_bool (let (x5, _) := xv in x5)
                                  (ZRange.normalize args0)
                               then
-                               Some
+                               Datatypes.Some
                                  (UnderLet
                                     (#(Z_cast2 range)%expr @
                                      (#(Z_add_get_carry)%expr @
@@ -2180,11 +2196,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                        #(Z_cast (Datatypes.snd range))%expr @
                                        (#(snd)%expr @
                                         (#(Z_cast2 range)%expr @ ($vc)%expr)))%expr_pat))
-                              else None);
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
+                              else Datatypes.None);
+                       Datatypes.Some (fv0 <-- fv;
+                                       Base fv0)%under_lets
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
               | (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _
                  (@expr.Ident _ _ _ t2 idc2) x6)%expr_pat =>
@@ -2205,7 +2221,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                           (((s2 -> s5) -> s8) -> s)%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2221,7 +2237,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                    (ZRange.normalize args2 <=?
                                     - ZRange.normalize args4)%zrange
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (UnderLet
                                         (#(Z_cast2
                                              (Datatypes.fst range,
@@ -2249,11 +2265,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (Datatypes.fst range,
                                                    - Datatypes.snd range))%expr @
                                                $vc)))%expr_pat)%expr)%expr_pat))
-                                  else None);
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
@@ -2266,7 +2282,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                       (_ @ _) _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat =>
+                      Datatypes.None
                   | (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.Ident _ _ _ t4 idc4 @ #(_)))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @
@@ -2275,7 +2292,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                      None
+                      Datatypes.None
                   | (@expr.Ident _ _ _ t3 idc3 @ #(_))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -2285,8 +2302,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end;;
                   match x0 with
                   | (@expr.Ident _ _ _ t3 idc3 @
@@ -2305,7 +2322,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                           (((s2 -> s5) -> s0) -> s8)%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2321,7 +2338,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                    (ZRange.normalize args2 <=?
                                     - ZRange.normalize args4)%zrange
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (UnderLet
                                         (#(Z_cast2
                                              (Datatypes.fst range,
@@ -2349,11 +2366,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (Datatypes.fst range,
                                                    - Datatypes.snd range))%expr @
                                                $vc)))%expr_pat)%expr)%expr_pat))
-                                  else None);
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
@@ -2366,7 +2383,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                       (_ @ _) _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s8 _
-                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                      (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat =>
+                      Datatypes.None
                   | (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.Ident _ _ _ t4 idc4 @ #(_)))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @
@@ -2375,7 +2393,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                      None
+                      Datatypes.None
                   | (@expr.Ident _ _ _ t3 idc3 @ #(_))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -2385,8 +2403,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     (@expr.Ident _ _ _ t3 idc3 @
                      (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end;;
                   match x1 with
                   | (@expr.Ident _ _ _ t3 idc3 @ @expr.Ident _ _ _ t4 idc4)%expr_pat =>
@@ -2402,7 +2420,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                           (((s2 -> s5) -> (projT1 args)) -> s)%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2421,7 +2439,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                      (let (x8, _) := xv in x8)
                                      (ZRange.normalize args0)
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (UnderLet
                                         (#(Z_cast2
                                              (Datatypes.fst range,
@@ -2449,18 +2467,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (Datatypes.fst range,
                                                    - Datatypes.snd range))%expr @
                                                $vc)))%expr_pat)%expr)%expr_pat))
-                                  else None);
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end;;
                   match x0 with
                   | (@expr.Ident _ _ _ t3 idc3 @ @expr.Ident _ _ _ t4 idc4)%expr_pat =>
@@ -2476,7 +2494,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                           (((s2 -> s5) -> s0) -> (projT1 args))%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2495,7 +2513,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                      (let (x8, _) := xv in x8)
                                      (ZRange.normalize args0)
                                   then
-                                   Some
+                                   Datatypes.Some
                                      (UnderLet
                                         (#(Z_cast2
                                              (Datatypes.fst range,
@@ -2523,31 +2541,31 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (Datatypes.fst range,
                                                    - Datatypes.snd range))%expr @
                                                $vc)))%expr_pat)%expr)%expr_pat))
-                                  else None);
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  else Datatypes.None);
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end
               | (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _ ($_)%expr _)%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _
                  (@expr.Abs _ _ _ _ _ _) _)%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _ (_ @ _) _)%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ @expr.App _ _ _ s5 _
-                 (@expr.LetIn _ _ _ _ _ _ _) _)%expr_pat => None
+                 (@expr.LetIn _ _ _ _ _ _ _) _)%expr_pat => Datatypes.None
               | (@expr.Ident _ _ _ t1 idc1 @ #(_))%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                  None
-              | _ => None
+                  Datatypes.None
+              | _ => Datatypes.None
               end;;
               match x3 with
               | (@expr.Ident _ _ _ t1 idc1 @ @expr.Ident _ _ _ t2 idc2)%expr_pat =>
@@ -2571,7 +2589,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((((projT1 args3) -> s3) -> (projT1 args1)) ->
                                (projT1 args))%ptype
                           with
-                          | Some (_, _, _, _)%zrange =>
+                          | Datatypes.Some (_, _, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2602,7 +2620,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                          (let (x8, _) := xv1 in x8)
                                          (ZRange.normalize args0)
                                       then
-                                       Some
+                                       Datatypes.Some
                                          (UnderLet
                                             (#(Z_cast2 range)%expr @
                                              (#(Z_add_with_get_carry)%expr @
@@ -2623,44 +2641,46 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                   ($vc)%expr)),
                                                #(Z_cast r[0 ~> 0])%expr @
                                                (##0)%expr)%expr_pat))
-                                      else None);
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                      else Datatypes.None);
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end
               | (@expr.Ident _ _ _ t1 idc1 @ ($_)%expr)%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ (_ @ _))%expr_pat |
                 (@expr.Ident _ _ _ t1 idc1 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                  None
-              | _ => None
+                  Datatypes.None
+              | _ => Datatypes.None
               end
           | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s3 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-          | _ => None
+            _ | @expr.App _ _ _ s3 _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           _ <- invert_bind_args idc Raw.ident.Z_add_with_get_carry;
           match
             pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
               (((s2 -> s1) -> s0) -> s)%ptype
           with
-          | Some (_, _, _, _)%zrange =>
+          | Datatypes.Some (_, _, _, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((s2 -> s1) -> s0) -> s)%ptype
@@ -2669,7 +2689,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v0 <- type.try_make_transport_cps s1 ℤ;
                v1 <- type.try_make_transport_cps s0 ℤ;
                v2 <- type.try_make_transport_cps s ℤ;
-               Some
+               Datatypes.Some
                  (UnderLet
                     (#(Z_cast2 range)%expr @
                      (#(Z_add_with_get_carry)%expr @ v (Compile.reflect x3) @
@@ -2681,15 +2701,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v3)%expr)),
                        #(Z_cast (Datatypes.snd range))%expr @
                        (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v3)%expr)))%expr_pat))
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end);;
          _ <- invert_bind_args idc Raw.ident.Z_sub_with_get_borrow;
          match
            pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
              (((s2 -> s1) -> s0) -> s)%ptype
          with
-         | Some (_, _, _, _)%zrange =>
+         | Datatypes.Some (_, _, _, _)%zrange =>
              if
               type.type_beq base.type base.type.type_beq
                 (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype (((s2 -> s1) -> s0) -> s)%ptype
@@ -2698,7 +2718,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               v0 <- type.try_make_transport_cps s1 ℤ;
               v1 <- type.try_make_transport_cps s0 ℤ;
               v2 <- type.try_make_transport_cps s ℤ;
-              Some
+              Datatypes.Some
                 (UnderLet
                    (#(Z_cast2 range)%expr @
                     (#(Z_sub_with_get_borrow)%expr @ v (Compile.reflect x3) @
@@ -2710,8 +2730,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                        (#(fst)%expr @ (#(Z_cast2 range)%expr @ ($v3)%expr)),
                       #(Z_cast (Datatypes.snd range))%expr @
                       (#(snd)%expr @ (#(Z_cast2 range)%expr @ ($v3)%expr)))%expr_pat))
-             else None
-         | None => None
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
      | @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _
@@ -2726,24 +2746,45 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
        _ | @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _
         (@expr.App _ _ _ s1 _
-         (@expr.App _ _ _ s2 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _) _ => None
+         (@expr.App _ _ _ s2 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _) _ =>
+         Datatypes.None
      | @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ ($_)%expr _) _) _ |
        @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ (@expr.Abs _ _ _ _ _ _) _)
         _) _ | @expr.App _ _ _ s _
        (@expr.App _ _ _ s0 _
-        (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ => None
+        (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ =>
+         Datatypes.None
      | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App _
        _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ | @expr.App
        _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
-         None
+         Datatypes.None
      | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
        _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-       _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-     | _ => None
+       _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+     | _ => Datatypes.None
      end;;;
      Base (#(Z_cast2 range)%expr @ x)%expr_pat)%option
+| Some A => fun x : expr A => Base (#(Some)%expr @ x)%expr_pat
+| None A => Base #(None)%expr
+| @option_rect A P =>
+    fun (x : expr A -> UnderLets (expr P))
+      (x0 : expr unit -> UnderLets (expr P)) (x1 : expr (base.type.option A))
+    =>
+    Base
+      (#(option_rect)%expr @ (λ x2 : var A,
+                              to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| Build_zrange =>
+    fun x x0 : expr ℤ => Base (#(Build_zrange)%expr @ x @ x0)%expr_pat
+| @zrange_rect P =>
+    fun (x : expr ℤ -> expr ℤ -> UnderLets (expr P))
+      (x0 : expr base.type.zrange) =>
+    Base
+      (#(zrange_rect)%expr @ (λ x1 x2 : var ℤ,
+                              to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
 | fancy_add log2wordmax imm =>
     fun x : expr (ℤ * ℤ)%etype =>
     Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat

--- a/src/fancy_rewrite_head.out
+++ b/src/fancy_rewrite_head.out
@@ -125,13 +125,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_log2_up => fun x : expr ℤ => Base (#(Z_log2_up)%expr @ x)%expr_pat
 | Z_eqb => fun x x0 : expr ℤ => Base (#(Z_eqb)%expr @ x @ x0)%expr_pat
 | Z_leb => fun x x0 : expr ℤ => Base (#(Z_leb)%expr @ x @ x0)%expr_pat
+| Z_ltb => fun x x0 : expr ℤ => Base (#(Z_ltb)%expr @ x @ x0)%expr_pat
 | Z_geb => fun x x0 : expr ℤ => Base (#(Z_geb)%expr @ x @ x0)%expr_pat
+| Z_gtb => fun x x0 : expr ℤ => Base (#(Z_gtb)%expr @ x @ x0)%expr_pat
 | Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
 | Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
 | Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
 | Z_shiftl => fun x x0 : expr ℤ => Base (x << x0)%expr
 | Z_land => fun x x0 : expr ℤ => Base (x &' x0)%expr
 | Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
+| Z_min => fun x x0 : expr ℤ => Base (#(Z_min)%expr @ x @ x0)%expr_pat
+| Z_max => fun x x0 : expr ℤ => Base (#(Z_max)%expr @ x @ x0)%expr_pat
 | Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
 | Z_lnot_modulo =>
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
@@ -164,6 +168,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_cast range => fun x : expr ℤ => Base (#(Z_cast range)%expr @ x)%expr_pat
 | Z_cast2 range =>
     fun x : expr (ℤ * ℤ)%etype => Base (#(Z_cast2 range)%expr @ x)%expr_pat
+| Some A => fun x : expr A => Base (#(Some)%expr @ x)%expr_pat
+| None A => Base #(None)%expr
+| @option_rect A P =>
+    fun (x : expr A -> UnderLets (expr P))
+      (x0 : expr unit -> UnderLets (expr P)) (x1 : expr (base.type.option A))
+    =>
+    Base
+      (#(option_rect)%expr @ (λ x2 : var A,
+                              to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| Build_zrange =>
+    fun x x0 : expr ℤ => Base (#(Build_zrange)%expr @ x @ x0)%expr_pat
+| @zrange_rect P =>
+    fun (x : expr ℤ -> expr ℤ -> UnderLets (expr P))
+      (x0 : expr base.type.zrange) =>
+    Base
+      (#(zrange_rect)%expr @ (λ x1 x2 : var ℤ,
+                              to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
 | fancy_add log2wordmax imm =>
     fun x : expr (ℤ * ℤ)%etype =>
     Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat

--- a/src/fancy_with_casts_rewrite_head.out
+++ b/src/fancy_with_casts_rewrite_head.out
@@ -125,13 +125,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_log2_up => fun x : expr ℤ => Base (#(Z_log2_up)%expr @ x)%expr_pat
 | Z_eqb => fun x x0 : expr ℤ => Base (#(Z_eqb)%expr @ x @ x0)%expr_pat
 | Z_leb => fun x x0 : expr ℤ => Base (#(Z_leb)%expr @ x @ x0)%expr_pat
+| Z_ltb => fun x x0 : expr ℤ => Base (#(Z_ltb)%expr @ x @ x0)%expr_pat
 | Z_geb => fun x x0 : expr ℤ => Base (#(Z_geb)%expr @ x @ x0)%expr_pat
+| Z_gtb => fun x x0 : expr ℤ => Base (#(Z_gtb)%expr @ x @ x0)%expr_pat
 | Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
 | Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
 | Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
 | Z_shiftl => fun x x0 : expr ℤ => Base (x << x0)%expr
 | Z_land => fun x x0 : expr ℤ => Base (x &' x0)%expr
 | Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
+| Z_min => fun x x0 : expr ℤ => Base (#(Z_min)%expr @ x @ x0)%expr_pat
+| Z_max => fun x x0 : expr ℤ => Base (#(Z_max)%expr @ x @ x0)%expr_pat
 | Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
 | Z_lnot_modulo =>
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
@@ -160,13 +164,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
        pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
          ((ℤ -> ℤ) -> ℤ)%ptype
      with
-     | Some (_, _, _)%zrange =>
+     | Datatypes.Some (_, _, _)%zrange =>
          if
           type.type_beq base.type base.type.type_beq ((ℤ -> ℤ) -> ℤ)%ptype
             ((ℤ -> ℤ) -> ℤ)%ptype
-         then Some (Base (#(fancy_addm)%expr @ (x, x0, x1))%expr_pat)
-         else None
-     | None => None
+         then
+          Datatypes.Some (Base (#(fancy_addm)%expr @ (x, x0, x1))%expr_pat)
+         else Datatypes.None
+     | Datatypes.None => Datatypes.None
      end;;;
      Base (#(Z_add_modulo)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_rshi =>
@@ -198,7 +203,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
                           ((projT1 args4) -> s5 -> (projT1 args))%ptype
                       with
-                      | Some (_, (_, _))%zrange =>
+                      | Datatypes.Some (_, (_, _))%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (ℤ -> ℤ -> ℤ)%ptype
@@ -234,7 +239,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                      (let (x8, _) := xv0 in
                                                       x8))
                                                   (let (x8, _) := xv in x8);
-                                          Some
+                                          Datatypes.Some
                                             (#(Z_cast range)%expr @
                                              (#(fancy_mulll
                                                   (2 *
@@ -244,14 +249,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                               ((##x8)%expr,
                                               #(Z_cast args1)%expr @
                                               v (Compile.reflect x6))))%expr_pat
-                                         else None);
-                                  Some (Base x8));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                         else Datatypes.None);
+                                  Datatypes.Some (Base x8));
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x6 with
                   | @expr.Ident _ _ _ t6 idc6 =>
@@ -267,7 +272,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
                            ((projT1 args4) -> (projT1 args) -> s6)%ptype
                        with
-                       | Some (_, (_, _))%zrange =>
+                       | Datatypes.Some (_, (_, _))%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               (ℤ -> ℤ -> ℤ)%ptype
@@ -303,7 +308,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       (let (x8, _) := xv0 in
                                                        x8))
                                                    (let (x8, _) := xv in x8);
-                                           Some
+                                           Datatypes.Some
                                              (#(Z_cast range)%expr @
                                               (#(fancy_mulll
                                                    (2 *
@@ -313,12 +318,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                ((##x8)%expr,
                                                #(Z_cast args0)%expr @
                                                v (Compile.reflect x7))))%expr_pat
-                                          else None);
-                                   Some (Base x8));
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
+                                          else Datatypes.None);
+                                   Datatypes.Some (Base x8));
+                            Datatypes.Some (fv0 <-- fv;
+                                            Base fv0)%under_lets
+                           else Datatypes.None
+                       | Datatypes.None => Datatypes.None
                        end);;
                       args <- invert_bind_args idc6 Raw.ident.Literal;
                       args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
@@ -332,7 +337,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
                           ((projT1 args4) -> (projT1 args) -> s6)%ptype
                       with
-                      | Some (_, (_, _))%zrange =>
+                      | Datatypes.Some (_, (_, _))%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (ℤ -> ℤ -> ℤ)%ptype
@@ -368,7 +373,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                      (let (x8, _) := xv0 in
                                                       x8))
                                                   (let (x8, _) := xv in x8);
-                                          Some
+                                          Datatypes.Some
                                             (#(Z_cast range)%expr @
                                              (#(fancy_mulhl
                                                   (2 *
@@ -378,14 +383,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                               ((##x8)%expr,
                                               #(Z_cast args0)%expr @
                                               v (Compile.reflect x7))))%expr_pat
-                                         else None);
-                                  Some (Base x8));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                         else Datatypes.None);
+                                  Datatypes.Some (Base x8));
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x7 with
                   | @expr.Ident _ _ _ t6 idc6 =>
@@ -401,7 +406,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
                           ((projT1 args4) -> s5 -> (projT1 args))%ptype
                       with
-                      | Some (_, (_, _))%zrange =>
+                      | Datatypes.Some (_, (_, _))%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (ℤ -> ℤ -> ℤ)%ptype
@@ -437,7 +442,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                      (let (x8, _) := xv0 in
                                                       x8))
                                                   (let (x8, _) := xv in x8);
-                                          Some
+                                          Datatypes.Some
                                             (#(Z_cast range)%expr @
                                              (#(fancy_mulhl
                                                   (2 *
@@ -447,25 +452,26 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                               ((##x8)%expr,
                                               #(Z_cast args1)%expr @
                                               v (Compile.reflect x6))))%expr_pat
-                                         else None);
-                                  Some (Base x8));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                         else Datatypes.None);
+                                  Datatypes.Some (Base x8));
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end
               | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6 _
                 (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
                 (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
+                (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+              | _ => Datatypes.None
               end
           | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-          | _ => None
+            _ | @expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           match x5 with
           | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t4 idc4) x6 =>
@@ -483,7 +489,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                      pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
                        ((projT1 args4) -> s5 -> (projT1 args))%ptype
                    with
-                   | Some (_, (_, _))%zrange =>
+                   | Datatypes.Some (_, (_, _))%zrange =>
                        if
                         type.type_beq base.type base.type.type_beq
                           (ℤ -> ℤ -> ℤ)%ptype
@@ -511,7 +517,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                (2 *
                                                 (let (x8, _) := xv0 in x8))
                                                (let (x8, _) := xv in x8);
-                                       Some
+                                       Datatypes.Some
                                          (#(Z_cast range)%expr @
                                           (#(fancy_mullh
                                                (2 *
@@ -519,12 +525,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                            ((##x8)%expr,
                                            #(Z_cast args1)%expr @
                                            v (Compile.reflect x6))))%expr_pat
-                                      else None);
-                               Some (Base x8));
-                        Some (fv0 <-- fv;
-                              Base fv0)%under_lets
-                       else None
-                   | None => None
+                                      else Datatypes.None);
+                               Datatypes.Some (Base x8));
+                        Datatypes.Some (fv0 <-- fv;
+                                        Base fv0)%under_lets
+                       else Datatypes.None
+                   | Datatypes.None => Datatypes.None
                    end);;
                   args <- invert_bind_args idc6 Raw.ident.Literal;
                   args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
@@ -538,7 +544,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted (ℤ -> ℤ -> ℤ)%ptype
                       ((projT1 args4) -> s5 -> (projT1 args))%ptype
                   with
-                  | Some (_, (_, _))%zrange =>
+                  | Datatypes.Some (_, (_, _))%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          (ℤ -> ℤ -> ℤ)%ptype
@@ -565,31 +571,32 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       x8 <- invert_high
                                               (2 * (let (x8, _) := xv0 in x8))
                                               (let (x8, _) := xv in x8);
-                                      Some
+                                      Datatypes.Some
                                         (#(Z_cast range)%expr @
                                          (#(fancy_mulhh
                                               (2 * (let (x9, _) := xv0 in x9)))%expr @
                                           ((##x8)%expr,
                                           #(Z_cast args1)%expr @
                                           v (Compile.reflect x6))))%expr_pat
-                                     else None);
-                              Some (Base x8));
-                       Some (fv0 <-- fv;
-                             Base fv0)%under_lets
-                      else None
-                  | None => None
+                                     else Datatypes.None);
+                              Datatypes.Some (Base x8));
+                       Datatypes.Some (fv0 <-- fv;
+                                       Base fv0)%under_lets
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
               | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                 (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                 (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
                 (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                  None
-              | _ => None
+                  Datatypes.None
+              | _ => Datatypes.None
               end
           | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-          | _ => None
+            _ | @expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+              Datatypes.None
+          | _ => Datatypes.None
           end
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
@@ -638,7 +645,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
         (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-          None
+          Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
@@ -663,7 +670,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat)
-        (@expr.LetIn _ _ _ _ _ _ _) => None
+        (@expr.LetIn _ _ _ _ _ _ _) => Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
          (@expr.Ident _ _ _ t0 idc0 @ (@expr.Ident _ _ _ t1 idc1 @ x4 @ x3))%expr_pat)
@@ -690,7 +697,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ)%ptype
                               (((projT1 args2) -> s5) -> (projT1 args))%ptype
                           with
-                          | Some (_, _, _)%zrange =>
+                          | Datatypes.Some (_, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ)%ptype
@@ -727,7 +734,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                          x8))
                                                      (let (x8, _) := xv0 in
                                                       x8);
-                                              Some
+                                              Datatypes.Some
                                                 (#(Z_cast range)%expr @
                                                  (#(fancy_mulll
                                                       (2 *
@@ -738,27 +745,28 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                   (#(Z_cast args1)%expr @
                                                    v (Compile.reflect x6),
                                                   (##y)%expr)))%expr_pat
-                                             else None);
-                                      Some (Base x8));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                             else Datatypes.None);
+                                      Datatypes.Some (Base x8));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
                   | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
                     (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
                     (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                  | _ => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end;;
               match x3 with
               | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6 =>
@@ -780,7 +788,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ)%ptype
                               ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
                           with
-                          | Some (_, _, _)%zrange =>
+                          | Datatypes.Some (_, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ)%ptype
@@ -817,7 +825,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                          x8))
                                                      (let (x8, _) := xv0 in
                                                       x8);
-                                              Some
+                                              Datatypes.Some
                                                 (#(Z_cast range)%expr @
                                                  (#(fancy_mulll
                                                       (2 *
@@ -828,21 +836,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                   (#(Z_cast args3)%expr @
                                                    v (Compile.reflect x5),
                                                   (##y)%expr)))%expr_pat
-                                             else None);
-                                      Some (Base x8));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                             else Datatypes.None);
+                                      Datatypes.Some (Base x8));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x5 with
                   | @expr.Ident _ _ _ t4 idc4 =>
@@ -862,7 +871,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ)%ptype
                               (((projT1 args1) -> s5) -> (projT1 args))%ptype
                           with
-                          | Some (_, _, _)%zrange =>
+                          | Datatypes.Some (_, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ)%ptype
@@ -899,7 +908,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                          x8))
                                                      (let (x8, _) := xv0 in
                                                       x8);
-                                              Some
+                                              Datatypes.Some
                                                 (#(Z_cast range)%expr @
                                                  (#(fancy_mullh
                                                       (2 *
@@ -910,21 +919,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                   (#(Z_cast args2)%expr @
                                                    v (Compile.reflect x6),
                                                   (##y)%expr)))%expr_pat
-                                             else None);
-                                      Some (Base x8));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                             else Datatypes.None);
+                                      Datatypes.Some (Base x8));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x6 with
                   | @expr.Ident _ _ _ t4 idc4 =>
@@ -944,7 +954,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ)%ptype
                               ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
                           with
-                          | Some (_, _, _)%zrange =>
+                          | Datatypes.Some (_, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ)%ptype
@@ -981,7 +991,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                          x8))
                                                      (let (x8, _) := xv0 in
                                                       x8);
-                                              Some
+                                              Datatypes.Some
                                                 (#(Z_cast range)%expr @
                                                  (#(fancy_mullh
                                                       (2 *
@@ -992,21 +1002,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                   (#(Z_cast args3)%expr @
                                                    v (Compile.reflect x5),
                                                   (##y)%expr)))%expr_pat
-                                             else None);
-                                      Some (Base x8));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                             else Datatypes.None);
+                                      Datatypes.Some (Base x8));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ (_ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x5 with
                   | @expr.Ident _ _ _ t4 idc4 =>
@@ -1033,7 +1044,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (((projT1 args4) -> s5) ->
                                (projT1 args0) -> s10)%ptype
                           with
-                          | Some (_, _, (_, _))%zrange =>
+                          | Datatypes.Some (_, _, (_, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -1078,7 +1089,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                  (let (x12, _) := xv0 in x12)
                                                  (ZRange.normalize args1)
                                               then
-                                               Some
+                                               Datatypes.Some
                                                  (#(Z_cast range)%expr @
                                                   (#(fancy_mulll
                                                        (2 *
@@ -1090,12 +1101,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     v (Compile.reflect x6),
                                                    #(Z_cast args)%expr @
                                                    v0 (Compile.reflect x11))))%expr_pat
-                                              else None);
-                                      Some (Base x12));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                              else Datatypes.None);
+                                      Datatypes.Some (Base x12));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @
@@ -1114,7 +1126,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
                            idc8) @ @expr.App _ _ _ s10 _
-                          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat =>
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
@@ -1131,7 +1144,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
                            idc8) @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr) @ _))%expr_pat |
@@ -1145,7 +1158,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _ _ _
-                           _ _) @ _))%expr_pat => None
+                           _ _) @ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
@@ -1165,7 +1178,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
-                          _ @ _))%expr_pat => None
+                          _ @ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1182,10 +1195,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x6 with
                   | @expr.Ident _ _ _ t4 idc4 =>
@@ -1212,7 +1225,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((s4 -> (projT1 args4)) ->
                                (projT1 args0) -> s10)%ptype
                           with
-                          | Some (_, _, (_, _))%zrange =>
+                          | Datatypes.Some (_, _, (_, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -1257,7 +1270,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                  (let (x12, _) := xv0 in x12)
                                                  (ZRange.normalize args1)
                                               then
-                                               Some
+                                               Datatypes.Some
                                                  (#(Z_cast range)%expr @
                                                   (#(fancy_mulll
                                                        (2 *
@@ -1269,12 +1282,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     v (Compile.reflect x5),
                                                    #(Z_cast args)%expr @
                                                    v0 (Compile.reflect x11))))%expr_pat
-                                              else None);
-                                      Some (Base x12));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                              else Datatypes.None);
+                                      Datatypes.Some (Base x12));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @
@@ -1293,7 +1307,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
                            idc8) @ @expr.App _ _ _ s10 _
-                          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat => None
+                          (@expr.LetIn _ _ _ _ _ _ _) _))%expr_pat =>
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
@@ -1310,7 +1325,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ @expr.Ident _ _ _ t8
                            idc8) @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr) @ _))%expr_pat |
@@ -1324,7 +1339,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @
                           (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _ _ _
-                           _ _) @ _))%expr_pat => None
+                           _ _) @ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
@@ -1344,7 +1359,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
-                          _ @ _))%expr_pat => None
+                          _ @ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1361,10 +1376,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x5 with
                   | @expr.Ident _ _ _ t4 idc4 =>
@@ -1390,7 +1405,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
                               (((projT1 args4) -> s5) -> s9 -> (projT1 args))%ptype
                           with
-                          | Some (_, _, (_, _))%zrange =>
+                          | Datatypes.Some (_, _, (_, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -1435,7 +1450,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                  (let (x12, _) := xv0 in x12)
                                                  (ZRange.normalize args0)
                                               then
-                                               Some
+                                               Datatypes.Some
                                                  (#(Z_cast range)%expr @
                                                   (#(fancy_mulll
                                                        (2 *
@@ -1447,12 +1462,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     v (Compile.reflect x6),
                                                    #(Z_cast args1)%expr @
                                                    v0 (Compile.reflect x10))))%expr_pat
-                                              else None);
-                                      Some (Base x12));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                              else Datatypes.None);
+                                      Datatypes.Some (Base x12));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
@@ -1470,7 +1486,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @
                           (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
-                           _ _)))%expr_pat => None
+                           _ _)))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @ #(_)))%expr_pat |
@@ -1498,7 +1514,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.LetIn _ _ _
-                          _ _ _ _))%expr_pat => None
+                          _ _ _ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           ($_)%expr _ @ _))%expr_pat |
@@ -1511,7 +1527,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
@@ -1521,7 +1537,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
-                          _ @ _))%expr_pat => None
+                          _ @ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1538,10 +1554,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x6 with
                   | @expr.Ident _ _ _ t4 idc4 =>
@@ -1567,7 +1583,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
                               ((s4 -> (projT1 args4)) -> s9 -> (projT1 args))%ptype
                           with
-                          | Some (_, _, (_, _))%zrange =>
+                          | Datatypes.Some (_, _, (_, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -1612,7 +1628,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                  (let (x12, _) := xv0 in x12)
                                                  (ZRange.normalize args0)
                                               then
-                                               Some
+                                               Datatypes.Some
                                                  (#(Z_cast range)%expr @
                                                   (#(fancy_mulll
                                                        (2 *
@@ -1624,12 +1640,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     v (Compile.reflect x5),
                                                    #(Z_cast args1)%expr @
                                                    v0 (Compile.reflect x10))))%expr_pat
-                                              else None);
-                                      Some (Base x12));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                              else Datatypes.None);
+                                      Datatypes.Some (Base x12));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
@@ -1647,7 +1664,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @
                           (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
-                           _ _)))%expr_pat => None
+                           _ _)))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @ #(_)))%expr_pat |
@@ -1675,7 +1692,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.LetIn _ _ _
-                          _ _ _ _))%expr_pat => None
+                          _ _ _ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           ($_)%expr _ @ _))%expr_pat |
@@ -1688,7 +1705,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
@@ -1698,7 +1715,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
-                          _ @ _))%expr_pat => None
+                          _ @ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1715,10 +1732,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x5 with
                   | @expr.Ident _ _ _ t4 idc4 =>
@@ -1744,7 +1761,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
                               (((projT1 args4) -> s5) -> s9 -> (projT1 args))%ptype
                           with
-                          | Some (_, _, (_, _))%zrange =>
+                          | Datatypes.Some (_, _, (_, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -1782,7 +1799,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                  (let (x12, _) := xv0 in x12)
                                                  (ZRange.normalize args0)
                                               then
-                                               Some
+                                               Datatypes.Some
                                                  (#(Z_cast range)%expr @
                                                   (#(fancy_mullh
                                                        (2 *
@@ -1793,12 +1810,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     v (Compile.reflect x6),
                                                    #(Z_cast args1)%expr @
                                                    v0 (Compile.reflect x10))))%expr_pat
-                                              else None);
-                                      Some (Base x12));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                              else Datatypes.None);
+                                      Datatypes.Some (Base x12));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
@@ -1816,7 +1834,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @
                           (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
-                           _ _)))%expr_pat => None
+                           _ _)))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @ #(_)))%expr_pat |
@@ -1844,7 +1862,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.LetIn _ _ _
-                          _ _ _ _))%expr_pat => None
+                          _ _ _ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           ($_)%expr _ @ _))%expr_pat |
@@ -1857,7 +1875,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
@@ -1867,7 +1885,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
-                          _ @ _))%expr_pat => None
+                          _ @ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -1884,10 +1902,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x6 with
                   | @expr.Ident _ _ _ t4 idc4 =>
@@ -1913,7 +1931,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
                               ((s4 -> (projT1 args4)) -> s9 -> (projT1 args))%ptype
                           with
-                          | Some (_, _, (_, _))%zrange =>
+                          | Datatypes.Some (_, _, (_, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -1951,7 +1969,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                  (let (x12, _) := xv0 in x12)
                                                  (ZRange.normalize args0)
                                               then
-                                               Some
+                                               Datatypes.Some
                                                  (#(Z_cast range)%expr @
                                                   (#(fancy_mullh
                                                        (2 *
@@ -1962,12 +1980,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     v (Compile.reflect x5),
                                                    #(Z_cast args1)%expr @
                                                    v0 (Compile.reflect x10))))%expr_pat
-                                              else None);
-                                      Some (Base x12));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                              else Datatypes.None);
+                                      Datatypes.Some (Base x12));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
@@ -1985,7 +2004,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @
                           (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
-                           _ _)))%expr_pat => None
+                           _ _)))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @ #(_)))%expr_pat |
@@ -2013,7 +2032,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.Ident _ _ _ t7 idc7) x10 @ @expr.LetIn _ _ _
-                          _ _ _ _))%expr_pat => None
+                          _ _ _ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           ($_)%expr _ @ _))%expr_pat |
@@ -2026,7 +2045,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s9 _
                           (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
@@ -2036,7 +2055,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
-                          _ @ _))%expr_pat => None
+                          _ @ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -2053,21 +2072,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t5 idc5 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                         _)%expr_pat => None
-                      | _ => None
+                         _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end
               | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
                 (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
                 (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
+                (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+              | _ => Datatypes.None
               end
           | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-          | _ => None
+            _ | @expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           match x4 with
           | @expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5 =>
@@ -2087,7 +2107,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                            ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
                        with
-                       | Some (_, _, _)%zrange =>
+                       | Datatypes.Some (_, _, _)%zrange =>
                            if
                             type.type_beq base.type base.type.type_beq
                               ((ℤ -> ℤ) -> ℤ)%ptype
@@ -2115,7 +2135,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                   (2 *
                                                    (let (x8, _) := xv in x8))
                                                   (let (x8, _) := xv0 in x8);
-                                           Some
+                                           Datatypes.Some
                                              (#(Z_cast range)%expr @
                                               (#(fancy_mulhl
                                                    (2 *
@@ -2123,12 +2143,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                (#(Z_cast args3)%expr @
                                                 v (Compile.reflect x5),
                                                (##y)%expr)))%expr_pat
-                                          else None);
-                                   Some (Base x8));
-                            Some (fv0 <-- fv;
-                                  Base fv0)%under_lets
-                           else None
-                       | None => None
+                                          else Datatypes.None);
+                                   Datatypes.Some (Base x8));
+                            Datatypes.Some (fv0 <-- fv;
+                                            Base fv0)%under_lets
+                           else Datatypes.None
+                       | Datatypes.None => Datatypes.None
                        end);;
                       args <- invert_bind_args idc6 Raw.ident.Literal;
                       args0 <- invert_bind_args idc5 Raw.ident.Z_cast;
@@ -2142,7 +2162,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                           ((s4 -> (projT1 args1)) -> (projT1 args))%ptype
                       with
-                      | Some (_, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              ((ℤ -> ℤ) -> ℤ)%ptype
@@ -2170,7 +2190,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                  (2 *
                                                   (let (x8, _) := xv in x8))
                                                  (let (x8, _) := xv0 in x8);
-                                          Some
+                                          Datatypes.Some
                                             (#(Z_cast range)%expr @
                                              (#(fancy_mulhh
                                                   (2 *
@@ -2178,12 +2198,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                               (#(Z_cast args3)%expr @
                                                v (Compile.reflect x5),
                                               (##y)%expr)))%expr_pat
-                                         else None);
-                                  Some (Base x8));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                         else Datatypes.None);
+                                  Datatypes.Some (Base x8));
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t5 idc5 @
                      (@expr.Ident _ _ _ t6 idc6 @ x9 @ x8))%expr_pat =>
@@ -2221,7 +2241,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       ((s4 -> (projT1 args4)) ->
                                        (projT1 args0) -> s10)%ptype
                                   with
-                                  | Some (_, _, (_, _))%zrange =>
+                                  | Datatypes.Some (_, _, (_, _))%zrange =>
                                       if
                                        type.type_beq base.type
                                          base.type.type_beq
@@ -2276,7 +2296,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                          (ZRange.normalize
                                                             args5)
                                                       then
-                                                       Some
+                                                       Datatypes.Some
                                                          (#(Z_cast range)%expr @
                                                           (#(fancy_mulhl
                                                                (2 *
@@ -2293,21 +2313,23 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                            v0
                                                              (Compile.reflect
                                                                 x11))))%expr_pat
-                                                      else None);
-                                              Some (Base x12));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
+                                                      else Datatypes.None);
+                                              Datatypes.Some (Base x12));
+                                       Datatypes.Some
+                                         (fv0 <-- fv;
+                                          Base fv0)%under_lets
+                                      else Datatypes.None
+                                  | Datatypes.None => Datatypes.None
                                   end
                               | @expr.App _ _ _ s10 _ ($_)%expr _ | @expr.App
                                 _ _ _ s10 _ (@expr.Abs _ _ _ _ _ _) _ |
                                 @expr.App _ _ _ s10 _ (_ @ _)%expr_pat _ |
                                 @expr.App _ _ _ s10 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
+                                (@expr.LetIn _ _ _ _ _ _ _) _ =>
+                                  Datatypes.None
+                              | _ => Datatypes.None
                               end
-                          | _ => None
+                          | _ => Datatypes.None
                           end;;
                           match x8 with
                           | (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
@@ -2330,7 +2352,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   ((s4 -> (projT1 args4)) ->
                                    s9 -> (projT1 args))%ptype
                               with
-                              | Some (_, _, (_, _))%zrange =>
+                              | Datatypes.Some (_, _, (_, _))%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -2373,7 +2395,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       x12)
                                                      (ZRange.normalize args5)
                                                   then
-                                                   Some
+                                                   Datatypes.Some
                                                      (#(Z_cast range)%expr @
                                                       (#(fancy_mulhl
                                                            (2 *
@@ -2386,26 +2408,27 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                        #(Z_cast args1)%expr @
                                                        v0
                                                          (Compile.reflect x10))))%expr_pat
-                                                  else None);
-                                          Some (Base x12));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                                  else Datatypes.None);
+                                          Datatypes.Some (Base x12));
+                                   Datatypes.Some
+                                     (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                                  else Datatypes.None
+                              | Datatypes.None => Datatypes.None
                               end
                           | (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)%expr_pat |
                             (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _
                              _)%expr_pat |
                             (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))%expr_pat |
                             (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _
-                             _ _ _)%expr_pat => None
-                          | _ => None
+                             _ _ _)%expr_pat => Datatypes.None
+                          | _ => Datatypes.None
                           end
                       | @expr.App _ _ _ s9 _ ($_)%expr _ | @expr.App _ _ _ s9
                         _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s9 _
                         (_ @ _)%expr_pat _ | @expr.App _ _ _ s9 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                      | _ => Datatypes.None
                       end;;
                       match x9 with
                       | @expr.App _ _ _ s9 _ (@expr.Ident _ _ _ t7 idc7)
@@ -2431,7 +2454,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   ((s4 -> (projT1 args4)) ->
                                    s9 -> (projT1 args))%ptype
                               with
-                              | Some (_, _, (_, _))%zrange =>
+                              | Datatypes.Some (_, _, (_, _))%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -2472,7 +2495,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       x12)
                                                      (ZRange.normalize args0)
                                                   then
-                                                   Some
+                                                   Datatypes.Some
                                                      (#(Z_cast range)%expr @
                                                       (#(fancy_mulhh
                                                            (2 *
@@ -2485,26 +2508,27 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                        #(Z_cast args1)%expr @
                                                        v0
                                                          (Compile.reflect x10))))%expr_pat
-                                                  else None);
-                                          Some (Base x12));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                                  else Datatypes.None);
+                                          Datatypes.Some (Base x12));
+                                   Datatypes.Some
+                                     (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                                  else Datatypes.None
+                              | Datatypes.None => Datatypes.None
                               end
                           | (@expr.Ident _ _ _ t8 idc8 @ ($_)%expr)%expr_pat |
                             (@expr.Ident _ _ _ t8 idc8 @ @expr.Abs _ _ _ _ _
                              _)%expr_pat |
                             (@expr.Ident _ _ _ t8 idc8 @ (_ @ _))%expr_pat |
                             (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _
-                             _ _ _)%expr_pat => None
-                          | _ => None
+                             _ _ _)%expr_pat => Datatypes.None
+                          | _ => Datatypes.None
                           end
                       | @expr.App _ _ _ s9 _ ($_)%expr _ | @expr.App _ _ _ s9
                         _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s9 _
                         (_ @ _)%expr_pat _ | @expr.App _ _ _ s9 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                      | _ => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
@@ -2520,20 +2544,21 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     (@expr.Ident _ _ _ t5 idc5 @
                      (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end
               | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
                 (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                 (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
                 (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                  None
-              | _ => None
+                  Datatypes.None
+              | _ => Datatypes.None
               end
           | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
             (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _ (_ @ _)%expr_pat
-            _ | @expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-          | _ => None
+            _ | @expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _ =>
+              Datatypes.None
+          | _ => Datatypes.None
           end
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
@@ -2568,7 +2593,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
          (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat)
-        _ => None
+        _ => Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) #(_)%expr_pat) _ |
         @expr.App _ _ _ s _
@@ -2585,7 +2610,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
          (@expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat) _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc)
-         (@expr.LetIn _ _ _ _ _ _ _)) _ => None
+         (@expr.LetIn _ _ _ _ _ _ _)) _ => Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t idc) x2) x1) x0 =>
@@ -2616,7 +2641,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                                   ((((projT1 args2) -> s6) -> s7) -> s8)%ptype
                               with
-                              | Some (_, _, _, _)%zrange =>
+                              | Datatypes.Some (_, _, _, _)%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2645,7 +2670,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       x10)
                                                      (ZRange.normalize args3)
                                                   then
-                                                   Some
+                                                   Datatypes.Some
                                                      (#(Z_cast range)%expr @
                                                       (#(fancy_selm
                                                            (Z.log2
@@ -2662,37 +2687,38 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                        #(Z_cast args)%expr @
                                                        v1
                                                          (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                                  else Datatypes.None);
+                                          Datatypes.Some (Base x10));
+                                   Datatypes.Some
+                                     (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                                  else Datatypes.None
+                              | Datatypes.None => Datatypes.None
                               end
                           | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _
                             _ s8 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
                             _ s8 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
+                            (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                          | _ => Datatypes.None
                           end
                       | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _ _ s7
                         _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s7 _
                         (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                      | _ => Datatypes.None
                       end
                   | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6 _
                     (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
                     (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                  | _ => Datatypes.None
                   end
               | (@expr.Ident _ _ _ t2 idc2 @ ($_)%expr)%expr_pat |
                 (@expr.Ident _ _ _ t2 idc2 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                 (@expr.Ident _ _ _ t2 idc2 @ (_ @ _))%expr_pat |
                 (@expr.Ident _ _ _ t2 idc2 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                  None
-              | _ => None
+                  Datatypes.None
+              | _ => Datatypes.None
               end;;
               match x5 with
               | @expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t2 idc2) x6 =>
@@ -2727,7 +2753,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                                       ((((projT1 args2) -> s6) -> s7) -> s8)%ptype
                                   with
-                                  | Some (_, _, _, _)%zrange =>
+                                  | Datatypes.Some (_, _, _, _)%zrange =>
                                       if
                                        type.type_beq base.type
                                          base.type.type_beq
@@ -2761,7 +2787,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                          (ZRange.normalize
                                                             args3)
                                                       then
-                                                       Some
+                                                       Datatypes.Some
                                                          (#(Z_cast range)%expr @
                                                           (#(fancy_sell)%expr @
                                                            (#(Z_cast args1)%expr @
@@ -2776,33 +2802,35 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                            v1
                                                              (Compile.reflect
                                                                 x9))))%expr_pat
-                                                      else None);
-                                              Some (Base x10));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
+                                                      else Datatypes.None);
+                                              Datatypes.Some (Base x10));
+                                       Datatypes.Some
+                                         (fv0 <-- fv;
+                                          Base fv0)%under_lets
+                                      else Datatypes.None
+                                  | Datatypes.None => Datatypes.None
                                   end
                               | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App
                                 _ _ _ s8 _ (@expr.Abs _ _ _ _ _ _) _ |
                                 @expr.App _ _ _ s8 _ (_ @ _)%expr_pat _ |
                                 @expr.App _ _ _ s8 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
+                                (@expr.LetIn _ _ _ _ _ _ _) _ =>
+                                  Datatypes.None
+                              | _ => Datatypes.None
                               end
                           | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _
                             _ s7 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
                             _ s7 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
+                            (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                          | _ => Datatypes.None
                           end
                       | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6
                         _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
                         (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                      | _ => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end;;
                   match x4 with
                   | (@expr.Ident _ _ _ t3 idc3 @ @expr.Ident _ _ _ t4 idc4)%expr_pat =>
@@ -2826,7 +2854,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                                   (((s5 -> (projT1 args1)) -> s7) -> s8)%ptype
                               with
-                              | Some (_, _, _, _)%zrange =>
+                              | Datatypes.Some (_, _, _, _)%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2852,7 +2880,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       x10)
                                                      (ZRange.normalize args2)
                                                   then
-                                                   Some
+                                                   Datatypes.Some
                                                      (#(Z_cast range)%expr @
                                                       (#(fancy_sell)%expr @
                                                        (#(Z_cast args3)%expr @
@@ -2864,37 +2892,38 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                        #(Z_cast args)%expr @
                                                        v1
                                                          (Compile.reflect x9))))%expr_pat
-                                                  else None);
-                                          Some (Base x10));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                                  else Datatypes.None);
+                                          Datatypes.Some (Base x10));
+                                   Datatypes.Some
+                                     (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                                  else Datatypes.None
+                              | Datatypes.None => Datatypes.None
                               end
                           | @expr.App _ _ _ s8 _ ($_)%expr _ | @expr.App _ _
                             _ s8 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
                             _ s8 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s8 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
+                            (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                          | _ => Datatypes.None
                           end
                       | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _ _ s7
                         _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s7 _
                         (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                      | _ => Datatypes.None
                       end
                   | (@expr.Ident _ _ _ t3 idc3 @ ($_)%expr)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ (_ @ _))%expr_pat |
                     (@expr.Ident _ _ _ t3 idc3 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                      None
-                  | _ => None
+                      Datatypes.None
+                  | _ => Datatypes.None
                   end
               | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
                 (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
                 (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
+                (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+              | _ => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @ #(_))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
@@ -2908,15 +2937,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             (@expr.Ident _ _ _ t0 idc0 @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           _ <- invert_bind_args idc Raw.ident.Z_zselect;
           match
             pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
               ((s1 -> s0) -> s)%ptype
           with
-          | Some (_, _, _)%zrange =>
+          | Datatypes.Some (_, _, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  ((ℤ -> ℤ) -> ℤ)%ptype ((s1 -> s0) -> s)%ptype
@@ -2924,14 +2953,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v <- type.try_make_transport_cps s1 ℤ;
                v0 <- type.try_make_transport_cps s0 ℤ;
                v1 <- type.try_make_transport_cps s ℤ;
-               Some
+               Datatypes.Some
                  (Base
                     (#(Z_cast range)%expr @
                      (#(fancy_selc)%expr @
                       (v (Compile.reflect x2), v0 (Compile.reflect x1),
                       v1 (Compile.reflect x0))))%expr_pat)
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
@@ -2952,7 +2981,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             pattern.type.unify_extracted (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
               ((((projT1 args3) -> s4) -> s5) -> (projT1 args))%ptype
           with
-          | Some (_, _, _, _)%zrange =>
+          | Datatypes.Some (_, _, _, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2970,7 +2999,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               is_bounded_by_bool (let (x8, _) := xv0 in x8)
                                 (ZRange.normalize args0)
                              then
-                              Some
+                              Datatypes.Some
                                 (#(Z_cast range)%expr @
                                  (#(fancy_rshi
                                       (Z.log2 (let (x8, _) := xv in x8))
@@ -2979,12 +3008,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                    v (Compile.reflect x5),
                                   #(Z_cast args1)%expr @
                                   v0 (Compile.reflect x6))))%expr_pat
-                             else None);
-                      Some (Base x8));
-               Some (fv0 <-- fv;
-                     Base fv0)%under_lets
-              else None
-          | None => None
+                             else Datatypes.None);
+                      Datatypes.Some (Base x8));
+               Datatypes.Some (fv0 <-- fv;
+                               Base fv0)%under_lets
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
@@ -3017,7 +3046,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
          (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
         (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-          None
+          Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
@@ -3074,7 +3103,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
           (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
          (@expr.App _ _ _ s5 _ (@expr.Ident _ _ _ t3 idc3) x6))
-        (@expr.LetIn _ _ _ _ _ _ _) => None
+        (@expr.LetIn _ _ _ _ _ _ _) => Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
@@ -3100,7 +3129,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           (@expr.Ident _ _ _ t idc @
            (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
           (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
-         (@expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _ => None
+         (@expr.App _ _ _ s5 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
@@ -3125,7 +3155,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           (@expr.Ident _ _ _ t idc @
            (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
           (@expr.App _ _ _ s4 _ (@expr.Ident _ _ _ t2 idc2) x5))
-         (@expr.LetIn _ _ _ _ _ _ _)) _ => None
+         (@expr.LetIn _ _ _ _ _ _ _)) _ => Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
@@ -3148,7 +3178,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          (@expr.App _ _ _ s1 _
           (@expr.Ident _ _ _ t idc @
            (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
-          (@expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _) _ => None
+          (@expr.App _ _ _ s4 _ (@expr.LetIn _ _ _ _ _ _ _) _)) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
@@ -3169,7 +3200,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          (@expr.App _ _ _ s1 _
           (@expr.Ident _ _ _ t idc @
            (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1))%expr_pat
-          (@expr.LetIn _ _ _ _ _ _ _)) _) _ => None
+          (@expr.LetIn _ _ _ _ _ _ _)) _) _ => Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
@@ -3188,7 +3219,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          (@expr.App _ _ _ s1 _
           (@expr.Ident _ _ _ t idc @
            (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _))%expr_pat
-          _) _) _ => None
+          _) _) _ => Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _ (@expr.Ident _ _ _ t idc @ #(_))%expr_pat _)
@@ -3219,7 +3250,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.App _ _ _ s0 _
          (@expr.App _ _ _ s1 _
           (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat _)
-         _) _ => None
+         _) _ => Datatypes.None
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.App _ _ _ s1 _ ($_)%expr _) _) _ |
         @expr.App _ _ _ s _
@@ -3238,30 +3269,33 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat _) _)
         _ | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _
-         (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ => None
+         (@expr.App _ _ _ s1 _ (@expr.LetIn _ _ _ _ _ _ _) _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
       match pattern.type.unify_extracted ℤ ℤ with
-      | Some _ =>
+      | Datatypes.Some _ =>
           if type.type_beq base.type base.type.type_beq ℤ ℤ
           then
            fv <- (x0 <- (if
                           (range <=? value_range)%zrange
                           || (range <=? flag_range)%zrange
-                         then Some (#(Z_cast range)%expr @ x)%expr_pat
-                         else None);
-                  Some (Base x0));
-           Some (fv0 <-- fv;
-                 Base fv0)%under_lets
-          else None
-      | None => None
+                         then
+                          Datatypes.Some (#(Z_cast range)%expr @ x)%expr_pat
+                         else Datatypes.None);
+                  Datatypes.Some (Base x0));
+           Datatypes.Some (fv0 <-- fv;
+                           Base fv0)%under_lets
+          else Datatypes.None
+      | Datatypes.None => Datatypes.None
       end);;;
      Base (#(Z_cast range)%expr @ x)%expr_pat)%option
 | Z_cast2 range =>
@@ -3302,7 +3336,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (((projT1 args9) -> s3) ->
                                (s10 -> (projT1 args1)) -> (projT1 args))%ptype
                           with
-                          | Some (_, _, (_, _, _))%zrange =>
+                          | Datatypes.Some (_, _, (_, _, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
@@ -3349,13 +3383,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                 is_bounded_by_bool offset
                                                   (ZRange.normalize roffset)
                                                then
-                                                Some
+                                                Datatypes.Some
                                                   (#(Z_cast2 (r1, r2))%expr @
                                                    (#(fancy_add (Z.log2 s13)
                                                         offset)%expr @
                                                     (#(Z_cast rx)%expr @ x14,
                                                     #(Z_cast ry)%expr @ y)))%expr_pat
-                                               else None) args10
+                                               else Datatypes.None) args10
                                                (let (x14, _) := xv in x14)
                                                args8 (v (Compile.reflect x4))
                                                args7 args5 args3
@@ -3364,11 +3398,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                (let (x14, _) := xv0 in x14)
                                                args0
                                                (let (x14, _) := xv1 in x14);
-                                      Some (Base x14));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                      Datatypes.Some (Base x14));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
@@ -3397,7 +3432,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
                             idc9))) @
                          (@expr.Ident _ _ _ t10 idc10 @ @expr.LetIn _ _ _ _ _
-                          _ _))%expr_pat => None
+                          _ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
@@ -3446,7 +3481,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (@expr.Ident _ _ _ t7 idc7) x11 @
                            (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
                             idc9))) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
@@ -3468,7 +3503,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.Ident _ _ _ t7 idc7) x11 @
                            (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
-                            _ _))) @ _)%expr_pat => None
+                            _ _))) @ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
@@ -3506,7 +3541,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.LetIn _ _
-                           _ _ _ _ _)) @ _)%expr_pat => None
+                           _ _ _ _ _)) @ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
@@ -3523,7 +3558,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _)) @ _)%expr_pat |
@@ -3537,7 +3572,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _
-                           _ _ @ _)) @ _)%expr_pat => None
+                           _ _ @ _)) @ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @ #(_)) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @
@@ -3568,7 +3603,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                          _) @ _)%expr_pat => None
+                          _) @ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _ @
@@ -3580,8 +3615,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
-                         _ @ _)%expr_pat => None
-                      | _ => None
+                         _ @ _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end;;
                       match x4 with
                       | (@expr.Ident _ _ _ t4 idc4 @
@@ -3612,7 +3647,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 (s10 -> (projT1 args1)) -> (projT1 args)) ->
                                s4)%ptype
                           with
-                          | Some (_, (_, _, _), _)%zrange =>
+                          | Datatypes.Some (_, (_, _, _), _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -3660,13 +3695,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                 is_bounded_by_bool offset
                                                   (ZRange.normalize roffset)
                                                then
-                                                Some
+                                                Datatypes.Some
                                                   (#(Z_cast2 (r1, r2))%expr @
                                                    (#(fancy_add (Z.log2 s13)
                                                         offset)%expr @
                                                     (#(Z_cast rx)%expr @ x14,
                                                     #(Z_cast ry)%expr @ y)))%expr_pat
-                                               else None) args10
+                                               else Datatypes.None) args10
                                                (let (x14, _) := xv in x14)
                                                args8 args5 args3
                                                (v (Compile.reflect x11))
@@ -3676,11 +3711,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                (let (x14, _) := xv1 in x14)
                                                args7
                                                (v0 (Compile.reflect x5));
-                                      Some (Base x14));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                      Datatypes.Some (Base x14));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
@@ -3709,7 +3745,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
                             idc9))) @
                          (@expr.Ident _ _ _ t10 idc10 @ @expr.LetIn _ _ _ _ _
-                          _ _))%expr_pat => None
+                          _ _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
@@ -3758,7 +3794,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (@expr.Ident _ _ _ t7 idc7) x11 @
                            (@expr.Ident _ _ _ t8 idc8 @ @expr.Ident _ _ _ t9
                             idc9))) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
@@ -3780,7 +3816,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.Ident _ _ _ t7 idc7) x11 @
                            (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _ _ _
-                            _ _))) @ _)%expr_pat => None
+                            _ _))) @ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
@@ -3818,7 +3854,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.LetIn _ _
-                           _ _ _ _ _)) @ _)%expr_pat => None
+                           _ _ _ _ _)) @ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
@@ -3835,7 +3871,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10 _
                            (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
-                          None
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _)) @ _)%expr_pat |
@@ -3849,7 +3885,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @
                           (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _
-                           _ _ @ _)) @ _)%expr_pat => None
+                           _ _ @ _)) @ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @ #(_)) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @
@@ -3880,7 +3916,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _ _ _
-                          _) @ _)%expr_pat => None
+                          _) @ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _ @
@@ -3892,8 +3928,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t4 idc4 @
                          (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
-                         _ @ _)%expr_pat => None
-                      | _ => None
+                         _ @ _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end;;
                       match x5 with
                       | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
@@ -3914,7 +3950,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
                               (((projT1 args5) -> s3) -> s7 -> (projT1 args))%ptype
                           with
-                          | Some (_, _, (_, _))%zrange =>
+                          | Datatypes.Some (_, _, (_, _))%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ) -> ℤ -> ℤ)%ptype
@@ -3948,24 +3984,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                 is_bounded_by_bool offset
                                                   (ZRange.normalize roffset)
                                                then
-                                                Some
+                                                Datatypes.Some
                                                   (#(Z_cast2 (r1, r2))%expr @
                                                    (#(fancy_add (Z.log2 s9)
                                                         (- offset))%expr @
                                                     (#(Z_cast rx)%expr @ x10,
                                                     #(Z_cast ry)%expr @ y)))%expr_pat
-                                               else None) args6
+                                               else Datatypes.None) args6
                                                (let (x10, _) := xv in x10)
                                                args4 (v (Compile.reflect x4))
                                                args3 args1
                                                (v0 (Compile.reflect x8))
                                                args0
                                                (let (x10, _) := xv0 in x10);
-                                      Some (Base x10));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                      Datatypes.Some (Base x10));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Ident _ _ _ t5 idc5) x8 @
@@ -3979,7 +4016,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Ident _ _ _ t5 idc5) x8 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
-                          _))%expr_pat => None
+                          _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Ident _ _ _ t5 idc5) x8 @ #(_))%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
@@ -3999,7 +4036,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.LetIn _ _ _ _
-                         _ _ _)%expr_pat => None
+                         _ _ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          ($_)%expr _ @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
@@ -4007,14 +4044,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (_ @ _) _ @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                         (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat => None
+                         (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _ @
                          _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
-                         _ @ _)%expr_pat => None
-                      | _ => None
+                         _ @ _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end;;
                       match x4 with
                       | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
@@ -4035,7 +4073,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               ((ℤ -> ℤ -> ℤ) -> ℤ)%ptype
                               (((projT1 args5) -> s7 -> (projT1 args)) -> s4)%ptype
                           with
-                          | Some (_, (_, _), _)%zrange =>
+                          | Datatypes.Some (_, (_, _), _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  ((ℤ -> ℤ -> ℤ) -> ℤ)%ptype
@@ -4069,24 +4107,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                 is_bounded_by_bool offset
                                                   (ZRange.normalize roffset)
                                                then
-                                                Some
+                                                Datatypes.Some
                                                   (#(Z_cast2 (r1, r2))%expr @
                                                    (#(fancy_add (Z.log2 s9)
                                                         (- offset))%expr @
                                                     (#(Z_cast rx)%expr @ x10,
                                                     #(Z_cast ry)%expr @ y)))%expr_pat
-                                               else None) args6
+                                               else Datatypes.None) args6
                                                (let (x10, _) := xv in x10)
                                                args4 args1
                                                (v (Compile.reflect x8)) args0
                                                (let (x10, _) := xv0 in x10)
                                                args3
                                                (v0 (Compile.reflect x5));
-                                      Some (Base x10));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                      Datatypes.Some (Base x10));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Ident _ _ _ t5 idc5) x8 @
@@ -4100,7 +4139,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Ident _ _ _ t5 idc5) x8 @
                          (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _ _ _
-                          _))%expr_pat => None
+                          _))%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Ident _ _ _ t5 idc5) x8 @ #(_))%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
@@ -4120,7 +4159,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (@expr.Ident _ _ _ t5 idc5) x8 @ @expr.LetIn _ _ _ _
-                         _ _ _)%expr_pat => None
+                         _ _ _)%expr_pat => Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          ($_)%expr _ @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
@@ -4128,14 +4167,15 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
                          (_ @ _) _ @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.App _ _ _ s7 _
-                         (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat => None
+                         (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
+                          Datatypes.None
                       | (@expr.Ident _ _ _ t4 idc4 @ #(_) @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ ($_)%expr @ _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.Abs _ _ _ _ _ _ @
                          _)%expr_pat |
                         (@expr.Ident _ _ _ t4 idc4 @ @expr.LetIn _ _ _ _ _ _
-                         _ @ _)%expr_pat => None
-                      | _ => None
+                         _ @ _)%expr_pat => Datatypes.None
+                      | _ => Datatypes.None
                       end;;
                       args <- invert_bind_args idc3 Raw.ident.Z_cast;
                       args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
@@ -4146,7 +4186,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                           (((projT1 args1) -> s3) -> s4)%ptype
                       with
-                      | Some (_, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              ((ℤ -> ℤ) -> ℤ)%ptype
@@ -4168,39 +4208,39 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                            is_bounded_by_bool s5
                                              (ZRange.normalize rs)
                                           then
-                                           Some
+                                           Datatypes.Some
                                              (#(Z_cast2 (r1, r2))%expr @
                                               (#(fancy_add (Z.log2 s5) 0)%expr @
                                                (#(Z_cast rx)%expr @ x6,
                                                #(Z_cast ry)%expr @ y)))%expr_pat
-                                          else None) args2
+                                          else Datatypes.None) args2
                                           (let (x6, _) := xv in x6) args0
                                           (v (Compile.reflect x4)) args
                                           (v0 (Compile.reflect x5));
-                                  Some (Base x6));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  Datatypes.Some (Base x6));
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
                     (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
                     (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                  | _ => Datatypes.None
                   end
               | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
                 (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
                 (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
+                (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+              | _ => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           match x2 with
           | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
@@ -4251,7 +4291,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                        (s10 -> (projT1 args1)) ->
                                        (projT1 args))%ptype
                                   with
-                                  | Some (_, _, (_, _, _))%zrange =>
+                                  | Datatypes.Some
+                                    (_, _, (_, _, _))%zrange =>
                                       if
                                        type.type_beq base.type
                                          base.type.type_beq
@@ -4324,7 +4365,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                           (ZRange.normalize
                                                              roffset)
                                                        then
-                                                        Some
+                                                        Datatypes.Some
                                                           (#(Z_cast2 (r1, r2))%expr @
                                                            (#(fancy_sub
                                                                 (Z.log2 s13)
@@ -4333,7 +4374,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                              x14,
                                                             #(Z_cast ry)%expr @
                                                             y)))%expr_pat
-                                                       else None) args10
+                                                       else Datatypes.None)
+                                                       args10
                                                        (let (x14, _) := xv in
                                                         x14) args8
                                                        (v
@@ -4348,19 +4390,20 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                        (let (x14, _) :=
                                                           xv1 in
                                                         x14);
-                                              Some (Base x14));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
+                                              Datatypes.Some (Base x14));
+                                       Datatypes.Some
+                                         (fv0 <-- fv;
+                                          Base fv0)%under_lets
+                                      else Datatypes.None
+                                  | Datatypes.None => Datatypes.None
                                   end
                               | (@expr.Ident _ _ _ t10 idc10 @ ($_)%expr)%expr_pat |
                                 (@expr.Ident _ _ _ t10 idc10 @ @expr.Abs _ _
                                  _ _ _ _)%expr_pat |
                                 (@expr.Ident _ _ _ t10 idc10 @ (_ @ _))%expr_pat |
                                 (@expr.Ident _ _ _ t10 idc10 @ @expr.LetIn _
-                                 _ _ _ _ _ _)%expr_pat => None
-                              | _ => None
+                                 _ _ _ _ _ _)%expr_pat => Datatypes.None
+                              | _ => Datatypes.None
                               end
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
@@ -4379,7 +4422,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
                               _ (@expr.Ident _ _ _ t7 idc7) x11 @
                               (@expr.Ident _ _ _ t8 idc8 @ @expr.LetIn _ _ _
-                               _ _ _ _)))%expr_pat => None
+                               _ _ _ _)))%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
                               _ (@expr.Ident _ _ _ t7 idc7) x11 @ #(_)))%expr_pat |
@@ -4408,7 +4451,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
                               _ (@expr.Ident _ _ _ t7 idc7) x11 @ @expr.LetIn
-                              _ _ _ _ _ _ _))%expr_pat => None
+                              _ _ _ _ _ _ _))%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
                               _ ($_)%expr _ @ _))%expr_pat |
@@ -4421,7 +4464,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.App _ _ _ s10
                               _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ #(_) @ _))%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @
@@ -4431,7 +4474,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               _ @ _))%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _
-                              _ _ _ @ _))%expr_pat => None
+                              _ _ _ @ _))%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ #(_))%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
@@ -4449,8 +4492,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                             _ _ _)%expr_pat => None
-                          | _ => None
+                             _ _ _)%expr_pat => Datatypes.None
+                          | _ => Datatypes.None
                           end;;
                           match x7 with
                           | @expr.App _ _ _ s7 _ (@expr.Ident _ _ _ t5 idc5)
@@ -4482,7 +4525,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                       (((projT1 args5) -> s3) ->
                                        s7 -> (projT1 args))%ptype
                                   with
-                                  | Some (_, _, (_, _))%zrange =>
+                                  | Datatypes.Some (_, _, (_, _))%zrange =>
                                       if
                                        type.type_beq base.type
                                          base.type.type_beq
@@ -4529,7 +4572,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                           (ZRange.normalize
                                                              roffset)
                                                        then
-                                                        Some
+                                                        Datatypes.Some
                                                           (#(Z_cast2 (r1, r2))%expr @
                                                            (#(fancy_sub
                                                                 (Z.log2 s9)
@@ -4538,7 +4581,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                              x10,
                                                             #(Z_cast ry)%expr @
                                                             y)))%expr_pat
-                                                       else None) args6
+                                                       else Datatypes.None)
+                                                       args6
                                                        (let (x10, _) := xv in
                                                         x10) args4
                                                        (v
@@ -4550,27 +4594,28 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                        (let (x10, _) :=
                                                           xv0 in
                                                         x10);
-                                              Some (Base x10));
-                                       Some (fv0 <-- fv;
-                                             Base fv0)%under_lets
-                                      else None
-                                  | None => None
+                                              Datatypes.Some (Base x10));
+                                       Datatypes.Some
+                                         (fv0 <-- fv;
+                                          Base fv0)%under_lets
+                                      else Datatypes.None
+                                  | Datatypes.None => Datatypes.None
                                   end
                               | (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr)%expr_pat |
                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
                                  _ _ _)%expr_pat |
                                 (@expr.Ident _ _ _ t6 idc6 @ (_ @ _))%expr_pat |
                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
+                                 _ _ _ _ _)%expr_pat => Datatypes.None
+                              | _ => Datatypes.None
                               end
                           | @expr.App _ _ _ s7 _ ($_)%expr _ | @expr.App _ _
                             _ s7 _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _
                             _ s7 _ (_ @ _)%expr_pat _ | @expr.App _ _ _ s7 _
-                            (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                          | _ => None
+                            (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                          | _ => Datatypes.None
                           end
-                      | _ => None
+                      | _ => Datatypes.None
                       end;;
                       args <- invert_bind_args idc3 Raw.ident.Z_cast;
                       args0 <- invert_bind_args idc2 Raw.ident.Z_cast;
@@ -4581,7 +4626,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                         pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                           (((projT1 args1) -> s3) -> s4)%ptype
                       with
-                      | Some (_, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              ((ℤ -> ℤ) -> ℤ)%ptype
@@ -4603,39 +4648,39 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                            is_bounded_by_bool s5
                                              (ZRange.normalize rs)
                                           then
-                                           Some
+                                           Datatypes.Some
                                              (#(Z_cast2 (r1, r2))%expr @
                                               (#(fancy_sub (Z.log2 s5) 0)%expr @
                                                (#(Z_cast rx)%expr @ x6,
                                                #(Z_cast ry)%expr @ y)))%expr_pat
-                                          else None) args2
+                                          else Datatypes.None) args2
                                           (let (x6, _) := xv in x6) args0
                                           (v (Compile.reflect x4)) args
                                           (v0 (Compile.reflect x5));
-                                  Some (Base x6));
-                           Some (fv0 <-- fv;
-                                 Base fv0)%under_lets
-                          else None
-                      | None => None
+                                  Datatypes.Some (Base x6));
+                           Datatypes.Some (fv0 <-- fv;
+                                           Base fv0)%under_lets
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
                   | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
                     (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
                     (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                  | _ => Datatypes.None
                   end
               | @expr.App _ _ _ s3 _ ($_)%expr _ | @expr.App _ _ _ s3 _
                 (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s3 _
                 (_ @ _)%expr_pat _ | @expr.App _ _ _ s3 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
+                (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+              | _ => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end
       | (@expr.Ident _ _ _ t idc @ x3 @ x2 @ x1 @ x0)%expr_pat =>
           match x3 with
@@ -4682,7 +4727,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   ((((projT1 args10) -> s4) -> s5) ->
                                    (s12 -> (projT1 args1)) -> (projT1 args))%ptype
                               with
-                              | Some (_, _, _, (_, _, _))%zrange =>
+                              | Datatypes.Some (_, _, _, (_, _, _))%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      (((ℤ -> ℤ) -> ℤ) -> (ℤ -> ℤ) -> ℤ)%ptype
@@ -4740,7 +4785,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       (ZRange.normalize
                                                          roffset)
                                                    then
-                                                    Some
+                                                    Datatypes.Some
                                                       (#(Z_cast2 (r1, r2))%expr @
                                                        (#(fancy_addc
                                                             (Z.log2 s15)
@@ -4750,7 +4795,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                         #(Z_cast rx)%expr @
                                                         x16,
                                                         #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None) args11
+                                                   else Datatypes.None)
+                                                   args11
                                                    (let (x16, _) := xv in x16)
                                                    args9
                                                    (v (Compile.reflect x5))
@@ -4763,11 +4809,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                     x16) args0
                                                    (let (x16, _) := xv1 in
                                                     x16);
-                                          Some (Base x16));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                          Datatypes.Some (Base x16));
+                                   Datatypes.Some
+                                     (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                                  else Datatypes.None
+                              | Datatypes.None => Datatypes.None
                               end
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
@@ -4798,7 +4845,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
                                 t10 idc10))) @
                              (@expr.Ident _ _ _ t11 idc11 @ @expr.LetIn _ _ _
-                              _ _ _ _))%expr_pat => None
+                              _ _ _ _))%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -4848,7 +4895,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
                                (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
                                 t10 idc10))) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -4870,7 +4917,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
                                (@expr.Ident _ _ _ t9 idc9 @ @expr.LetIn _ _ _
-                                _ _ _ _))) @ _)%expr_pat => None
+                                _ _ _ _))) @ _)%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -4911,7 +4958,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
                                @expr.LetIn _ _ _ _ _ _ _)) @ _)%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -4928,7 +4975,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                s12 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ #(_) @ _)) @ _)%expr_pat |
@@ -4943,7 +4990,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _
-                               _ _ _ _ @ _)) @ _)%expr_pat => None
+                               _ _ _ _ @ _)) @ _)%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ #(_)) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @
@@ -4976,7 +5023,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _
-                              _ _ _) @ _)%expr_pat => None
+                              _ _ _) @ _)%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
@@ -4988,8 +5035,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
+                             _ _ _ @ _)%expr_pat => Datatypes.None
+                          | _ => Datatypes.None
                           end;;
                           match x6 with
                           | (@expr.Ident _ _ _ t5 idc5 @
@@ -5027,7 +5074,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                     (s12 -> (projT1 args1)) -> (projT1 args)) ->
                                    s6)%ptype
                               with
-                              | Some (_, _, (_, _, _), _)%zrange =>
+                              | Datatypes.Some (_, _, (_, _, _), _)%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      (((ℤ -> ℤ) -> (ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -5085,7 +5132,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       (ZRange.normalize
                                                          roffset)
                                                    then
-                                                    Some
+                                                    Datatypes.Some
                                                       (#(Z_cast2 (r1, r2))%expr @
                                                        (#(fancy_addc
                                                             (Z.log2 s15)
@@ -5095,7 +5142,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                         #(Z_cast rx)%expr @
                                                         x16,
                                                         #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None) args11
+                                                   else Datatypes.None)
+                                                   args11
                                                    (let (x16, _) := xv in x16)
                                                    args9
                                                    (v (Compile.reflect x5))
@@ -5107,11 +5155,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (let (x16, _) := xv1 in
                                                     x16) args7
                                                    (v1 (Compile.reflect x7));
-                                          Some (Base x16));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                          Datatypes.Some (Base x16));
+                                   Datatypes.Some
+                                     (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                                  else Datatypes.None
+                              | Datatypes.None => Datatypes.None
                               end
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
@@ -5142,7 +5191,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
                                 t10 idc10))) @
                              (@expr.Ident _ _ _ t11 idc11 @ @expr.LetIn _ _ _
-                              _ _ _ _))%expr_pat => None
+                              _ _ _ _))%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -5192,7 +5241,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
                                (@expr.Ident _ _ _ t9 idc9 @ @expr.Ident _ _ _
                                 t10 idc10))) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -5214,7 +5263,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
                                (@expr.Ident _ _ _ t9 idc9 @ @expr.LetIn _ _ _
-                                _ _ _ _))) @ _)%expr_pat => None
+                                _ _ _ _))) @ _)%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -5255,7 +5304,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
                                @expr.LetIn _ _ _ _ _ _ _)) @ _)%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -5272,7 +5321,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                s12 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _)) @ _)%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ #(_) @ _)) @ _)%expr_pat |
@@ -5287,7 +5336,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @
                               (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _
-                               _ _ _ _ @ _)) @ _)%expr_pat => None
+                               _ _ _ _ @ _)) @ _)%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ #(_)) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @
@@ -5320,7 +5369,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (@expr.LetIn _ _ _ _ _ _ _ @ _)) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _ _ _
-                              _ _ _) @ _)%expr_pat => None
+                              _ _ _) @ _)%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
@@ -5332,8 +5381,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @
                              (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
+                             _ _ _ @ _)%expr_pat => Datatypes.None
+                          | _ => Datatypes.None
                           end;;
                           match x7 with
                           | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
@@ -5358,7 +5407,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   ((((projT1 args6) -> s4) -> s5) ->
                                    s9 -> (projT1 args))%ptype
                               with
-                              | Some (_, _, _, (_, _))%zrange =>
+                              | Datatypes.Some (_, _, _, (_, _))%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      (((ℤ -> ℤ) -> ℤ) -> ℤ -> ℤ)%ptype
@@ -5399,7 +5448,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       (ZRange.normalize
                                                          roffset)
                                                    then
-                                                    Some
+                                                    Datatypes.Some
                                                       (#(Z_cast2 (r1, r2))%expr @
                                                        (#(fancy_addc
                                                             (Z.log2 s11)
@@ -5409,7 +5458,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                         #(Z_cast rx)%expr @
                                                         x12,
                                                         #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None) args7
+                                                   else Datatypes.None) args7
                                                    (let (x12, _) := xv in x12)
                                                    args5
                                                    (v (Compile.reflect x5))
@@ -5420,11 +5469,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    args0
                                                    (let (x12, _) := xv0 in
                                                     x12);
-                                          Some (Base x12));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                          Datatypes.Some (Base x12));
+                                   Datatypes.Some
+                                     (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                                  else Datatypes.None
+                              | Datatypes.None => Datatypes.None
                               end
                           | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.Ident _ _ _ t6 idc6) x10 @
@@ -5439,7 +5489,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.Ident _ _ _ t6 idc6) x10 @
                              (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _ _
-                              _ _ _))%expr_pat => None
+                              _ _ _))%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.Ident _ _ _ t6 idc6) x10 @ #(_))%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
@@ -5460,7 +5510,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.LetIn _
-                             _ _ _ _ _ _)%expr_pat => None
+                             _ _ _ _ _ _)%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              ($_)%expr _ @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
@@ -5469,14 +5519,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (_ @ _) _ @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
                              _ @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
+                             _ _ _ @ _)%expr_pat => Datatypes.None
+                          | _ => Datatypes.None
                           end;;
                           match x6 with
                           | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
@@ -5501,7 +5551,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   ((((projT1 args6) -> s4) ->
                                     s9 -> (projT1 args)) -> s6)%ptype
                               with
-                              | Some (_, _, (_, _), _)%zrange =>
+                              | Datatypes.Some (_, _, (_, _), _)%zrange =>
                                   if
                                    type.type_beq base.type base.type.type_beq
                                      (((ℤ -> ℤ) -> ℤ -> ℤ) -> ℤ)%ptype
@@ -5542,7 +5592,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                       (ZRange.normalize
                                                          roffset)
                                                    then
-                                                    Some
+                                                    Datatypes.Some
                                                       (#(Z_cast2 (r1, r2))%expr @
                                                        (#(fancy_addc
                                                             (Z.log2 s11)
@@ -5552,7 +5602,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                         #(Z_cast rx)%expr @
                                                         x12,
                                                         #(Z_cast ry)%expr @ y)))%expr_pat
-                                                   else None) args7
+                                                   else Datatypes.None) args7
                                                    (let (x12, _) := xv in x12)
                                                    args5
                                                    (v (Compile.reflect x5))
@@ -5562,11 +5612,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                    (let (x12, _) := xv0 in
                                                     x12) args3
                                                    (v1 (Compile.reflect x7));
-                                          Some (Base x12));
-                                   Some (fv0 <-- fv;
-                                         Base fv0)%under_lets
-                                  else None
-                              | None => None
+                                          Datatypes.Some (Base x12));
+                                   Datatypes.Some
+                                     (fv0 <-- fv;
+                                      Base fv0)%under_lets
+                                  else Datatypes.None
+                              | Datatypes.None => Datatypes.None
                               end
                           | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.Ident _ _ _ t6 idc6) x10 @
@@ -5581,7 +5632,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.Ident _ _ _ t6 idc6) x10 @
                              (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _ _ _
-                              _ _ _))%expr_pat => None
+                              _ _ _))%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.Ident _ _ _ t6 idc6) x10 @ #(_))%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
@@ -5602,7 +5653,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.Ident _ _ _ t6 idc6) x10 @ @expr.LetIn _
-                             _ _ _ _ _ _)%expr_pat => None
+                             _ _ _ _ _ _)%expr_pat => Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              ($_)%expr _ @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
@@ -5611,14 +5662,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              (_ @ _) _ @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.App _ _ _ s9 _
                              (@expr.LetIn _ _ _ _ _ _ _) _ @ _)%expr_pat =>
-                              None
+                              Datatypes.None
                           | (@expr.Ident _ _ _ t5 idc5 @ #(_) @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ ($_)%expr @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.Abs _ _ _ _ _
                              _ @ _)%expr_pat |
                             (@expr.Ident _ _ _ t5 idc5 @ @expr.LetIn _ _ _ _
-                             _ _ _ @ _)%expr_pat => None
-                          | _ => None
+                             _ _ _ @ _)%expr_pat => Datatypes.None
+                          | _ => Datatypes.None
                           end;;
                           args <- invert_bind_args idc4 Raw.ident.Z_cast;
                           args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
@@ -5632,7 +5683,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                               ((((projT1 args2) -> s4) -> s5) -> s6)%ptype
                           with
-                          | Some (_, _, _, _)%zrange =>
+                          | Datatypes.Some (_, _, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -5656,47 +5707,48 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                is_bounded_by_bool s7
                                                  (ZRange.normalize rs)
                                               then
-                                               Some
+                                               Datatypes.Some
                                                  (#(Z_cast2 (r1, r2))%expr @
                                                   (#(fancy_addc (Z.log2 s7) 0)%expr @
                                                    (#(Z_cast rc)%expr @ c,
                                                    #(Z_cast rx)%expr @ x8,
                                                    #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None) args3
+                                              else Datatypes.None) args3
                                               (let (x8, _) := xv in x8) args1
                                               (v (Compile.reflect x5)) args0
                                               (v0 (Compile.reflect x6)) args
                                               (v1 (Compile.reflect x7));
-                                      Some (Base x8));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                      Datatypes.Some (Base x8));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6
                         _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
                         (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                      | _ => Datatypes.None
                       end
                   | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
                     (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
                     (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                  | _ => Datatypes.None
                   end
               | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
                 (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
                 (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
+                (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+              | _ => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end;;
           match x3 with
           | (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1)%expr_pat =>
@@ -5753,7 +5805,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                            (s12 -> (projT1 args1)) ->
                                            (projT1 args))%ptype
                                       with
-                                      | Some (_, _, _, (_, _, _))%zrange =>
+                                      | Datatypes.Some
+                                        (_, _, _, (_, _, _))%zrange =>
                                           if
                                            type.type_beq base.type
                                              base.type.type_beq
@@ -5831,7 +5884,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                               (ZRange.normalize
                                                                  roffset)
                                                            then
-                                                            Some
+                                                            Datatypes.Some
                                                               (#(Z_cast2
                                                                    (r1, r2))%expr @
                                                                (#(fancy_subb
@@ -5844,7 +5897,9 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                                 x16,
                                                                 #(Z_cast ry)%expr @
                                                                 y)))%expr_pat
-                                                           else None) args11
+                                                           else
+                                                            Datatypes.None)
+                                                           args11
                                                            (let (x16, _) :=
                                                               xv in
                                                             x16) args9
@@ -5864,12 +5919,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                            (let (x16, _) :=
                                                               xv1 in
                                                             x16);
-                                                  Some (Base x16));
-                                           Some
+                                                  Datatypes.Some (Base x16));
+                                           Datatypes.Some
                                              (fv0 <-- fv;
                                               Base fv0)%under_lets
-                                          else None
-                                      | None => None
+                                          else Datatypes.None
+                                      | Datatypes.None => Datatypes.None
                                       end
                                   | (@expr.Ident _ _ _ t11 idc11 @ ($_)%expr)%expr_pat |
                                     (@expr.Ident _ _ _ t11 idc11 @ @expr.Abs
@@ -5877,8 +5932,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                     (@expr.Ident _ _ _ t11 idc11 @ (_ @ _))%expr_pat |
                                     (@expr.Ident _ _ _ t11 idc11 @
                                      @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-                                      None
-                                  | _ => None
+                                      Datatypes.None
+                                  | _ => Datatypes.None
                                   end
                               | (@expr.Ident _ _ _ t6 idc6 @
                                  (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
@@ -5897,7 +5952,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                  (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                   s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
                                   (@expr.Ident _ _ _ t9 idc9 @ @expr.LetIn _
-                                   _ _ _ _ _ _)))%expr_pat => None
+                                   _ _ _ _ _ _)))%expr_pat => Datatypes.None
                               | (@expr.Ident _ _ _ t6 idc6 @
                                  (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                   s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
@@ -5930,7 +5985,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                  (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                   s12 _ (@expr.Ident _ _ _ t8 idc8) x13 @
                                   @expr.LetIn _ _ _ _ _ _ _))%expr_pat =>
-                                  None
+                                  Datatypes.None
                               | (@expr.Ident _ _ _ t6 idc6 @
                                  (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                   s12 _ ($_)%expr _ @ _))%expr_pat |
@@ -5943,7 +5998,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 (@expr.Ident _ _ _ t6 idc6 @
                                  (@expr.Ident _ _ _ t7 idc7 @ @expr.App _ _ _
                                   s12 _ (@expr.LetIn _ _ _ _ _ _ _) _ @ _))%expr_pat =>
-                                  None
+                                  Datatypes.None
                               | (@expr.Ident _ _ _ t6 idc6 @
                                  (@expr.Ident _ _ _ t7 idc7 @ #(_) @ _))%expr_pat |
                                 (@expr.Ident _ _ _ t6 idc6 @
@@ -5953,7 +6008,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                   _ _ _ @ _))%expr_pat |
                                 (@expr.Ident _ _ _ t6 idc6 @
                                  (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn _ _
-                                  _ _ _ _ _ @ _))%expr_pat => None
+                                  _ _ _ _ _ @ _))%expr_pat => Datatypes.None
                               | (@expr.Ident _ _ _ t6 idc6 @ #(_))%expr_pat |
                                 (@expr.Ident _ _ _ t6 idc6 @ ($_)%expr)%expr_pat |
                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.Abs _ _ _
@@ -5972,8 +6027,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 (@expr.Ident _ _ _ t6 idc6 @
                                  (@expr.LetIn _ _ _ _ _ _ _ @ _))%expr_pat |
                                 (@expr.Ident _ _ _ t6 idc6 @ @expr.LetIn _ _
-                                 _ _ _ _ _)%expr_pat => None
-                              | _ => None
+                                 _ _ _ _ _)%expr_pat => Datatypes.None
+                              | _ => Datatypes.None
                               end;;
                               match x9 with
                               | @expr.App _ _ _ s9 _
@@ -6007,7 +6062,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                           ((((projT1 args6) -> s4) -> s5) ->
                                            s9 -> (projT1 args))%ptype
                                       with
-                                      | Some (_, _, _, (_, _))%zrange =>
+                                      | Datatypes.Some
+                                        (_, _, _, (_, _))%zrange =>
                                           if
                                            type.type_beq base.type
                                              base.type.type_beq
@@ -6060,7 +6116,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                               (ZRange.normalize
                                                                  roffset)
                                                            then
-                                                            Some
+                                                            Datatypes.Some
                                                               (#(Z_cast2
                                                                    (r1, r2))%expr @
                                                                (#(fancy_subb
@@ -6073,7 +6129,9 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                                 x12,
                                                                 #(Z_cast ry)%expr @
                                                                 y)))%expr_pat
-                                                           else None) args7
+                                                           else
+                                                            Datatypes.None)
+                                                           args7
                                                            (let (x12, _) :=
                                                               xv in
                                                             x12) args5
@@ -6090,29 +6148,31 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                            (let (x12, _) :=
                                                               xv0 in
                                                             x12);
-                                                  Some (Base x12));
-                                           Some
+                                                  Datatypes.Some (Base x12));
+                                           Datatypes.Some
                                              (fv0 <-- fv;
                                               Base fv0)%under_lets
-                                          else None
-                                      | None => None
+                                          else Datatypes.None
+                                      | Datatypes.None => Datatypes.None
                                       end
                                   | (@expr.Ident _ _ _ t7 idc7 @ ($_)%expr)%expr_pat |
                                     (@expr.Ident _ _ _ t7 idc7 @ @expr.Abs _
                                      _ _ _ _ _)%expr_pat |
                                     (@expr.Ident _ _ _ t7 idc7 @ (_ @ _))%expr_pat |
                                     (@expr.Ident _ _ _ t7 idc7 @ @expr.LetIn
-                                     _ _ _ _ _ _ _)%expr_pat => None
-                                  | _ => None
+                                     _ _ _ _ _ _ _)%expr_pat =>
+                                      Datatypes.None
+                                  | _ => Datatypes.None
                                   end
                               | @expr.App _ _ _ s9 _ ($_)%expr _ | @expr.App
                                 _ _ _ s9 _ (@expr.Abs _ _ _ _ _ _) _ |
                                 @expr.App _ _ _ s9 _ (_ @ _)%expr_pat _ |
                                 @expr.App _ _ _ s9 _
-                                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                              | _ => None
+                                (@expr.LetIn _ _ _ _ _ _ _) _ =>
+                                  Datatypes.None
+                              | _ => Datatypes.None
                               end
-                          | _ => None
+                          | _ => Datatypes.None
                           end;;
                           args <- invert_bind_args idc4 Raw.ident.Z_cast;
                           args0 <- invert_bind_args idc3 Raw.ident.Z_cast;
@@ -6126,7 +6186,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
                               ((((projT1 args2) -> s4) -> s5) -> s6)%ptype
                           with
-                          | Some (_, _, _, _)%zrange =>
+                          | Datatypes.Some (_, _, _, _)%zrange =>
                               if
                                type.type_beq base.type base.type.type_beq
                                  (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -6150,52 +6210,72 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                                is_bounded_by_bool s7
                                                  (ZRange.normalize rs)
                                               then
-                                               Some
+                                               Datatypes.Some
                                                  (#(Z_cast2 (r1, r2))%expr @
                                                   (#(fancy_subb (Z.log2 s7) 0)%expr @
                                                    (#(Z_cast rb)%expr @ b2,
                                                    #(Z_cast rx)%expr @ x8,
                                                    #(Z_cast ry)%expr @ y)))%expr_pat
-                                              else None) args3
+                                              else Datatypes.None) args3
                                               (let (x8, _) := xv in x8) args1
                                               (v (Compile.reflect x5)) args0
                                               (v0 (Compile.reflect x6)) args
                                               (v1 (Compile.reflect x7));
-                                      Some (Base x8));
-                               Some (fv0 <-- fv;
-                                     Base fv0)%under_lets
-                              else None
-                          | None => None
+                                      Datatypes.Some (Base x8));
+                               Datatypes.Some
+                                 (fv0 <-- fv;
+                                  Base fv0)%under_lets
+                              else Datatypes.None
+                          | Datatypes.None => Datatypes.None
                           end
                       | @expr.App _ _ _ s6 _ ($_)%expr _ | @expr.App _ _ _ s6
                         _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s6 _
                         (_ @ _)%expr_pat _ | @expr.App _ _ _ s6 _
-                        (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                      | _ => None
+                        (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                      | _ => Datatypes.None
                       end
                   | @expr.App _ _ _ s5 _ ($_)%expr _ | @expr.App _ _ _ s5 _
                     (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s5 _
                     (_ @ _)%expr_pat _ | @expr.App _ _ _ s5 _
-                    (@expr.LetIn _ _ _ _ _ _ _) _ => None
-                  | _ => None
+                    (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+                  | _ => Datatypes.None
                   end
               | @expr.App _ _ _ s4 _ ($_)%expr _ | @expr.App _ _ _ s4 _
                 (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s4 _
                 (_ @ _)%expr_pat _ | @expr.App _ _ _ s4 _
-                (@expr.LetIn _ _ _ _ _ _ _) _ => None
-              | _ => None
+                (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+              | _ => Datatypes.None
               end
           | (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.Abs _ _ _ _ _ _)%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ (_ @ _))%expr_pat |
             (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
-              None
-          | _ => None
+              Datatypes.None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_cast2 range)%expr @ x)%expr_pat)%option
+| Some A => fun x : expr A => Base (#(Some)%expr @ x)%expr_pat
+| None A => Base #(None)%expr
+| @option_rect A P =>
+    fun (x : expr A -> UnderLets (expr P))
+      (x0 : expr unit -> UnderLets (expr P)) (x1 : expr (base.type.option A))
+    =>
+    Base
+      (#(option_rect)%expr @ (λ x2 : var A,
+                              to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| Build_zrange =>
+    fun x x0 : expr ℤ => Base (#(Build_zrange)%expr @ x @ x0)%expr_pat
+| @zrange_rect P =>
+    fun (x : expr ℤ -> expr ℤ -> UnderLets (expr P))
+      (x0 : expr base.type.zrange) =>
+    Base
+      (#(zrange_rect)%expr @ (λ x1 x2 : var ℤ,
+                              to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
 | fancy_add log2wordmax imm =>
     fun x : expr (ℤ * ℤ)%etype =>
     Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat

--- a/src/nbe_rewrite_head.out
+++ b/src/nbe_rewrite_head.out
@@ -7,17 +7,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
       | @expr.Ident _ _ _ t idc =>
           args <- invert_bind_args idc Raw.ident.Literal;
           match pattern.type.unify_extracted ℕ (projT1 args) with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℕ (projT1 args)
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some (Base (##(Nat.succ (let (x0, _) := xv in x0)))%expr)
-              else None
-          | None => None
+               Datatypes.Some
+                 (Base (##(Nat.succ (let (x0, _) := xv in x0)))%expr)
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Nat_succ)%expr @ x)%expr_pat)%option
 | Nat_pred =>
     fun x : expr ℕ =>
@@ -25,17 +26,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
       | @expr.Ident _ _ _ t idc =>
           args <- invert_bind_args idc Raw.ident.Literal;
           match pattern.type.unify_extracted ℕ (projT1 args) with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℕ (projT1 args)
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some (Base (##(Nat.pred (let (x0, _) := xv in x0)))%expr)
-              else None
-          | None => None
+               Datatypes.Some
+                 (Base (##(Nat.pred (let (x0, _) := xv in x0)))%expr)
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Nat_pred)%expr @ x)%expr_pat)%option
 | Nat_max =>
     fun x x0 : expr ℕ =>
@@ -49,25 +51,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℕ -> ℕ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℕ -> ℕ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##(Nat.max (let (x1, _) := xv in x1)
                               (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Nat_max)%expr @ x @ x0)%expr_pat)%option
 | Nat_mul =>
     fun x x0 : expr ℕ =>
@@ -81,25 +83,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℕ -> ℕ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℕ -> ℕ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) *
                             (let (x1, _) := xv0 in x1))%nat)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Nat_mul)%expr @ x @ x0)%expr_pat)%option
 | Nat_add =>
     fun x x0 : expr ℕ =>
@@ -113,25 +115,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℕ -> ℕ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℕ -> ℕ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) +
                             (let (x1, _) := xv0 in x1))%nat)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Nat_add)%expr @ x @ x0)%expr_pat)%option
 | Nat_sub =>
     fun x x0 : expr ℕ =>
@@ -145,25 +147,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℕ -> ℕ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℕ -> ℕ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) -
                             (let (x1, _) := xv0 in x1))%nat)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Nat_sub)%expr @ x @ x0)%expr_pat)%option
 | Nat_eqb =>
     fun x x0 : expr ℕ =>
@@ -177,25 +179,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℕ -> ℕ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℕ -> ℕ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) =?
                             (let (x1, _) := xv0 in x1))%nat)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Nat_eqb)%expr @ x @ x0)%expr_pat)%option
 | @nil t => Base []%expr_pat
 | @cons t => fun (x : expr t) (x0 : expr (list t)) => Base (x :: x0)%expr_pat
@@ -217,7 +219,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Datatypes.Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b3) ->
@@ -236,21 +238,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                _ <- base.try_make_transport_cps b2 b2;
                v3 <- base.try_make_transport_cps b3 A;
                v4 <- base.try_make_transport_cps A A;
-               Some (Base (v4 (v3 (v1 (v (Compile.reflect x1))))))
-              else None
-          | None => None
+               Datatypes.Some (Base (v4 (v3 (v1 (v (Compile.reflect x1))))))
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(fst)%expr @ x)%expr_pat)%option
 | @snd A B =>
     fun x : expr (A * B)%etype =>
@@ -269,7 +272,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x2, _) := args in x2) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype
           with
-          | Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
+          | Datatypes.Some (_, _, _, (_, (_, (_, _)), b3, b2))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b3 * b2)%etype -> b2) ->
@@ -288,21 +291,22 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v2 <- base.try_make_transport_cps b2 b2;
                v3 <- base.try_make_transport_cps b2 B;
                v4 <- base.try_make_transport_cps B B;
-               Some (Base (v4 (v3 (v2 (v0 (Compile.reflect x0))))))
-              else None
-          | None => None
+               Datatypes.Some (Base (v4 (v3 (v2 (v0 (Compile.reflect x0))))))
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(snd)%expr @ x)%expr_pat)%option
 | @prod_rect A B T =>
     fun (x : expr A -> expr B -> UnderLets (expr T))
@@ -324,7 +328,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  ((let (x3, _) := args in x3) * (let (_, y) := args in y))%etype) ->
                 s0) -> s)%ptype
           with
-          | Some
+          | Datatypes.Some
             (_, (_, _), (_, _, _), (_, (_, b7)), (_, (_, (_, _)), b9, b8))%zrange =>
               if
                type.type_beq base.type base.type.type_beq
@@ -351,25 +355,26 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v2 <- base.try_make_transport_cps b8 b8;
                v3 <- base.try_make_transport_cps b7 T;
                v4 <- base.try_make_transport_cps T T;
-               Some
+               Datatypes.Some
                  (fv1 <-- x'4 (x'3 (x'2 (x'1 (x'0 (x' x)))))
                             (v1 (v (Compile.reflect x2)))
                             (v2 (v0 (Compile.reflect x1)));
                   Base (v4 (v3 fv1)))%under_lets
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(prod_rect)%expr @
         (λ (x1 : var A)(x2 : var B),
@@ -387,7 +392,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               (((((unit -> T) -> (unit -> T) -> bool -> T) -> unit -> T) ->
                 unit -> T) -> (projT1 args))%ptype
           with
-          | Some (_, _, (_, _, (_, _)), (_, _), (_, b8), _)%zrange =>
+          | Datatypes.Some
+            (_, _, (_, _, (_, _)), (_, _), (_, b8), _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((((unit -> b8) -> (unit -> b8) -> bool -> b8) ->
@@ -403,17 +409,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                x'2 <- base.try_make_transport_cps b8 b8;
                v <- base.try_make_transport_cps b8 T;
                v0 <- base.try_make_transport_cps T T;
-               Some
+               Datatypes.Some
                  (fv0 <-- (if let (x2, _) := xv in x2
                            then x'1 (x' x) (##tt)%expr
                            else x'2 (x'0 x0) (##tt)%expr);
                   Base (v0 (v fv0)))%under_lets
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(bool_rect)%expr @ (λ x2 : var unit,
                              to_expr (x ($x2)))%expr @
@@ -433,7 +439,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               (((((unit -> P) -> (ℕ -> P -> P) -> ℕ -> P) -> unit -> P) ->
                 ℕ -> P -> P) -> (projT1 args))%ptype
           with
-          | Some
+          | Datatypes.Some
             (_, _, (_, (_, _), (_, _)), (_, _), (_, (_, b10)), _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
@@ -452,7 +458,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                x'4 <- base.try_make_transport_cps b10 b10;
                v <- base.try_make_transport_cps b10 P;
                v0 <- base.try_make_transport_cps P P;
-               Some
+               Datatypes.Some
                  (fv0 <-- Datatypes.nat_rect
                             (fun _ : nat => UnderLets (expr b10))
                             (x'2 (x' x) (##tt)%expr)
@@ -461,12 +467,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                              x'4 (x'3 (x'1 (x'0 x0))) (##n')%expr rec0)
                             (let (x2, _) := xv in x2);
                   Base (v0 (v fv0)))%under_lets
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(nat_rect)%expr @ (λ x2 : var unit,
                             to_expr (x ($x2)))%expr @
@@ -490,7 +496,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              ((((((P -> Q) -> (ℕ -> (P -> Q) -> P -> Q) -> ℕ -> P -> Q) ->
                  P -> Q) -> ℕ -> (P -> Q) -> P -> Q) -> (projT1 args)) -> P)%ptype
          with
-         | Some
+         | Datatypes.Some
            (_, _, (_, (_, _, (_, _)), (_, (_, _))), (_, _),
            (_, (_, _, (_, b16))), _, b)%zrange =>
              if
@@ -520,7 +526,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               v0 <- base.try_make_transport_cps b b;
               v1 <- base.try_make_transport_cps b16 Q;
               v2 <- base.try_make_transport_cps Q Q;
-              Some
+              Datatypes.Some
                 (fv0 <-- Datatypes.nat_rect
                            (fun _ : nat => expr b -> UnderLets (expr b16))
                            (x'6 (x'5 (x'0 (x' x))))
@@ -531,10 +537,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                               (##n')%expr rec v3) (let (x3, _) := xv in x3)
                            (v0 (v x2));
                  Base (v2 (v1 fv0)))%under_lets
-             else None
-         | None => None
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
-     | _ => None
+     | _ => Datatypes.None
      end;;;
      Base
        (#(nat_rect_arrow)%expr @ (λ x3 : var P,
@@ -559,7 +565,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           (((((unit -> P) -> (A -> (list A) -> P -> P) -> (list A) -> P) ->
              unit -> P) -> A -> (list A) -> P -> P) -> (list A))%ptype
       with
-      | Some
+      | Datatypes.Some
         (_, _, (_, (_, (_, _)), (_, _)), (_, _), (_, (_, (_, b12))), b)%zrange =>
           if
            type.type_beq base.type base.type.type_beq
@@ -585,7 +591,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            v1 <- base.try_make_transport_cps b12 P;
            v2 <- base.try_make_transport_cps P P;
            fv0 <- (ls <- reflect_list (v0 (v x1));
-                   Some
+                   Datatypes.Some
                      (Datatypes.list_rect
                         (fun _ : Datatypes.list (expr b) =>
                          UnderLets (expr b12)) (x'4 (x' x) (##tt)%expr)
@@ -594,12 +600,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (rec' <-- rec;
                           x'8 (x'7 (x'6 (x'5 (x'3 (x'2 (x'1 (x'0 x0))))))) x2
                             (Compilers.reify_list xs) rec')%under_lets) ls));
-           Some (fv1 <-- fv0;
-                 Base (v2 (v1 fv1)))%under_lets
-          else None
-      | None => None
+           Datatypes.Some (fv1 <-- fv0;
+                           Base (v2 (v1 fv1)))%under_lets
+          else Datatypes.None
+      | Datatypes.None => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(list_rect)%expr @ (λ x2 : var unit,
                              to_expr (x ($x2)))%expr @
@@ -623,7 +629,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               (((((unit -> P) -> (A -> (list A) -> P) -> (list A) -> P) ->
                  unit -> P) -> A -> (list A) -> P) -> (list args))%ptype
           with
-          | Some
+          | Datatypes.Some
             (_, _, (_, (_, _), (_, _)), (_, _), (_, (_, b10)), b)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
@@ -645,11 +651,11 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                _ <- base.try_make_transport_cps b10 b10;
                v <- base.try_make_transport_cps b10 P;
                v0 <- base.try_make_transport_cps P P;
-               Some
+               Datatypes.Some
                  (fv0 <-- x'3 (x' x) (##tt)%expr;
                   Base (v0 (v fv0)))%under_lets
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _
         (@expr.App _ _ _ s0 _ (@expr.Ident _ _ _ t idc) x3) x2 =>
@@ -668,7 +674,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                  unit -> P) -> A -> (list A) -> P) ->
                ((args -> (list args) -> (list args)) -> s0) -> s)%ptype
           with
-          | Some
+          | Datatypes.Some
             (_, _, (_, (_, _), (_, _)), (_, _), (_, (_, b10)),
             (_, (_, _), _, b11))%zrange =>
               if
@@ -697,25 +703,26 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v2 <- base.try_make_transport_cps b11 b11;
                v3 <- base.try_make_transport_cps b10 P;
                v4 <- base.try_make_transport_cps P P;
-               Some
+               Datatypes.Some
                  (fv1 <-- x'6 (x'5 (x'4 (x'2 (x'1 (x'0 x0)))))
                             (v1 (v (Compile.reflect x3)))
                             (v2 (v0 (Compile.reflect x2)));
                   Base (v4 (v3 fv1)))%under_lets
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ ($_)%expr _) _ | @expr.App
         _ _ _ s _ (@expr.App _ _ _ s0 _ (@expr.Abs _ _ _ _ _ _) _) _ |
         @expr.App _ _ _ s _ (@expr.App _ _ _ s0 _ (_ @ _)%expr_pat _) _ |
         @expr.App _ _ _ s _
-        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ => None
+        (@expr.App _ _ _ s0 _ (@expr.LetIn _ _ _ _ _ _ _) _) _ =>
+          Datatypes.None
       | @expr.App _ _ _ s _ #(_)%expr_pat _ | @expr.App _ _ _ s _ ($_)%expr
         _ | @expr.App _ _ _ s _ (@expr.Abs _ _ _ _ _ _) _ | @expr.App _ _ _ s
-        _ (@expr.LetIn _ _ _ _ _ _ _) _ => None
-      | _ => None
+        _ (@expr.LetIn _ _ _ _ _ _ _) _ => Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(list_case)%expr @ (λ x2 : var unit,
                              to_expr (x ($x2)))%expr @
@@ -728,7 +735,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          (((pattern.base.type.list '1) -> ℕ) -> (pattern.base.type.list '1))%ptype
          (((list T) -> ℕ) -> (list T))%ptype
      with
-     | Some (_, _, b)%zrange =>
+     | Datatypes.Some (_, _, b)%zrange =>
          if
           type.type_beq base.type base.type.type_beq
             (((list b) -> ℕ) -> (list b))%ptype
@@ -738,12 +745,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           v <- base.try_make_transport_cps T b;
           v0 <- base.try_make_transport_cps b b;
           fv0 <- (x0 <- (xs <- reflect_list (v0 (v x));
-                         Some (##(length xs))%expr);
-                  Some (Base x0));
-          Some (fv1 <-- fv0;
-                Base fv1)%under_lets
-         else None
-     | None => None
+                         Datatypes.Some (##(length xs))%expr);
+                  Datatypes.Some (Base x0));
+          Datatypes.Some (fv1 <-- fv0;
+                          Base fv1)%under_lets
+         else Datatypes.None
+     | Datatypes.None => Datatypes.None
      end;;;
      Base (#(List_length)%expr @ x)%expr_pat)%option
 | List_seq =>
@@ -758,27 +765,27 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℕ -> ℕ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℕ -> ℕ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (Compilers.reify_list
-                           (map (fun v : nat => (##v)%expr)
+                           (List.map (fun v : nat => (##v)%expr)
                               (seq (let (x1, _) := xv in x1)
                                  (let (x1, _) := xv0 in x1)))))
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(List_seq)%expr @ x @ x0)%expr_pat)%option
 | @List_firstn A =>
     fun (x : expr ℕ) (x0 : expr (list A)) =>
@@ -792,7 +799,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 ℕ) -> (pattern.base.type.list '1))%ptype
               (((ℕ -> (list A) -> (list A)) -> (projT1 args)) -> (list A))%ptype
           with
-          | Some (_, (_, _), _, b)%zrange =>
+          | Datatypes.Some (_, (_, _), _, b)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((ℕ -> (list b) -> (list b)) -> ℕ) -> (list b))%ptype
@@ -805,18 +812,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v1 <- base.try_make_transport_cps b A;
                v2 <- base.try_make_transport_cps A A;
                fv0 <- (xs <- reflect_list (v0 (v x0));
-                       Some
+                       Datatypes.Some
                          (Base
                             (Compilers.reify_list
                                (firstn (let (x1, _) := xv in x1) xs))));
-               Some (fv1 <-- fv0;
-                     Base (v2 (v1 fv1)))%under_lets
-              else None
-          | None => None
+               Datatypes.Some (fv1 <-- fv0;
+                               Base (v2 (v1 fv1)))%under_lets
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(List_firstn)%expr @ x @ x0)%expr_pat)%option
 | @List_skipn A =>
     fun (x : expr ℕ) (x0 : expr (list A)) =>
@@ -830,7 +837,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 ℕ) -> (pattern.base.type.list '1))%ptype
               (((ℕ -> (list A) -> (list A)) -> (projT1 args)) -> (list A))%ptype
           with
-          | Some (_, (_, _), _, b)%zrange =>
+          | Datatypes.Some (_, (_, _), _, b)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((ℕ -> (list b) -> (list b)) -> ℕ) -> (list b))%ptype
@@ -843,18 +850,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v1 <- base.try_make_transport_cps b A;
                v2 <- base.try_make_transport_cps A A;
                fv0 <- (xs <- reflect_list (v0 (v x0));
-                       Some
+                       Datatypes.Some
                          (Base
                             (Compilers.reify_list
                                (skipn (let (x1, _) := xv in x1) xs))));
-               Some (fv1 <-- fv0;
-                     Base (v2 (v1 fv1)))%under_lets
-              else None
-          | None => None
+               Datatypes.Some (fv1 <-- fv0;
+                               Base (v2 (v1 fv1)))%under_lets
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(List_skipn)%expr @ x @ x0)%expr_pat)%option
 | @List_repeat A =>
     fun (x : expr A) (x0 : expr ℕ) =>
@@ -866,7 +873,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               ((('1%pbtype -> ℕ -> (pattern.base.type.list '1)) -> '1%pbtype) ->
                ℕ)%ptype (((A -> ℕ -> (list A)) -> A) -> (projT1 args))%ptype
           with
-          | Some (_, (_, _), b0, _)%zrange =>
+          | Datatypes.Some (_, (_, _), b0, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  (((b0 -> ℕ -> (list b0)) -> b0) -> ℕ)%ptype
@@ -878,18 +885,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v0 <- base.try_make_transport_cps b0 b0;
                v1 <- base.try_make_transport_cps b0 A;
                v2 <- base.try_make_transport_cps A A;
-               Some
+               Datatypes.Some
                  (Base
                     (v2
                        (v1
                           (Compilers.reify_list
                              (repeat (v0 (v x)) (let (x1, _) := xv in x1))))))
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(List_repeat)%expr @ x @ x0)%expr_pat)%option
 | @List_combine A B =>
     fun (x : expr (list A)) (x0 : expr (list B)) =>
@@ -900,7 +907,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            (pattern.base.type.list '1)) -> (pattern.base.type.list '2))%ptype
          ((((list A) -> (list B) -> (list (A * B))) -> (list A)) -> (list B))%ptype
      with
-     | Some (_, (_, (_, _)), b0, b)%zrange =>
+     | Datatypes.Some (_, (_, (_, _)), b0, b)%zrange =>
          if
           type.type_beq base.type base.type.type_beq
             ((((list b0) -> (list b) -> (list (b0 * b))) -> (list b0)) ->
@@ -919,15 +926,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           x'2 <- base.try_make_transport_cps B B;
           fv0 <- (x1 <- (xs <- reflect_list (v1 (v x));
                          ys <- reflect_list (v2 (v0 x0));
-                         Some
+                         Datatypes.Some
                            (Compilers.reify_list
-                              (map (fun '(x1, y)%zrange => (x1, y)%expr_pat)
-                                 (combine xs ys))));
-                  Some (Base x1));
-          Some (fv1 <-- fv0;
-                Base (x'2 (x'1 (x'0 (x' fv1)))))%under_lets
-         else None
-     | None => None
+                              (List.map
+                                 (fun '(x1, y)%zrange => (x1, y)%expr_pat)
+                                 (List.combine xs ys))));
+                  Datatypes.Some (Base x1));
+          Datatypes.Some
+            (fv1 <-- fv0;
+             Base (x'2 (x'1 (x'0 (x' fv1)))))%under_lets
+         else Datatypes.None
+     | Datatypes.None => Datatypes.None
      end;;;
      Base (#(List_combine)%expr @ x @ x0)%expr_pat)%option
 | @List_map A B =>
@@ -939,7 +948,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             '1%pbtype -> '2%pbtype) -> (pattern.base.type.list '1))%ptype
           ((((A -> B) -> (list A) -> (list B)) -> A -> B) -> (list A))%ptype
       with
-      | Some (_, _, (_, _), (_, b4), b)%zrange =>
+      | Datatypes.Some (_, _, (_, _), (_, b4), b)%zrange =>
           if
            type.type_beq base.type base.type.type_beq
              ((((b -> b4) -> (list b) -> (list b4)) -> b -> b4) -> (list b))%ptype
@@ -955,7 +964,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            v1 <- base.try_make_transport_cps b4 B;
            v2 <- base.try_make_transport_cps B B;
            fv0 <- (ls <- reflect_list (v0 (v x0));
-                   Some
+                   Datatypes.Some
                      (Datatypes.list_rect
                         (fun _ : Datatypes.list (expr b) =>
                          UnderLets (expr (list b4))) (Base []%expr_pat)
@@ -964,12 +973,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (rec' <-- rec;
                           fx <-- x'2 (x'1 (x'0 (x' x))) x1;
                           Base (fx :: rec')%expr_pat)%under_lets) ls));
-           Some (fv1 <-- fv0;
-                 Base (v2 (v1 fv1)))%under_lets
-          else None
-      | None => None
+           Datatypes.Some (fv1 <-- fv0;
+                           Base (v2 (v1 fv1)))%under_lets
+          else Datatypes.None
+      | Datatypes.None => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(List_map)%expr @ (λ x1 : var A,
                             to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
@@ -982,7 +991,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
             (pattern.base.type.list '1)) -> (pattern.base.type.list '1))%ptype
           ((((list A) -> (list A) -> (list A)) -> (list A)) -> (list A))%ptype
       with
-      | Some (_, (_, _), _, b)%zrange =>
+      | Datatypes.Some (_, (_, _), _, b)%zrange =>
           if
            type.type_beq base.type base.type.type_beq
              ((((list b) -> (list b) -> (list b)) -> (list b)) -> (list b))%ptype
@@ -996,7 +1005,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            v3 <- base.try_make_transport_cps b A;
            v4 <- base.try_make_transport_cps A A;
            fv0 <- (ls <- reflect_list (v1 (v x));
-                   Some
+                   Datatypes.Some
                      (Datatypes.list_rect
                         (fun _ : Datatypes.list (expr b) =>
                          UnderLets (expr (list b))) (Base (v2 (v0 x0)))
@@ -1004,12 +1013,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                            (rec : UnderLets (expr (list b))) =>
                          (rec' <-- rec;
                           Base (x1 :: rec')%expr_pat)%under_lets) ls));
-           Some (fv1 <-- fv0;
-                 Base (v4 (v3 fv1)))%under_lets
-          else None
-      | None => None
+           Datatypes.Some (fv1 <-- fv0;
+                           Base (v4 (v3 fv1)))%under_lets
+          else Datatypes.None
+      | Datatypes.None => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x ++ x0)%expr)%option
 | @List_rev A =>
     fun x : expr (list A) =>
@@ -1019,7 +1028,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            (pattern.base.type.list '1))%ptype
           (((list A) -> (list A)) -> (list A))%ptype
       with
-      | Some (_, _, b)%zrange =>
+      | Datatypes.Some (_, _, b)%zrange =>
           if
            type.type_beq base.type base.type.type_beq
              (((list b) -> (list b)) -> (list b))%ptype
@@ -1031,13 +1040,13 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            v1 <- base.try_make_transport_cps b A;
            v2 <- base.try_make_transport_cps A A;
            fv0 <- (xs <- reflect_list (v0 (v x));
-                   Some (Base (Compilers.reify_list (rev xs))));
-           Some (fv1 <-- fv0;
-                 Base (v2 (v1 fv1)))%under_lets
-          else None
-      | None => None
+                   Datatypes.Some (Base (Compilers.reify_list (rev xs))));
+           Datatypes.Some (fv1 <-- fv0;
+                           Base (v2 (v1 fv1)))%under_lets
+          else Datatypes.None
+      | Datatypes.None => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(List_rev)%expr @ x)%expr_pat)%option
 | @List_flat_map A B =>
     fun (x : expr A -> UnderLets (expr (list B))) (x0 : expr (list A)) =>
@@ -1050,7 +1059,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           ((((A -> (list B)) -> (list A) -> (list B)) -> A -> (list B)) ->
            (list A))%ptype
       with
-      | Some (_, _, (_, _), (_, b4), b)%zrange =>
+      | Datatypes.Some (_, _, (_, _), (_, b4), b)%zrange =>
           if
            type.type_beq base.type base.type.type_beq
              ((((b -> (list b4)) -> (list b) -> (list b4)) -> b -> (list b4)) ->
@@ -1068,7 +1077,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            v1 <- base.try_make_transport_cps b4 B;
            v2 <- base.try_make_transport_cps B B;
            fv0 <- (ls <- reflect_list (v0 (v x0));
-                   Some
+                   Datatypes.Some
                      (Datatypes.list_rect
                         (fun _ : Datatypes.list (expr b) =>
                          UnderLets (expr (list b4))) (Base []%expr_pat)
@@ -1077,14 +1086,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (rec' <-- rec;
                           fx <-- x'2 (x'1 (x'0 (x' x))) x1;
                           Base ($fx ++ rec')%expr)%under_lets) ls));
-           Some
+           Datatypes.Some
              (fv1 <-- fv0;
               fv2 <-- do_again (list B) (v1 fv1);
               Base (v2 fv2))%under_lets
-          else None
-      | None => None
+          else Datatypes.None
+      | Datatypes.None => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(List_flat_map)%expr @ (λ x1 : var A,
                                  to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
@@ -1099,7 +1108,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           ((((A -> bool) -> (list A) -> (list A * list A)%etype) -> A -> bool) ->
            (list A))%ptype
       with
-      | Some (_, _, (_, (_, _)), (_, _), b)%zrange =>
+      | Datatypes.Some (_, _, (_, (_, _)), (_, _), b)%zrange =>
           if
            type.type_beq base.type base.type.type_beq
              ((((b -> bool) -> (list b) -> (list b * list b)%etype) ->
@@ -1117,7 +1126,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            x'3 <- base.try_make_transport_cps A A;
            x'4 <- base.try_make_transport_cps A A;
            fv0 <- (ls <- reflect_list (v0 (v x0));
-                   Some
+                   Datatypes.Some
                      (Datatypes.list_rect
                         (fun _ : Datatypes.list (expr b) =>
                          UnderLets (expr (list b * list b)%etype))
@@ -1136,14 +1145,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                (λ _ : expr unit,
                                 ($g, $x1 :: $d)%expr_pat) @ $fx)%expr_pat)%expr @
                              rec')%expr_pat)%under_lets) ls));
-           Some
+           Datatypes.Some
              (fv1 <-- fv0;
               fv2 <-- do_again (list A * list A) (x'2 (x'1 fv1));
               Base (x'4 (x'3 fv2)))%under_lets
-          else None
-      | None => None
+          else Datatypes.None
+      | Datatypes.None => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(List_partition)%expr @ (λ x1 : var A,
                                   to_expr (x ($x1)))%expr @ x0)%expr_pat)%option
@@ -1159,7 +1168,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           (((((B -> A -> A) -> A -> (list B) -> A) -> B -> A -> A) -> A) ->
            (list B))%ptype
       with
-      | Some (_, (_, _), (_, (_, _)), (_, (_, _)), b0, b)%zrange =>
+      | Datatypes.Some (_, (_, _), (_, (_, _)), (_, (_, _)), b0, b)%zrange =>
           if
            type.type_beq base.type base.type.type_beq
              (((((b -> b0 -> b0) -> b0 -> (list b) -> b0) -> b -> b0 -> b0) ->
@@ -1181,7 +1190,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
            v3 <- base.try_make_transport_cps b0 A;
            v4 <- base.try_make_transport_cps A A;
            fv0 <- (ls <- reflect_list (v2 (v0 x1));
-                   Some
+                   Datatypes.Some
                      (Datatypes.list_rect
                         (fun _ : Datatypes.list (expr b) =>
                          UnderLets (expr b0)) (Base (v1 (v x0)))
@@ -1190,12 +1199,12 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                          (rec' <-- rec;
                           x'4 (x'3 (x'2 (x'1 (x'0 (x' x))))) x2 rec')%under_lets)
                         ls));
-           Some (fv1 <-- fv0;
-                 Base (v4 (v3 fv1)))%under_lets
-          else None
-      | None => None
+           Datatypes.Some (fv1 <-- fv0;
+                           Base (v4 (v3 fv1)))%under_lets
+          else Datatypes.None
+      | Datatypes.None => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base
        (#(List_fold_right)%expr @
         (λ (x2 : var B)(x3 : var A),
@@ -1215,7 +1224,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
              ((((ℕ -> (T -> T) -> (list T) -> (list T)) -> (projT1 args)) ->
                T -> T) -> (list T))%ptype
          with
-         | Some (_, (_, _, (_, _)), _, (_, _), b)%zrange =>
+         | Datatypes.Some (_, (_, _, (_, _)), _, (_, _), b)%zrange =>
              if
               type.type_beq base.type base.type.type_beq
                 ((((ℕ -> (b -> b) -> (list b) -> (list b)) -> ℕ) -> b -> b) ->
@@ -1234,19 +1243,19 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               v1 <- base.try_make_transport_cps b T;
               v2 <- base.try_make_transport_cps T T;
               fv0 <- (ls <- reflect_list (v0 (v x1));
-                      Some
+                      Datatypes.Some
                         (retv <---- update_nth (let (x2, _) := xv in x2)
                                       (fun x2 : UnderLets (expr b) =>
                                        x3 <-- x2;
                                        x'2 (x'1 (x'0 (x' x0))) x3)
-                                      (map Base ls);
+                                      (List.map Base ls);
                          Base (Compilers.reify_list retv))%under_lets);
-              Some (fv1 <-- fv0;
-                    Base (v2 (v1 fv1)))%under_lets
-             else None
-         | None => None
+              Datatypes.Some (fv1 <-- fv0;
+                              Base (v2 (v1 fv1)))%under_lets
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
-     | _ => None
+     | _ => Datatypes.None
      end;;;
      Base
        (#(List_update_nth)%expr @ x @ (λ x2 : var T,
@@ -1263,7 +1272,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
               ((((T -> (list T) -> ℕ -> T) -> T) -> (list T)) ->
                (projT1 args))%ptype
           with
-          | Some (_, (_, (_, _)), _, b0, _)%zrange =>
+          | Datatypes.Some (_, (_, (_, _)), _, b0, _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  ((((b0 -> (list b0) -> ℕ -> b0) -> b0) -> (list b0)) -> ℕ)%ptype
@@ -1280,18 +1289,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                v3 <- base.try_make_transport_cps b0 T;
                v4 <- base.try_make_transport_cps T T;
                fv0 <- (x2 <- (ls <- reflect_list (v2 (v0 x0));
-                              Some
+                              Datatypes.Some
                                 (nth_default (v1 (v x)) ls
                                    (let (x2, _) := xv in x2)));
-                       Some (Base x2));
-               Some (fv1 <-- fv0;
-                     Base (v4 (v3 fv1)))%under_lets
-              else None
-          | None => None
+                       Datatypes.Some (Base x2));
+               Datatypes.Some (fv1 <-- fv0;
+                               Base (v4 (v3 fv1)))%under_lets
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(List_nth_default)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add =>
     fun x x0 : expr ℤ =>
@@ -1305,25 +1314,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) +
                             (let (x1, _) := xv0 in x1))%Z)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x + x0)%expr)%option
 | Z_mul =>
     fun x x0 : expr ℤ =>
@@ -1337,25 +1346,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) *
                             (let (x1, _) := xv0 in x1))%Z)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x * x0)%expr)%option
 | Z_pow =>
     fun x x0 : expr ℤ =>
@@ -1369,25 +1378,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1)
                             ^ (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_pow)%expr @ x @ x0)%expr_pat)%option
 | Z_sub =>
     fun x x0 : expr ℤ =>
@@ -1401,25 +1410,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) -
                             (let (x1, _) := xv0 in x1))%Z)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x - x0)%expr)%option
 | Z_opp =>
     fun x : expr ℤ =>
@@ -1427,17 +1436,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
       | @expr.Ident _ _ _ t idc =>
           args <- invert_bind_args idc Raw.ident.Literal;
           match pattern.type.unify_extracted ℤ (projT1 args) with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some (Base (##(- (let (x0, _) := xv in x0))%Z)%expr)
-              else None
-          | None => None
+               Datatypes.Some (Base (##(- (let (x0, _) := xv in x0))%Z)%expr)
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (- x)%expr)%option
 | Z_div =>
     fun x x0 : expr ℤ =>
@@ -1451,25 +1460,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) /
                             (let (x1, _) := xv0 in x1))%Z)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x / x0)%expr)%option
 | Z_modulo =>
     fun x x0 : expr ℤ =>
@@ -1483,25 +1492,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1)
                             mod (let (x1, _) := xv0 in x1))%Z)%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x mod x0)%expr)%option
 | Z_log2 =>
     fun x : expr ℤ =>
@@ -1509,17 +1518,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
       | @expr.Ident _ _ _ t idc =>
           args <- invert_bind_args idc Raw.ident.Literal;
           match pattern.type.unify_extracted ℤ (projT1 args) with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some (Base (##(Z.log2 (let (x0, _) := xv in x0)))%expr)
-              else None
-          | None => None
+               Datatypes.Some
+                 (Base (##(Z.log2 (let (x0, _) := xv in x0)))%expr)
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_log2)%expr @ x)%expr_pat)%option
 | Z_log2_up =>
     fun x : expr ℤ =>
@@ -1527,17 +1537,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
       | @expr.Ident _ _ _ t idc =>
           args <- invert_bind_args idc Raw.ident.Literal;
           match pattern.type.unify_extracted ℤ (projT1 args) with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some (Base (##(Z.log2_up (let (x0, _) := xv in x0)))%expr)
-              else None
-          | None => None
+               Datatypes.Some
+                 (Base (##(Z.log2_up (let (x0, _) := xv in x0)))%expr)
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_log2_up)%expr @ x)%expr_pat)%option
 | Z_eqb =>
     fun x x0 : expr ℤ =>
@@ -1551,25 +1562,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) =?
                             (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_eqb)%expr @ x @ x0)%expr_pat)%option
 | Z_leb =>
     fun x x0 : expr ℤ =>
@@ -1583,26 +1594,58 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) <=?
                             (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_leb)%expr @ x @ x0)%expr_pat)%option
+| Z_ltb =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype
+              with
+              | Datatypes.Some (_, _)%zrange =>
+                  if
+                   type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                     ((projT1 args0) -> (projT1 args))%ptype
+                  then
+                   xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+                   Datatypes.Some
+                     (Base
+                        (##((let (x1, _) := xv in x1) <?
+                            (let (x1, _) := xv0 in x1)))%expr)
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
+              end
+          | _ => Datatypes.None
+          end
+      | _ => Datatypes.None
+      end;;
+      Datatypes.None);;;
+     Base (#(Z_ltb)%expr @ x @ x0)%expr_pat)%option
 | Z_geb =>
     fun x x0 : expr ℤ =>
     ((match x with
@@ -1615,43 +1658,76 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##((let (x1, _) := xv in x1) >=?
                             (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_geb)%expr @ x @ x0)%expr_pat)%option
+| Z_gtb =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype
+              with
+              | Datatypes.Some (_, _)%zrange =>
+                  if
+                   type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                     ((projT1 args0) -> (projT1 args))%ptype
+                  then
+                   xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+                   Datatypes.Some
+                     (Base
+                        (##((let (x1, _) := xv in x1) >?
+                            (let (x1, _) := xv0 in x1)))%expr)
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
+              end
+          | _ => Datatypes.None
+          end
+      | _ => Datatypes.None
+      end;;
+      Datatypes.None);;;
+     Base (#(Z_gtb)%expr @ x @ x0)%expr_pat)%option
 | Z_of_nat =>
     fun x : expr ℕ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
           args <- invert_bind_args idc Raw.ident.Literal;
           match pattern.type.unify_extracted ℕ (projT1 args) with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℕ (projT1 args)
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some (Base (##(Z.of_nat (let (x0, _) := xv in x0)))%expr)
-              else None
-          | None => None
+               Datatypes.Some
+                 (Base (##(Z.of_nat (let (x0, _) := xv in x0)))%expr)
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_of_nat)%expr @ x)%expr_pat)%option
 | Z_to_nat =>
     fun x : expr ℤ =>
@@ -1659,17 +1735,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
       | @expr.Ident _ _ _ t idc =>
           args <- invert_bind_args idc Raw.ident.Literal;
           match pattern.type.unify_extracted ℤ (projT1 args) with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some (Base (##(Z.to_nat (let (x0, _) := xv in x0)))%expr)
-              else None
-          | None => None
+               Datatypes.Some
+                 (Base (##(Z.to_nat (let (x0, _) := xv in x0)))%expr)
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_to_nat)%expr @ x)%expr_pat)%option
 | Z_shiftr =>
     fun x x0 : expr ℤ =>
@@ -1683,25 +1760,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##(Z.shiftr (let (x1, _) := xv in x1)
                               (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x >> x0)%expr)%option
 | Z_shiftl =>
     fun x x0 : expr ℤ =>
@@ -1715,25 +1792,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##(Z.shiftl (let (x1, _) := xv in x1)
                               (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x << x0)%expr)%option
 | Z_land =>
     fun x x0 : expr ℤ =>
@@ -1747,25 +1824,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##(Z.land (let (x1, _) := xv in x1)
                               (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x &' x0)%expr)%option
 | Z_lor =>
     fun x x0 : expr ℤ =>
@@ -1779,43 +1856,108 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##(Z.lor (let (x1, _) := xv in x1)
                               (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (x || x0)%expr)%option
+| Z_min =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype
+              with
+              | Datatypes.Some (_, _)%zrange =>
+                  if
+                   type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                     ((projT1 args0) -> (projT1 args))%ptype
+                  then
+                   xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+                   Datatypes.Some
+                     (Base
+                        (##(Z.min (let (x1, _) := xv in x1)
+                              (let (x1, _) := xv0 in x1)))%expr)
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
+              end
+          | _ => Datatypes.None
+          end
+      | _ => Datatypes.None
+      end;;
+      Datatypes.None);;;
+     Base (#(Z_min)%expr @ x @ x0)%expr_pat)%option
+| Z_max =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype
+              with
+              | Datatypes.Some (_, _)%zrange =>
+                  if
+                   type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                     ((projT1 args0) -> (projT1 args))%ptype
+                  then
+                   xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+                   Datatypes.Some
+                     (Base
+                        (##(Z.max (let (x1, _) := xv in x1)
+                              (let (x1, _) := xv0 in x1)))%expr)
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
+              end
+          | _ => Datatypes.None
+          end
+      | _ => Datatypes.None
+      end;;
+      Datatypes.None);;;
+     Base (#(Z_max)%expr @ x @ x0)%expr_pat)%option
 | Z_bneg =>
     fun x : expr ℤ =>
     ((match x with
       | @expr.Ident _ _ _ t idc =>
           args <- invert_bind_args idc Raw.ident.Literal;
           match pattern.type.unify_extracted ℤ (projT1 args) with
-          | Some _ =>
+          | Datatypes.Some _ =>
               if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
               then
                xv <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some (Base (##(Z.bneg (let (x0, _) := xv in x0)))%expr)
-              else None
-          | None => None
+               Datatypes.Some
+                 (Base (##(Z.bneg (let (x0, _) := xv in x0)))%expr)
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_bneg)%expr @ x)%expr_pat)%option
 | Z_lnot_modulo =>
     fun x x0 : expr ℤ =>
@@ -1829,25 +1971,25 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##(Z.lnot_modulo (let (x1, _) := xv in x1)
                               (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat)%option
 | Z_mul_split =>
     fun x x0 x1 : expr ℤ =>
@@ -1864,7 +2006,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                       (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
                   with
-                  | Some (_, _, _)%zrange =>
+                  | Datatypes.Some (_, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          ((ℤ -> ℤ) -> ℤ)%ptype
@@ -1876,7 +2018,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 ##(projT2 args0);
                        xv1 <- ident.unify pattern.ident.Literal
                                 ##(projT2 args);
-                       Some
+                       Datatypes.Some
                          (Base
                             (let
                              '(a1, b1)%zrange :=
@@ -1884,16 +2026,16 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 (let (x2, _) := xv0 in x2)
                                 (let (x2, _) := xv1 in x2) in
                               ((##a1)%expr, (##b1)%expr)%expr_pat))
-                      else None
-                  | None => None
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_mul_split)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_get_carry =>
     fun x x0 x1 : expr ℤ =>
@@ -1910,7 +2052,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                       (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
                   with
-                  | Some (_, _, _)%zrange =>
+                  | Datatypes.Some (_, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          ((ℤ -> ℤ) -> ℤ)%ptype
@@ -1922,7 +2064,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 ##(projT2 args0);
                        xv1 <- ident.unify pattern.ident.Literal
                                 ##(projT2 args);
-                       Some
+                       Datatypes.Some
                          (Base
                             (let
                              '(a1, b1)%zrange :=
@@ -1930,16 +2072,16 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 (let (x2, _) := xv0 in x2)
                                 (let (x2, _) := xv1 in x2) in
                               ((##a1)%expr, (##b1)%expr)%expr_pat))
-                      else None
-                  | None => None
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_add_get_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_carry =>
     fun x x0 x1 : expr ℤ =>
@@ -1956,7 +2098,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                       (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
                   with
-                  | Some (_, _, _)%zrange =>
+                  | Datatypes.Some (_, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          ((ℤ -> ℤ) -> ℤ)%ptype
@@ -1968,21 +2110,21 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 ##(projT2 args0);
                        xv1 <- ident.unify pattern.ident.Literal
                                 ##(projT2 args);
-                       Some
+                       Datatypes.Some
                          (Base
                             (##(Z.add_with_carry (let (x2, _) := xv in x2)
                                   (let (x2, _) := xv0 in x2)
                                   (let (x2, _) := xv1 in x2)))%expr)
-                      else None
-                  | None => None
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_add_with_carry)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_with_get_carry =>
     fun x x0 x1 x2 : expr ℤ =>
@@ -2004,7 +2146,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           ((((projT1 args2) -> (projT1 args1)) ->
                             (projT1 args0)) -> (projT1 args))%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2019,7 +2161,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                     ##(projT2 args0);
                            xv2 <- ident.unify pattern.ident.Literal
                                     ##(projT2 args);
-                           Some
+                           Datatypes.Some
                              (Base
                                 (let
                                  '(a2, b2)%zrange :=
@@ -2029,18 +2171,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                     (let (x3, _) := xv1 in x3)
                                     (let (x3, _) := xv2 in x3) in
                                   ((##a2)%expr, (##b2)%expr)%expr_pat))
-                          else None
-                      | None => None
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_add_with_get_carry)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
 | Z_sub_get_borrow =>
     fun x x0 x1 : expr ℤ =>
@@ -2057,7 +2199,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                       (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
                   with
-                  | Some (_, _, _)%zrange =>
+                  | Datatypes.Some (_, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          ((ℤ -> ℤ) -> ℤ)%ptype
@@ -2069,7 +2211,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 ##(projT2 args0);
                        xv1 <- ident.unify pattern.ident.Literal
                                 ##(projT2 args);
-                       Some
+                       Datatypes.Some
                          (Base
                             (let
                              '(a1, b1)%zrange :=
@@ -2077,16 +2219,16 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 (let (x2, _) := xv0 in x2)
                                 (let (x2, _) := xv1 in x2) in
                               ((##a1)%expr, (##b1)%expr)%expr_pat))
-                      else None
-                  | None => None
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_sub_get_borrow)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_sub_with_get_borrow =>
     fun x x0 x1 x2 : expr ℤ =>
@@ -2108,7 +2250,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           ((((projT1 args2) -> (projT1 args1)) ->
                             (projT1 args0)) -> (projT1 args))%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2123,7 +2265,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                     ##(projT2 args0);
                            xv2 <- ident.unify pattern.ident.Literal
                                     ##(projT2 args);
-                           Some
+                           Datatypes.Some
                              (Base
                                 (let
                                  '(a2, b2)%zrange :=
@@ -2133,18 +2275,18 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                     (let (x3, _) := xv1 in x3)
                                     (let (x3, _) := xv2 in x3) in
                                   ((##a2)%expr, (##b2)%expr)%expr_pat))
-                          else None
-                      | None => None
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_sub_with_get_borrow)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
 | Z_zselect =>
     fun x x0 x1 : expr ℤ =>
@@ -2161,7 +2303,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                       (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
                   with
-                  | Some (_, _, _)%zrange =>
+                  | Datatypes.Some (_, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          ((ℤ -> ℤ) -> ℤ)%ptype
@@ -2173,21 +2315,21 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 ##(projT2 args0);
                        xv1 <- ident.unify pattern.ident.Literal
                                 ##(projT2 args);
-                       Some
+                       Datatypes.Some
                          (Base
                             (##(Z.zselect (let (x2, _) := xv in x2)
                                   (let (x2, _) := xv0 in x2)
                                   (let (x2, _) := xv1 in x2)))%expr)
-                      else None
-                  | None => None
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_zselect)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_add_modulo =>
     fun x x0 x1 : expr ℤ =>
@@ -2204,7 +2346,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                     pattern.type.unify_extracted ((ℤ -> ℤ) -> ℤ)%ptype
                       (((projT1 args1) -> (projT1 args0)) -> (projT1 args))%ptype
                   with
-                  | Some (_, _, _)%zrange =>
+                  | Datatypes.Some (_, _, _)%zrange =>
                       if
                        type.type_beq base.type base.type.type_beq
                          ((ℤ -> ℤ) -> ℤ)%ptype
@@ -2216,21 +2358,21 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                 ##(projT2 args0);
                        xv1 <- ident.unify pattern.ident.Literal
                                 ##(projT2 args);
-                       Some
+                       Datatypes.Some
                          (Base
                             (##(Z.add_modulo (let (x2, _) := xv in x2)
                                   (let (x2, _) := xv0 in x2)
                                   (let (x2, _) := xv1 in x2)))%expr)
-                      else None
-                  | None => None
+                      else Datatypes.None
+                  | Datatypes.None => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_add_modulo)%expr @ x @ x0 @ x1)%expr_pat)%option
 | Z_rshi =>
     fun x x0 x1 x2 : expr ℤ =>
@@ -2252,7 +2394,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                           ((((projT1 args2) -> (projT1 args1)) ->
                             (projT1 args0)) -> (projT1 args))%ptype
                       with
-                      | Some (_, _, _, _)%zrange =>
+                      | Datatypes.Some (_, _, _, _)%zrange =>
                           if
                            type.type_beq base.type base.type.type_beq
                              (((ℤ -> ℤ) -> ℤ) -> ℤ)%ptype
@@ -2267,24 +2409,24 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                                     ##(projT2 args0);
                            xv2 <- ident.unify pattern.ident.Literal
                                     ##(projT2 args);
-                           Some
+                           Datatypes.Some
                              (Base
                                 (##(Z.rshi (let (x3, _) := xv in x3)
                                       (let (x3, _) := xv0 in x3)
                                       (let (x3, _) := xv1 in x3)
                                       (let (x3, _) := xv2 in x3)))%expr)
-                          else None
-                      | None => None
+                          else Datatypes.None
+                      | Datatypes.None => Datatypes.None
                       end
-                  | _ => None
+                  | _ => Datatypes.None
                   end
-              | _ => None
+              | _ => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_rshi)%expr @ x @ x0 @ x1 @ x2)%expr_pat)%option
 | Z_cc_m =>
     fun x x0 : expr ℤ =>
@@ -2298,29 +2440,79 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                 pattern.type.unify_extracted (ℤ -> ℤ)%ptype
                   ((projT1 args0) -> (projT1 args))%ptype
               with
-              | Some (_, _)%zrange =>
+              | Datatypes.Some (_, _)%zrange =>
                   if
                    type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
                      ((projT1 args0) -> (projT1 args))%ptype
                   then
                    xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
                    xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
-                   Some
+                   Datatypes.Some
                      (Base
                         (##(Z.cc_m (let (x1, _) := xv in x1)
                               (let (x1, _) := xv0 in x1)))%expr)
-                  else None
-              | None => None
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
               end
-          | _ => None
+          | _ => Datatypes.None
           end
-      | _ => None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(Z_cc_m)%expr @ x @ x0)%expr_pat)%option
 | Z_cast range => fun x : expr ℤ => Base (#(Z_cast range)%expr @ x)%expr_pat
 | Z_cast2 range =>
     fun x : expr (ℤ * ℤ)%etype => Base (#(Z_cast2 range)%expr @ x)%expr_pat
+| Some A => fun x : expr A => Base (#(Some)%expr @ x)%expr_pat
+| None A => Base #(None)%expr
+| @option_rect A P =>
+    fun (x : expr A -> UnderLets (expr P))
+      (x0 : expr unit -> UnderLets (expr P)) (x1 : expr (base.type.option A))
+    =>
+    Base
+      (#(option_rect)%expr @ (λ x2 : var A,
+                              to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| Build_zrange =>
+    fun x x0 : expr ℤ =>
+    ((match x with
+      | @expr.Ident _ _ _ t idc =>
+          match x0 with
+          | @expr.Ident _ _ _ t0 idc0 =>
+              args <- invert_bind_args idc0 Raw.ident.Literal;
+              args0 <- invert_bind_args idc Raw.ident.Literal;
+              match
+                pattern.type.unify_extracted (ℤ -> ℤ)%ptype
+                  ((projT1 args0) -> (projT1 args))%ptype
+              with
+              | Datatypes.Some (_, _)%zrange =>
+                  if
+                   type.type_beq base.type base.type.type_beq (ℤ -> ℤ)%ptype
+                     ((projT1 args0) -> (projT1 args))%ptype
+                  then
+                   xv <- ident.unify pattern.ident.Literal ##(projT2 args0);
+                   xv0 <- ident.unify pattern.ident.Literal ##(projT2 args);
+                   Datatypes.Some
+                     (Base
+                        (##r[(let (x1, _) := xv in x1) ~> let (x1, _) :=
+                                                            xv0 in
+                                                          x1]%zrange)%expr)
+                  else Datatypes.None
+              | Datatypes.None => Datatypes.None
+              end
+          | _ => Datatypes.None
+          end
+      | _ => Datatypes.None
+      end;;
+      Datatypes.None);;;
+     Base (#(Build_zrange)%expr @ x @ x0)%expr_pat)%option
+| @zrange_rect P =>
+    fun (x : expr ℤ -> expr ℤ -> UnderLets (expr P))
+      (x0 : expr base.type.zrange) =>
+    Base
+      (#(zrange_rect)%expr @ (λ x1 x2 : var ℤ,
+                              to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
 | fancy_add log2wordmax imm =>
     fun x : expr (ℤ * ℤ)%etype =>
     Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat
@@ -2371,7 +2563,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   ((let (x4, _) := args2 in x4) * (let (_, y) := args2 in y))%etype) ->
                  (projT1 args1)) -> (projT1 args0)) -> (projT1 args))%ptype
           with
-          | Some (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _)%zrange =>
+          | Datatypes.Some
+            (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  ((((ℤ * ℤ)%etype -> ℤ -> (ℤ * ℤ * ℤ)%etype) ->
@@ -2391,13 +2584,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                xv <- ident.unify pattern.ident.Literal ##(projT2 args1);
                xv0 <- ident.unify pattern.ident.Literal ##(projT2 args0);
                xv1 <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some
+               Datatypes.Some
                  (Base
-                    (##(fancy.interp (invert_Some (to_fancy fancy_selc))
+                    (##(fancy.interp
+                          (Option.invert_Some (to_fancy fancy_selc))
                           (let (x4, _) := xv in x4, let (x4, _) := xv0 in x4,
                           let (x4, _) := xv1 in x4)%zrange))%expr)
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
@@ -2410,7 +2604,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           _ _ _ t2 idc2) @ (_ @ _))%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
-          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+          Datatypes.None
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ ($_)%expr) @
          _)%expr_pat |
@@ -2422,7 +2617,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.LetIn
-          _ _ _ _ _ _ _) @ _)%expr_pat => None
+          _ _ _ _ _ _ _) @ _)%expr_pat => Datatypes.None
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
@@ -2431,7 +2626,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat =>
-          None
+          Datatypes.None
       | (@expr.Ident _ _ _ t idc @ #(_) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ ($_)%expr @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _ @ _)%expr_pat |
@@ -2444,10 +2639,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat =>
-          None
-      | _ => None
+          Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(fancy_selc)%expr @ x)%expr_pat)%option
 | fancy_selm log2wordmax =>
     fun x : expr (ℤ * ℤ * ℤ)%etype =>
@@ -2475,7 +2670,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   ((let (x4, _) := args2 in x4) * (let (_, y) := args2 in y))%etype) ->
                  (projT1 args1)) -> (projT1 args0)) -> (projT1 args))%ptype
           with
-          | Some (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _)%zrange =>
+          | Datatypes.Some
+            (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  ((((ℤ * ℤ)%etype -> ℤ -> (ℤ * ℤ * ℤ)%etype) ->
@@ -2495,13 +2691,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                xv <- ident.unify pattern.ident.Literal ##(projT2 args1);
                xv0 <- ident.unify pattern.ident.Literal ##(projT2 args0);
                xv1 <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some
+               Datatypes.Some
                  (Base
-                    (##(fancy.interp (invert_Some (to_fancy fancy_sell))
+                    (##(fancy.interp
+                          (Option.invert_Some (to_fancy fancy_sell))
                           (let (x4, _) := xv in x4, let (x4, _) := xv0 in x4,
                           let (x4, _) := xv1 in x4)%zrange))%expr)
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
@@ -2514,7 +2711,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           _ _ _ t2 idc2) @ (_ @ _))%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
-          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+          Datatypes.None
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ ($_)%expr) @
          _)%expr_pat |
@@ -2526,7 +2724,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.LetIn
-          _ _ _ _ _ _ _) @ _)%expr_pat => None
+          _ _ _ _ _ _ _) @ _)%expr_pat => Datatypes.None
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
@@ -2535,7 +2733,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat =>
-          None
+          Datatypes.None
       | (@expr.Ident _ _ _ t idc @ #(_) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ ($_)%expr @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _ @ _)%expr_pat |
@@ -2548,10 +2746,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat =>
-          None
-      | _ => None
+          Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(fancy_sell)%expr @ x)%expr_pat)%option
 | fancy_addm =>
     fun x : expr (ℤ * ℤ * ℤ)%etype =>
@@ -2576,7 +2774,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                   ((let (x4, _) := args2 in x4) * (let (_, y) := args2 in y))%etype) ->
                  (projT1 args1)) -> (projT1 args0)) -> (projT1 args))%ptype
           with
-          | Some (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _)%zrange =>
+          | Datatypes.Some
+            (_, _, (_, (_, _, _)), (_, (_, (_, _)), _, _), _)%zrange =>
               if
                type.type_beq base.type base.type.type_beq
                  ((((ℤ * ℤ)%etype -> ℤ -> (ℤ * ℤ * ℤ)%etype) ->
@@ -2596,13 +2795,14 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
                xv <- ident.unify pattern.ident.Literal ##(projT2 args1);
                xv0 <- ident.unify pattern.ident.Literal ##(projT2 args0);
                xv1 <- ident.unify pattern.ident.Literal ##(projT2 args);
-               Some
+               Datatypes.Some
                  (Base
-                    (##(fancy.interp (invert_Some (to_fancy fancy_addm))
+                    (##(fancy.interp
+                          (Option.invert_Some (to_fancy fancy_addm))
                           (let (x4, _) := xv in x4, let (x4, _) := xv0 in x4,
                           let (x4, _) := xv1 in x4)%zrange))%expr)
-              else None
-          | None => None
+              else Datatypes.None
+          | Datatypes.None => Datatypes.None
           end
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
@@ -2615,7 +2815,8 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
           _ _ _ t2 idc2) @ (_ @ _))%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.Ident
-          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat => None
+          _ _ _ t2 idc2) @ @expr.LetIn _ _ _ _ _ _ _)%expr_pat =>
+          Datatypes.None
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ ($_)%expr) @
          _)%expr_pat |
@@ -2627,7 +2828,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.Ident _ _ _ t1 idc1 @ @expr.LetIn
-          _ _ _ _ _ _ _) @ _)%expr_pat => None
+          _ _ _ _ _ _ _) @ _)%expr_pat => Datatypes.None
       | (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ ($_)%expr @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
@@ -2636,7 +2837,7 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
          _)%expr_pat |
         (@expr.Ident _ _ _ t idc @
          (@expr.Ident _ _ _ t0 idc0 @ @expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat =>
-          None
+          Datatypes.None
       | (@expr.Ident _ _ _ t idc @ #(_) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ ($_)%expr @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.Abs _ _ _ _ _ _ @ _)%expr_pat |
@@ -2649,10 +2850,10 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
         (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _ @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ (@expr.LetIn _ _ _ _ _ _ _ @ _) @ _)%expr_pat |
         (@expr.Ident _ _ _ t idc @ @expr.LetIn _ _ _ _ _ _ _ @ _)%expr_pat =>
-          None
-      | _ => None
+          Datatypes.None
+      | _ => Datatypes.None
       end;;
-      None);;;
+      Datatypes.None);;;
      Base (#(fancy_addm)%expr @ x)%expr_pat)%option
 end
      : Compile.value' true t

--- a/src/strip_literal_casts_rewrite_head.out
+++ b/src/strip_literal_casts_rewrite_head.out
@@ -125,13 +125,17 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
 | Z_log2_up => fun x : expr ℤ => Base (#(Z_log2_up)%expr @ x)%expr_pat
 | Z_eqb => fun x x0 : expr ℤ => Base (#(Z_eqb)%expr @ x @ x0)%expr_pat
 | Z_leb => fun x x0 : expr ℤ => Base (#(Z_leb)%expr @ x @ x0)%expr_pat
+| Z_ltb => fun x x0 : expr ℤ => Base (#(Z_ltb)%expr @ x @ x0)%expr_pat
 | Z_geb => fun x x0 : expr ℤ => Base (#(Z_geb)%expr @ x @ x0)%expr_pat
+| Z_gtb => fun x x0 : expr ℤ => Base (#(Z_gtb)%expr @ x @ x0)%expr_pat
 | Z_of_nat => fun x : expr ℕ => Base (#(Z_of_nat)%expr @ x)%expr_pat
 | Z_to_nat => fun x : expr ℤ => Base (#(Z_to_nat)%expr @ x)%expr_pat
 | Z_shiftr => fun x x0 : expr ℤ => Base (x >> x0)%expr
 | Z_shiftl => fun x x0 : expr ℤ => Base (x << x0)%expr
 | Z_land => fun x x0 : expr ℤ => Base (x &' x0)%expr
 | Z_lor => fun x x0 : expr ℤ => Base (x || x0)%expr
+| Z_min => fun x x0 : expr ℤ => Base (#(Z_min)%expr @ x @ x0)%expr_pat
+| Z_max => fun x x0 : expr ℤ => Base (#(Z_max)%expr @ x @ x0)%expr_pat
 | Z_bneg => fun x : expr ℤ => Base (#(Z_bneg)%expr @ x)%expr_pat
 | Z_lnot_modulo =>
     fun x x0 : expr ℤ => Base (#(Z_lnot_modulo)%expr @ x @ x0)%expr_pat
@@ -167,26 +171,47 @@ match idc in (Compilers.ident t) return (Compile.value' true t) with
      | @expr.Ident _ _ _ t idc =>
          args <- invert_bind_args idc Raw.ident.Literal;
          match pattern.type.unify_extracted ℤ (projT1 args) with
-         | Some _ =>
+         | Datatypes.Some _ =>
              if type.type_beq base.type base.type.type_beq ℤ (projT1 args)
              then
               xv <- ident.unify pattern.ident.Literal ##(projT2 args);
               fv <- (x0 <- (if
                              is_bounded_by_bool (let (x0, _) := xv in x0)
                                (ZRange.normalize range)
-                            then Some (##(let (x0, _) := xv in x0))%expr
-                            else None);
-                     Some (Base x0));
-              Some (fv0 <-- fv;
-                    Base fv0)%under_lets
-             else None
-         | None => None
+                            then
+                             Datatypes.Some
+                               (##(let (x0, _) := xv in x0))%expr
+                            else Datatypes.None);
+                     Datatypes.Some (Base x0));
+              Datatypes.Some (fv0 <-- fv;
+                              Base fv0)%under_lets
+             else Datatypes.None
+         | Datatypes.None => Datatypes.None
          end
-     | _ => None
+     | _ => Datatypes.None
      end;;;
      Base (#(Z_cast range)%expr @ x)%expr_pat)%option
 | Z_cast2 range =>
     fun x : expr (ℤ * ℤ)%etype => Base (#(Z_cast2 range)%expr @ x)%expr_pat
+| Some A => fun x : expr A => Base (#(Some)%expr @ x)%expr_pat
+| None A => Base #(None)%expr
+| @option_rect A P =>
+    fun (x : expr A -> UnderLets (expr P))
+      (x0 : expr unit -> UnderLets (expr P)) (x1 : expr (base.type.option A))
+    =>
+    Base
+      (#(option_rect)%expr @ (λ x2 : var A,
+                              to_expr (x ($x2)))%expr @
+       (λ x2 : var unit,
+        to_expr (x0 ($x2)))%expr @ x1)%expr_pat
+| Build_zrange =>
+    fun x x0 : expr ℤ => Base (#(Build_zrange)%expr @ x @ x0)%expr_pat
+| @zrange_rect P =>
+    fun (x : expr ℤ -> expr ℤ -> UnderLets (expr P))
+      (x0 : expr base.type.zrange) =>
+    Base
+      (#(zrange_rect)%expr @ (λ x1 x2 : var ℤ,
+                              to_expr (x ($x1) ($x2)))%expr @ x0)%expr_pat
 | fancy_add log2wordmax imm =>
     fun x : expr (ℤ * ℤ)%etype =>
     Base (#(fancy_add log2wordmax imm)%expr @ x)%expr_pat


### PR DESCRIPTION
This is needed to reify statements for the rewriter.

On top of #519 

You could look at this as a proof-of-concept of how hard/easy it is to add new types to the language.  Note that most of the pain of adding `option` is in supporting it in a semi-reasonable manner in abstract interpretation.

Note to self: I still need to:
- [x] check to make sure that this doesn't break the `.c` files in any way; I can't build the binaries on Windows because I get uncaught exceptions when invoking `ocamlopt -o` without appending `.exe` to the binary name.