### PR TITLE
Kludge around coq/coq#9906

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -635,6 +635,10 @@ clean::
 
 cleanall:: clean
 
+ifneq ($(filter install,$(MAKECMDGOALS)),)
+FILESTOINSTALL := $(wildcard $(FILESTOINSTALL))
+endif
+
 install: coq
 
 printenv::


### PR DESCRIPTION
Since we in general don't build all the files (in fact, we never do), we
only try to install files that actually exist, to avoid errors from
Coq's new way of installing things.

Note that including `install` as a target along with targets that build
things is no longer supported, as it would require fancier makefile
hackery.

Fixes #548 (I hope)