### PR TITLE
Adds inlining for fiat-rust generated functions

### DIFF
--- a/fiat-rust/src/curve25519_32.rs
+++ b/fiat-rust/src/curve25519_32.rs
@@ -31,6 +31,7 @@ pub type fiat_25519_i2 = i8;
  *   out1: [0x0 ~> 0x3ffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_25519_addcarryx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0x3ffffff);
@@ -53,6 +54,7 @@ pub fn fiat_25519_addcarryx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: 
  *   out1: [0x0 ~> 0x3ffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_25519_subborrowx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_25519_i1 = ((x1 >> 26) as fiat_25519_i1);
@@ -75,6 +77,7 @@ pub fn fiat_25519_subborrowx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1:
  *   out1: [0x0 ~> 0x1ffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_25519_addcarryx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0x1ffffff);
@@ -97,6 +100,7 @@ pub fn fiat_25519_addcarryx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: 
  *   out1: [0x0 ~> 0x1ffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_25519_subborrowx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_25519_i1 = ((x1 >> 25) as fiat_25519_i1);
@@ -117,6 +121,7 @@ pub fn fiat_25519_subborrowx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1:
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_25519_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
   let x1: fiat_25519_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_25519_i2) - (x1 as fiat_25519_i2)) as fiat_25519_i1) as i64) & (0xffffffff as i64)) as u32);
@@ -135,6 +140,7 @@ pub fn fiat_25519_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_u1, arg2: u32, ar
  * Output Bounds:
  *   out1: [[0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333]]
  */
+#[inline]
 pub fn fiat_25519_carry_mul(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: &[u32; 10]) -> () {
   let x1: u64 = (((arg1[9]) as u64) * (((arg2[9]) * ((0x2 as u32) * (0x13 as u32))) as u64));
   let x2: u64 = (((arg1[9]) as u64) * (((arg2[8]) * (0x13 as u32)) as u64));
@@ -305,6 +311,7 @@ pub fn fiat_25519_carry_mul(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: &[u32;
  * Output Bounds:
  *   out1: [[0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333]]
  */
+#[inline]
 pub fn fiat_25519_carry_square(out1: &mut [u32; 10], arg1: &[u32; 10]) -> () {
   let x1: u32 = ((arg1[9]) * (0x13 as u32));
   let x2: u32 = (x1 * (0x2 as u32));
@@ -448,6 +455,7 @@ pub fn fiat_25519_carry_square(out1: &mut [u32; 10], arg1: &[u32; 10]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333]]
  */
+#[inline]
 pub fn fiat_25519_carry_scmul_121666(out1: &mut [u32; 10], arg1: &[u32; 10]) -> () {
   let x1: u64 = ((0x1db42 as u64) * ((arg1[9]) as u64));
   let x2: u64 = ((0x1db42 as u64) * ((arg1[8]) as u64));
@@ -518,6 +526,7 @@ pub fn fiat_25519_carry_scmul_121666(out1: &mut [u32; 10], arg1: &[u32; 10]) -> 
  * Output Bounds:
  *   out1: [[0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333]]
  */
+#[inline]
 pub fn fiat_25519_carry(out1: &mut [u32; 10], arg1: &[u32; 10]) -> () {
   let x1: u32 = (arg1[0]);
   let x2: u32 = ((x1 >> 26) + (arg1[1]));
@@ -564,6 +573,7 @@ pub fn fiat_25519_carry(out1: &mut [u32; 10], arg1: &[u32; 10]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999]]
  */
+#[inline]
 pub fn fiat_25519_add(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: &[u32; 10]) -> () {
   let x1: u32 = ((arg1[0]) + (arg2[0]));
   let x2: u32 = ((arg1[1]) + (arg2[1]));
@@ -598,6 +608,7 @@ pub fn fiat_25519_add(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: &[u32; 10]) 
  * Output Bounds:
  *   out1: [[0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999]]
  */
+#[inline]
 pub fn fiat_25519_sub(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: &[u32; 10]) -> () {
   let x1: u32 = ((0x7ffffda + (arg1[0])) - (arg2[0]));
   let x2: u32 = ((0x3fffffe + (arg1[1])) - (arg2[1]));
@@ -631,6 +642,7 @@ pub fn fiat_25519_sub(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: &[u32; 10]) 
  * Output Bounds:
  *   out1: [[0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999], [0x0 ~> 0xd333332], [0x0 ~> 0x6999999]]
  */
+#[inline]
 pub fn fiat_25519_opp(out1: &mut [u32; 10], arg1: &[u32; 10]) -> () {
   let x1: u32 = (0x7ffffda - (arg1[0]));
   let x2: u32 = (0x3fffffe - (arg1[1]));
@@ -666,6 +678,7 @@ pub fn fiat_25519_opp(out1: &mut [u32; 10], arg1: &[u32; 10]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_25519_selectznz(out1: &mut [u32; 10], arg1: fiat_25519_u1, arg2: &[u32; 10], arg3: &[u32; 10]) -> () {
   let mut x1: u32 = 0;
   fiat_25519_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -709,6 +722,7 @@ pub fn fiat_25519_selectznz(out1: &mut [u32; 10], arg1: fiat_25519_u1, arg2: &[u
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x7f]]
  */
+#[inline]
 pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 10]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_25519_u1 = 0;
@@ -893,6 +907,7 @@ pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 10]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333], [0x0 ~> 0x4666666], [0x0 ~> 0x2333333]]
  */
+#[inline]
 pub fn fiat_25519_from_bytes(out1: &mut [u32; 10], arg1: &[u8; 32]) -> () {
   let x1: u32 = (((arg1[31]) as u32) << 18);
   let x2: u32 = (((arg1[30]) as u32) << 10);

--- a/fiat-rust/src/curve25519_64.rs
+++ b/fiat-rust/src/curve25519_64.rs
@@ -33,6 +33,7 @@ pub type fiat_25519_i128 = i128;
  *   out1: [0x0 ~> 0x7ffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_25519_addcarryx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u64, arg3: u64) -> () {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0x7ffffffffffff);
@@ -55,6 +56,7 @@ pub fn fiat_25519_addcarryx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1: 
  *   out1: [0x0 ~> 0x7ffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_25519_subborrowx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u64, arg3: u64) -> () {
   let x1: i64 = ((((((arg2 as fiat_25519_i128) - (arg1 as fiat_25519_i128)) as i64) as fiat_25519_i128) - (arg3 as fiat_25519_i128)) as i64);
   let x2: fiat_25519_i1 = ((x1 >> 51) as fiat_25519_i1);
@@ -75,6 +77,7 @@ pub fn fiat_25519_subborrowx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1:
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_25519_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_25519_i2) - (x1 as fiat_25519_i2)) as fiat_25519_i1) as fiat_25519_i128) & (0xffffffffffffffff as fiat_25519_i128)) as u64);
@@ -93,6 +96,7 @@ pub fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, ar
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc]]
  */
+#[inline]
 pub fn fiat_25519_carry_mul(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) -> () {
   let x1: fiat_25519_u128 = (((arg1[4]) as fiat_25519_u128) * (((arg2[4]) * (0x13 as u64)) as fiat_25519_u128));
   let x2: fiat_25519_u128 = (((arg1[4]) as fiat_25519_u128) * (((arg2[3]) * (0x13 as u64)) as fiat_25519_u128));
@@ -163,6 +167,7 @@ pub fn fiat_25519_carry_mul(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc]]
  */
+#[inline]
 pub fn fiat_25519_carry_square(out1: &mut [u64; 5], arg1: &[u64; 5]) -> () {
   let x1: u64 = ((arg1[4]) * (0x13 as u64));
   let x2: u64 = (x1 * (0x2 as u64));
@@ -231,6 +236,7 @@ pub fn fiat_25519_carry_square(out1: &mut [u64; 5], arg1: &[u64; 5]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc]]
  */
+#[inline]
 pub fn fiat_25519_carry_scmul_121666(out1: &mut [u64; 5], arg1: &[u64; 5]) -> () {
   let x1: fiat_25519_u128 = ((0x1db42 as fiat_25519_u128) * ((arg1[4]) as fiat_25519_u128));
   let x2: fiat_25519_u128 = ((0x1db42 as fiat_25519_u128) * ((arg1[3]) as fiat_25519_u128));
@@ -276,6 +282,7 @@ pub fn fiat_25519_carry_scmul_121666(out1: &mut [u64; 5], arg1: &[u64; 5]) -> ()
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc]]
  */
+#[inline]
 pub fn fiat_25519_carry(out1: &mut [u64; 5], arg1: &[u64; 5]) -> () {
   let x1: u64 = (arg1[0]);
   let x2: u64 = ((x1 >> 51) + (arg1[1]));
@@ -307,6 +314,7 @@ pub fn fiat_25519_carry(out1: &mut [u64; 5], arg1: &[u64; 5]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664]]
  */
+#[inline]
 pub fn fiat_25519_add(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) -> () {
   let x1: u64 = ((arg1[0]) + (arg2[0]));
   let x2: u64 = ((arg1[1]) + (arg2[1]));
@@ -331,6 +339,7 @@ pub fn fiat_25519_add(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) -> 
  * Output Bounds:
  *   out1: [[0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664]]
  */
+#[inline]
 pub fn fiat_25519_sub(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) -> () {
   let x1: u64 = ((0xfffffffffffda + (arg1[0])) - (arg2[0]));
   let x2: u64 = ((0xffffffffffffe + (arg1[1])) - (arg2[1]));
@@ -354,6 +363,7 @@ pub fn fiat_25519_sub(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) -> 
  * Output Bounds:
  *   out1: [[0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664], [0x0 ~> 0x1a666666666664]]
  */
+#[inline]
 pub fn fiat_25519_opp(out1: &mut [u64; 5], arg1: &[u64; 5]) -> () {
   let x1: u64 = (0xfffffffffffda - (arg1[0]));
   let x2: u64 = (0xffffffffffffe - (arg1[1]));
@@ -379,6 +389,7 @@ pub fn fiat_25519_opp(out1: &mut [u64; 5], arg1: &[u64; 5]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_25519_selectznz(out1: &mut [u64; 5], arg1: fiat_25519_u1, arg2: &[u64; 5], arg3: &[u64; 5]) -> () {
   let mut x1: u64 = 0;
   fiat_25519_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -407,6 +418,7 @@ pub fn fiat_25519_selectznz(out1: &mut [u64; 5], arg1: fiat_25519_u1, arg2: &[u6
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x7f]]
  */
+#[inline]
 pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 5]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_25519_u1 = 0;
@@ -554,6 +566,7 @@ pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 5]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc]]
  */
+#[inline]
 pub fn fiat_25519_from_bytes(out1: &mut [u64; 5], arg1: &[u8; 32]) -> () {
   let x1: u64 = (((arg1[31]) as u64) << 44);
   let x2: u64 = (((arg1[30]) as u64) << 36);

--- a/fiat-rust/src/p224_32.rs
+++ b/fiat-rust/src/p224_32.rs
@@ -34,6 +34,7 @@ pub type fiat_p224_i2 = i8;
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p224_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u32, arg3: u32) -> () {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
@@ -56,6 +57,7 @@ pub fn fiat_p224_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: fi
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p224_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u32, arg3: u32) -> () {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_p224_i1 = ((x1 >> 32) as fiat_p224_i1);
@@ -77,6 +79,7 @@ pub fn fiat_p224_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: f
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p224_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
@@ -97,6 +100,7 @@ pub fn fiat_p224_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p224_cmovznz_u32(out1: &mut u32, arg1: fiat_p224_u1, arg2: u32, arg3: u32) -> () {
   let x1: fiat_p224_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p224_i2) - (x1 as fiat_p224_i2)) as fiat_p224_i1) as i64) & (0xffffffff as i64)) as u32);
@@ -119,6 +123,7 @@ pub fn fiat_p224_cmovznz_u32(out1: &mut u32, arg1: fiat_p224_u1, arg2: u32, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_mul(out1: &mut [u32; 7], arg1: &[u32; 7], arg2: &[u32; 7]) -> () {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
@@ -1003,6 +1008,7 @@ pub fn fiat_p224_mul(out1: &mut [u32; 7], arg1: &[u32; 7], arg2: &[u32; 7]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_square(out1: &mut [u32; 7], arg1: &[u32; 7]) -> () {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
@@ -1889,6 +1895,7 @@ pub fn fiat_p224_square(out1: &mut [u32; 7], arg1: &[u32; 7]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_add(out1: &mut [u32; 7], arg1: &[u32; 7], arg2: &[u32; 7]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p224_u1 = 0;
@@ -1973,6 +1980,7 @@ pub fn fiat_p224_add(out1: &mut [u32; 7], arg1: &[u32; 7], arg2: &[u32; 7]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_sub(out1: &mut [u32; 7], arg1: &[u32; 7], arg2: &[u32; 7]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p224_u1 = 0;
@@ -2040,6 +2048,7 @@ pub fn fiat_p224_sub(out1: &mut [u32; 7], arg1: &[u32; 7], arg2: &[u32; 7]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_opp(out1: &mut [u32; 7], arg1: &[u32; 7]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p224_u1 = 0;
@@ -2107,6 +2116,7 @@ pub fn fiat_p224_opp(out1: &mut [u32; 7], arg1: &[u32; 7]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_from_montgomery(out1: &mut [u32; 7], arg1: &[u32; 7]) -> () {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
@@ -2648,6 +2658,7 @@ pub fn fiat_p224_from_montgomery(out1: &mut [u32; 7], arg1: &[u32; 7]) -> () {
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p224_nonzero(out1: &mut u32, arg1: &[u32; 7]) -> () {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | (0x0 as u32))))))));
   *out1 = x1;
@@ -2665,6 +2676,7 @@ pub fn fiat_p224_nonzero(out1: &mut u32, arg1: &[u32; 7]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_selectznz(out1: &mut [u32; 7], arg1: fiat_p224_u1, arg2: &[u32; 7], arg3: &[u32; 7]) -> () {
   let mut x1: u32 = 0;
   fiat_p224_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -2701,6 +2713,7 @@ pub fn fiat_p224_selectznz(out1: &mut [u32; 7], arg1: fiat_p224_u1, arg2: &[u32;
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
  */
+#[inline]
 pub fn fiat_p224_to_bytes(out1: &mut [u8; 28], arg1: &[u32; 7]) -> () {
   let x1: u32 = (arg1[6]);
   let x2: u32 = (arg1[5]);
@@ -2800,6 +2813,7 @@ pub fn fiat_p224_to_bytes(out1: &mut [u8; 28], arg1: &[u32; 7]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_from_bytes(out1: &mut [u32; 7], arg1: &[u8; 28]) -> () {
   let x1: u32 = (((arg1[27]) as u32) << 24);
   let x2: u32 = (((arg1[26]) as u32) << 16);

--- a/fiat-rust/src/p224_64.rs
+++ b/fiat-rust/src/p224_64.rs
@@ -36,6 +36,7 @@ pub type fiat_p224_i128 = i128;
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p224_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p224_u128 = (((arg1 as fiat_p224_u128) + (arg2 as fiat_p224_u128)) + (arg3 as fiat_p224_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_p224_u128)) as u64);
@@ -58,6 +59,7 @@ pub fn fiat_p224_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: fi
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p224_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p224_i128 = (((arg2 as fiat_p224_i128) - (arg1 as fiat_p224_i128)) - (arg3 as fiat_p224_i128));
   let x2: fiat_p224_i1 = ((x1 >> 64) as fiat_p224_i1);
@@ -79,6 +81,7 @@ pub fn fiat_p224_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: f
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p224_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
   let x1: fiat_p224_u128 = ((arg1 as fiat_p224_u128) * (arg2 as fiat_p224_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_p224_u128)) as u64);
@@ -99,6 +102,7 @@ pub fn fiat_p224_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p224_cmovznz_u64(out1: &mut u64, arg1: fiat_p224_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p224_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p224_i2) - (x1 as fiat_p224_i2)) as fiat_p224_i1) as fiat_p224_i128) & (0xffffffffffffffff as fiat_p224_i128)) as u64);
@@ -121,6 +125,7 @@ pub fn fiat_p224_cmovznz_u64(out1: &mut u64, arg1: fiat_p224_u1, arg2: u64, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p224_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -465,6 +470,7 @@ pub fn fiat_p224_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p224_square(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -811,6 +817,7 @@ pub fn fiat_p224_square(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p224_add(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p224_u1 = 0;
@@ -868,6 +875,7 @@ pub fn fiat_p224_add(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p224_sub(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p224_u1 = 0;
@@ -914,6 +922,7 @@ pub fn fiat_p224_sub(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p224_opp(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p224_u1 = 0;
@@ -960,6 +969,7 @@ pub fn fiat_p224_opp(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p224_from_montgomery(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
@@ -1183,6 +1193,7 @@ pub fn fiat_p224_from_montgomery(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p224_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | (0x0 as u64)))));
   *out1 = x1;
@@ -1200,6 +1211,7 @@ pub fn fiat_p224_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p224_selectznz(out1: &mut [u64; 4], arg1: fiat_p224_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   fiat_p224_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -1227,6 +1239,7 @@ pub fn fiat_p224_selectznz(out1: &mut [u64; 4], arg1: fiat_p224_u1, arg2: &[u64;
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x0], [0x0 ~> 0x0], [0x0 ~> 0x0], [0x0 ~> 0x0]]
  */
+#[inline]
 pub fn fiat_p224_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
@@ -1331,6 +1344,7 @@ pub fn fiat_p224_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p224_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
   let x1: u64 = (((arg1[27]) as u64) << 24);
   let x2: u64 = (((arg1[26]) as u64) << 16);

--- a/fiat-rust/src/p256_32.rs
+++ b/fiat-rust/src/p256_32.rs
@@ -34,6 +34,7 @@ pub type fiat_p256_i2 = i8;
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p256_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u32, arg3: u32) -> () {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
@@ -56,6 +57,7 @@ pub fn fiat_p256_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: fi
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p256_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u32, arg3: u32) -> () {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_p256_i1 = ((x1 >> 32) as fiat_p256_i1);
@@ -77,6 +79,7 @@ pub fn fiat_p256_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: f
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p256_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
@@ -97,6 +100,7 @@ pub fn fiat_p256_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p256_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_u1, arg2: u32, arg3: u32) -> () {
   let x1: fiat_p256_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p256_i2) - (x1 as fiat_p256_i2)) as fiat_p256_i1) as i64) & (0xffffffff as i64)) as u32);
@@ -119,6 +123,7 @@ pub fn fiat_p256_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_u1, arg2: u32, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p256_mul(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> () {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
@@ -1175,6 +1180,7 @@ pub fn fiat_p256_mul(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p256_square(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
@@ -2233,6 +2239,7 @@ pub fn fiat_p256_square(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p256_add(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_u1 = 0;
@@ -2326,6 +2333,7 @@ pub fn fiat_p256_add(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p256_sub(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_u1 = 0;
@@ -2400,6 +2408,7 @@ pub fn fiat_p256_sub(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p256_opp(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_u1 = 0;
@@ -2474,6 +2483,7 @@ pub fn fiat_p256_opp(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p256_from_montgomery(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
@@ -3084,6 +3094,7 @@ pub fn fiat_p256_from_montgomery(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p256_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | ((arg1[7]) | (0x0 as u32)))))))));
   *out1 = x1;
@@ -3101,6 +3112,7 @@ pub fn fiat_p256_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p256_selectznz(out1: &mut [u32; 8], arg1: fiat_p256_u1, arg2: &[u32; 8], arg3: &[u32; 8]) -> () {
   let mut x1: u32 = 0;
   fiat_p256_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -3140,6 +3152,7 @@ pub fn fiat_p256_selectznz(out1: &mut [u32; 8], arg1: fiat_p256_u1, arg2: &[u32;
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
  */
+#[inline]
 pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
   let x1: u32 = (arg1[7]);
   let x2: u32 = (arg1[6]);
@@ -3251,6 +3264,7 @@ pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p256_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
   let x1: u32 = (((arg1[31]) as u32) << 24);
   let x2: u32 = (((arg1[30]) as u32) << 16);

--- a/fiat-rust/src/p256_64.rs
+++ b/fiat-rust/src/p256_64.rs
@@ -36,6 +36,7 @@ pub type fiat_p256_i128 = i128;
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p256_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p256_u128 = (((arg1 as fiat_p256_u128) + (arg2 as fiat_p256_u128)) + (arg3 as fiat_p256_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_p256_u128)) as u64);
@@ -58,6 +59,7 @@ pub fn fiat_p256_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: fi
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p256_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p256_i128 = (((arg2 as fiat_p256_i128) - (arg1 as fiat_p256_i128)) - (arg3 as fiat_p256_i128));
   let x2: fiat_p256_i1 = ((x1 >> 64) as fiat_p256_i1);
@@ -79,6 +81,7 @@ pub fn fiat_p256_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: f
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p256_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
   let x1: fiat_p256_u128 = ((arg1 as fiat_p256_u128) * (arg2 as fiat_p256_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_p256_u128)) as u64);
@@ -99,6 +102,7 @@ pub fn fiat_p256_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p256_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p256_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p256_i2) - (x1 as fiat_p256_i2)) as fiat_p256_i1) as fiat_p256_i128) & (0xffffffffffffffff as fiat_p256_i128)) as u64);
@@ -121,6 +125,7 @@ pub fn fiat_p256_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_u1, arg2: u64, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p256_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -441,6 +446,7 @@ pub fn fiat_p256_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p256_square(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -763,6 +769,7 @@ pub fn fiat_p256_square(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p256_add(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_u1 = 0;
@@ -820,6 +827,7 @@ pub fn fiat_p256_add(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p256_sub(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_u1 = 0;
@@ -866,6 +874,7 @@ pub fn fiat_p256_sub(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p256_opp(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_u1 = 0;
@@ -912,6 +921,7 @@ pub fn fiat_p256_opp(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p256_from_montgomery(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
@@ -1099,6 +1109,7 @@ pub fn fiat_p256_from_montgomery(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p256_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | (0x0 as u64)))));
   *out1 = x1;
@@ -1116,6 +1127,7 @@ pub fn fiat_p256_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p256_selectznz(out1: &mut [u64; 4], arg1: fiat_p256_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   fiat_p256_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -1143,6 +1155,7 @@ pub fn fiat_p256_selectznz(out1: &mut [u64; 4], arg1: fiat_p256_u1, arg2: &[u64;
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
  */
+#[inline]
 pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
@@ -1254,6 +1267,7 @@ pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p256_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
   let x1: u64 = (((arg1[31]) as u64) << 56);
   let x2: u64 = (((arg1[30]) as u64) << 48);

--- a/fiat-rust/src/p384_32.rs
+++ b/fiat-rust/src/p384_32.rs
@@ -34,6 +34,7 @@ pub type fiat_p384_i2 = i8;
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p384_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u32, arg3: u32) -> () {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
@@ -56,6 +57,7 @@ pub fn fiat_p384_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: fi
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p384_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u32, arg3: u32) -> () {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_p384_i1 = ((x1 >> 32) as fiat_p384_i1);
@@ -77,6 +79,7 @@ pub fn fiat_p384_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: f
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p384_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
@@ -97,6 +100,7 @@ pub fn fiat_p384_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p384_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_u1, arg2: u32, arg3: u32) -> () {
   let x1: fiat_p384_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p384_i2) - (x1 as fiat_p384_i2)) as fiat_p384_i1) as i64) & (0xffffffff as i64)) as u32);
@@ -119,6 +123,7 @@ pub fn fiat_p384_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_u1, arg2: u32, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p384_mul(out1: &mut [u32; 12], arg1: &[u32; 12], arg2: &[u32; 12]) -> () {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
@@ -2703,6 +2708,7 @@ pub fn fiat_p384_mul(out1: &mut [u32; 12], arg1: &[u32; 12], arg2: &[u32; 12]) -
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p384_square(out1: &mut [u32; 12], arg1: &[u32; 12]) -> () {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
@@ -5289,6 +5295,7 @@ pub fn fiat_p384_square(out1: &mut [u32; 12], arg1: &[u32; 12]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p384_add(out1: &mut [u32; 12], arg1: &[u32; 12], arg2: &[u32; 12]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_u1 = 0;
@@ -5418,6 +5425,7 @@ pub fn fiat_p384_add(out1: &mut [u32; 12], arg1: &[u32; 12], arg2: &[u32; 12]) -
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p384_sub(out1: &mut [u32; 12], arg1: &[u32; 12], arg2: &[u32; 12]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_u1 = 0;
@@ -5520,6 +5528,7 @@ pub fn fiat_p384_sub(out1: &mut [u32; 12], arg1: &[u32; 12], arg2: &[u32; 12]) -
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p384_opp(out1: &mut [u32; 12], arg1: &[u32; 12]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_u1 = 0;
@@ -5622,6 +5631,7 @@ pub fn fiat_p384_opp(out1: &mut [u32; 12], arg1: &[u32; 12]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p384_from_montgomery(out1: &mut [u32; 12], arg1: &[u32; 12]) -> () {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
@@ -7261,6 +7271,7 @@ pub fn fiat_p384_from_montgomery(out1: &mut [u32; 12], arg1: &[u32; 12]) -> () {
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p384_nonzero(out1: &mut u32, arg1: &[u32; 12]) -> () {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | ((arg1[7]) | ((arg1[8]) | ((arg1[9]) | ((arg1[10]) | ((arg1[11]) | (0x0 as u32)))))))))))));
   *out1 = x1;
@@ -7278,6 +7289,7 @@ pub fn fiat_p384_nonzero(out1: &mut u32, arg1: &[u32; 12]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p384_selectznz(out1: &mut [u32; 12], arg1: fiat_p384_u1, arg2: &[u32; 12], arg3: &[u32; 12]) -> () {
   let mut x1: u32 = 0;
   fiat_p384_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -7329,6 +7341,7 @@ pub fn fiat_p384_selectznz(out1: &mut [u32; 12], arg1: fiat_p384_u1, arg2: &[u32
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
  */
+#[inline]
 pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u32; 12]) -> () {
   let x1: u32 = (arg1[11]);
   let x2: u32 = (arg1[10]);
@@ -7488,6 +7501,7 @@ pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u32; 12]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p384_from_bytes(out1: &mut [u32; 12], arg1: &[u8; 48]) -> () {
   let x1: u32 = (((arg1[47]) as u32) << 24);
   let x2: u32 = (((arg1[46]) as u32) << 16);

--- a/fiat-rust/src/p384_64.rs
+++ b/fiat-rust/src/p384_64.rs
@@ -36,6 +36,7 @@ pub type fiat_p384_i128 = i128;
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p384_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p384_u128 = (((arg1 as fiat_p384_u128) + (arg2 as fiat_p384_u128)) + (arg3 as fiat_p384_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_p384_u128)) as u64);
@@ -58,6 +59,7 @@ pub fn fiat_p384_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: fi
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p384_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p384_i128 = (((arg2 as fiat_p384_i128) - (arg1 as fiat_p384_i128)) - (arg3 as fiat_p384_i128));
   let x2: fiat_p384_i1 = ((x1 >> 64) as fiat_p384_i1);
@@ -79,6 +81,7 @@ pub fn fiat_p384_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: f
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p384_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
   let x1: fiat_p384_u128 = ((arg1 as fiat_p384_u128) * (arg2 as fiat_p384_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_p384_u128)) as u64);
@@ -99,6 +102,7 @@ pub fn fiat_p384_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p384_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p384_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p384_i2) - (x1 as fiat_p384_i2)) as fiat_p384_i1) as fiat_p384_i128) & (0xffffffffffffffff as fiat_p384_i128)) as u64);
@@ -121,6 +125,7 @@ pub fn fiat_p384_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_u1, arg2: u64, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p384_mul(out1: &mut [u64; 6], arg1: &[u64; 6], arg2: &[u64; 6]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -881,6 +886,7 @@ pub fn fiat_p384_mul(out1: &mut [u64; 6], arg1: &[u64; 6], arg2: &[u64; 6]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p384_square(out1: &mut [u64; 6], arg1: &[u64; 6]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -1643,6 +1649,7 @@ pub fn fiat_p384_square(out1: &mut [u64; 6], arg1: &[u64; 6]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p384_add(out1: &mut [u64; 6], arg1: &[u64; 6], arg2: &[u64; 6]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_u1 = 0;
@@ -1718,6 +1725,7 @@ pub fn fiat_p384_add(out1: &mut [u64; 6], arg1: &[u64; 6], arg2: &[u64; 6]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p384_sub(out1: &mut [u64; 6], arg1: &[u64; 6], arg2: &[u64; 6]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_u1 = 0;
@@ -1778,6 +1786,7 @@ pub fn fiat_p384_sub(out1: &mut [u64; 6], arg1: &[u64; 6], arg2: &[u64; 6]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p384_opp(out1: &mut [u64; 6], arg1: &[u64; 6]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_u1 = 0;
@@ -1838,6 +1847,7 @@ pub fn fiat_p384_opp(out1: &mut [u64; 6], arg1: &[u64; 6]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p384_from_montgomery(out1: &mut [u64; 6], arg1: &[u64; 6]) -> () {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
@@ -2376,6 +2386,7 @@ pub fn fiat_p384_from_montgomery(out1: &mut [u64; 6], arg1: &[u64; 6]) -> () {
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p384_nonzero(out1: &mut u64, arg1: &[u64; 6]) -> () {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | (0x0 as u64)))))));
   *out1 = x1;
@@ -2393,6 +2404,7 @@ pub fn fiat_p384_nonzero(out1: &mut u64, arg1: &[u64; 6]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p384_selectznz(out1: &mut [u64; 6], arg1: fiat_p384_u1, arg2: &[u64; 6], arg3: &[u64; 6]) -> () {
   let mut x1: u64 = 0;
   fiat_p384_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -2426,6 +2438,7 @@ pub fn fiat_p384_selectznz(out1: &mut [u64; 6], arg1: fiat_p384_u1, arg2: &[u64;
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
  */
+#[inline]
 pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u64; 6]) -> () {
   let x1: u64 = (arg1[5]);
   let x2: u64 = (arg1[4]);
@@ -2585,6 +2598,7 @@ pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u64; 6]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p384_from_bytes(out1: &mut [u64; 6], arg1: &[u8; 48]) -> () {
   let x1: u64 = (((arg1[47]) as u64) << 56);
   let x2: u64 = (((arg1[46]) as u64) << 48);

--- a/fiat-rust/src/p434_64.rs
+++ b/fiat-rust/src/p434_64.rs
@@ -36,6 +36,7 @@ pub type fiat_p434_i128 = i128;
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p434_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: fiat_p434_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p434_u128 = (((arg1 as fiat_p434_u128) + (arg2 as fiat_p434_u128)) + (arg3 as fiat_p434_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_p434_u128)) as u64);
@@ -58,6 +59,7 @@ pub fn fiat_p434_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: fi
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p434_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: fiat_p434_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p434_i128 = (((arg2 as fiat_p434_i128) - (arg1 as fiat_p434_i128)) - (arg3 as fiat_p434_i128));
   let x2: fiat_p434_i1 = ((x1 >> 64) as fiat_p434_i1);
@@ -79,6 +81,7 @@ pub fn fiat_p434_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: f
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p434_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
   let x1: fiat_p434_u128 = ((arg1 as fiat_p434_u128) * (arg2 as fiat_p434_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_p434_u128)) as u64);
@@ -99,6 +102,7 @@ pub fn fiat_p434_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p434_cmovznz_u64(out1: &mut u64, arg1: fiat_p434_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p434_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p434_i2) - (x1 as fiat_p434_i2)) as fiat_p434_i1) as fiat_p434_i128) & (0xffffffffffffffff as fiat_p434_i128)) as u64);
@@ -121,6 +125,7 @@ pub fn fiat_p434_cmovznz_u64(out1: &mut u64, arg1: fiat_p434_u1, arg2: u64, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p434_mul(out1: &mut [u64; 7], arg1: &[u64; 7], arg2: &[u64; 7]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -1110,6 +1115,7 @@ pub fn fiat_p434_mul(out1: &mut [u64; 7], arg1: &[u64; 7], arg2: &[u64; 7]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p434_square(out1: &mut [u64; 7], arg1: &[u64; 7]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -2101,6 +2107,7 @@ pub fn fiat_p434_square(out1: &mut [u64; 7], arg1: &[u64; 7]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p434_add(out1: &mut [u64; 7], arg1: &[u64; 7], arg2: &[u64; 7]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p434_u1 = 0;
@@ -2185,6 +2192,7 @@ pub fn fiat_p434_add(out1: &mut [u64; 7], arg1: &[u64; 7], arg2: &[u64; 7]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p434_sub(out1: &mut [u64; 7], arg1: &[u64; 7], arg2: &[u64; 7]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p434_u1 = 0;
@@ -2252,6 +2260,7 @@ pub fn fiat_p434_sub(out1: &mut [u64; 7], arg1: &[u64; 7], arg2: &[u64; 7]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p434_opp(out1: &mut [u64; 7], arg1: &[u64; 7]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p434_u1 = 0;
@@ -2319,6 +2328,7 @@ pub fn fiat_p434_opp(out1: &mut [u64; 7], arg1: &[u64; 7]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p434_from_montgomery(out1: &mut [u64; 7], arg1: &[u64; 7]) -> () {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
@@ -2968,6 +2978,7 @@ pub fn fiat_p434_from_montgomery(out1: &mut [u64; 7], arg1: &[u64; 7]) -> () {
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p434_nonzero(out1: &mut u64, arg1: &[u64; 7]) -> () {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | (0x0 as u64))))))));
   *out1 = x1;
@@ -2985,6 +2996,7 @@ pub fn fiat_p434_nonzero(out1: &mut u64, arg1: &[u64; 7]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p434_selectznz(out1: &mut [u64; 7], arg1: fiat_p434_u1, arg2: &[u64; 7], arg3: &[u64; 7]) -> () {
   let mut x1: u64 = 0;
   fiat_p434_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -3021,6 +3033,7 @@ pub fn fiat_p434_selectznz(out1: &mut [u64; 7], arg1: fiat_p434_u1, arg2: &[u64;
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x3], [0x0 ~> 0x0]]
  */
+#[inline]
 pub fn fiat_p434_to_bytes(out1: &mut [u8; 56], arg1: &[u64; 7]) -> () {
   let x1: u64 = (arg1[6]);
   let x2: u64 = (arg1[5]);
@@ -3203,6 +3216,7 @@ pub fn fiat_p434_to_bytes(out1: &mut [u8; 56], arg1: &[u64; 7]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0x3ffffffffffff]]
  */
+#[inline]
 pub fn fiat_p434_from_bytes(out1: &mut [u64; 7], arg1: &[u8; 56]) -> () {
   let x1: u64 = (((arg1[54]) as u64) << 48);
   let x2: u64 = (((arg1[53]) as u64) << 40);

--- a/fiat-rust/src/p448_solinas_64.rs
+++ b/fiat-rust/src/p448_solinas_64.rs
@@ -33,6 +33,7 @@ pub type fiat_p448_i128 = i128;
  *   out1: [0x0 ~> 0xffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p448_addcarryx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u64, arg3: u64) -> () {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0xffffffffffffff);
@@ -55,6 +56,7 @@ pub fn fiat_p448_addcarryx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: fi
  *   out1: [0x0 ~> 0xffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p448_subborrowx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u64, arg3: u64) -> () {
   let x1: i64 = ((((((arg2 as fiat_p448_i128) - (arg1 as fiat_p448_i128)) as i64) as fiat_p448_i128) - (arg3 as fiat_p448_i128)) as i64);
   let x2: fiat_p448_i1 = ((x1 >> 56) as fiat_p448_i1);
@@ -75,6 +77,7 @@ pub fn fiat_p448_subborrowx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: f
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p448_cmovznz_u64(out1: &mut u64, arg1: fiat_p448_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p448_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p448_i2) - (x1 as fiat_p448_i2)) as fiat_p448_i1) as fiat_p448_i128) & (0xffffffffffffffff as fiat_p448_i128)) as u64);
@@ -93,6 +96,7 @@ pub fn fiat_p448_cmovznz_u64(out1: &mut u64, arg1: fiat_p448_u1, arg2: u64, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999]]
  */
+#[inline]
 pub fn fiat_p448_carry_mul(out1: &mut [u64; 8], arg1: &[u64; 8], arg2: &[u64; 8]) -> () {
   let x1: fiat_p448_u128 = (((arg1[7]) as fiat_p448_u128) * ((arg2[7]) as fiat_p448_u128));
   let x2: fiat_p448_u128 = (((arg1[7]) as fiat_p448_u128) * ((arg2[6]) as fiat_p448_u128));
@@ -258,6 +262,7 @@ pub fn fiat_p448_carry_mul(out1: &mut [u64; 8], arg1: &[u64; 8], arg2: &[u64; 8]
  * Output Bounds:
  *   out1: [[0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999]]
  */
+#[inline]
 pub fn fiat_p448_carry_square(out1: &mut [u64; 8], arg1: &[u64; 8]) -> () {
   let x1: u64 = (arg1[7]);
   let x2: u64 = (arg1[7]);
@@ -402,6 +407,7 @@ pub fn fiat_p448_carry_square(out1: &mut [u64; 8], arg1: &[u64; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999]]
  */
+#[inline]
 pub fn fiat_p448_carry(out1: &mut [u64; 8], arg1: &[u64; 8]) -> () {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[7]);
@@ -446,6 +452,7 @@ pub fn fiat_p448_carry(out1: &mut [u64; 8], arg1: &[u64; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb]]
  */
+#[inline]
 pub fn fiat_p448_add(out1: &mut [u64; 8], arg1: &[u64; 8], arg2: &[u64; 8]) -> () {
   let x1: u64 = ((arg1[0]) + (arg2[0]));
   let x2: u64 = ((arg1[1]) + (arg2[1]));
@@ -476,6 +483,7 @@ pub fn fiat_p448_add(out1: &mut [u64; 8], arg1: &[u64; 8], arg2: &[u64; 8]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb]]
  */
+#[inline]
 pub fn fiat_p448_sub(out1: &mut [u64; 8], arg1: &[u64; 8], arg2: &[u64; 8]) -> () {
   let x1: u64 = ((0x1fffffffffffffe + (arg1[0])) - (arg2[0]));
   let x2: u64 = ((0x1fffffffffffffe + (arg1[1])) - (arg2[1]));
@@ -505,6 +513,7 @@ pub fn fiat_p448_sub(out1: &mut [u64; 8], arg1: &[u64; 8], arg2: &[u64; 8]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb], [0x0 ~> 0x34ccccccccccccb]]
  */
+#[inline]
 pub fn fiat_p448_opp(out1: &mut [u64; 8], arg1: &[u64; 8]) -> () {
   let x1: u64 = (0x1fffffffffffffe - (arg1[0]));
   let x2: u64 = (0x1fffffffffffffe - (arg1[1]));
@@ -536,6 +545,7 @@ pub fn fiat_p448_opp(out1: &mut [u64; 8], arg1: &[u64; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p448_selectznz(out1: &mut [u64; 8], arg1: fiat_p448_u1, arg2: &[u64; 8], arg3: &[u64; 8]) -> () {
   let mut x1: u64 = 0;
   fiat_p448_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -573,6 +583,7 @@ pub fn fiat_p448_selectznz(out1: &mut [u64; 8], arg1: fiat_p448_u1, arg2: &[u64;
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
  */
+#[inline]
 pub fn fiat_p448_to_bytes(out1: &mut [u8; 56], arg1: &[u64; 8]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p448_u1 = 0;
@@ -795,6 +806,7 @@ pub fn fiat_p448_to_bytes(out1: &mut [u8; 56], arg1: &[u64; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999], [0x0 ~> 0x119999999999999]]
  */
+#[inline]
 pub fn fiat_p448_from_bytes(out1: &mut [u64; 8], arg1: &[u8; 56]) -> () {
   let x1: u64 = (((arg1[55]) as u64) << 48);
   let x2: u64 = (((arg1[54]) as u64) << 40);

--- a/fiat-rust/src/p521_32.rs
+++ b/fiat-rust/src/p521_32.rs
@@ -33,6 +33,7 @@ pub type fiat_p521_i128 = i128;
  *   out1: [0x0 ~> 0x3fffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p521_addcarryx_u30(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0x3fffffff);
@@ -55,6 +56,7 @@ pub fn fiat_p521_addcarryx_u30(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fi
  *   out1: [0x0 ~> 0x3fffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p521_subborrowx_u30(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_p521_i1 = ((x1 >> 30) as fiat_p521_i1);
@@ -77,6 +79,7 @@ pub fn fiat_p521_subborrowx_u30(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: f
  *   out1: [0x0 ~> 0x7fffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p521_addcarryx_u31(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0x7fffffff);
@@ -99,6 +102,7 @@ pub fn fiat_p521_addcarryx_u31(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fi
  *   out1: [0x0 ~> 0x7fffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p521_subborrowx_u31(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_p521_i1 = (((x1 as i64) >> 31) as fiat_p521_i1);
@@ -119,6 +123,7 @@ pub fn fiat_p521_subborrowx_u31(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: f
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_p521_cmovznz_u32(out1: &mut u32, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
   let x1: fiat_p521_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p521_i2) - (x1 as fiat_p521_i2)) as fiat_p521_i1) as i64) & (0xffffffff as i64)) as u32);
@@ -137,6 +142,7 @@ pub fn fiat_p521_cmovznz_u32(out1: &mut u32, arg1: fiat_p521_u1, arg2: u32, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666]]
  */
+#[inline]
 pub fn fiat_p521_carry_mul(out1: &mut [u32; 17], arg1: &[u64; 17], arg2: &[u64; 17]) -> () {
   let x1: fiat_p521_u128 = ((((arg1[16]) as u32) as fiat_p521_u128) * (((((arg2[16]) as u32) as u64) * (0x2 as u64)) as fiat_p521_u128));
   let x2: fiat_p521_u128 = ((((arg1[16]) as u32) as fiat_p521_u128) * ((arg2[15]) as fiat_p521_u128));
@@ -530,6 +536,7 @@ pub fn fiat_p521_carry_mul(out1: &mut [u32; 17], arg1: &[u64; 17], arg2: &[u64; 
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666]]
  */
+#[inline]
 pub fn fiat_p521_carry_square(out1: &mut [u32; 17], arg1: &[u64; 17]) -> () {
   let x1: u32 = ((arg1[16]) as u32);
   let x2: u64 = ((x1 as u64) * (0x2 as u64));
@@ -819,6 +826,7 @@ pub fn fiat_p521_carry_square(out1: &mut [u32; 17], arg1: &[u64; 17]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666]]
  */
+#[inline]
 pub fn fiat_p521_carry(out1: &mut [u32; 17], arg1: &[u64; 17]) -> () {
   let x1: u64 = (arg1[0]);
   let x2: u64 = ((((x1 >> 31) as u32) as u64) + (arg1[1]));
@@ -886,6 +894,7 @@ pub fn fiat_p521_carry(out1: &mut [u32; 17], arg1: &[u64; 17]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332]]
  */
+#[inline]
 pub fn fiat_p521_add(out1: &mut [u64; 17], arg1: &[u32; 17], arg2: &[u32; 17]) -> () {
   let x1: u64 = (((arg1[0]) as u64) + ((arg2[0]) as u64));
   let x2: u64 = (((arg1[1]) as u64) + ((arg2[1]) as u64));
@@ -934,6 +943,7 @@ pub fn fiat_p521_add(out1: &mut [u64; 17], arg1: &[u32; 17], arg2: &[u32; 17]) -
  * Output Bounds:
  *   out1: [[0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332]]
  */
+#[inline]
 pub fn fiat_p521_sub(out1: &mut [u64; 17], arg1: &[u32; 17], arg2: &[u32; 17]) -> () {
   let x1: u64 = (((0xfffffffe as u64) + ((arg1[0]) as u64)) - ((arg2[0]) as u64));
   let x2: u64 = (((0xfffffffe as u64) + ((arg1[1]) as u64)) - ((arg2[1]) as u64));
@@ -981,6 +991,7 @@ pub fn fiat_p521_sub(out1: &mut [u64; 17], arg1: &[u32; 17], arg2: &[u32; 17]) -
  * Output Bounds:
  *   out1: [[0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332], [0x0 ~> 0x1a6666664], [0x0 ~> 0xd3333332]]
  */
+#[inline]
 pub fn fiat_p521_opp(out1: &mut [u32; 17], arg1: &[u32; 17]) -> () {
   let x1: u32 = (0xfffffffe - (arg1[0]));
   let x2: u32 = (0xfffffffe - (arg1[1]));
@@ -1030,6 +1041,7 @@ pub fn fiat_p521_opp(out1: &mut [u32; 17], arg1: &[u32; 17]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_p521_selectznz(out1: &mut [u32; 17], arg1: fiat_p521_u1, arg2: &[u32; 17], arg3: &[u32; 17]) -> () {
   let mut x1: u32 = 0;
   fiat_p521_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -1094,6 +1106,7 @@ pub fn fiat_p521_selectznz(out1: &mut [u32; 17], arg1: fiat_p521_u1, arg2: &[u32
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x1]]
  */
+#[inline]
 pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &[u32; 17]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_p521_u1 = 0;
@@ -1433,6 +1446,7 @@ pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &[u32; 17]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666], [0x0 ~> 0x8ccccccc], [0x0 ~> 0x46666666]]
  */
+#[inline]
 pub fn fiat_p521_from_bytes(out1: &mut [u32; 17], arg1: &[u8; 66]) -> () {
   let x1: u32 = ((((arg1[65]) as fiat_p521_u1) as u32) << 29);
   let x2: u32 = (((arg1[64]) as u32) << 21);

--- a/fiat-rust/src/p521_64.rs
+++ b/fiat-rust/src/p521_64.rs
@@ -33,6 +33,7 @@ pub type fiat_p521_i128 = i128;
  *   out1: [0x0 ~> 0x3ffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p521_addcarryx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0x3ffffffffffffff);
@@ -55,6 +56,7 @@ pub fn fiat_p521_addcarryx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fi
  *   out1: [0x0 ~> 0x3ffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p521_subborrowx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
   let x1: i64 = ((((((arg2 as fiat_p521_i128) - (arg1 as fiat_p521_i128)) as i64) as fiat_p521_i128) - (arg3 as fiat_p521_i128)) as i64);
   let x2: fiat_p521_i1 = ((x1 >> 58) as fiat_p521_i1);
@@ -77,6 +79,7 @@ pub fn fiat_p521_subborrowx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: f
  *   out1: [0x0 ~> 0x1ffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p521_addcarryx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0x1ffffffffffffff);
@@ -99,6 +102,7 @@ pub fn fiat_p521_addcarryx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fi
  *   out1: [0x0 ~> 0x1ffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_p521_subborrowx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
   let x1: i64 = ((((((arg2 as fiat_p521_i128) - (arg1 as fiat_p521_i128)) as i64) as fiat_p521_i128) - (arg3 as fiat_p521_i128)) as i64);
   let x2: fiat_p521_i1 = ((x1 >> 57) as fiat_p521_i1);
@@ -119,6 +123,7 @@ pub fn fiat_p521_subborrowx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: f
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_p521_cmovznz_u64(out1: &mut u64, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_p521_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p521_i2) - (x1 as fiat_p521_i2)) as fiat_p521_i1) as fiat_p521_i128) & (0xffffffffffffffff as fiat_p521_i128)) as u64);
@@ -137,6 +142,7 @@ pub fn fiat_p521_cmovznz_u64(out1: &mut u64, arg1: fiat_p521_u1, arg2: u64, arg3
  * Output Bounds:
  *   out1: [[0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x233333333333333]]
  */
+#[inline]
 pub fn fiat_p521_carry_mul(out1: &mut [u64; 9], arg1: &[u64; 9], arg2: &[u64; 9]) -> () {
   let x1: fiat_p521_u128 = (((arg1[8]) as fiat_p521_u128) * (((arg2[8]) * (0x2 as u64)) as fiat_p521_u128));
   let x2: fiat_p521_u128 = (((arg1[8]) as fiat_p521_u128) * (((arg2[7]) * (0x2 as u64)) as fiat_p521_u128));
@@ -282,6 +288,7 @@ pub fn fiat_p521_carry_mul(out1: &mut [u64; 9], arg1: &[u64; 9], arg2: &[u64; 9]
  * Output Bounds:
  *   out1: [[0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x233333333333333]]
  */
+#[inline]
 pub fn fiat_p521_carry_square(out1: &mut [u64; 9], arg1: &[u64; 9]) -> () {
   let x1: u64 = (arg1[8]);
   let x2: u64 = (x1 * (0x2 as u64));
@@ -407,6 +414,7 @@ pub fn fiat_p521_carry_square(out1: &mut [u64; 9], arg1: &[u64; 9]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x233333333333333]]
  */
+#[inline]
 pub fn fiat_p521_carry(out1: &mut [u64; 9], arg1: &[u64; 9]) -> () {
   let x1: u64 = (arg1[0]);
   let x2: u64 = ((x1 >> 58) + (arg1[1]));
@@ -450,6 +458,7 @@ pub fn fiat_p521_carry(out1: &mut [u64; 9], arg1: &[u64; 9]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0x699999999999999]]
  */
+#[inline]
 pub fn fiat_p521_add(out1: &mut [u64; 9], arg1: &[u64; 9], arg2: &[u64; 9]) -> () {
   let x1: u64 = ((arg1[0]) + (arg2[0]));
   let x2: u64 = ((arg1[1]) + (arg2[1]));
@@ -482,6 +491,7 @@ pub fn fiat_p521_add(out1: &mut [u64; 9], arg1: &[u64; 9], arg2: &[u64; 9]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0x699999999999999]]
  */
+#[inline]
 pub fn fiat_p521_sub(out1: &mut [u64; 9], arg1: &[u64; 9], arg2: &[u64; 9]) -> () {
   let x1: u64 = ((0x7fffffffffffffe + (arg1[0])) - (arg2[0]));
   let x2: u64 = ((0x7fffffffffffffe + (arg1[1])) - (arg2[1]));
@@ -513,6 +523,7 @@ pub fn fiat_p521_sub(out1: &mut [u64; 9], arg1: &[u64; 9], arg2: &[u64; 9]) -> (
  * Output Bounds:
  *   out1: [[0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0xd33333333333332], [0x0 ~> 0x699999999999999]]
  */
+#[inline]
 pub fn fiat_p521_opp(out1: &mut [u64; 9], arg1: &[u64; 9]) -> () {
   let x1: u64 = (0x7fffffffffffffe - (arg1[0]));
   let x2: u64 = (0x7fffffffffffffe - (arg1[1]));
@@ -546,6 +557,7 @@ pub fn fiat_p521_opp(out1: &mut [u64; 9], arg1: &[u64; 9]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_p521_selectznz(out1: &mut [u64; 9], arg1: fiat_p521_u1, arg2: &[u64; 9], arg3: &[u64; 9]) -> () {
   let mut x1: u64 = 0;
   fiat_p521_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -586,6 +598,7 @@ pub fn fiat_p521_selectznz(out1: &mut [u64; 9], arg1: fiat_p521_u1, arg2: &[u64;
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x1]]
  */
+#[inline]
 pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &[u64; 9]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_p521_u1 = 0;
@@ -861,6 +874,7 @@ pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &[u64; 9]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x466666666666666], [0x0 ~> 0x233333333333333]]
  */
+#[inline]
 pub fn fiat_p521_from_bytes(out1: &mut [u64; 9], arg1: &[u8; 66]) -> () {
   let x1: u64 = ((((arg1[65]) as fiat_p521_u1) as u64) << 56);
   let x2: u64 = (((arg1[64]) as u64) << 48);

--- a/fiat-rust/src/secp256k1_32.rs
+++ b/fiat-rust/src/secp256k1_32.rs
@@ -34,6 +34,7 @@ pub type fiat_secp256k1_i2 = i8;
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_secp256k1_addcarryx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_u1, arg1: fiat_secp256k1_u1, arg2: u32, arg3: u32) -> () {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
@@ -56,6 +57,7 @@ pub fn fiat_secp256k1_addcarryx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_u1
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_secp256k1_subborrowx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_u1, arg1: fiat_secp256k1_u1, arg2: u32, arg3: u32) -> () {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_secp256k1_i1 = ((x1 >> 32) as fiat_secp256k1_i1);
@@ -77,6 +79,7 @@ pub fn fiat_secp256k1_subborrowx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_u
  *   out1: [0x0 ~> 0xffffffff]
  *   out2: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_secp256k1_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
@@ -97,6 +100,7 @@ pub fn fiat_secp256k1_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_secp256k1_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_u1, arg2: u32, arg3: u32) -> () {
   let x1: fiat_secp256k1_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_secp256k1_i2) - (x1 as fiat_secp256k1_i2)) as fiat_secp256k1_i1) as i64) & (0xffffffff as i64)) as u32);
@@ -119,6 +123,7 @@ pub fn fiat_secp256k1_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_u1, arg2:
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_mul(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> () {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
@@ -1415,6 +1420,7 @@ pub fn fiat_secp256k1_mul(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8])
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_square(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
@@ -2713,6 +2719,7 @@ pub fn fiat_secp256k1_square(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_add(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_u1 = 0;
@@ -2806,6 +2813,7 @@ pub fn fiat_secp256k1_add(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8])
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_sub(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_u1 = 0;
@@ -2880,6 +2888,7 @@ pub fn fiat_secp256k1_sub(out1: &mut [u32; 8], arg1: &[u32; 8], arg2: &[u32; 8])
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_opp(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_u1 = 0;
@@ -2954,6 +2963,7 @@ pub fn fiat_secp256k1_opp(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_from_montgomery(out1: &mut [u32; 8], arg1: &[u32; 8]) -> () {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
@@ -3858,6 +3868,7 @@ pub fn fiat_secp256k1_from_montgomery(out1: &mut [u32; 8], arg1: &[u32; 8]) -> (
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffff]
  */
+#[inline]
 pub fn fiat_secp256k1_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | ((arg1[7]) | (0x0 as u32)))))))));
   *out1 = x1;
@@ -3875,6 +3886,7 @@ pub fn fiat_secp256k1_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_selectznz(out1: &mut [u32; 8], arg1: fiat_secp256k1_u1, arg2: &[u32; 8], arg3: &[u32; 8]) -> () {
   let mut x1: u32 = 0;
   fiat_secp256k1_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -3914,6 +3926,7 @@ pub fn fiat_secp256k1_selectznz(out1: &mut [u32; 8], arg1: fiat_secp256k1_u1, ar
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
  */
+#[inline]
 pub fn fiat_secp256k1_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
   let x1: u32 = (arg1[7]);
   let x2: u32 = (arg1[6]);
@@ -4025,6 +4038,7 @@ pub fn fiat_secp256k1_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
   let x1: u32 = (((arg1[31]) as u32) << 24);
   let x2: u32 = (((arg1[30]) as u32) << 16);

--- a/fiat-rust/src/secp256k1_64.rs
+++ b/fiat-rust/src/secp256k1_64.rs
@@ -36,6 +36,7 @@ pub type fiat_secp256k1_i128 = i128;
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_secp256k1_addcarryx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_u1, arg1: fiat_secp256k1_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_secp256k1_u128 = (((arg1 as fiat_secp256k1_u128) + (arg2 as fiat_secp256k1_u128)) + (arg3 as fiat_secp256k1_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_secp256k1_u128)) as u64);
@@ -58,6 +59,7 @@ pub fn fiat_secp256k1_addcarryx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_u1
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0x1]
  */
+#[inline]
 pub fn fiat_secp256k1_subborrowx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_u1, arg1: fiat_secp256k1_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_secp256k1_i128 = (((arg2 as fiat_secp256k1_i128) - (arg1 as fiat_secp256k1_i128)) - (arg3 as fiat_secp256k1_i128));
   let x2: fiat_secp256k1_i1 = ((x1 >> 64) as fiat_secp256k1_i1);
@@ -79,6 +81,7 @@ pub fn fiat_secp256k1_subborrowx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_u
  *   out1: [0x0 ~> 0xffffffffffffffff]
  *   out2: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_secp256k1_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
   let x1: fiat_secp256k1_u128 = ((arg1 as fiat_secp256k1_u128) * (arg2 as fiat_secp256k1_u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as fiat_secp256k1_u128)) as u64);
@@ -99,6 +102,7 @@ pub fn fiat_secp256k1_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: 
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_secp256k1_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_u1, arg2: u64, arg3: u64) -> () {
   let x1: fiat_secp256k1_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_secp256k1_i2) - (x1 as fiat_secp256k1_i2)) as fiat_secp256k1_i1) as fiat_secp256k1_i128) & (0xffffffffffffffff as fiat_secp256k1_i128)) as u64);
@@ -121,6 +125,7 @@ pub fn fiat_secp256k1_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_u1, arg2:
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -489,6 +494,7 @@ pub fn fiat_secp256k1_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4])
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_square(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
@@ -859,6 +865,7 @@ pub fn fiat_secp256k1_square(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_add(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_u1 = 0;
@@ -916,6 +923,7 @@ pub fn fiat_secp256k1_add(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4])
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_sub(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_u1 = 0;
@@ -962,6 +970,7 @@ pub fn fiat_secp256k1_sub(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4])
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_opp(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_u1 = 0;
@@ -1008,6 +1017,7 @@ pub fn fiat_secp256k1_opp(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_from_montgomery(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
@@ -1276,6 +1286,7 @@ pub fn fiat_secp256k1_from_montgomery(out1: &mut [u64; 4], arg1: &[u64; 4]) -> (
  * Output Bounds:
  *   out1: [0x0 ~> 0xffffffffffffffff]
  */
+#[inline]
 pub fn fiat_secp256k1_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | (0x0 as u64)))));
   *out1 = x1;
@@ -1293,6 +1304,7 @@ pub fn fiat_secp256k1_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_selectznz(out1: &mut [u64; 4], arg1: fiat_secp256k1_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
   let mut x1: u64 = 0;
   fiat_secp256k1_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
@@ -1320,6 +1332,7 @@ pub fn fiat_secp256k1_selectznz(out1: &mut [u64; 4], arg1: fiat_secp256k1_u1, ar
  * Output Bounds:
  *   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
  */
+#[inline]
 pub fn fiat_secp256k1_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
@@ -1431,6 +1444,7 @@ pub fn fiat_secp256k1_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
  * Output Bounds:
  *   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
  */
+#[inline]
 pub fn fiat_secp256k1_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
   let x1: u64 = (((arg1[31]) as u64) << 56);
   let x2: u64 = (((arg1[30]) as u64) << 48);

--- a/src/RustStringification.v
+++ b/src/RustStringification.v
@@ -317,7 +317,7 @@ Module Rust.
              (f : type.for_each_lhs_of_arrow var_data t * var_data (type.final_codomain t) * IR.expr)
     : list string :=
     let '(args, rets, body) := f in
-    ((if static then "fn " else "pub fn ") ++ name ++
+    ("#[inline]" ++ String.NewLine ++ (if static then "fn " else "pub fn ") ++ name ++
       "(" ++ String.concat ", " (to_arg_list prefix Out rets ++ to_arg_list_for_each_lhs_of_arrow prefix args) ++
       ") -> () {")%string :: (List.map (fun s => "  " ++ s)%string (to_strings prefix body)) ++ ["}"%string]%list.
 


### PR DESCRIPTION
As the typical integration in a crypto library:
https://github.com/dalek-cryptography/curve25519-dalek/compare/master...calibra:fiat

is using combination of primitives, it makes sense to inline all primitive functions.

Fixes #575.