### PR TITLE
Add bedrock2 as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = coqprime
 	url = https://github.com/thery/coqprime
 	ignore = dirty
+[submodule "bedrock2"]
+	path = bedrock2
+	url = https://github.com/mit-plv/bedrock2.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
       env: COQ_VERSION="8.9.1"  COQ_PACKAGE="coq-8.9.1" PPA="ppa:jgross-h/many-coq-versions"
       language: rust
       rust: nightly
-      script: PREV=standalone-ocaml CUR=test-rust TOUCH=rust-files ./etc/ci/travis.sh -j2 test-rust-files
+      script: PREV=standalone-ocaml CUR=test-rust EXTERNAL_DEPENDENCIES=1 TOUCH=rust-files ./etc/ci/travis.sh -j2 test-rust-files
 
 #    - stage: selected-test selected-bench
 #      env: COQ_VERSION="8.9.1"  COQ_PACKAGE="coq-8.9.1" PPA="ppa:jgross-h/many-coq-versions"

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ INSTALLDEFAULTROOT := Crypto
 
 .PHONY: coq clean update-_CoqProject cleanall install \
 	install-coqprime clean-coqprime coqprime coqprime-all \
+	bedrock2 clean-bedrock2 coqutil clean-coqutil \
 	install-standalone install-standalone-ocaml install-standalone-haskell \
 	util c-files rust-files \
 	nobigmem print-nobigmem \
@@ -38,9 +39,17 @@ include etc/coq-scripts/Makefile.vo_closure
 .DEFAULT_GOAL := all
 
 SORT_COQPROJECT = sed 's,[^/]*/,~&,g' | env LC_COLLATE=C sort | sed 's,~,,g' | uniq
+BEDROCK2_FOLDER := bedrock2/bedrock2
+BEDROCK2_SRC := $(BEDROCK2_FOLDER)/src
+BEDROCK2_NAME := bedrock2
+COQUTIL_FOLDER := bedrock2/deps/coqutil
+COQUTIL_SRC := $(COQUTIL_FOLDER)/src
+COQUTIL_NAME := coqutil
 update-_CoqProject::
 	$(SHOW)'ECHO > _CoqProject'
-	$(HIDE)(echo '-R $(SRC_DIR) $(MOD_NAME)'; (git ls-files 'src/*.v' | $(GREP_EXCLUDE_SPECIAL_VOFILES) | $(SORT_COQPROJECT))) > _CoqProject
+	$(HIDE)(echo '-R $(SRC_DIR) $(MOD_NAME)'; echo '-R $(BEDROCK2_SRC) $(BEDROCK2_NAME)'; \
+        echo '-R $(COQUTIL_SRC) $(COQUTIL_NAME)'; \
+        (git ls-files 'src/*.v' | $(GREP_EXCLUDE_SPECIAL_VOFILES) | $(SORT_COQPROJECT))) > _CoqProject
 
 # coq .vo files that are not compiled using coq_makefile
 SPECIAL_VOFILES := \
@@ -170,7 +179,19 @@ clean-coqprime:
 install-coqprime:
 	$(MAKE) --no-print-directory -C $(COQPRIME_FOLDER) install
 
-cleanall:: clean-coqprime
+coqutil:
+	$(MAKE) --no-print-directory -C $(COQUTIL_FOLDER)
+
+clean-coqutil:
+	$(MAKE) --no-print-directory -C $(COQUTIL_FOLDER) clean
+
+bedrock2: coqutil
+	$(MAKE) --no-print-directory -C $(BEDROCK2_FOLDER)
+
+clean-bedrock2:
+	$(MAKE) --no-print-directory -C $(BEDROCK2_FOLDER) clean
+
+cleanall:: clean-coqprime clean-bedrock2 clean-coqutil
 
 install: install-coqprime
 

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ COQUTIL_SRC := $(COQUTIL_FOLDER)/src
 COQUTIL_NAME := coqutil
 update-_CoqProject::
 	$(SHOW)'ECHO > _CoqProject'
-	$(HIDE)(echo '-R $(SRC_DIR) $(MOD_NAME)'; echo '-R $(BEDROCK2_SRC) $(BEDROCK2_NAME)'; \
-        echo '-R $(COQUTIL_SRC) $(COQUTIL_NAME)'; \
+	$(HIDE)(echo '-R $(SRC_DIR) $(MOD_NAME)'; echo '-Q $(BEDROCK2_SRC) $(BEDROCK2_NAME)'; \
+        echo '-Q $(COQUTIL_SRC) $(COQUTIL_NAME)'; \
         (git ls-files 'src/*.v' | $(GREP_EXCLUDE_SPECIAL_VOFILES) | $(SORT_COQPROJECT))) > _CoqProject
 
 # coq .vo files that are not compiled using coq_makefile

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build (if your COQPATH variable is empty):
 
 To build:
 
-       export COQPATH="$(pwd)/coqprime/src${COQPATH:+:}$COQPATH"
+       export COQPATH="$(pwd)/coqprime/src:$(pwd)/bedrock2/bedrock2/src:$(pwd)/bedrock2/deps/coqutil/src${COQPATH:+:}$COQPATH"
        make
 
 Usage

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,6 @@
 -R src Crypto
+-R bedrock2/bedrock2/src bedrock2
+-R bedrock2/deps/coqutil/src coqutil
 src/BoundsPipeline.v
 src/CLI.v
 src/COperationSpecifications.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,4 @@
 -R src Crypto
--R bedrock2/bedrock2/src bedrock2
--R bedrock2/deps/coqutil/src coqutil
 src/BoundsPipeline.v
 src/CLI.v
 src/COperationSpecifications.v

--- a/etc/ci/travis.sh
+++ b/etc/ci/travis.sh
@@ -17,7 +17,7 @@ rm -f finished.ok
 (make "$@" TIMED=1 2>&1 && touch finished.ok) | tee -a time-of-build.log
 python "./etc/coq-scripts/timing/make-one-time-file.py" "time-of-build.log" "time-of-build-pretty.log" || exit $?
 rm -f "${CUR_ARCHIVE}"
-tar -czf "${CUR_ARCHIVE}" time-of-build.log src coqprime || exit $?
+tar -czf "${CUR_ARCHIVE}" time-of-build.log src coqprime bedrock2 || exit $?
 
 git update-index --assume-unchanged _CoqProject
 git status

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -1,5 +1,5 @@
 Require Import Coq.Lists.List.
-Require Import Coq.omega.Omega Lia.
+Require Import Coq.omega.Omega Coq.micromega.Lia.
 Require Import Coq.Arith.Peano_dec.
 Require Import Coq.Classes.Morphisms.
 Require Import Coq.Numbers.Natural.Peano.NPeano.


### PR DESCRIPTION
This is so that we can make fiat-crypto output code in a format that can be consumed by the bedrock2 compiler.