### PR TITLE
Add constr_fail and constr_fail_with

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -219,6 +219,7 @@ src/Util/Tactics/ChangeInAll.v
 src/Util/Tactics/ClearAll.v
 src/Util/Tactics/ClearDuplicates.v
 src/Util/Tactics/ClearbodyAll.v
+src/Util/Tactics/ConstrFail.v
 src/Util/Tactics/Contains.v
 src/Util/Tactics/ConvoyDestruct.v
 src/Util/Tactics/DebugPrint.v

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -16,6 +16,7 @@ Require Import Crypto.Util.ZUtil.Zselect.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.Tactics.HasBody.
 Require Import Crypto.Util.Tactics.Head.
+Require Import Crypto.Util.Tactics.ConstrFail.
 Require Import Crypto.LanguageWf.
 Require Import Crypto.Language.
 Require Import Crypto.CStringification.
@@ -210,8 +211,8 @@ Module CorrectnessStringification.
                                              exact v)
                                end)
     | ?T
-      => let __ := match goal with _ => idtac "Unrecognized bounds component:" T end in
-         constr:(I : I)
+      => constr_fail_with ltac:(fun _ => idtac "Unrecognized bounds component:" T;
+                                         fail 1 "Unrecognized bounds component:" T)
     end.
 
   Ltac with_assoc_list ctx correctness arg_var_names out_var_names cont :=
@@ -339,8 +340,8 @@ Module CorrectnessStringification.
                        exact (" " ++ xn ++ res))
                 end) with
          | fun _ => ?f => f
-         | ?F => let __ := match goal with _ => idtac "Failed to eliminate functional dependencies in" F end in
-                 constr:(I : I)
+         | ?F => constr_fail_with ltac:(fun _ => idtac "Failed to eliminate functional dependencies in" F;
+                                                 fail 1 "Failed to eliminate functional dependencies in" F)
          end
     | ?v => let res := stringify_body ctx v in
             constr:(", " ++ res)
@@ -422,8 +423,8 @@ Module CorrectnessStringification.
               | prod ?A ?B
                 => let v := (eval cbn [fst snd] in (fst x = fst y /\ snd x = snd y)) in
                    recurse v lvl
-              | ?T' => let __ := match goal with _ => idtac "Error: Unrecognized type for equality:" T' end in
-                       constr:(I : I)
+              | ?T' => constr_fail_with ltac:(fun _ => idtac "Error: Unrecognized type for equality:" T';
+                                                       fail 1 "Error: Unrecognized type for equality:" T')
               end
          | eval (weight 8 1) _ ?v
            => let sv := recurse v 9 in
@@ -500,12 +501,12 @@ Module CorrectnessStringification.
                    | Z => show_Z ()
                    | nat => show_nat ()
                    | _
-                     => let __ := match goal with _ => idtac "Error: Unrecognized var:" v " in " ctx end in
-                        constr:(I : I)
+                     => constr_fail_with ltac:(fun _ => idtac "Error: Unrecognized var:" v " in " ctx;
+                                                        fail 1 "Error: Unrecognized var:" v " in " ctx)
                    end
               | false
-                => let __ := match goal with _ => idtac "Error: Unrecognized term:" v " in " ctx end in
-                   constr:(I : I)
+                => constr_fail_with ltac:(fun _ => idtac "Error: Unrecognized term:" v " in " ctx;
+                                                   fail 1 "Error: Unrecognized term:" v " in " ctx)
               end
          end
     end.

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -12,6 +12,7 @@ Require Export Crypto.Util.Tactics.BreakMatch.
 Require Export Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Util.Tactics.SpecializeBy.
 Require Import Crypto.Util.Tactics.RewriteHyp.
+Require Import Crypto.Util.Tactics.ConstrFail.
 Import ListNotations.
 Local Open Scope list_scope.
 
@@ -1910,8 +1911,7 @@ Ltac expand_lists _ :=
   let default_for A :=
       match goal with
       | _ => (eval lazy in (_ : pointed A))
-      | _ => let __ := match goal with _ => idtac "Warning: could not infer a default value for list type" A end in
-             constr:(I : I)
+      | _ => constr_fail_with ltac:(fun _ => idtac "Warning: could not infer a default value for list type" A)
       end in
   let T := lazymatch goal with |- _ = _ :> ?T => T end in
   let v := fresh in

--- a/src/Util/Tactics.v
+++ b/src/Util/Tactics.v
@@ -6,6 +6,7 @@ Require Export Crypto.Util.Tactics.ChangeInAll.
 Require Export Crypto.Util.Tactics.ClearAll.
 Require Export Crypto.Util.Tactics.ClearDuplicates.
 Require Export Crypto.Util.Tactics.ClearbodyAll.
+Require Export Crypto.Util.Tactics.ConstrFail.
 Require Export Crypto.Util.Tactics.Contains.
 Require Export Crypto.Util.Tactics.ConvoyDestruct.
 Require Export Crypto.Util.Tactics.CPSId.

--- a/src/Util/Tactics/ConstrFail.v
+++ b/src/Util/Tactics/ConstrFail.v
@@ -1,0 +1,9 @@
+(** A tactic that executes immediately (during expression evaluation / constr-construction) and fails.  Ideally we can eventually give it a nicer error message.  COQBUG(3913) *)
+
+Ltac constr_fail :=
+  let __ := match goal with _ => fail 1 "Constr construction failed.  Please look at the message log (*coq*, or run your tactic again inside Fail or try) to see more details" end in
+  ().
+
+Ltac constr_fail_with msg_tac :=
+  let __ := match goal with _ => msg_tac () end in
+  constr_fail.

--- a/src/Util/Tactics/DebugPrint.v
+++ b/src/Util/Tactics/DebugPrint.v
@@ -1,3 +1,5 @@
+Require Import Crypto.Util.Tactics.ConstrFail.
+
 Ltac debuglevel := constr:(0%nat).
 
 Ltac solve_debugfail tac :=
@@ -36,7 +38,7 @@ Ltac constr_run_tac_fail tac :=
   let dummy := match goal with
                | _ => tac ()
                end in
-  constr:(I : I).
+  constr_fail.
 
 Ltac cidtac msg :=
   constr_run_tac ltac:(fun _ => idtac msg).


### PR DESCRIPTION
Rather than taking the convention that failures during constr
construction emit a type error from `I : I` with the actual error
message `idtac`d above them (because Coq has no way to emit multiple
things on stderr), we instead factor everything through a new
`constr_fail` or `constr_fail_with msg_tac`, which emit more helpful
messages instructing the user to look in `*coq*` or to use `Fail`/`try`
to see the more informative error message.  When we can make our own
version that does both `idtac` and `fail` (c.f.
https://github.com/coq/coq/issues/3913), then we can do something a bit
more sane, hopefully.