### PR TITLE
Hard-code overflow behavior to be wrapping

### DIFF
--- a/curve25519_32.c
+++ b/curve25519_32.c
@@ -12,6 +12,10 @@
 typedef unsigned char fiat_25519_uint1;
 typedef signed char fiat_25519_int1;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_25519_addcarryx_u26 is an addition with carry.

--- a/curve25519_64.c
+++ b/curve25519_64.c
@@ -14,6 +14,10 @@ typedef signed char fiat_25519_int1;
 typedef signed __int128 fiat_25519_int128;
 typedef unsigned __int128 fiat_25519_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_25519_addcarryx_u51 is an addition with carry.

--- a/p224_32.c
+++ b/p224_32.c
@@ -15,6 +15,10 @@
 typedef unsigned char fiat_p224_uint1;
 typedef signed char fiat_p224_int1;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p224_addcarryx_u32 is an addition with carry.

--- a/p224_64.c
+++ b/p224_64.c
@@ -17,6 +17,10 @@ typedef signed char fiat_p224_int1;
 typedef signed __int128 fiat_p224_int128;
 typedef unsigned __int128 fiat_p224_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p224_addcarryx_u64 is an addition with carry.

--- a/p256_32.c
+++ b/p256_32.c
@@ -15,6 +15,10 @@
 typedef unsigned char fiat_p256_uint1;
 typedef signed char fiat_p256_int1;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p256_addcarryx_u32 is an addition with carry.

--- a/p256_64.c
+++ b/p256_64.c
@@ -17,6 +17,10 @@ typedef signed char fiat_p256_int1;
 typedef signed __int128 fiat_p256_int128;
 typedef unsigned __int128 fiat_p256_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p256_addcarryx_u64 is an addition with carry.

--- a/p384_32.c
+++ b/p384_32.c
@@ -15,6 +15,10 @@
 typedef unsigned char fiat_p384_uint1;
 typedef signed char fiat_p384_int1;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p384_addcarryx_u32 is an addition with carry.

--- a/p384_64.c
+++ b/p384_64.c
@@ -17,6 +17,10 @@ typedef signed char fiat_p384_int1;
 typedef signed __int128 fiat_p384_int128;
 typedef unsigned __int128 fiat_p384_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p384_addcarryx_u64 is an addition with carry.

--- a/p434_64.c
+++ b/p434_64.c
@@ -17,6 +17,10 @@ typedef signed char fiat_p434_int1;
 typedef signed __int128 fiat_p434_int128;
 typedef unsigned __int128 fiat_p434_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p434_addcarryx_u64 is an addition with carry.

--- a/p448_solinas_64.c
+++ b/p448_solinas_64.c
@@ -14,6 +14,10 @@ typedef signed char fiat_p448_int1;
 typedef signed __int128 fiat_p448_int128;
 typedef unsigned __int128 fiat_p448_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p448_addcarryx_u56 is an addition with carry.

--- a/p521_32.c
+++ b/p521_32.c
@@ -14,6 +14,10 @@ typedef signed char fiat_p521_int1;
 typedef signed __int128 fiat_p521_int128;
 typedef unsigned __int128 fiat_p521_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p521_addcarryx_u30 is an addition with carry.

--- a/p521_64.c
+++ b/p521_64.c
@@ -14,6 +14,10 @@ typedef signed char fiat_p521_int1;
 typedef signed __int128 fiat_p521_int128;
 typedef unsigned __int128 fiat_p521_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_p521_addcarryx_u58 is an addition with carry.

--- a/secp256k1_32.c
+++ b/secp256k1_32.c
@@ -15,6 +15,10 @@
 typedef unsigned char fiat_secp256k1_uint1;
 typedef signed char fiat_secp256k1_int1;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_secp256k1_addcarryx_u32 is an addition with carry.

--- a/secp256k1_64.c
+++ b/secp256k1_64.c
@@ -17,6 +17,10 @@ typedef signed char fiat_secp256k1_int1;
 typedef signed __int128 fiat_secp256k1_int128;
 typedef unsigned __int128 fiat_secp256k1_uint128;
 
+#if (-1 & 3) != 3
+#error "This code only works on a two's complement system"
+#endif
+
 
 /*
  * The function fiat_secp256k1_addcarryx_u64 is an addition with carry.

--- a/src/CastLemmas.v
+++ b/src/CastLemmas.v
@@ -131,6 +131,7 @@ Module ident.
       edestruct is_bounded_by_bool; tauto.
     Qed.
 
+    (*
     Lemma cast_out_of_bounds_in_range_pos r v
       : ident.is_more_pos_than_neg (ZRange.normalize r) v = true
         -> is_bounded_by_bool v (ZRange.normalize r) = false
@@ -146,7 +147,9 @@ Module ident.
       end.
       all: Z.div_mod_to_quot_rem; nia.
     Qed.
+     *)
 
+    (*
     Lemma cast_out_of_bounds_in_range_neg r v
       : ident.is_more_pos_than_neg (ZRange.normalize r) v = false
         -> is_bounded_by_bool v (ZRange.normalize r) = false
@@ -164,7 +167,9 @@ Module ident.
       end.
       all: Z.div_mod_to_quot_rem; nia.
     Qed.
+     *)
 
+    (*
     Lemma cast_out_of_bounds_in_range r v
       : is_bounded_by_bool v (ZRange.normalize r) = false
         -> (ident.is_more_pos_than_neg (ZRange.normalize r) v = true -> is_bounded_by_bool (cast_outside_of_range (ZRange.normalize r) v) (ZRange.normalize r) = true)
@@ -177,7 +182,9 @@ Module ident.
       pose proof (cast_out_of_bounds_in_range_neg r v).
       break_innermost_match; intros; auto.
     Qed.
+     *)
 
+    (*
     Lemma cast_out_of_bounds_simple r v
       : (is_bounded_by_bool v (ZRange.normalize r) = true -> cast_outside_of_range (ZRange.normalize r) v = v)
         -> (ident.is_more_pos_than_neg (ZRange.normalize r) v = false -> (is_bounded_by_bool (-v) (-ZRange.normalize r))%Z = true -> (-cast_outside_of_range (-ZRange.normalize r) (-v) = v)%Z)
@@ -198,6 +205,7 @@ Module ident.
       { rewrite cast_in_normalized_bounds by assumption; intros; symmetry; break_innermost_match; auto. }
       { auto. }
     Qed.
+     *)
 
     Lemma is_more_pos_then_neg_0_u u v
       : (0 <= u)%Z
@@ -212,6 +220,7 @@ Module ident.
       cbv [andb orb]; break_innermost_match; Z.ltb_to_lt; try lia; reflexivity.
     Qed.
 
+    (*
     Lemma cast_out_of_bounds_simple_0 u v
       : (0 <= u)%Z
         -> ((0 <= v <= u)%Z -> cast_outside_of_range r[0~>u] v = v)
@@ -227,7 +236,8 @@ Module ident.
       cbv [is_bounded_by_bool ZRange.opp] in *; cbn [lower upper] in *; rewrite ?Bool.andb_true_iff, ?Z.leb_le in *.
       intros; apply H; intros; destruct_head'_and; repeat apply conj; Z.ltb_to_lt; auto; try congruence.
     Qed.
-
+     *)
+    (*
     Lemma cast_out_of_bounds_simple_0_mod u v
       : (0 <= u)%Z
         -> ((0 <= v <= u)%Z -> cast_outside_of_range r[0~>u] v = v)
@@ -242,6 +252,40 @@ Module ident.
       rewrite !Z.sub_0_r, !Z.add_0_r.
       break_innermost_match; split_andb; Z.ltb_to_lt; intro H';
         rewrite ?H' by lia; Z.rewrite_mod_small; reflexivity.
+    Qed.
+     *)
+
+    Lemma cast_out_of_bounds_simple_0_mod u v
+      : (0 <= u)%Z
+        -> ((cast_outside_of_range r[0~>u] v) mod (u + 1) = v mod (u + 1))%Z
+        -> (cast r[0~>u] v = (cast_outside_of_range r[0~>u] v) mod (u + 1))%Z.
+    Proof.
+      intro H0.
+      pose proof (is_more_pos_then_neg_0_u u v H0) as H1.
+      cbv [cast]; rewrite H1.
+      rewrite (proj1 ZRange.normalize_id_iff_goodb)
+        by (cbv [ZRange.goodb lower upper]; Z.ltb_to_lt; assumption).
+      cbn [lower upper].
+      rewrite !Z.sub_0_r, !Z.add_0_r.
+      break_innermost_match; split_andb; Z.ltb_to_lt; intro H';
+        rewrite ?H' by lia; Z.rewrite_mod_small; reflexivity.
+    Qed.
+
+    (* N.B. This lemma depends on the hard-coded behavior of casting
+        out of range being modulo, and hence we label it
+        "platform-specific". *)
+    Lemma platform_specific_cast_0_is_mod u v
+      : (0 <= u)%Z
+        -> (cast r[0~>u] v = v mod (u + 1))%Z.
+    Proof.
+      intro H0.
+      pose proof (is_more_pos_then_neg_0_u u v H0) as H1.
+      cbv [cast]; rewrite H1.
+      rewrite (proj1 ZRange.normalize_id_iff_goodb)
+        by (cbv [ZRange.goodb lower upper]; Z.ltb_to_lt; assumption).
+      cbn [lower upper].
+      rewrite !Z.sub_0_r, !Z.add_0_r.
+      break_innermost_match; split_andb; Z.ltb_to_lt; Z.rewrite_mod_small; reflexivity.
     Qed.
 
     Lemma cast_normalize r v : cast (ZRange.normalize r) v = cast r v.

--- a/src/Fancy/Compiler.v
+++ b/src/Fancy/Compiler.v
@@ -566,7 +566,7 @@ Section of_prefancy.
       ident.cast cast_oor r[0~>u] v = v mod (u + 1).
     Proof.
       intros.
-      rewrite ident.cast_out_of_bounds_simple_0_mod by auto using cast_oor_id.
+      rewrite ident.cast_out_of_bounds_simple_0_mod by auto using cast_oor_id, cast_oor_mod.
       cbv [cast_oor upper]. apply Z.mod_mod. omega.
     Qed.
 

--- a/src/Language/Pre.v
+++ b/src/Language/Pre.v
@@ -19,10 +19,17 @@ Module ident.
           || ((Z.abs (lower r) =? Z.abs (upper r)) && (0 <=? v))).
 
     (** We ensure that [ident.cast] is symmetric under [Z.opp], as
-            this makes some rewrite rules much, much easier to
-            prove. *)
+        this makes some rewrite rules much, much easier to prove. *)
+    (** We actually ignore [cast_outside_of_range] and hard-code it to
+        the identity.  This is needed for one of our rewrite rules.
+
+        XXX TODO: Come up with a good way of proving boundedness for
+          the abstract interpreter, now that we no longer can even
+          guarantee that we have the same behavior independent of
+          overflow behavior. *)
     Let cast_outside_of_range' (r : zrange) (v : BinInt.Z) : BinInt.Z
-      := ((cast_outside_of_range r v - lower r) mod (upper r - lower r + 1)) + lower r.
+      := let v' := let dummy := cast_outside_of_range r v in v in
+         ((v' - lower r) mod (upper r - lower r + 1)) + lower r.
 
     Definition cast (r : zrange) (x : BinInt.Z)
       := let r := ZRange.normalize r in

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -53,7 +53,11 @@ Module Compilers.
                 ++ (if PositiveSet.mem 128 bitwidths_used
                     then ["typedef signed __int128 " ++ prefix ++ "int128;";
                             "typedef unsigned __int128 " ++ prefix ++ "uint128;"]%string
-                    else []))%list.
+                    else [])
+                ++ [""
+                    ; "#if (-1 & 3) != 3"
+                    ; "#error ""This code only works on a two's complement system"""
+                    ; "#endif"])%list.
 
         Definition stdint_bitwidths : list Z := [8; 16; 32; 64].
         Definition is_special_bitwidth (bw : Z) := negb (existsb (Z.eqb bw) stdint_bitwidths).


### PR DESCRIPTION
This is required for dropping the carry in the mul-split addition
rewrite rule.

We also insert a compile-time test into the C code for twos-complement
wrapping behavior.

Question/TODO: Should we insert a test or use, e.g., `Wrapping`, in the
Rust code?

Note that this weakens the guarantee we get from bounds analysis; now
our guarantee is that we perform correctly when doing twos-complement
wrapping on overflow, rather than that we perform correctly regardless
of overflow behavior (as long as it is well-defined).  (@achlipala do you have thoughts/objections?)

Note also that we leave everything parameterized over the now-useless
`cast_outside_of_range` so that we don't have to change large amounts of
code just to support targeting bedrock2.