### PR TITLE
Add CPS'd versions of arithmetic operations

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -68,6 +68,12 @@ src/Arithmetic/BarrettReduction/RidiculousFish.v
 src/Arithmetic/BarrettReduction/Wikipedia.v
 src/Arithmetic/MontgomeryReduction/Definition.v
 src/Arithmetic/MontgomeryReduction/Proofs.v
+src/ArithmeticCPS/BaseConversion.v
+src/ArithmeticCPS/Core.v
+src/ArithmeticCPS/Freeze.v
+src/ArithmeticCPS/ModOps.v
+src/ArithmeticCPS/Saturated.v
+src/ArithmeticCPS/WordByWordMontgomery.v
 src/Curves/Edwards/AffineProofs.v
 src/Curves/Edwards/Pre.v
 src/Curves/Edwards/XYZT/Basic.v

--- a/src/ArithmeticCPS/BaseConversion.v
+++ b/src/ArithmeticCPS/BaseConversion.v
@@ -1,0 +1,158 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.derive.Derive.
+Require Import Coq.Lists.List.
+Require Import Crypto.ArithmeticCPS.Core.
+Require Import Crypto.ArithmeticCPS.ModOps.
+Require Import Crypto.Arithmetic.Partition.
+Require Import Crypto.ArithmeticCPS.Saturated.
+Require Import Crypto.Util.CPSUtil.
+Require Import Crypto.Util.CPSNotations.
+Require Import Crypto.Util.LetIn.
+Require Import Crypto.Util.ListUtil.
+
+Require Import Crypto.Util.Notations.
+Local Open Scope Z_scope.
+Import CPSBindNotations.
+Local Open Scope cps_scope.
+
+Module BaseConversion (Import RT : Runtime).
+  Module Import Deps.
+    Module Export Positional := Positional RT.
+    Module Rows := Rows RT.
+    Module Export Saturated.
+      Module Associational := ArithmeticCPS.Saturated.Associational RT.
+    End Saturated.
+    Module Export Core.
+      Module Associational := ArithmeticCPS.Core.Associational RT.
+    End Core.
+  End Deps.
+  Section BaseConversion.
+    Context (sw dw : nat -> Z) (* source/destination weight functions *).
+
+    Definition convert_bases_cps (sn dn : nat) (p : list Z) : ~> list Z :=
+      (p' <- Positional.from_associational_cps dw dn (Positional.to_associational sw sn p);
+      chained_carries_no_reduce_cps dw dn p' (seq 0 (pred dn))).
+
+    Definition to_associational_cps n m p : ~> list (Z * Z) :=
+      (p' <- convert_bases_cps n m p;
+         return (Positional.to_associational dw m p')).
+
+    (* TODO : move to Associational? *)
+    Section reorder.
+      Definition reordering_carry_cps (w fw : Z) (p : list (Z * Z)) : ~> _ :=
+        fun T => fold_right_cps2 (fun t acc =>
+                      r <- Associational.carryterm_cps w fw t;
+                        return (if fst t =? w then acc ++ r else r ++ acc)) nil p.
+    End reorder.
+
+    (* carry at specified indices in dw, then use Rows.flatten to convert to Positional with sw *)
+    Definition from_associational_cps idxs n (p : list (Z * Z)) : ~> list Z :=
+      (* important not to use Positional.carry here; we don't want to accumulate yet *)
+      (p' <- Associational.bind_snd_cps p;
+         p' <- (fun T => fold_right_cps2 (fun i acc => reordering_carry_cps (dw i) (dw (S i) / dw i) acc) p' (rev idxs));
+         p' <- Rows.from_associational_cps sw n p';
+         p' <- Rows.flatten_cps sw n p';
+       return (fst p')).
+
+(*    Derive from_associational_inlined
+           SuchThat (forall idxs n p,
+                        from_associational_inlined idxs n p = from_associational idxs n p)
+           As from_associational_inlined_correct.
+    Proof.
+      intros.
+      cbv beta iota delta [from_associational reordering_carry Associational.carryterm].
+      cbv beta iota delta [Let_In]. (* inlines all shifts/lands from carryterm *)
+      cbv beta iota delta [from_associational Rows.from_associational Columns.from_associational].
+      cbv beta iota delta [Let_In]. (* inlines the shifts from place *)
+      subst from_associational_inlined; reflexivity.
+    Qed.
+
+    Derive to_associational_inlined
+           SuchThat (forall n m p,
+                        to_associational_inlined n m p = to_associational n m p)
+           As to_associational_inlined_correct.
+    Proof.
+      intros.
+      cbv beta iota delta [ to_associational convert_bases
+                                             Positional.to_associational
+                                             Positional.from_associational
+                                             chained_carries_no_reduce
+                                             carry
+                                             Associational.carry
+                                             Associational.carryterm
+                          ].
+      cbv beta iota delta [Let_In].
+      subst to_associational_inlined; reflexivity.
+    Qed.
+*)
+    (* carry chain that aligns terms in the intermediate weight with the final weight *)
+    Definition aligned_carries (log_dw_sw nout : nat)
+      := (map (fun i => ((log_dw_sw * (i + 1)) - 1))%nat (seq 0 nout)).
+
+    Section mul_converted.
+  (*    Definition mul_converted
+              n1 n2 (* lengths in original format *)
+              m1 m2 (* lengths in converted format *)
+              (n3 : nat) (* final length *)
+              (idxs : list nat) (* carries to do -- this helps preemptively line up weights *)
+              (p1 p2 : list Z) :=
+        let p1_a := to_associational n1 m1 p1 in
+        let p2_a := to_associational n2 m2 p2 in
+        let p3_a := Associational.mul p1_a p2_a in
+        from_associational idxs n3 p3_a.
+*)
+    End mul_converted.
+  End BaseConversion.
+
+  (* multiply two (n*k)-bit numbers by converting them to n k-bit limbs each, multiplying, then converting back *)
+  Section widemul.
+    Context (log2base : Z) (log2base_pos : 0 < log2base).
+    Context (m n : nat) (m_nz : m <> 0%nat) (n_nz : n <> 0%nat) (n_le_log2base : Z.of_nat n <= log2base).
+    Let dw : nat -> Z := weight (log2base / Z.of_nat n) 1.
+    Let sw : nat -> Z := weight log2base 1.
+    Let mn := (m * n)%nat.
+    Let nout := (m * 2)%nat.
+
+    (*Definition widemul a b := mul_converted sw dw m m mn mn nout (aligned_carries n nout) a b.*)
+
+(*    Derive widemul_inlined
+           SuchThat (forall a b,
+                        length a = m ->
+                        length b = m ->
+                        widemul_inlined a b = Partition.partition sw nout (seval m a * seval m b))
+           As widemul_inlined_correct.
+    Proof.
+      intros.
+      rewrite <-widemul_correct by auto.
+      cbv beta iota delta [widemul mul_converted].
+      rewrite <-to_associational_inlined_correct with (p:=a).
+      rewrite <-to_associational_inlined_correct with (p:=b).
+      rewrite <-from_associational_inlined_correct.
+      subst widemul_inlined; reflexivity.
+    Qed.
+
+    Derive widemul_inlined_reverse
+           SuchThat (forall a b,
+                        length a = m ->
+                        length b = m ->
+                        widemul_inlined_reverse a b = Partition.partition sw nout (seval m a * seval m b))
+           As widemul_inlined_reverse_correct.
+    Proof.
+      intros.
+      rewrite <-widemul_inlined_correct by assumption.
+      cbv [widemul_inlined].
+      match goal with |- _ = from_associational_inlined sw dw ?idxs ?n ?p =>
+                      transitivity (from_associational_inlined sw dw idxs n (rev p));
+                        [ | transitivity (from_associational sw dw idxs n p); [ | reflexivity ] ](* reverse to make addc chains line up *)
+      end.
+      { subst widemul_inlined_reverse; reflexivity. }
+      { rewrite from_associational_inlined_correct by auto.
+        cbv [from_associational].
+        rewrite !Rows.flatten_correct by eauto using Rows.length_from_associational.
+        rewrite !Rows.eval_from_associational by auto.
+        f_equal.
+        rewrite !eval_carries, !Associational.bind_snd_correct, !Associational.eval_rev by auto.
+        reflexivity. }
+    Qed.*)
+  End widemul.
+End BaseConversion.

--- a/src/ArithmeticCPS/Core.v
+++ b/src/ArithmeticCPS/Core.v
@@ -1,0 +1,415 @@
+(* Following http://adam.chlipala.net/theses/andreser.pdf chapter 3 *)
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.Structures.Orders.
+Require Import Coq.Lists.List.
+Require Import Crypto.Algebra.Nsatz.
+Require Import Crypto.Arithmetic.ModularArithmeticTheorems.
+Require Import Crypto.Util.Decidable.
+Require Import Crypto.Util.LetIn.
+Require Import Crypto.Util.ListUtil.
+Require Import Crypto.Util.NatUtil.
+Require Import Crypto.Util.Prod.
+Require Import Crypto.Util.Decidable.Bool2Prop.
+Require Import Crypto.Util.Tactics.SpecializeBy.
+Require Import Crypto.Util.Tactics.UniquePose.
+Require Import Crypto.Util.CPSUtil.
+Require Import Crypto.Util.CPSNotations.
+Require Import Crypto.Util.ZUtil.Definitions.
+Require Import Crypto.Util.ZUtil.EquivModulo.
+Require Import Crypto.Util.ZUtil.Modulo Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Zselect.
+Require Import Crypto.Util.ZUtil.Hints.Core.
+Require Import Crypto.Util.ZUtil.Modulo.PullPush.
+Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
+Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
+Require Import Crypto.Util.ZUtil.Tactics.RewriteModSmall.
+Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
+Require Import Crypto.Util.Notations.
+Import ListNotations. Local Open Scope Z_scope.
+
+
+Reserved Notation "'dlet_list_pair_only_snd' x := v 'in' f"
+         (at level 200, f at level 200, format "'dlet_list_pair_only_snd'  x  :=  v  'in' '//' f").
+Reserved Notation "'dlet_list_pair' x := v 'in' f"
+         (at level 200, f at level 200, format "'dlet_list_pair'  x  :=  v  'in' '//' f").
+Reserved Notation "'dlet_list' x := v 'in' f"
+         (at level 200, f at level 200, format "'dlet_list'  x  :=  v  'in' '//' f").
+Delimit Scope runtime_scope with RT.
+Import CPSBindNotations.
+Local Open Scope cps_scope.
+
+Module Type Runtime.
+  Parameter Let_In : forall {A P} (x : A) (f : forall a : A, P a), P x.
+  Parameter runtime_nth_default : forall {A}, A -> list A -> nat -> A.
+  Parameter runtime_add : Z -> Z -> Z.
+  Parameter runtime_sub : Z -> Z -> Z.
+  Parameter runtime_mul : Z -> Z -> Z.
+  Parameter runtime_div : Z -> Z -> Z.
+  Parameter runtime_modulo : Z -> Z -> Z.
+  Parameter runtime_opp : Z -> Z.
+  Arguments runtime_add (_ _)%RT.
+  Arguments runtime_sub (_ _)%RT.
+  Arguments runtime_mul (_ _)%RT.
+  Arguments runtime_div _%RT _%Z.
+  Arguments runtime_modulo _%RT _%Z.
+  Arguments runtime_opp _%RT.
+  Infix "*" := runtime_mul : runtime_scope.
+  Infix "+" := runtime_add : runtime_scope.
+  Infix "-" := runtime_sub : runtime_scope.
+  Infix "/" := runtime_div : runtime_scope.
+  Notation "x 'mod' y" := (runtime_modulo x y) : runtime_scope.
+  Notation "- x" := (runtime_opp x) : runtime_scope.
+  Notation "'dlet_nd' x .. y := v 'in' f" := (Let_In (P:=fun _ => _) v (fun x => .. (fun y => f) .. )) (only parsing).
+  Notation "'dlet' x .. y := v 'in' f" := (Let_In v (fun x => .. (fun y => f) .. )).
+
+  Module RT_Z.
+    Parameter zselect : Z -> Z -> Z -> Z.
+    Parameter add_get_carry_full : Z -> Z -> Z -> Z * Z.
+    Parameter add_with_get_carry_full : Z -> Z -> Z -> Z -> Z * Z.
+    Parameter mul_split : Z -> Z -> Z -> Z * Z.
+    Parameter land : Z -> Z -> Z.
+  End RT_Z.
+End Runtime.
+
+Module RuntimeDefinitions <: Runtime.
+  Definition Let_In := @LetIn.Let_In.
+  Definition runtime_nth_default := List.nth_default.
+  Definition runtime_add := Z.add.
+  Definition runtime_sub := Z.sub.
+  Definition runtime_mul := Z.mul.
+  Definition runtime_opp := Z.opp.
+  Definition runtime_div := Z.div.
+  Definition runtime_modulo := Z.modulo.
+  Module RT_Z.
+    Definition zselect := Z.zselect.
+    Definition add_get_carry_full := Z.add_get_carry_full.
+    Definition add_with_get_carry_full := Z.add_with_get_carry_full.
+    Definition mul_split := Z.mul_split.
+    Definition land := Z.land.
+  End RT_Z.
+End RuntimeDefinitions.
+
+Module Export RuntimeDefinitionsCbv.
+  Import RuntimeDefinitions.
+  Declare Reduction cbv_no_rt
+    := cbv -[Let_In
+               runtime_nth_default
+               runtime_add
+               runtime_sub
+               runtime_mul
+               runtime_opp
+               runtime_div
+               runtime_modulo
+               RT_Z.add_get_carry_full
+               RT_Z.add_with_get_carry_full
+               RT_Z.mul_split].
+  Declare Reduction lazy_no_rt
+    := lazy -[Let_In
+                runtime_nth_default
+                runtime_add
+                runtime_sub
+                runtime_mul
+                runtime_opp
+                runtime_div
+                runtime_modulo
+                RT_Z.add_get_carry_full
+                RT_Z.add_with_get_carry_full
+                RT_Z.mul_split].
+End RuntimeDefinitionsCbv.
+
+Module RuntimeAxioms : Runtime.
+  Include RuntimeDefinitions.
+End RuntimeAxioms.
+
+Module RT_Extra (Import RT : Runtime).
+  Fixpoint dlet_nd_list_pair {A B} (ls : list (A * B)) {T} (f : list (A * B) -> T) : T
+    := match ls with
+       | nil => f nil
+       | cons x xs
+         => dlet_nd x1 := fst x in dlet_nd x2 := snd x in @dlet_nd_list_pair A B xs T (fun xs => f ((x1, x2) :: xs))
+       end.
+
+  Fixpoint dlet_nd_list {A} (ls : list A) {T} (f : list A -> T) : T
+    := match ls with
+       | nil => f nil
+       | cons x xs
+         => dlet_nd x := x in @dlet_nd_list A xs T (fun xs => f (x :: xs))
+       end.
+
+  Fixpoint dlet_nd_list_pair_only_snd {A B} (ls : list (A * B)) {T} (f : list (A * B) -> T) : T
+    := match ls with
+       | nil => f nil
+       | cons x xs
+         => dlet_nd x2 := snd x in @dlet_nd_list_pair_only_snd A B xs T (fun xs => f ((fst x, x2) :: xs))
+       end.
+
+  Notation "'dlet_list_pair_only_snd' x := v 'in' f" := (dlet_nd_list_pair_only_snd v (fun x => f)).
+  Notation "'dlet_list_pair' x := v 'in' f" := (dlet_nd_list_pair v (fun x => f)).
+  Notation "'dlet_list' x := v 'in' f" := (dlet_nd_list v (fun x => f)).
+
+
+  Definition expand_list_helper {A} (default : A) (ls : list A) (n : nat) (idx : nat) : list A
+  := nat_rect
+       (fun _ => nat -> list A)
+       (fun _ => nil)
+       (fun n' rec_call idx
+        => cons (runtime_nth_default default ls idx) (rec_call (S idx)))
+       n
+       idx.
+  Definition expand_list {A} (default : A) (ls : list A) (n : nat) : list A
+    := expand_list_helper default ls n 0.
+End RT_Extra.
+
+Module Associational (Import RT : Runtime).
+  Module Import Deps.
+    Module Export RT_Extra := RT_Extra RT.
+  End Deps.
+  Definition eval (p:list (Z*Z)) : Z :=
+    fold_right (fun x y => x + y) 0%Z (map (fun t => fst t * snd t) p).
+
+  Definition mul (p q:list (Z*Z)) : list (Z*Z) :=
+    flat_map (fun t =>
+      map (fun t' =>
+        (fst t * fst t', (snd t * snd t')%RT))
+    q) p.
+
+  Definition square_cps (p:list (Z*Z)) : ~> list (Z*Z) :=
+    list_rect
+      _
+      (return nil)
+      (fun t ts acc T k
+       => (dlet two_t2 := (2 * snd t)%RT in
+               acc
+                 _
+                 (fun acc
+                  => k (((fst t * fst t, (snd t * snd t)%RT)
+                           :: (map (fun t'
+                                    => (fst t * fst t', (two_t2 * snd t')%RT))
+                                   ts))
+                          ++ acc))))
+      p.
+
+  Definition negate_snd (p:list (Z*Z)) : list (Z*Z) :=
+    map (fun cx => (fst cx, (-snd cx)%RT)) p.
+
+  Definition split (s:Z) (p:list (Z*Z)) : list (Z*Z) * list (Z*Z)
+    := let hi_lo := partition (fun t => fst t mod s =? 0) p in
+       (snd hi_lo, map (fun t => (fst t / s, snd t)) (fst hi_lo)).
+
+  Definition reduce (s:Z) (c:list _) (p:list _) : list (Z*Z) :=
+    let lo_hi := split s p in fst lo_hi ++ mul c (snd lo_hi).
+
+  (* reduce at most [n] times, stopping early if the high list is nil at any point *)
+  Definition repeat_reduce (n : nat) (s:Z) (c:list _) (p:list _) : list (Z * Z)
+    := nat_rect
+         _
+         (fun p => p)
+         (fun n' repeat_reduce_n' p
+          => let lo_hi := split s p in
+             if (length (snd lo_hi) =? 0)%nat
+             then p
+             else let p := fst lo_hi ++ mul c (snd lo_hi) in
+                  repeat_reduce_n' p)
+         n
+         p.
+
+  (* rough template (we actually have to do things a bit differently to account for duplicate weights):
+[ dlet fi_c := c * fi in
+   let (fj_high, fj_low) := split fj at s/fi.weight in
+   dlet fi_2 := 2 * fi in
+    dlet fi_2_c := 2 * fi_c in
+    (if fi.weight^2 >= s then fi_c * fi else fi * fi)
+       ++ fi_2_c * fj_high
+       ++ fi_2 * fj_low
+ | fi <- f , fj := (f weight less than i) ]
+   *)
+  (** N.B. We take advantage of dead code elimination to allow us to
+      let-bind partial products that we don't end up using *)
+  (** [v] -> [(v, v*c, v*c*2, v*2)] *)
+  Definition let_bind_for_reduce_square_cps (c:list (Z*Z)) (p:list (Z*Z)) : ~> list ((Z*Z) * list(Z*Z) * list(Z*Z) * list(Z*Z)) :=
+    fun T
+    => let two := [(1,2)] (* (weight, value) *) in
+       map_cps2 (fun t T k => dlet_list_pair_only_snd c_t := mul [t] c in dlet_list_pair_only_snd two_c_t := mul c_t two in dlet_list_pair_only_snd two_t := mul [t] two in k (t, c_t, two_c_t, two_t)) p.
+  Definition reduce_square_cps (s:Z) (c:list (Z*Z)) (p:list (Z*Z)) : ~>list (Z*Z) :=
+    (p <- let_bind_for_reduce_square_cps c p;
+    let div_s := map (fun t => (fst t / s, snd t)) in
+    return (list_rect
+      _
+      nil
+      (fun t ts acc
+       => (let '(t, c_t, two_c_t, two_t) := t in
+           (if ((fst t * fst t) mod s =? 0)
+            then div_s (mul [t] c_t)
+            else mul [t] [t])
+             ++ (flat_map
+                   (fun '(t', c_t', two_c_t', two_t')
+                    => if ((fst t * fst t') mod s =? 0)
+                       then div_s
+                              (if fst t' <=? fst t
+                               then mul [t'] two_c_t
+                               else mul [t] two_c_t')
+                       else (if fst t' <=? fst t
+                             then mul [t'] two_t
+                             else mul [t] two_t'))
+                   ts))
+            ++ acc)
+      p)).
+
+  Definition bind_snd_cps (p : list (Z*Z)) : ~>list (Z * Z) :=
+    @dlet_nd_list_pair_only_snd _ _ p.
+
+  Section Carries.
+    Definition carryterm_cps (w fw:Z) (t:Z * Z) : ~> list (Z * Z) :=
+      fun T k
+      => if (Z.eqb (fst t) w)
+         then dlet_nd t2 := snd t in
+              dlet_nd d2 := (t2 / fw)%RT in
+              dlet_nd m2 := (t2 mod fw)%RT in
+              k [(w * fw, d2);(w,m2)]
+         else k [t].
+
+    Definition carry_cps (w fw:Z) (p:list (Z * Z)) : ~> list (Z * Z):=
+      fun T => flat_map_cps (carryterm_cps w fw) p.
+  End Carries.
+End Associational.
+
+Module Positional (Import RT : Runtime).
+  Module Import Deps.
+    Module Associational := Associational RT.
+  End Deps.
+  Section Positional.
+  Context (weight : nat -> Z).
+
+  Definition to_associational (n:nat) (xs:list Z) : list (Z*Z)
+    := combine (map weight (List.seq 0 n)) xs.
+  Definition eval n x := Associational.eval (@to_associational n x).
+  Definition zeros n : list Z := repeat 0 n.
+  Definition add_to_nth i x (ls : list Z) : list Z
+    := ListUtil.update_nth i (fun y => (x + y)%RT) ls.
+
+  Definition place (t:Z*Z) (i:nat) : nat * Z :=
+    nat_rect
+      (fun _ => unit -> (nat * Z)%type)
+      (fun _ => (O, if fst t =? 1 then snd t else (fst t * snd t)%RT))
+      (fun i' place_i' _
+       => let i := S i' in
+          if (fst t mod weight i =? 0)
+          then (i, let c := fst t / weight i in if c =? 1 then snd t else (c * snd t)%RT)
+          else place_i' tt)
+      i
+      tt.
+
+  Definition from_associational_cps n (p:list (Z*Z)) : ~> list Z :=
+    fun T => fold_right_cps2 (fun t ls T k =>
+      let '(p1, p2) := place t (pred n) in
+      dlet_nd p2 := p2 in
+      k (add_to_nth p1 p2 ls)) (zeros n) p.
+
+  Definition extend_to_length (n_in n_out : nat) (p:list Z) : list Z :=
+    p ++ zeros (n_out - n_in).
+
+  Definition drop_high_to_length (n : nat) (p:list Z) : list Z :=
+    firstn n p.
+
+  Section mulmod.
+    Context (s:Z)
+            (c:list (Z*Z)).
+    Definition mulmod_cps (n:nat) (a b:list Z) : ~> list Z
+      := let a_a := to_associational n a in
+         let b_a := to_associational n b in
+         let ab_a := Associational.mul a_a b_a in
+         let abm_a := Associational.repeat_reduce n s c ab_a in
+         from_associational_cps n abm_a.
+
+    Definition squaremod_cps (n:nat) (a:list Z) : ~> list Z
+      := (let a_a := to_associational n a in
+         aa_a <- Associational.reduce_square_cps s c a_a;
+         let aam_a := Associational.repeat_reduce (pred n) s c aa_a in
+         from_associational_cps n aam_a).
+  End mulmod.
+
+  Definition add_cps (n:nat) (a b:list Z) : ~> list Z
+    := let a_a := to_associational n a in
+       let b_a := to_associational n b in
+       from_associational_cps n (a_a ++ b_a).
+
+  Section Carries.
+    Definition carry_cps n m (index:nat) (p:list Z) : ~> list Z :=
+      (p <- @Associational.carry_cps (weight index)
+         (weight (S index) / weight index)
+         (to_associational n p);
+       from_associational_cps
+           m p).
+
+    Definition carry_reduce_cps n (s:Z) (c:list (Z * Z))
+               (index:nat) (p : list Z) : ~> list Z :=
+      (p <- @carry_cps n (S n) index p;
+         p <- from_associational_cps
+           n (Associational.reduce
+                s c (to_associational (S n) p));
+       return p).
+
+    (* N.B. It is important to reverse [idxs] here, because fold_right is
+      written such that the first terms in the list are actually used
+      last in the computation. For example, running:
+
+      `Eval cbv - [Z.add] in (fun a b c d => fold_right Z.add d [a;b;c]).`
+
+      will produce [fun a b c d => (a + (b + (c + d)))].*)
+    Definition chained_carries_cps n s c p (idxs : list nat) : ~> _ :=
+      fun T => fold_right_cps2 (fun a b => carry_reduce_cps n s c a b) p (rev idxs).
+
+    (* carries without modular reduction; useful for converting between bases *)
+    Definition chained_carries_no_reduce_cps n p (idxs : list nat) : ~> _ :=
+      fun T => fold_right_cps2 (fun a b => carry_cps n n a b) p (rev idxs).
+
+    (* Reverse of [eval]; translate from Z to basesystem by putting
+    everything in first digit and then carrying. *)
+    Definition encode_cps n s c (x : Z) : ~> list Z :=
+      (p <- from_associational_cps n [(1,x)]; chained_carries_cps n s c p (seq 0 n)).
+
+    (* Reverse of [eval]; translate from Z to basesystem by putting
+    everything in first digit and then carrying, but without reduction. *)
+    Definition encode_no_reduce_cps n (x : Z) : ~> list Z :=
+      (p <- from_associational_cps n [(1,x)]; chained_carries_no_reduce_cps n p (seq 0 n)).
+  End Carries.
+
+  Section sub.
+    Context (n:nat)
+            (s:Z)
+            (c:list (Z * Z))
+            (coef:Z).
+
+    Definition negate_snd_cps (a:list Z) : ~> list Z
+      := let A := to_associational n a in
+         let negA := Associational.negate_snd A in
+         from_associational_cps n negA.
+
+    Definition scmul_cps (x:Z) (a:list Z) : ~> list Z
+      := let A := to_associational n a in
+         let R := Associational.mul A [(1, x)] in
+         from_associational_cps n R.
+
+    Definition balance_cps : ~> list Z
+      := (sc <- encode_cps n s c (s - Associational.eval c); v <- scmul_cps coef sc; return v).
+
+    Definition sub_cps (a b:list Z) : ~> list Z
+      := (balance <- balance_cps;
+            ca <- add_cps n balance a;
+            _b <- negate_snd_cps b;
+            camb <- add_cps n ca _b;
+            return camb).
+
+    Definition opp_cps (a:list Z) : ~> list Z
+      := sub_cps (zeros n) a.
+  End sub.
+
+  Section select.
+    Definition zselect_cps (mask cond:Z) (p:list Z) : ~> _ :=
+      fun T k => dlet t := RT_Z.zselect cond 0 mask in k (List.map (RT_Z.land t) p).
+
+    Definition select (cond:Z) (if_zero if_nonzero:list Z) :=
+      List.map (fun '(p, q) => RT_Z.zselect cond p q) (List.combine if_zero if_nonzero).
+  End select.
+End Positional.
+End Positional.

--- a/src/ArithmeticCPS/Freeze.v
+++ b/src/ArithmeticCPS/Freeze.v
@@ -1,0 +1,99 @@
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import QArith.QArith_base QArith.Qround Crypto.Util.QUtil.
+Require Import Crypto.ArithmeticCPS.BaseConversion.
+Require Import Crypto.ArithmeticCPS.Core.
+Require Import Crypto.ArithmeticCPS.ModOps.
+Require Import Crypto.Arithmetic.Partition.
+Require Import Crypto.ArithmeticCPS.Saturated.
+Require Import Crypto.Util.CPSUtil.
+Require Import Crypto.Util.CPSNotations.
+Require Import Crypto.Util.Decidable.
+Require Import Crypto.Util.ListUtil.
+Require Import Crypto.Util.Prod.
+Require Import Crypto.Util.Tactics.BreakMatch.
+Require Import Crypto.Util.Tactics.DestructHead.
+Require Import Crypto.Util.ZUtil.EquivModulo.
+Require Import Crypto.Util.ZUtil.Opp.
+Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
+Require Import Crypto.Util.ZUtil.Tactics.PeelLe.
+Require Import Crypto.Util.ZUtil.Tactics.RewriteModSmall.
+Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
+
+Require Import Crypto.Util.Notations.
+Local Open Scope Z_scope.
+
+Import CPSBindNotations.
+Local Open Scope cps_scope.
+
+(* TODO: rename this module? (Should it be, e.g., [Rows.freeze]?) *)
+Module Freeze (Import RT : Runtime).
+  Module Import Deps.
+    Module Rows := Rows RT.
+  End Deps.
+  Section Freeze.
+    Context (weight : nat -> Z).
+
+    Definition freeze_cps n mask (m p:list Z) : ~> list Z :=
+      (p_carry <- Rows.sub_cps weight n p m;
+         let '(p, carry) := p_carry in
+         r_carry <- Rows.conditional_add_cps weight n mask (-carry)%RT p m;
+           let '(r, carry) := r_carry in
+           return r).
+  End Freeze.
+End Freeze.
+
+Module FreezeModOps (Import RT : Runtime).
+  Module Import Deps.
+    Module Export Positional := Positional RT.
+    Module Export Freeze := Freeze RT.
+    Module BaseConversion := BaseConversion RT.
+    Module Export Core.
+      Module Associational := ArithmeticCPS.Core.Associational RT.
+    End Core.
+  End Deps.
+  Section mod_ops.
+  Local Coercion Z.of_nat : nat >-> Z.
+  Local Coercion QArith_base.inject_Z : Z >-> Q.
+  (* Design constraints:
+     - inputs must be [Z] (b/c reification does not support Q)
+     - internal structure must not match on the arguments (b/c reification does not support [positive]) *)
+  Context (limbwidth_num limbwidth_den : Z)
+          (limbwidth_good : 0 < limbwidth_den <= limbwidth_num)
+          (s : Z)
+          (c : list (Z*Z))
+          (n : nat)
+          (bitwidth : Z)
+          (m_enc : list Z)
+          (Hn_nz : n <> 0%nat).
+  Local Notation bytes_weight := (@weight 8 1).
+  Local Notation weight := (@weight limbwidth_num limbwidth_den).
+  Let m := (s - Associational.eval c).
+
+  Context (Hs : s = weight n).
+  Context (c_small : 0 < Associational.eval c < weight n)
+          (m_enc_bounded : List.map (BinInt.Z.land (Z.ones bitwidth)) m_enc = m_enc)
+          (m_enc_correct : Positional.eval weight n m_enc = m)
+          (Hm_enc_len : length m_enc = n).
+
+  Definition bytes_n
+    := Eval cbv [Qceiling Qdiv inject_Z Qfloor Qmult Qopp Qnum Qden Qinv Pos.mul]
+      in Z.to_nat (Qceiling (Z.log2_up (weight n) / 8)).
+
+  Definition to_bytes_cps (v : list Z) : ~> _
+    := BaseConversion.convert_bases_cps weight bytes_weight n bytes_n v.
+
+  Definition from_bytes_cps (v : list Z) : ~> _
+    := BaseConversion.convert_bases_cps bytes_weight weight bytes_n n v.
+
+  Definition freeze_to_bytesmod_cps (f : list Z) : ~> list Z
+    := (f <- freeze_cps weight n (Z.ones bitwidth) m_enc f; to_bytes_cps f).
+
+  Definition to_bytesmod_cps (f : list Z) : ~> list Z
+    := to_bytes_cps f.
+  Definition to_bytesmod (f : list Z) : list Z := to_bytesmod_cps f _ id.
+
+  Definition from_bytesmod_cps (f : list Z) : ~> list Z
+    := from_bytes_cps f.
+  Definition from_bytesmod (f : list Z) : list Z := from_bytesmod_cps f _ id.
+  End mod_ops.
+End FreezeModOps.

--- a/src/ArithmeticCPS/ModOps.v
+++ b/src/ArithmeticCPS/ModOps.v
@@ -1,0 +1,194 @@
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.derive.Derive.
+Require Import QArith.QArith_base QArith.Qround Crypto.Util.QUtil.
+Require Import Crypto.ArithmeticCPS.Core.
+Require Import Crypto.Util.CPSUtil.
+Require Import Crypto.Util.CPSNotations.
+Require Import Crypto.Util.ListUtil.
+Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
+Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
+
+Require Import Crypto.Util.Notations.
+Local Open Scope Z_scope.
+Import CPSBindNotations.
+Local Open Scope cps_scope.
+
+Section mod_ops.
+  Local Coercion Z.of_nat : nat >-> Z.
+  Local Coercion QArith_base.inject_Z : Z >-> Q.
+  (* Design constraints:
+     - inputs must be [Z] (b/c reification does not support Q)
+     - internal structure must not match on the arguments (b/c reification does not support [positive]) *)
+  Context (limbwidth_num limbwidth_den : Z)
+          (limbwidth_good : 0 < limbwidth_den <= limbwidth_num)
+          (s : Z)
+          (c : list (Z*Z))
+          (n : nat)
+          (len_c : nat)
+          (idxs : list nat)
+          (len_idxs : nat)
+          (Hn_nz : n <> 0%nat)
+          (Hc : length c = len_c)
+          (Hidxs : length idxs = len_idxs).
+  Definition weight (i : nat)
+    := 2^(-(-(limbwidth_num * i) / limbwidth_den)).
+End mod_ops.
+(*
+Require Import Crypto.Arithmetic.ModOps.
+Print encodemod.
+*)
+
+Module ModOps (Import RT : Runtime).
+  Module Import Deps.
+    Module Export Positional := Positional RT.
+  End Deps.
+
+  Section mod_ops.
+  Local Coercion Z.of_nat : nat >-> Z.
+  Local Coercion QArith_base.inject_Z : Z >-> Q.
+  (* Design constraints:
+     - inputs must be [Z] (b/c reification does not support Q)
+     - internal structure must not match on the arguments (b/c reification does not support [positive]) *)
+  Context (limbwidth_num limbwidth_den : Z)
+          (limbwidth_good : 0 < limbwidth_den <= limbwidth_num)
+          (s : Z)
+          (c : list (Z*Z))
+          (n : nat)
+          (len_c : nat)
+          (idxs : list nat)
+          (len_idxs : nat)
+          (Hn_nz : n <> 0%nat)
+          (Hc : length c = len_c)
+          (Hidxs : length idxs = len_idxs).
+
+  Local Notation weight := (weight limbwidth_num limbwidth_den).
+
+  Definition carry_mulmod_cps (f g : list Z) : ~> list Z
+    := (fg <- mulmod_cps weight s c n f g; v <- chained_carries_cps weight n s c fg idxs; return v).
+  Definition carry_mulmod (f g : list Z) : list Z := carry_mulmod_cps f g _ id.
+
+  Definition carry_squaremod_cps (f : list Z) : ~> list Z
+    := (ff <- squaremod_cps weight s c n f; v <- chained_carries_cps weight n s c ff idxs; return v).
+  Definition carry_squaremod (f : list Z) : list Z := carry_squaremod_cps f _ id.
+
+  Definition carry_scmulmod_cps (x : Z) (f : list Z) : ~> list Z
+    := (x <- encode_cps weight n s c x;
+          xf <- mulmod_cps weight s c n x f;
+          xf <- chained_carries_cps weight n s c xf idxs;
+          return xf).
+  Definition carry_scmulmod (x : Z) (f : list Z) : list Z := carry_scmulmod_cps x f _ id.
+
+  Definition carrymod_cps (f : list Z) : ~> list Z
+    := chained_carries_cps weight n s c f idxs.
+  Definition carrymod (f : list Z) : list Z := carrymod_cps f _ id.
+
+  Definition addmod_cps (f g : list Z) : ~> list Z
+    := add_cps weight n f g.
+  Definition addmod (f g : list Z) : list Z := addmod_cps f g _ id.
+
+  Definition submod_cps (coef : Z) (f g : list Z) : ~> list Z
+    := sub_cps weight n s c coef f g.
+  Definition submod (coef : Z) (f g : list Z) : list Z := submod_cps coef f g _ id.
+
+  Definition oppmod_cps (coef : Z) (f : list Z) : ~> list Z
+    := opp_cps weight n s c coef f.
+  Definition oppmod (coef : Z) (f : list Z) : list Z := oppmod_cps coef f _ id.
+
+  Definition encodemod_cps (f : Z) : ~> list Z
+    := encode_cps weight n s c f.
+  Definition encodemod (f : Z) : list Z := encodemod_cps f _ id.
+  End mod_ops.
+End ModOps.
+
+(*
+Module Import RT_ExtraAx := RT_Extra RuntimeAxioms.
+Module ModOpsAx := ModOps RuntimeAxioms.
+
+Import List.ListNotations.
+Import RuntimeAxioms.
+
+Axiom hide : forall {T} {v : T}, True.
+Time Compute @hide _ (fun f g => ModOpsAx.addmod 51 2 5 (expand_list 0 f 5) (expand_list 0 g 5)).
+Time Compute @hide _ (fun f g => ModOpsAx.carry_mulmod 51 2 (2^255) [(1,19)] 5 (List.seq 0 5 ++ [0; 1])%nat%list (expand_list 0 f 5) (expand_list 0 g 5)).
+Time Eval cbv in @hide _ (fun f g => ModOpsAx.carry_mulmod 51 2 (2^255) [(1,19)] 5 (List.seq 0 5 ++ [0; 1])%nat%list (expand_list 0 f 5) (expand_list 0 g 5)).
+Time Eval lazy in @hide _ (fun f g => ModOpsAx.carry_mulmod 51 2 (2^255) [(1,19)] 5 (List.seq 0 5 ++ [0; 1])%nat%list (expand_list 0 f 5) (expand_list 0 g 5)).
+
+
+
+
+Module Import RT_ExtraDef := RT_Extra RuntimeDefinitions.
+Module ModOpsDef := ModOps RuntimeDefinitions.
+Import RuntimeDefinitions.
+
+
+Time Eval cbv_no_rt in @hide _ (fun f g => ModOpsDef.carry_mulmod 51 2 (2^255) [(1,19)] 5 (List.seq 0 5 ++ [0; 1])%nat%list (expand_list 0 f 5) (expand_list 0 g 5)).
+Time Eval lazy_no_rt in @hide _ (fun f g => ModOpsDef.carry_mulmod 51 2 (2^255) [(1,19)] 5 (List.seq 0 5 ++ [0; 1])%nat%list (expand_list 0 f 5) (expand_list 0 g 5)).
+
+(* Goal forall f g : list Z, True.
+  intros.
+  pose (ModOpsAx.addmod 51 2 5 (expand_list 0 f 5) (expand_list 0 g 5)) as e.
+  cbv [ModOpsAx.addmod expand_list expand_list_helper nat_rect List.seq List.app] in e.
+  cbv [Z.pow Pos.pow Init.Nat.pred nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd] in e.
+  vm_compute in e.
+  cbv [ModOpsAx.addmod_cps]
+  cbv [
+  ModOpsAx.carry_mulmod ModOpsAx.carry_mulmod_cps cpsbind cpsreturn] in e.
+  cbv [ModOpsAx.Deps.Positional.mulmod_cps ModOpsAx.Deps.Positional.from_associational_cps ModOpsAx.Deps.Positional.zeros List.repeat] in e.
+  cbv [cpscall] in e.
+  set (k :=  ModOpsAx.Deps.Positional.Deps.Associational.repeat_reduce _ _ _) in (value of e).
+  set (k' := k _) in (value of e).
+  subst k.
+  vm_compute in k'.
+  subst k'.
+  cbv [fold_right_cps2] in e.
+  cbv [fold_right_cps2_specialized] in e.
+  cbv [fold_right_cps2_specialized_step] in e.
+  cbv [weight Init.Nat.pred ModOpsAx.Deps.Positional.place nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd] in e.
+  cbv [ModOpsAx.Deps.Positional.add_to_nth update_nth cpscall] in e.
+  set (w := fun i : nat => _) in (value of e).
+  cbv [ModOpsAx.Deps.Positional.chained_carries_cps] in e.
+  cbv [List.rev List.app id] in e.
+  cbv [fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step] in e.
+  cbv [ModOpsAx.Deps.Positional.carry_reduce_cps] in e.
+  cbv [ModOpsAx.Deps.Positional.to_associational] in e.
+  unfold ModOpsAx.Deps.Positional.carry_cps at 1 in (value of e).
+  cbv [ModOpsAx.Deps.Positional.Deps.Associational.carry_cps] in e.
+  cbv [ModOpsAx.Deps.Positional.to_associational List.map List.seq] in e.
+  Arguments List.combine _ _ !_ !_.
+  cbn [List.combine] in e.
+  cbv [flat_map_cps flat_map_cps_specialized] in e.
+  cbv [ModOpsAx.Deps.Positional.Deps.Associational.carryterm_cps ] in e.
+  cbv [fst snd] in e.
+  cbv [w] in e.
+  clear w.
+  set (w := fun i : nat => _) in (value of e).
+  cbv [weight Init.Nat.pred ModOpsAx.Deps.Positional.place nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd] in e.
+  cbv [List.app] in e.
+  cbv [cpsbind cpsreturn cpscall] in e.
+  unfold ModOpsAx.Deps.Positional.from_associational_cps at 1 in (value of e).
+  cbv [ModOpsAx.Deps.Positional.zeros List.repeat ModOpsAx.Deps.Positional.add_to_nth fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step Init.Nat.pred ModOpsAx.Deps.Positional.place fst snd nat_rect] in e.
+  vm_compute in e.
+  cbv [] in e.
+  subst w; cbv beta iota zeta in e.
+  cbv beta iota zeta in
+  cbv [cpsbind cpsreturn cpscall ModOpsAx.Deps.Positional.carry_cps] in e.
+  cbv [ModOpsAx.Deps.Positional.Deps.Associational.carry_cps ModOpsAx.Deps.Positional.to_associational] in e.
+  cbv [List.map List.combine List.seq] in e.
+  cbv [flat_map_cps] in e.
+  cbv [ModOpsAx.Deps.Positional.from_associational_cps] in e.
+  cbv [flat_map_cps_specialized] in e.
+  cbv [ModOpsAx.Deps.Positional.Deps.Associational.carryterm_cps] in e.
+  cbv [ModOpsAx.Deps.Positional.zeros] in e.
+
+
+
+
+
+
+
+
+
+  cbv [ModOpsAx.Deps.Positional.Deps.Associational.split] in e.
+
+ *)
+*)

--- a/src/ArithmeticCPS/Saturated.v
+++ b/src/ArithmeticCPS/Saturated.v
@@ -1,0 +1,264 @@
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.Lists.List.
+Require Import Crypto.Algebra.Ring.
+Require Import Crypto.ArithmeticCPS.Core.
+Require Import Crypto.Arithmetic.Partition.
+Require Import Crypto.Util.CPSUtil.
+Require Import Crypto.Util.CPSNotations.
+Require Import Crypto.Util.Decidable.
+Require Import Crypto.Util.LetIn.
+Require Import Crypto.Util.ListUtil.
+Require Import Crypto.Util.NatUtil.
+Require Import Crypto.Util.Prod.
+Require Import Crypto.Util.Tactics.BreakMatch.
+Require Import Crypto.Util.Tactics.UniquePose.
+Require Import Crypto.Util.ZUtil.Definitions.
+Require Import Crypto.Util.ZUtil.AddGetCarry Crypto.Util.ZUtil.MulSplit.
+Require Import Crypto.Util.ZUtil.Modulo Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Hints.Core.
+Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
+Require Import Crypto.Util.ZUtil.Tactics.RewriteModSmall.
+Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
+
+Require Import Crypto.Util.Notations.
+Import ListNotations. Local Open Scope Z_scope.
+
+Import CPSBindNotations.
+Local Open Scope cps_scope.
+
+Module Associational (Import RT : Runtime).
+  Section Associational.
+
+    Definition sat_multerm_cps s (t t' : (Z * Z)) : ~> list (Z * Z) :=
+      fun T k => dlet_nd xy := RT_Z.mul_split s (snd t) (snd t') in
+      k [(fst t * fst t', fst xy); (fst t * fst t' * s, snd xy)].
+
+    Definition sat_mul_cps s (p q : list (Z * Z)) : ~> list (Z * Z) :=
+      fun T => flat_map_cps (fun t T => flat_map_cps (fun t' => sat_multerm_cps s t t') q) p.
+
+    Definition sat_multerm_const_cps s (t t' : (Z * Z)) : ~> list (Z * Z) :=
+      fun T k
+      => if snd t =? 1
+         then k [(fst t * fst t', snd t')]
+         else if snd t =? -1
+              then k [(fst t * fst t', - snd t')]
+              else if snd t =? 0
+                   then k nil
+                   else dlet_nd xy := RT_Z.mul_split s (snd t) (snd t') in
+          k [(fst t * fst t', fst xy); (fst t * fst t' * s, snd xy)].
+
+    Definition sat_mul_const_cps s (p q : list (Z * Z)) : ~> list (Z * Z) :=
+      fun T => flat_map_cps (fun t T => flat_map_cps (fun t' => sat_multerm_const_cps s t t') q) p.
+  End Associational.
+End Associational.
+
+Module Columns (Import RT : Runtime).
+  Module Import Deps.
+    Module Import Positional := Positional RT.
+  End Deps.
+  Section Columns.
+    Context (weight : nat -> Z).
+
+    Definition eval n (x : list (list Z)) : Z := Positional.eval weight n (map sum x).
+
+    Section Flatten.
+      Section flatten_column.
+        Context (fw : Z). (* maximum size of the result *)
+
+        (* Outputs (sum, carry) *)
+        Definition flatten_column_cps (digit: list Z) : ~> (Z * Z) :=
+          list_rect (fun _ => ~> (Z * Z)%type) (return (0,0))
+                    (fun xx tl flatten_column_tl =>
+                       list_case
+                         (fun _ => ~> (Z * Z)%type) (fun T k => k ((xx mod fw)%RT, (xx / fw)%RT))
+                         (fun yy tl' =>
+                            list_case
+                              (fun _ => ~> (Z * Z)%type) (fun T k => dlet_nd x := xx in dlet_nd y := yy in k (RT_Z.add_get_carry_full fw x y))
+                              (fun _ _ =>
+                                 flatten_column_tl <- flatten_column_tl;
+                                 fun T k => dlet_nd x := xx in
+                                   dlet_nd rec1 := fst flatten_column_tl in (* recursively get the sum and carry *)
+                                   dlet_nd rec2 := snd flatten_column_tl in
+                                   dlet_nd sum_carry := RT_Z.add_get_carry_full fw x rec1 in (* add the new value to the sum *)
+                                   dlet_nd carry' := (snd sum_carry + rec2)%RT in (* add the two carries together *)
+                                   k (fst sum_carry, carry'))
+                              tl')
+                         tl)
+                    digit.
+      End flatten_column.
+
+      Definition flatten_step_cps (digit:list Z) (acc_carry:list Z * Z) : ~> list Z * Z :=
+        (sum_carry <- flatten_column_cps (weight (S (length (fst acc_carry))) / weight (length (fst acc_carry))) (snd acc_carry::digit);
+           dlet_nd sum := fst sum_carry in
+           dlet_nd carry := snd sum_carry in
+             return (fst acc_carry ++ sum :: nil, carry)).
+
+      Definition flatten (xs : list (list Z)) : ~> list Z * Z :=
+        fun T => fold_right_cps2 (fun a b => flatten_step_cps a b) (nil,0) (rev xs).
+    End Flatten.
+
+    Section FromAssociational.
+      (* nils *)
+      Definition nils n : list (list Z) := repeat nil n.
+      (* cons_to_nth *)
+      Definition cons_to_nth i x (xs : list (list Z)) : list (list Z) :=
+        ListUtil.update_nth i (fun y => cons x y) xs.
+
+      (* from_associational *)
+      Definition from_associational_cps n (p:list (Z*Z)) : ~> list (list Z) :=
+        fun T => fold_right_cps2 (fun t ls T k =>
+                                    let '(p1, p2) := Positional.place weight t (pred n) in
+                                    dlet_nd p2 := p2 in
+                           k (cons_to_nth p1 p2 ls) ) (nils n) p.
+    End FromAssociational.
+  End Columns.
+End Columns.
+
+Module Rows (Import RT : Runtime).
+  Module Import Deps.
+    Module Associational := Associational RT.
+    Module Positional := Positional RT.
+    Module Columns := Columns RT.
+    Module Export Core.
+      Module Associational := ArithmeticCPS.Core.Associational RT.
+    End Core.
+  End Deps.
+  Section Rows.
+    Context (weight : nat -> Z).
+    Local Notation rows := (list (list Z)) (only parsing).
+    Local Notation cols := (list (list Z)) (only parsing).
+
+    Definition eval n (inp : rows) :=
+      sum (map (Positional.eval weight n) inp).
+
+    Section FromAssociational.
+      (* extract row *)
+      Definition extract_row (inp : cols) : cols * list Z := (map (fun c => tl c) inp, map (fun c => hd 0 c) inp).
+
+      Definition max_column_size (x:cols) := fold_right (fun a b => Nat.max a b) 0%nat (map (fun c => length c) x).
+
+      (* from_columns *)
+      Definition from_columns' n start_state : cols * rows :=
+        fold_right (fun _ (state : cols * rows) =>
+                      let cols'_row := extract_row (fst state) in
+                      (fst cols'_row, snd state ++ [snd cols'_row])
+                   ) start_state (repeat 0 n).
+
+      Definition from_columns (inp : cols) : rows := snd (from_columns' (max_column_size inp) (inp, [])).
+
+      (* from associational *)
+      Definition from_associational_cps n (p : list (Z * Z)) : ~> _ :=
+        (p <- Columns.from_associational_cps weight n p; return (from_columns p)).
+    End FromAssociational.
+
+    Section Flatten.
+      Local Notation fw := (fun i => weight (S i) / weight i) (only parsing).
+
+      Section SumRows.
+        Definition sum_rows'_cps start_state (row1 row2 : list Z) : ~> list Z * Z * nat :=
+          fun T => fold_right_cps2 (fun next (state : list Z * Z * nat) T k =>
+                        let i := snd state in
+                        let low_high := fst state in
+                        let low := fst low_high in
+                        let high := snd low_high in
+                        dlet_nd sum_carry := RT_Z.add_with_get_carry_full (fw i) high (fst next) (snd next) in
+                        let low_high' := (low ++ [fst sum_carry], snd sum_carry) in
+                        k (low_high', S i)) start_state (rev (combine row1 row2)).
+        Definition sum_rows_cps row1 row2 : ~> _ := (sum_rows' <- sum_rows'_cps (nil, 0, 0%nat) row1 row2; return (fst sum_rows')).
+      End SumRows.
+
+      Definition flatten'_cps (start_state : list Z * Z) (inp : rows) : ~> list Z * Z :=
+        fun T => fold_right_cps2 (fun next_row (state : list Z * Z)=>
+                      out_carry <- sum_rows_cps (fst state) next_row;
+                        return (fst out_carry, (snd state + snd out_carry)%RT)) start_state inp.
+
+      (* In order for the output to have the right length and bounds,
+         we insert rows of zeroes if there are fewer than two rows. *)
+      Definition flatten_cps n (inp : rows) : ~> list Z * Z :=
+        let default := Positional.zeros n in
+        flatten'_cps (hd default inp, 0) (hd default (tl inp) :: tl (tl inp)).
+    End Flatten.
+
+    Section Ops.
+      Definition add_cps n p q : ~> _ := flatten_cps n [p; q].
+
+      (* TODO: Although cleaner, using Positional.negate snd inserts
+      dlets which prevent add-opp=>sub transformation in partial
+      evaluation. Should probably either make partial evaluation
+      handle that or remove the dlet in Positional.from_associational.
+
+      NOTE(from jgross): I think partial evaluation now handles that
+      fine; we should check this. *)
+      Definition sub_cps n p q : ~> _ := (_q <- fun T => map_cps2 (fun x T k => dlet y := x in k (-y)%RT) q; flatten_cps n [p; _q]).
+
+      Definition conditional_add_cps n mask cond (p q:list Z) : ~> _ :=
+        (qq <- Positional.zselect_cps mask cond q;
+           add_cps n p qq).
+
+      (* Subtract q if and only if p >= q. *)
+      Definition conditional_sub_cps n (p q:list Z) : ~> _ :=
+        (vc <- sub_cps n p q;
+           let '(v, c) := vc in
+           return (Positional.select (-c)%RT v p)).
+
+      (* the carry will be 0 unless we underflow--we do the addition only
+         in the underflow case *)
+      Definition sub_then_maybe_add_cps n mask (p q r:list Z) : ~> _ :=
+        (p_minus_q_c <- sub_cps n p q;
+           let '(p_minus_q, c) := p_minus_q_c in
+           rr <- Positional.zselect_cps mask (-c)%RT r;
+             res_c' <- add_cps n p_minus_q rr;
+             let '(res, c') := res_c' in
+         return (res, (c' - c)%RT)).
+
+      Definition mul_cps base n m (p q : list Z) : ~> _ :=
+        let p_a := Positional.to_associational weight n p in
+        let q_a := Positional.to_associational weight n q in
+        (pq_a <- Associational.sat_mul_cps base p_a q_a;
+           pq_a <- from_associational_cps m pq_a;
+           flatten_cps m pq_a).
+
+      (* if [s] is not exactly equal to a weight, we must adjust it to
+         be a weight, so that rather than dividing by s and
+         multiplying by c, we divide by w and multiply by c*(w/s).
+         See
+         https://github.com/mit-plv/fiat-crypto/issues/326#issuecomment-404135131
+         for a bit more discussion *)
+      Definition adjust_s fuel s : Z * bool :=
+        fold_right
+          (fun w_i res
+           => let '(v, found_adjustment) := res in
+              let res := (v, found_adjustment) in
+              if found_adjustment:bool
+              then res
+              else if w_i mod s =? 0
+                   then (w_i, true)
+                   else res)
+          (s, false)
+          (map weight (List.rev (seq 0 fuel))).
+
+      (* TODO : move sat_reduce and repeat_sat_reduce to Saturated.Associational *)
+      Definition sat_reduce_cps base s c n (p : list (Z * Z)) : ~> _ :=
+        let '(s', _) := adjust_s (S (S n)) s in
+        let lo_hi := Associational.split s' p in
+        (p <- Associational.sat_mul_const_cps base c (snd lo_hi);
+           p <- Associational.sat_mul_const_cps base [(1, s'/s)] p;
+         return (fst lo_hi ++ p)).
+
+      Definition repeat_sat_reduce_cps base s c (p : list (Z * Z)) n : ~> _ :=
+        fun T => fold_right_cps2 (fun _ q => sat_reduce_cps base s c n q) p (seq 0 n).
+
+      Definition mulmod_cps base s c n nreductions (p q : list Z) : ~> _ :=
+        let p_a := Positional.to_associational weight n p in
+        let q_a := Positional.to_associational weight n q in
+        (pq_a <- Associational.sat_mul_cps base p_a q_a;
+           r_a <- repeat_sat_reduce_cps base s c pq_a nreductions;
+           r_a <- from_associational_cps n r_a;
+           flatten_cps n r_a).
+
+      (* returns all-but-lowest-limb and lowest limb *)
+      Definition divmod (p : list Z) : list Z * Z
+        := (tl p, hd 0 p).
+    End Ops.
+  End Rows.
+End Rows.

--- a/src/ArithmeticCPS/WordByWordMontgomery.v
+++ b/src/ArithmeticCPS/WordByWordMontgomery.v
@@ -1,0 +1,443 @@
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.Lists.List.
+Require Import Crypto.Algebra.Ring.
+Require Import Crypto.ArithmeticCPS.Core.
+Require Import Crypto.ArithmeticCPS.Freeze.
+Require Import Crypto.Arithmetic.Partition.
+Require Import Crypto.ArithmeticCPS.Saturated.
+Require Import Crypto.Arithmetic.UniformWeight.
+Require Import Crypto.Util.CPSUtil.
+Require Import Crypto.Util.CPSNotations.
+Require Import Crypto.Util.LetIn.
+Require Import Crypto.Util.ListUtil.
+Require Import Crypto.Util.Prod.
+Require Import Crypto.Util.Sigma.
+Require Import Crypto.Util.Tactics.SetEvars.
+Require Import Crypto.Util.Tactics.SubstEvars.
+Require Import Crypto.Util.ZUtil.Modulo Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Definitions.
+Require Import Crypto.Util.ZUtil.EquivModulo.
+Require Import Crypto.Util.ZUtil.AddGetCarry Crypto.Util.ZUtil.MulSplit.
+Require Import Crypto.Util.ZUtil.Modulo.PullPush.
+Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
+Require Import Crypto.Util.ZUtil.Tactics.LinearSubstitute.
+Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
+Require Import Crypto.Util.ZUtil.Tactics.PeelLe.
+Require Import Crypto.Util.ZUtil.Tactics.RewriteModSmall.
+Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
+Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
+
+Require Import Crypto.Util.Notations.
+Import ListNotations. Local Open Scope Z_scope.
+
+Import CPSBindNotations.
+Local Open Scope cps_scope.
+
+Module WordByWordMontgomery (Import RT : Runtime).
+  Module Import Deps.
+    Module Positional := Positional RT.
+    Module Rows := Rows RT.
+    Module Export FreezeModOps := FreezeModOps RT.
+    Module Export RT_Extra := RT_Extra RT.
+  End Deps.
+  Section with_args.
+    Context (lgr : Z)
+            (m : Z).
+    Local Notation weight := (uweight lgr).
+    Let T (n : nat) := list Z.
+    Let r := (2^lgr).
+    Definition eval {n} : T n -> Z := Positional.eval weight n.
+    Let zero {n} : T n := Positional.zeros n.
+    Let divmod {n} : T (S n) -> T n * Z := Rows.divmod.
+    Let scmul_cps {n} (c : Z) (p : T n) : ~> T (S n) (* uses double-output multiply *)
+      := (vc <- Rows.mul_cps weight r n (S n) (Positional.extend_to_length 1 n [c]) p;
+            let '(v, c) := vc in
+            return v).
+    Let addT_cps {n} (p q : T n) : ~> T (S n) (* joins carry *)
+      := (vc <- Rows.add_cps weight n p q;
+            let '(v, c) := vc in
+            return (v ++ [c])).
+    Let drop_high_addT'_cps {n} (p : T (S n)) (q : T n) : ~> T (S n) (* drops carry *)
+      := (pq <- Rows.add_cps weight (S n) p (Positional.extend_to_length n (S n) q); return (fst pq)).
+    Let conditional_sub_cps {n} (arg : T (S n)) (N : T n) : ~> T n  (* computes [arg - N] if [N <= arg], and drops high bit *)
+      := (v <- Rows.conditional_sub_cps weight (S n) arg (Positional.extend_to_length n (S n) N); return (Positional.drop_high_to_length n v)).
+    Context (R_numlimbs : nat)
+            (N : T R_numlimbs). (* encoding of m *)
+    Let sub_then_maybe_add_cps (a b : T R_numlimbs) : ~> T R_numlimbs (* computes [a - b + if (a - b) <? 0 then N else 0] *)
+      := (v <- Rows.sub_then_maybe_add_cps weight R_numlimbs (r-1) a b N; return (fst v)).
+    Local Opaque T.
+    Section Iteration.
+      Context (pred_A_numlimbs : nat)
+              (B : T R_numlimbs) (k : Z)
+              (A : T (S pred_A_numlimbs))
+              (S : T (S R_numlimbs)).
+      (* Given A, B < R, we want to compute A * B / R mod N. R = bound 0 * ... * bound (n-1) *)
+
+      Local Definition A'_S3_cps : ~> _
+        := fun _ cont
+           => let '(A', a) := @divmod _ A in
+              dlet_list A' := A' in
+              dlet a := a in
+           @scmul_cps _ a B _ (fun aB =>
+           @addT_cps _ S aB _ (fun S1 =>
+           dlet_list S1 := S1 in
+           dlet s := snd (@divmod (Datatypes.S (Datatypes.S R_numlimbs)) S1) in
+           dlet q := fst (RT_Z.mul_split r s k) in
+           @scmul_cps _ q N _ (fun qN =>
+           @drop_high_addT'_cps _ S1 qN _ (fun S2 =>
+           dlet_list S2 := S2 in
+           dlet_list S3 := fst (@divmod (Datatypes.S R_numlimbs) S2) in
+           cont (A', S3))))).
+     End Iteration.
+
+    Section loop.
+      Context (A_numlimbs : nat)
+              (A : T A_numlimbs)
+              (B : T R_numlimbs)
+              (k : Z)
+              (S' : T (S R_numlimbs)).
+
+      Definition redc_body_cps {pred_A_numlimbs} : T (S pred_A_numlimbs) * T (S R_numlimbs)
+                                               ~> T pred_A_numlimbs * T (S R_numlimbs)
+        := fun '(A, S') => A'_S3_cps _ B k A S'.
+
+      Definition redc_loop_cps (count : nat) : T count * T (S R_numlimbs) ~> T O * T (S R_numlimbs)
+        := nat_rect
+             (fun count => T count * _ ~> _)
+             (fun A_S => return A_S)
+             (fun count' redc_loop_count' A_S
+              => A'_S' <- redc_body_cps A_S; redc_loop_count' A'_S')
+             count.
+
+      Definition pre_redc_cps : ~> T (S R_numlimbs)
+        := (v <- redc_loop_cps A_numlimbs (A, @zero (1 + R_numlimbs)%nat); return (snd v)).
+
+      Definition redc_cps : ~> T R_numlimbs
+        := (pre_redc <- pre_redc_cps; conditional_sub_cps pre_redc N).
+    End loop.
+
+    Definition add_cps (A B : T R_numlimbs) : ~> T R_numlimbs
+      := (AB <- @addT_cps _ A B; conditional_sub_cps AB N).
+    Definition sub_cps (A B : T R_numlimbs) : ~> T R_numlimbs
+      := sub_then_maybe_add_cps A B.
+    Definition opp_cps (A : T R_numlimbs) : ~> T R_numlimbs
+      := sub_cps (@zero _) A.
+    Definition nonzero (A : list Z) : Z
+      := fold_right Z.lor 0 A.
+  End with_args.
+
+  Section modops.
+    Context (bitwidth : Z)
+            (n : nat)
+            (m : Z).
+    Let r := 2^bitwidth.
+    Local Notation weight := (uweight bitwidth).
+    Local Notation eval := (@eval bitwidth n).
+    Let m_enc := Partition.partition weight n m.
+    Local Coercion Z.of_nat : nat >-> Z.
+    Context (r' : Z)
+            (m' : Z)
+            (r'_correct : (r * r') mod m = 1)
+            (m'_correct : (m * m') mod r = (-1) mod r)
+            (bitwidth_big : 0 < bitwidth)
+            (m_big : 1 < m)
+            (n_nz : n <> 0%nat)
+            (m_small : m < r^n).
+
+    Definition mulmod_cps (a b : list Z) : ~> list Z := @redc_cps bitwidth n m_enc n a b m'.
+    Definition squaremod_cps (a : list Z) : ~> list Z := mulmod_cps a a.
+    Definition addmod_cps (a b : list Z) : ~> list Z := @add_cps bitwidth n m_enc a b.
+    Definition submod_cps (a b : list Z) : ~> list Z := @sub_cps bitwidth n m_enc a b.
+    Definition oppmod_cps (a : list Z) : ~> list Z := @opp_cps bitwidth n m_enc a.
+
+    Definition mulmod (a b : list Z) : list Z := mulmod_cps a b _ id.
+    Definition squaremod (a : list Z) : list Z := squaremod_cps a _ id.
+    Definition addmod (a b : list Z) : list Z := addmod_cps a b _ id.
+    Definition submod (a b : list Z) : list Z := submod_cps a b _ id.
+    Definition oppmod (a : list Z) : list Z := oppmod_cps a _ id.
+
+    Definition nonzeromod (a : list Z) : Z := @nonzero a.
+    Definition to_bytesmod_cps (a : list Z) : ~> list Z := @to_bytesmod_cps bitwidth 1 n a.
+    Definition to_bytesmod (a : list Z) : list Z := to_bytesmod_cps a _ id.
+    Definition onemod : list Z := Partition.partition weight n 1.
+    Definition R2mod : list Z := Partition.partition weight n ((r^n * r^n) mod m).
+    Definition from_montgomerymod_cps (v : list Z) : ~> list Z
+      := mulmod_cps v onemod.
+    Definition from_montgomerymod (v : list Z) : list Z := from_montgomerymod_cps v _ id.
+    Definition encodemod_cps (v : Z) : ~> list Z
+      := mulmod_cps (Partition.partition weight n v) R2mod.
+    Definition encodemod (v : Z) : list Z := encodemod_cps v _ id.
+  End modops.
+End WordByWordMontgomery.
+
+(*
+Module Import RT_ExtraAx := RT_Extra RuntimeAxioms.
+Module Import WordByWordMontgomeryAx := WordByWordMontgomery RuntimeAxioms.
+
+Import List.ListNotations.
+Import RuntimeAxioms.
+
+Axiom hide : forall {T} {v : T}, True.
+Require Import Crypto.Util.ZUtil.ModInv.
+
+Time Compute @hide _ (fun a b => (let m := (2^256 - 2^224 + 2^192 + 2^96 - 1) in mulmod 64 4 m match Z.modinv (-m) (2^64) with
+            | Some m' => m'
+            | None => 0
+                                                                     end (expand_list 0 a 4) (expand_list 0 b 4))).
+Time Eval lazy in @hide _ (fun a b => (let m := (2^256 - 2^224 + 2^192 + 2^96 - 1) in mulmod 64 4 m match Z.modinv (-m) (2^64) with
+            | Some m' => m'
+            | None => 0
+                                                                     end (expand_list 0 a 4) (expand_list 0 b 4))).
+
+Goal forall (a b : list Z), True.
+  intros.
+  pose (let m := (2^256 - 2^224 + 2^192 + 2^96 - 1) in mulmod 64 4 m match Z.modinv (-m) (2^64) with
+            | Some m' => m'
+            | None => 0
+                                                                     end (expand_list 0 a 4) (expand_list 0 b 4)) as e.
+  cbv [Z.pow Pos.pow Init.Nat.pred nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd Pos.pred_double Z.opp] in e.
+  set (k := Z.modinv _ _) in (value of e).
+  vm_compute in k; subst k.
+  cbv [expand_list expand_list_helper nat_rect] in e.
+  cbv [mulmod mulmod_cps] in e.
+  cbv [Partition.partition seq map] in e.
+  cbv [uweight ModOps.weight] in e.
+  cbv -[redc_cps] in e.
+  cbv [redc_cps] in e.
+  cbv [pre_redc_cps] in e.
+  cbv [redc_loop_cps] in e.
+  cbv [nat_rect] in e.
+  cbv [Deps.Positional.zeros Nat.add] in e.
+  cbv [cpscall cpsbind cpsreturn] in e.
+  cbv [repeat] in e.
+  cbv [redc_body_cps] in e.
+  unfold WordByWordMontgomeryAx.A'_S3_cps in (value of e) at 1.
+  cbv [Deps.Rows.divmod hd tl] in e.
+  cbn [Deps.RT_Extra.dlet_nd_list] in e.
+  cbv [Deps.Positional.extend_to_length] in e.
+  cbv [Nat.sub Deps.Positional.zeros repeat] in e.
+  cbn [List.app] in e.
+  unfold Deps.Rows.mul_cps at 1 in (value of e).
+  cbv [Deps.Rows.Deps.Positional.to_associational map seq] in e.
+  cbn [combine] in e.
+  set (uw := uweight 64) in (value of e).
+  cbv [Deps.Rows.Deps.Associational.sat_mul_cps ] in e.
+  cbv [flat_map_cps flat_map_cps_specialized] in e.
+  cbv [Deps.Rows.Deps.Associational.sat_multerm_cps] in e; cbn [fst snd] in e.
+  cbv [cpscall cpsbind cpsreturn id] in e.
+  Arguments app _ !_ !_.
+  cbn [app] in e.
+  unfold Deps.Rows.from_associational_cps in (value of e) at 1; cbv [Deps.Rows.Deps.Columns.from_associational_cps] in e.
+  cbv [cpscall cpsbind cpsreturn id] in e.
+  Set Printing Depth 1000000.
+  cbv [Deps.Rows.Deps.Columns.nils repeat Init.Nat.pred] in e.
+  cbv [Deps.Rows.Deps.Columns.cons_to_nth] in e.
+  cbv [fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step] in e.
+  cbv [Deps.Rows.Deps.Columns.Deps.Positional.place] in e.
+  cbv [nat_rect] in e.
+  cbn [fst snd] in e.
+  set (k := uw 0%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 1%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 2%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 3%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 4%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 5%nat) in (value of e); vm_compute in k; subst k.
+  cbv [Z.pow Pos.pow Init.Nat.pred nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd Pos.pred_double Z.opp] in e.
+  cbv [update_nth] in e.
+  cbv [Deps.Rows.from_columns Deps.Rows.max_column_size Deps.Rows.from_columns' map List.repeat length Nat.max Deps.Rows.extract_row map hd tl List.app] in e.
+  cbv delta [fold_right] in e.
+  cbn [fst snd combine] in e.
+  cbv [Deps.Rows.flatten_cps hd tl Deps.Rows.flatten'_cps] in e.
+  cbv [fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step] in e.
+  cbv [cpscall cpsbind cpsreturn id] in e.
+  cbn [fst snd] in e.
+  unfold Deps.Rows.sum_rows_cps at 1 in (value of e).
+  cbv [Deps.Rows.sum_rows'_cps rev] in e; cbn [app combine fst snd] in e.
+  cbv [fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step] in e.
+  cbv [cpscall cpsbind cpsreturn id] in e.
+  cbn [fst snd combine app] in e.
+  unfold Deps.Rows.sum_rows_cps at 1 in (value of e).
+  cbv [Deps.Rows.sum_rows'_cps rev fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e.
+  cbn [fst snd combine app] in e.
+  cbv [Deps.Rows.sum_rows_cps Deps.Rows.sum_rows'_cps rev fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e; cbn [fst snd combine app] in e.
+  unfold Deps.Rows.add_cps at 1 in (value of e).
+  cbv [Deps.Rows.flatten_cps hd tl Deps.Rows.flatten'_cps fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e.
+  cbn [fst snd] in e.
+  cbv [Deps.Rows.sum_rows_cps Deps.Rows.sum_rows'_cps rev fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e; cbn [fst snd combine app] in e.
+  cbn [Deps.RT_Extra.dlet_nd_list] in e.
+  cbv [Deps.Rows.mul_cps] in e.
+  cbv [Deps.Rows.Deps.Positional.to_associational map seq] in e.
+  cbn [combine] in e.
+  cbv [Deps.Rows.Deps.Associational.sat_mul_cps flat_map_cps flat_map_cps_specialized Deps.Rows.Deps.Associational.sat_multerm_cps cpscall cpsbind cpsreturn id] in e; cbn [fst snd app combine] in e.
+  unfold Deps.Rows.from_associational_cps in (value of e) at 1.
+  cbv [Deps.Rows.Deps.Columns.from_associational_cps cpscall cpsbind cpsreturn id Deps.Rows.Deps.Columns.nils repeat Init.Nat.pred Deps.Rows.Deps.Columns.cons_to_nth fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step Deps.Rows.Deps.Columns.Deps.Positional.place nat_rect] in e;
+    cbn [fst snd app combine] in e.
+  set (k := uw 0%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 1%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 2%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 3%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 4%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 5%nat) in (value of e); vm_compute in k; subst k.
+  cbv [Z.pow Pos.pow Init.Nat.pred nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd Pos.pred_double Z.opp] in e.
+  cbv [update_nth Deps.Rows.from_columns Deps.Rows.max_column_size Deps.Rows.from_columns' map List.repeat length Nat.max Deps.Rows.extract_row map hd tl List.app] in e.
+  cbv delta [fold_right] in e.
+  cbn [fst snd combine app] in e.
+  cbv [Deps.Rows.flatten_cps hd tl Deps.Rows.flatten'_cps fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e.
+  cbn [fst snd combine app] in e.
+  cbv [Deps.Rows.sum_rows_cps Deps.Rows.sum_rows'_cps rev fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e; cbn [fst snd combine app] in e.
+  unfold Deps.Rows.add_cps at 1 in (value of e).
+  cbv [Deps.Rows.flatten_cps hd tl Deps.Rows.flatten'_cps fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e.
+  cbv [Deps.Rows.sum_rows_cps Deps.Rows.sum_rows'_cps rev fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e; cbn [fst snd combine app] in e.
+  cbn [Deps.RT_Extra.dlet_nd_list] in e.
+  cbv [update_nth] in e.
+  unfold WordByWordMontgomeryAx.A'_S3_cps at 1 in (value of e).
+  cbv -[Deps.Positional.drop_high_to_length Deps.Rows.conditional_sub_cps WordByWordMontgomeryAx.A'_S3_cps] in e.
+  clear uw.
+  set (uw := fun i : nat => _) in (value of e).
+  cbv -[Deps.Positional.drop_high_to_length Deps.Rows.conditional_sub_cps] in e.
+  clear uw.
+  set (uw := fun i : nat => _) in (value of e).
+  cbv [Deps.Rows.conditional_sub_cps] in e.
+  change uw with (uweight 64) in (value of e).
+  clear uw.
+  set (uw := uweight 64) in (value of e).
+  cbv [Deps.Rows.sub_cps] in e.
+  cbv [map_cps2] in e.
+  cbv [cpscall cpsbind cpsreturn id] in e.
+  cbv [Deps.Rows.flatten_cps] in e.
+  cbv [hd tl] in e.
+  cbv [Deps.Rows.flatten'_cps] in e.
+  cbv [Deps.Rows.flatten_cps hd tl Deps.Rows.flatten'_cps fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e.
+  cbv [Deps.Rows.sum_rows_cps Deps.Rows.sum_rows'_cps rev fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step cpscall cpsbind cpsreturn id] in e; cbn [fst snd combine app] in e.
+  cbv [Deps.Rows.Deps.Positional.select] in e.
+  cbn [combine map] in e.
+  Print Z.zselect.
+  cbv -[Deps.Positional.drop_high_to_length] in e.
+  clear uw.
+  set (uw := fun i : nat => _) in (value of e).
+  vm_compute in e.
+
+
+  cbv [] in e.
+
+  cbv [Deps.Rows.from_columns]
+
+
+
+  set (k := Deps.Rows.mul_cps _ _ _ _) in (value of e) at 1
+  cbv [cpscall cpsbind cpsreturn id] in e.
+  cbv [List.app List.repeat] in e.
+  subst k.
+  cbv [Deps.Rows.mul_cps] in e.
+  cbv [Deps.Rows.Deps.Positional.to_associational ] in e.
+  set (k := map _ _) in (value of e).
+  vm_compute in k; subst k.
+  Arguments combine _ _ !_ !_.
+  cbn [combine] in e.
+  cbv [Z.pow Pos.pow Init.Nat.pred nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd Pos.pred_double Z.opp] in e.
+  unfold Deps.Rows.Deps.Associational.sat_mul_cps in (value of e) at 1.
+  cbv [flat_map_cps flat_map_cps_specialized] in e.
+  cbv [Deps.Rows.Deps.Associational.sat_multerm_cps] in e.
+  cbn [fst snd] in e.
+  cbv [cpscall cpsbind cpsreturn id] in e.
+  cbv [List.app] in e.
+  cbv [Z.mul Z.add Pos.mul Pos.add] in e.
+  unfold Deps.Rows.from_associational_cps in (value of e) at 1.
+  cbv [Deps.Rows.Deps.Columns.from_associational_cps] in e.
+  cbv [Deps.Rows.Deps.Columns.nils] in e.
+  cbv [repeat fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step Init.Nat.pred] in e.
+  cbv [Deps.Rows.Deps.Columns.Deps.Positional.place] in e.
+  cbn [fst snd] in e.
+  cbv [nat_rect] in e.
+  cbv [cpscall cpsbind cpsreturn] in e.
+  set (k := uw 0%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 1%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 2%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 3%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 4%nat) in (value of e); vm_compute in k; subst k.
+  cbv [Z.pow Pos.pow Init.Nat.pred nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd Pos.pred_double Z.opp] in e.
+  cbv [Deps.Rows.Deps.Columns.cons_to_nth] in e.
+  cbv [update_nth] in e.
+  cbv [Deps.Rows.from_columns Deps.Rows.max_column_size Deps.Rows.from_columns' map List.repeat length Nat.max] in e.
+  unfold fold_right in (value of e) at 2.
+  cbn [snd] in e.
+  cbv [Deps.Rows.extract_row] in e.
+  cbv [map hd tl List.app] in e.
+  cbv delta [fold_right] in e.
+  cbn [fst snd] in e.
+  cbv [Deps.Rows.flatten_cps hd tl Deps.Rows.flatten'_cps] in e.
+  cbv [fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step] in e.
+  cbv [cpsbind cpscall cpsreturn id] in e.
+  cbn [fst snd] in e.
+  unfold Deps.Rows.sum_rows_cps at 1 in (value of e).
+  cbv [cpscall cpsbind cpsreturn id Deps.Rows.sum_rows'_cps fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step rev app] in e.
+  cbn [combine fst snd] in e.
+  cbv [Deps.Rows.sum_rows_cps cpscall cpsbind cpsreturn id Deps.Rows.sum_rows'_cps fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step rev app] in e.
+  cbn [fst snd combine] in e.
+  cbv [Deps.Rows.add_cps] in e.
+  cbv [Deps.Rows.flatten_cps hd tl Deps.Rows.flatten'_cps] in e.
+  cbv [fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step] in e.
+  cbv [cpsbind cpscall cpsreturn id] in e.
+  cbn [fst snd] in e.
+  unfold Deps.Rows.sum_rows_cps at 1 in (value of e).
+  cbv [cpscall cpsbind cpsreturn id Deps.Rows.sum_rows'_cps fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step rev app] in e.
+  cbn [combine fst snd] in e.
+  cbv [Deps.Rows.sum_rows_cps cpscall cpsbind cpsreturn id Deps.Rows.sum_rows'_cps fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step rev app] in e.
+  cbn [fst snd combine] in e.
+  cbv [add_cps] in e.
+  cbv [Deps.Rows.Deps.Associational.sat_mul_cps] in e.
+  cbv [flat_map_cps flat_map_cps_specialized] in e.
+  cbv [Deps.Rows.Deps.Associational.sat_multerm_cps] in e.
+  cbn [fst snd] in e.
+  cbv [cpscall cpsbind cpsreturn id] in e.
+  cbv [List.app] in e.
+  cbv [Z.mul Z.add Pos.mul Pos.add] in e.
+  cbv [Deps.Rows.from_associational_cps] in e.
+ cbv [Deps.Rows.Deps.Columns.from_associational_cps] in e.
+ cbv [Deps.Rows.Deps.Columns.nils] in e.
+ cbv [Deps.Rows.Deps.Positional.zeros] in e.
+ cbv [repeat cpsbind cpscall cpsreturn] in e.
+  cbv [repeat fold_right_cps2 fold_right_cps2_specialized fold_right_cps2_specialized_step Init.Nat.pred] in e.
+  cbv [Deps.Rows.Deps.Columns.Deps.Positional.place] in e.
+  cbn [fst snd] in e.
+  cbv [nat_rect] in e.
+  cbv [cpscall cpsbind cpsreturn] in e.
+  set (k := uw 0%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 1%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 2%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 3%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 4%nat) in (value of e); vm_compute in k; subst k.
+  set (k := uw 5%nat) in (value of e); vm_compute in k; subst k.
+  Arguments Z.pow !_ !_.
+  Arguments Z.mul !_ !_.
+  Arguments Z.sub !_ !_.
+  Arguments Z.add !_ !_.
+
+  cbn [Z.pow Pos.pow Init.Nat.pred nat_rect fst Z.of_nat Pos.of_succ_nat Pos.succ Z.mul Pos.mul Pos.add Pos.iter Z.opp Z.div Z.div_eucl Z.pos_div_eucl Z.leb Z.compare Pos.compare Pos.compare_cont Z.add Z.ltb Z.sub Z.pos_sub Z.succ_double Z.double Z.pow Z.pow_pos Z.modulo Z.eqb Pos.eqb Pos.compare snd Pos.pred_double Z.opp] in e.
+  cbv [Deps.Rows.Deps.Columns.cons_to_nth] in e.
+  cbv [update_nth] in e.
+  cbv [Deps.Rows.from_columns Deps.Rows.max_column_size Deps.Rows.from_columns' map List.repeat length Nat.max] in e.
+  cbn [snd] in e.
+  cbv [Deps.Rows.extract_row map hd tl List.app] in e.
+  cbv delta [fold_right] in e.
+  cbn [fst snd] in e.
+  cbn [fst snd combine] in e.
+  cbv [List.app Lis
+   vm_compute in e.
+  unfold fold_right in (value of e) at 2.] i
+  unfold fold_right in (value of e) at 1.
+
+  cbn [fold_right] in e.
+  Deps.Rows.Deps.Columns.cons_to_nth Deps.Rows.Deps.Columns.Deps.Positional.place] in e.
+  vm_compute in e.
+
+Time Compute @hide _ (fun a b => let m := (2^256 - 2^224 + 2^192 + 2^96 - 1) in mulmod 64 4 m match Z.modinv (-m) (2^64) with
+            | Some m' => m'
+            | None => 0
+            end (expand_list 0 a 4) (expand_list 0 b 4)).
+Time Compute @hide _ (fun f g => ModOpsAx.carry_mulmod 51 2 (2^255) [(1,19)] 5 (List.seq 0 5 ++ [0; 1])%nat%list (expand_list 0 f 5) (expand_list 0 g 5)).
+Time Eval cbv in @hide _ (fun f g => ModOpsAx.carry_mulmod 51 2 (2^255) [(1,19)] 5 (List.seq 0 5 ++ [0; 1])%nat%list (expand_list 0 f 5) (expand_list 0 g 5)).
+Time Eval lazy in @hide _ (fun f g => ModOpsAx.carry_mulmod 51 2 (2^255) [(1,19)] 5 (List.seq 0 5 ++ [0; 1])%nat%list (expand_list 0 f 5) (expand_list 0 g 5)).
+
+
+*)


### PR DESCRIPTION
This is primarily for perf testing purposes, so we can evaluate the time
spent in the rewriter vs cbv/vm/native/etc for the cps'd versions.

We evaluate vm_compute and native_compute by parameterizing everything
over a module of runtime definitions, which can be instantiated with
module-locked opaque constants, which are not unfolded by the vm.