### PR TITLE
Thread `static` argument through `typedef_header`

### DIFF
--- a/src/CStringification.v
+++ b/src/CStringification.v
@@ -41,7 +41,7 @@ Module Compilers.
 
     Module C.
       Module String.
-        Definition typedef_header (prefix : string) (bitwidths_used : PositiveSet.t)
+        Definition typedef_header (static : bool) (prefix : string) (bitwidths_used : PositiveSet.t)
         : list string
           := (["#include <stdint.h>"]
                 ++ (if PositiveSet.mem 1 bitwidths_used
@@ -460,12 +460,12 @@ Module Compilers.
                 match t1, t2 with
                 | None, _ | _, None => (args, None)
                 | Some t1', Some t2' =>
-                  let args := 
+                  let args :=
                       if int.is_tighter_than t2' t1'
                       then (Zcast_up_if_needed desired_type (e1, t1), (e2, t2))
                       else ((e1, t1), Zcast_up_if_needed desired_type (e2, t2))
                   in
-                  let '((e1, t1), (e2, t2)) := args in 
+                  let '((e1, t1), (e2, t2)) := args in
                   let ct := (t1 <- t1; t2 <- t2; Some (C_common_type t1 t2))%option in
                   (args, ct)
                 end

--- a/src/LanguageStringification.v
+++ b/src/LanguageStringification.v
@@ -881,7 +881,7 @@ Module Compilers.
         (** Generates a header of any needed typedefs based on the bitwidths used and the curve-specific prefix *)
         (** TODO: should we pick a more generic name than "typedef_header"? *)
         typedef_header
-        : forall (prefix : string) (bitwidths_used : PositiveSet.t),
+        : forall (static : bool) (prefix : string) (bitwidths_used : PositiveSet.t),
             list string
       }.
   End ToString.

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -855,7 +855,7 @@ Section __.
          let types_used := PositiveSet.union extra_bit_widths (ToString.bitwidths_used infos) in
          let header :=
              (comment_header
-                ++ ToString.typedef_header function_name_prefix types_used
+                ++ ToString.typedef_header static function_name_prefix types_used
                 ++ [""]) in
          [("check_args" ++ String.NewLine ++ String.concat String.NewLine header,
            check_args (ErrorT.Success header))%string]

--- a/src/RustStringification.v
+++ b/src/RustStringification.v
@@ -24,22 +24,23 @@ Module Rust.
 
   (* Header imports and type defs *)
   (* TODO thread static flag in order to append pub *)
-  Definition typedef_header (prefix : string) (bitwidths_used : PositiveSet.t)
-  : list string :=
-    ([header]
-       ++ (if PositiveSet.mem 1 bitwidths_used
-           then ["pub type " ++ prefix ++ "u1 = u8;"; (* C: typedef unsigned char prefix_uint1 *)
-                   "pub type " ++ prefix ++ "i1 = i8;" ]%string (* C: typedef signed char prefix_int1 *)
-           else [])
-       ++ (if PositiveSet.mem 2 bitwidths_used
-           then ["pub type " ++ prefix ++ "u2 = u8;";
-                   "pub type " ++ prefix ++ "i2 = i8;" ]%string
-           else [])
-       ++ (if PositiveSet.mem 128 bitwidths_used
-           then ["pub type " ++ prefix ++ "u128 = u128;"; (* Since 128 bit integers exist in (nightly) rust consider removing the *)
-                                                          (* type synonym and extending stdint_ditwidths *)
-                   "pub type " ++ prefix ++ "i128 = i128;"]%string
-           else []))%list.
+  Definition typedef_header (static : bool) (prefix : string) (bitwidths_used : PositiveSet.t)
+    : list string
+    := let type_prefix := ((if static then "type " else "pub type ") ++ prefix)%string in
+       ([header]
+          ++ (if PositiveSet.mem 1 bitwidths_used
+              then [type_prefix ++ "u1 = u8;"; (* C: typedef unsigned char prefix_uint1 *)
+                      type_prefix ++ "i1 = i8;" ]%string (* C: typedef signed char prefix_int1 *)
+              else [])
+          ++ (if PositiveSet.mem 2 bitwidths_used
+              then [type_prefix ++ "u2 = u8;";
+                      type_prefix ++ "i2 = i8;" ]%string
+              else [])
+          ++ (if PositiveSet.mem 128 bitwidths_used
+              then [type_prefix ++ "u128 = u128;"; (* Since 128 bit integers exist in (nightly) rust consider removing the *)
+                      (* type synonym and extending stdint_ditwidths *)
+                      type_prefix ++ "i128 = i128;"]%string
+              else []))%list.
 
   (* Supported integer bitwidths *)
   Definition stdint_bitwidths : list Z := [8; 16; 32; 64].


### PR DESCRIPTION
This way we can correctly (not) insert `pub` in the Rust code when we
should(n't).

@zoep does this look good to you?