### PR TITLE
Add support for splitting multiplication

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -113,6 +113,7 @@ src/PushButtonSynthesis/WordByWordMontgomery.v
 src/PushButtonSynthesis/WordByWordMontgomeryReificationCache.v
 src/Rewriter/Arith.v
 src/Rewriter/ArithWithCasts.v
+src/Rewriter/MulSplit.v
 src/Rewriter/NBE.v
 src/Rewriter/StripLiteralCasts.v
 src/Rewriter/ToFancy.v

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -136,7 +136,7 @@ Notation prefix_with_carry bitwidths :=
   ((if widen_carry then (0::bitwidths) else (0::1::bitwidths))%Z)
     (only parsing).
 Notation prefix_with_carry_bytes bitwidths :=
-  (prefix_with_carry (if widen_bytes then bitwidths else 8%Z::bitwidths))
+  (prefix_with_carry (if widen_bytes then bitwidths%list else 8::bitwidths)%Z)
     (only parsing).
 
 Module Pipeline.

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -136,7 +136,7 @@ Notation prefix_with_carry bitwidths :=
   ((if widen_carry then (0::bitwidths) else (0::1::bitwidths))%Z)
     (only parsing).
 Notation prefix_with_carry_bytes bitwidths :=
-  (prefix_with_carry (if widen_bytes then bitwidths else 8::bitwidths)%Z)
+  (prefix_with_carry (if widen_bytes then bitwidths else 8%Z::bitwidths))
     (only parsing).
 
 Module Pipeline.

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -111,14 +111,19 @@ Proof.
         try (rewrite <- Z.log2_up_le_pow2_full in *; omega).
 Qed.
 
+(** Prefix function definitions with static/non-public? *)
 Class static_opt := static : bool.
 Typeclasses Opaque static_opt.
-Class split_mul_to_opt := split_mul_to : option (Z * Z).
-Typeclasses Opaque split_mul_to_opt.
+(** Split apart multiplications? *)
 Class should_split_mul_opt := should_split_mul : bool.
 Typeclasses Opaque should_split_mul_opt.
+(** If [None], don't split apart multiplications; if [Some (w, wc)], split apart multiplications to use wordsize [w] and widen carries to width [wc] *)
+Class split_mul_to_opt := split_mul_to : option (Z * Z).
+Typeclasses Opaque split_mul_to_opt.
+(** Widen carries to the machine wordsize? *)
 Class widen_carry_opt := widen_carry : bool.
 Typeclasses Opaque widen_carry_opt.
+(** Widen uint8 / bytes types to machine wordsize? *)
 Class widen_bytes_opt := widen_bytes : bool.
 Typeclasses Opaque widen_bytes_opt.
 Notation split_mul_to_of_should_split_mul machine_wordsize possible_bitwidths

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -136,7 +136,7 @@ Notation prefix_with_carry bitwidths :=
   ((if widen_carry then (0::bitwidths) else (0::1::bitwidths))%Z)
     (only parsing).
 Notation prefix_with_carry_bytes bitwidths :=
-  (prefix_with_carry (if widen_bytes then bitwidths%list else 8::bitwidths)%Z)
+  (prefix_with_carry (match bitwidths return _ with bw => if widen_bytes then bw else 8::bw end)%Z) (* master and 8.9 are incompatible about scoping of multiple occurrences of an argument *)
     (only parsing).
 
 Module Pipeline.

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -213,6 +213,13 @@ Module ForExtraction.
     {
       (** Is the code static / inlined *)
       static :> static_opt
+
+      (** Should we split apart oversized operations? *)
+      ; should_split_mul :> should_split_mul_opt := false
+      (** Should we widen the carry to the full bitwidth? *)
+      ; widen_carry :> widen_carry_opt := false
+      (** Should we widen the byte type to the full bitwidth? *)
+      ; widen_bytes :> widen_bytes_opt := false
     }.
 
   (** We define a class for the various operations that are specific to a pipeline *)

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -55,6 +55,8 @@ Section rbarrett_red.
     := [1; machine_wordsize / 2; machine_wordsize; 2 * machine_wordsize]%Z.
   Let possible_values := possible_values_of_machine_wordsize.
 
+  Local Instance split_mul_to : split_mul_to_opt := None.
+
   Let fancy_args
     := (Some {| Pipeline.invert_low log2wordsize := invert_low log2wordsize consts_list;
                 Pipeline.invert_high log2wordsize := invert_high log2wordsize consts_list;

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -62,6 +62,8 @@ Section rmontred.
 
   Let possible_values := possible_values_of_machine_wordsize.
 
+  Local Instance split_mul_to : split_mul_to_opt := None.
+
   Let fancy_args
     := (Some {| Pipeline.invert_low log2wordsize := invert_low log2wordsize consts_list;
                 Pipeline.invert_high log2wordsize := invert_high log2wordsize consts_list;

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -609,6 +609,9 @@ Notation "'docstring_with_summary_from_lemma!' summary correctness"
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {should_split_mul : should_split_mul_opt}
+          {widen_carry : widen_carry_opt}
+          {widen_bytes : widen_bytes_opt}
           (n : nat)
           (machine_wordsize : Z).
 
@@ -623,10 +626,12 @@ Section __.
     := [0; machine_wordsize; 2 * machine_wordsize]%Z.
 
   Definition possible_values_of_machine_wordsize_with_bytes
-    := [0; 1; 8; machine_wordsize; 2 * machine_wordsize]%Z.
+    := prefix_with_carry_bytes [machine_wordsize; 2 * machine_wordsize]%Z.
 
   Let possible_values := possible_values_of_machine_wordsize.
   Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
+
+  Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
 
   Lemma length_saturated_bounds_list : List.length saturated_bounds_list = n.
   Proof using Type. cbv [saturated_bounds_list]; now autorewrite with distr_length. Qed.

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -59,6 +59,9 @@ Local Opaque expr.Interp.
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {should_split_mul : should_split_mul_opt}
+          {widen_carry : widen_carry_opt}
+          {widen_bytes : widen_bytes_opt}
           (s : Z)
           (c : list (Z * Z))
           (machine_wordsize : Z).
@@ -66,7 +69,7 @@ Section __.
   (* We include [0], so that even after bounds relaxation, we can
        notice where the constant 0s are, and remove them. *)
   Definition possible_values_of_machine_wordsize
-    := [0; 1; machine_wordsize]%Z.
+    := prefix_with_carry [machine_wordsize].
 
   Let n : nat := Z.to_nat (Qceiling (Z.log2_up s / machine_wordsize)).
   Let m := s - Associational.eval c.
@@ -82,6 +85,8 @@ Section __.
   Let bound := Some r[0 ~> (2^machine_wordsize - 1)]%zrange.
   Let boundsn : list (ZRange.type.option.interp base.type.Z)
     := repeat bound n.
+
+  Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
 
   (** Note: If you change the name or type signature of this
         function, you will need to update the code in CLI.v *)

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -19,6 +19,24 @@ Import Compilers.defaults.
 
 Import Associational Positional.
 
+Local Instance : split_mul_to_opt := None.
+
+Time Compute
+     (Pipeline.BoundsPipeline
+        true None [64; 128]
+        ltac:(let r := Reify (fun f g => mulmod (weight 51 1) (2^255) [(1,19)] 5 f g) in
+              exact r)
+               (Some (repeat (@None _) 5), ((Some (repeat (@None _) 5), tt)))
+               ZRange.type.base.option.None).
+
+Time Compute
+     (Pipeline.BoundsPipeline
+        true None [64; 128]
+        ltac:(let r := Reify (fun f g => mulmod (weight 51 2) (2^255) [(1,19)] 10 f g) in
+              exact r)
+               (Some (repeat (@None _) 10), ((Some (repeat (@None _) 10), tt)))
+               ZRange.type.base.option.None).
+
 Time Compute
      (Pipeline.BoundsPipeline
         true None [64; 128]

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -74,6 +74,9 @@ Local Opaque
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {should_split_mul : should_split_mul_opt}
+          {widen_carry : widen_carry_opt}
+          {widen_bytes : widen_bytes_opt}
           (n : nat)
           (s : Z)
           (c : list (Z * Z))
@@ -110,7 +113,7 @@ Section __.
     := [0; machine_wordsize; 2 * machine_wordsize]%Z.
 
   Definition possible_values_of_machine_wordsize_with_bytes
-    := [0; 1; 8; machine_wordsize; 2 * machine_wordsize]%Z.
+    := prefix_with_carry_bytes [machine_wordsize; 2 * machine_wordsize]%Z.
 
   Let possible_values := possible_values_of_machine_wordsize.
   Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
@@ -118,6 +121,8 @@ Section __.
     := List.map (fun u => Some r[0~>u]%zrange) tight_upperbounds.
   Definition loose_bounds : list (ZRange.type.option.interp base.type.Z)
     := List.map (fun u => Some r[0 ~> loose_upperbound_extra_multiplicand*u]%zrange) tight_upperbounds.
+
+  Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
 
   Lemma length_prime_upperbound_list : List.length prime_upperbound_list = n.
   Proof using Type. cbv [prime_upperbound_list]; now autorewrite with distr_length. Qed.

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -88,6 +88,9 @@ Local Opaque
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {should_split_mul : should_split_mul_opt}
+          {widen_carry : widen_carry_opt}
+          {widen_bytes : widen_bytes_opt}
           (m : Z)
           (machine_wordsize : Z).
 
@@ -121,15 +124,17 @@ Section __.
   (* We include [0], so that even after bounds relaxation, we can
        notice where the constant 0s are, and remove them. *)
   Definition possible_values_of_machine_wordsize
-    := [0; 1; machine_wordsize; 2 * machine_wordsize]%Z.
+    := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
 
   Definition possible_values_of_machine_wordsize_with_bytes
-    := [0; 1; 8; machine_wordsize; 2 * machine_wordsize]%Z.
+    := prefix_with_carry_bytes [machine_wordsize; 2 * machine_wordsize]%Z.
 
   Let possible_values := possible_values_of_machine_wordsize.
   Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
   Definition bounds : list (ZRange.type.option.interp base.type.Z)
     := Option.invert_Some saturated_bounds (*List.map (fun u => Some r[0~>u]%zrange) upperbounds*).
+
+  Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
 
   (** Note: If you change the name or type signature of this
         function, you will need to update the code in CLI.v *)

--- a/src/Rewriter/MulSplit.v
+++ b/src/Rewriter/MulSplit.v
@@ -1,0 +1,43 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Crypto.Language.
+Require Import Crypto.LanguageWf.
+Require Import Crypto.RewriterAllTactics.
+Require Import Crypto.RewriterRulesProofs.
+Require Import Crypto.IdentifiersGENERATEDProofs.
+
+Module Compilers.
+  Import Language.Compilers.
+  Import Language.Compilers.defaults.
+  Import LanguageWf.Compilers.
+  Import RewriterAllTactics.Compilers.RewriteRules.GoalType.
+  Import RewriterAllTactics.Compilers.RewriteRules.Tactic.
+  Import IdentifiersGENERATEDProofs.Compilers.pattern.ident.
+
+  Module Import RewriteRules.
+    Section __.
+      Context (bitwidth : Z)
+              (lgcarrymax : Z).
+
+      Definition VerifiedRewriterMulSplit : VerifiedRewriter.
+      Proof using All. make_rewriter package_proofs false (mul_split_rewrite_rules_proofs bitwidth lgcarrymax). Defined.
+
+      Definition RewriteMulSplit {t} := Eval hnf in @Rewrite VerifiedRewriterMulSplit t.
+
+      Lemma Wf_RewriteMulSplit {t} e (Hwf : Wf e) : Wf (@RewriteMulSplit t e).
+      Proof. now apply VerifiedRewriterMulSplit. Qed.
+
+      Lemma Interp_gen_RewriteMulSplit {cast_outside_of_range t} e (Hwf : Wf e)
+        : expr.Interp (@ident.gen_interp cast_outside_of_range) (@RewriteMulSplit t e)
+          == expr.Interp (@ident.gen_interp cast_outside_of_range) e.
+      Proof. now apply VerifiedRewriterMulSplit. Qed.
+
+      Lemma Interp_RewriteMulSplit {t} e (Hwf : Wf e) : Interp (@RewriteMulSplit t e) == Interp e.
+      Proof. apply Interp_gen_RewriteMulSplit; assumption. Qed.
+    End __.
+  End RewriteRules.
+
+  Module Export Hints.
+    Hint Resolve Wf_RewriteMulSplit : wf.
+    Hint Rewrite @Interp_gen_RewriteMulSplit @Interp_RewriteMulSplit : interp.
+  End Hints.
+End Compilers.

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -40,6 +40,9 @@ Import
 
 Local Existing Instance CStringification.Compilers.ToString.C.OutputCAPI.
 Local Instance : static_opt := true.
+Local Instance : should_split_mul_opt := false.
+Local Instance : widen_bytes_opt := false.
+Local Instance : widen_carry_opt := false.
 
 Import defaults.
 

--- a/src/RewriterAll.v
+++ b/src/RewriterAll.v
@@ -2,6 +2,7 @@ Require Import Crypto.Rewriter.NBE.
 Require Import Crypto.Rewriter.Arith.
 Require Import Crypto.Rewriter.ArithWithCasts.
 Require Import Crypto.Rewriter.StripLiteralCasts.
+Require Import Crypto.Rewriter.MulSplit.
 Require Import Crypto.Rewriter.ToFancy.
 Require Import Crypto.Rewriter.ToFancyWithCasts.
 
@@ -10,6 +11,7 @@ Module Compilers.
   Export Arith.Compilers.
   Export ArithWithCasts.Compilers.
   Export StripLiteralCasts.Compilers.
+  Export MulSplit.Compilers.
   Export ToFancy.Compilers.
   Export ToFancyWithCasts.Compilers.
 
@@ -18,6 +20,7 @@ Module Compilers.
     Export Arith.Compilers.RewriteRules.
     Export ArithWithCasts.Compilers.RewriteRules.
     Export StripLiteralCasts.Compilers.RewriteRules.
+    Export MulSplit.Compilers.RewriteRules.
     Export ToFancy.Compilers.RewriteRules.
     Export ToFancyWithCasts.Compilers.RewriteRules.
   End RewriteRules.

--- a/src/RewriterRulesProofs.v
+++ b/src/RewriterRulesProofs.v
@@ -22,6 +22,7 @@ Require Import Crypto.Util.ZUtil.ZSimplify.Simple.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.AddGetCarry.
 Require Import Crypto.Util.ZUtil.MulSplit.
+Require Import Crypto.Util.ZUtil.TruncatingShiftl.
 Require Import Crypto.Util.ZUtil.Zselect.
 Require Import Crypto.Util.ZUtil.Div.
 Require Import Crypto.Util.ZUtil.Modulo.
@@ -117,6 +118,7 @@ Local Ltac interp_good_t_step_related :=
           | [ |- context[Z.mul_split ?a ?b ?c] ]
             => rewrite (surjective_pairing (Z.mul_split a b c)), Z.mul_split_div, Z.mul_split_mod
           | [ |- context[Z.zselect] ] => rewrite Z.zselect_correct
+          | [ |- context[Z.truncating_shiftl] ] => rewrite Z.truncating_shiftl_correct
           | [ |- context[Z.sub_get_borrow_full ?a ?b ?c] ]
             => rewrite (surjective_pairing (Z.sub_get_borrow_full a b c)), Z.sub_get_borrow_full_div, Z.sub_get_borrow_full_mod
           | [ |- context[Z.sub_with_get_borrow_full ?a ?b ?c ?d] ]
@@ -483,3 +485,11 @@ Section fancy.
     Time all: try solve [ systematically_handle_casts; repeat interp_good_t_step_arith ].
   Qed.
 End fancy.
+
+Lemma mul_split_rewrite_rules_proofs (bitwidth : Z) (lgcarrymax : Z)
+  : PrimitiveHList.hlist (@snd bool Prop) (mul_split_rewrite_rulesT bitwidth lgcarrymax).
+Proof using Type.
+  start_proof; auto; intros; try lia.
+  all: repeat interp_good_t_step_related.
+  all: systematically_handle_casts.
+Admitted.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -326,16 +326,6 @@ static void mul(uint64_t out1[5], const uint64_t arg1[5], const uint64_t arg2[5]
   out1[4] = x152;
 }
 *)
-  (*Time Compute
-     (Pipeline.BoundsPipeline
-        true None [64; 128]
-        ltac:(let r := Reify (fun f
-                              => (  (squaremod (weight limbwidth_num limbwidth_den) s c n f)
-                                    )) in
-              exact r)
-               (Some (repeat (@None _) n), tt)
-               ZRange.type.base.option.None).
-   *)
   End __.
 End debugging_remove_mul_split_to_C_uint1_carry.
 


### PR DESCRIPTION
This adds a rewriting pass (disabled by default) which can split apart
multiplications to emit code in a single integer type.

Note that we can emit PHOAS code with only a single integer type, but to
emit C code, we must also allow uint1; see
https://github.com/mit-plv/fiat-crypto/issues/524#issuecomment-529060374
for more details.

We leave it like this because the bedrock2 translation will be coming
from PHOAS.

Note that we must still permit wider integer types during bounds
analysis, because otherwise we'll fail to assign bounds before we even
get to the point of splitting multipliciations.

Note that this rewriting pass is still admitted, so this commit adds a
dependency on an axiom to the overall pass.  (We could create a separate
pipeline if we wanted the code we're extracting to not depend on this
admitted proof.)

The interesting files to look at here are `src/RewriterRules.v`
(defining the rewriting rules) and `src/SlowPrimeSynthesisExamples.v`
giving examples.  The admitted proof is in `src/RewriterRulesProofs.v`.