### PR TITLE
Generate most identifier definitions via tactics

### DIFF
--- a/src/AbstractInterpretation/Wf.v
+++ b/src/AbstractInterpretation/Wf.v
@@ -411,7 +411,7 @@ Module Compilers.
                            | break_innermost_match_step
                            | progress subst
                            | progress cbv [type_base ident.smart_Literal] in *
-                           | progress cbn [invert_Literal ident.invert_Literal] in *
+                           | progress cbn [invert_Literal] in *
                            | discriminate
                            | progress destruct_head' False
                            | progress expr.invert_subst
@@ -469,7 +469,7 @@ Module Compilers.
                               | apply DefaultValue.expr.base.wf_default
                               | apply DefaultValue.expr.wf_default
                               | progress expr.invert_subst
-                              | progress cbn [ident.annotate ident.smart_Literal invert_Literal ident.invert_Literal invert_pair invert_AppIdent2 invert_App2 fst snd projT2 projT1 eq_rect Option.bind] in *
+                              | progress cbn [ident.annotate ident.smart_Literal invert_Literal invert_pair invert_AppIdent2 invert_App2 fst snd projT2 projT1 eq_rect Option.bind] in *
                               | progress destruct_head' False
                               | progress inversion_option
                               | progress destruct_head'_ex

--- a/src/Fancy/Compiler.v
+++ b/src/Fancy/Compiler.v
@@ -567,6 +567,7 @@ Section of_prefancy.
                | progress subst
                | progress cbn [GallinaReify.base.reify ident.ident_Literal ident.buildIdent] in *
                | progress cbn [projT1 projT2 eq_rect of_prefancy_ident option_map] in *
+               | progress cbv [ident.literal] in *
                | progress inversion_sigma
                | progress Z.ltb_to_lt
                | progress break_innermost_match

--- a/src/Language/API.v
+++ b/src/Language/API.v
@@ -33,15 +33,15 @@ Compute API.type. (* to figure out what goes into a type *)
     Notation expr := (@expr base.type ident).
 
     (** [interp_type : type -> Type] is the type code denotation function *)
-    Notation interp_type := (@type.interp base_type base_type_interp).
+    Notation interp_type := (@type.interp base.type base.interp).
     (** [Interp : forall {t}, Expr t -> interp_type t] is the [Expr] denotation function *)
-    Notation Interp := (@expr.Interp base_type ident base_type_interp (@ident_interp)).
+    Notation Interp := (@expr.Interp base.type ident base.interp (@ident_interp)).
     (** [interp : forall {t}, @expr interp_type t -> interp_type t] is the [expr] denotation function *)
-    Notation interp := (@expr.interp base_type ident base_type_interp (@ident_interp)).
-    Notation gen_Interp cast_outside_of_range := (@expr.Interp base_type ident base_type_interp (@ident.gen_interp cast_outside_of_range)).
-    Notation gen_interp cast_outside_of_range := (@expr.interp base_type ident base_type_interp (@ident.gen_interp cast_outside_of_range)).
+    Notation interp := (@expr.interp base.type ident base.interp (@ident_interp)).
+    Notation gen_Interp cast_outside_of_range := (@expr.Interp base.type ident base.interp (@ident.gen_interp cast_outside_of_range)).
+    Notation gen_interp cast_outside_of_range := (@expr.interp base.type ident base.interp (@ident.gen_interp cast_outside_of_range)).
 
-    Ltac reify_type ty := type.reify ltac:(reify_base_type) constr:(base_type) ty.
+    Ltac reify_type ty := type.reify ltac:(reify_base_type) constr:(base.type) ty.
     Notation reify_type t := (ltac:(let rt := reify_type t in exact rt)) (only parsing).
     Notation reify_type_of e := (reify_type ((fun t (_ : t) => t) _ e)) (only parsing).
 

--- a/src/Language/Identifier.v
+++ b/src/Language/Identifier.v
@@ -30,40 +30,103 @@ Import EqNotations.
 Module Compilers.
   Export Language.Pre.
   Export Language.Compilers.
-  Local Set Boolean Equality Schemes.
-  Local Set Decidable Equality Schemes.
 
-  Inductive base := Z | bool | nat | zrange. (* Not Variant because COQBUG(https://github.com/coq/coq/issues/7738) *)
-  Notation base_type := (@base.type base).
+  Module GoalType.
+    Definition package := { exprInfo : Classes.ExprInfoT & Classes.ExprExtraInfoT }.
+  End GoalType.
 
-  Global Instance baseHasNat : base.type.BaseTypeHasNatT base := nat.
-  Definition eta_base_cps_gen
-             (P : base -> Type)
-             (f : forall t, P t)
-    : { f' : forall t, P t | forall t, f' t = f t }.
-  Proof. (unshelve eexists; let t := fresh in intro t; destruct t); shelve_unifiable; reflexivity. Defined.
+  Ltac get_min_and_incr min :=
+    lazymatch min with
+    | S ?min => let v := get_min_and_incr min in
+                constr:(S v)
+    | ?ev => let unif := open_constr:(eq_refl : S _ = ev) in
+             O
+    end.
+  Ltac build_index_of_base base :=
+    constr:(ltac:(let t := fresh "t" in
+                  let min := open_constr:(_ : Datatypes.nat) in
+                  unshelve (intro t; destruct t;
+                            [ > let v := get_min_and_incr min in refine v .. ]);
+                  exact O)
+            : base -> Datatypes.nat).
+  Ltac make_index_of_base base :=
+    let res := build_index_of_base base in refine res.
 
-  Definition eta_base_cps {P : base -> Type} (f : forall t, P t) : forall t, P t
-    := proj1_sig (eta_base_cps_gen _ f).
+  Ltac build_base_eq_dec base :=
+    constr:(ltac:(decide equality)
+            : forall x y : base, {x = y} + {x <> y}).
+  Ltac make_base_eq_dec base :=
+    let res := build_base_eq_dec base in refine res.
 
-  Global Instance reflect_base_beq : reflect_rel (@eq base) base_beq | 10
-    := reflect_of_beq internal_base_dec_bl internal_base_dec_lb.
+  Ltac build_eta_base_cps_gen base :=
+    constr:(ltac:((unshelve eexists; let t := fresh in intro t; destruct t); shelve_unifiable; reflexivity)
+            : forall (P : base -> Type)
+                     (f : forall t, P t),
+               { f' : forall t, P t | forall t, f' t = f t }).
+  Ltac make_eta_base_cps_gen base := let res := build_eta_base_cps_gen base in refine res.
 
-  Definition base_interp (ty : base)
-    := match ty with
-       | Z => BinInt.Z
-       | bool => Datatypes.bool
-       | nat => Datatypes.nat
-       | zrange => ZRange.zrange
-       end.
+  Ltac build_eta_base_cps eta_base_cps_gen :=
+    constr:((fun P f => proj1_sig (@eta_base_cps_gen _ f))
+            : forall {P : _ -> Type} (f : forall t, P t) t, P t).
+  Ltac make_eta_base_cps eta_base_cps_gen :=
+    let res := build_eta_base_cps eta_base_cps_gen in refine res.
 
-  Global Instance baseHasNatCorrect : base.BaseHasNatCorrectT base_interp
-    := {
-        to_nat := fun x => x;
-        of_nat := fun x => x;
-        to_of_nat := fun P x v => v;
-        of_to_nat := fun P x v => v;
-      }.
+  Ltac build_base_interp eta_base_cps base_type_list index_of_base :=
+    let eta_base_cps := (eval cbv in eta_base_cps) in
+    let base_type_list := (eval hnf in base_type_list) in
+    let index_of_base := (eval cbv in index_of_base) in
+    (eval cbv [TypeList.nth] in
+        (fun ty => @eta_base_cps (fun _ => Type) (fun t => TypeList.nth (index_of_base t) base_type_list True) ty)).
+  Ltac make_base_interp eta_base_cps base_type_list index_of_base :=
+    let res := build_base_interp eta_base_cps base_type_list index_of_base in refine res.
+
+  Ltac build_baseHasNatAndCorrect base_interp :=
+    constr:(ltac:(unshelve eexists; hnf; [ constructor | unshelve econstructor ]; cbv;
+                  [ exact (fun x => x)
+                  | exact (fun x => x)
+                  | exact (fun P x v => v)
+                  | exact (fun P x v => v) ])
+            : { hasNat : base.type.BaseTypeHasNatT _ & @base.BaseHasNatCorrectT _ base_interp hasNat }).
+  Ltac make_baseHasNatAndCorrect base_interp :=
+    let res := build_baseHasNatAndCorrect base_interp in refine res.
+
+  Ltac make_baseHasNat baseHasNatAndCorrect :=
+    let res := (eval cbv in (projT1 baseHasNatAndCorrect)) in refine res.
+  Ltac build_baseHasNat base baseHasNatAndCorrect :=
+    constr:(ltac:(make_baseHasNat baseHasNatAndCorrect)
+            : base.type.BaseTypeHasNatT base).
+
+  Ltac make_baseHasNatCorrect baseHasNatAndCorrect :=
+    let res := (eval cbv in (projT2 baseHasNatAndCorrect)) in refine res.
+  Ltac build_baseHasNatCorrect base_interp baseHasNat baseHasNatAndCorrect :=
+    constr:(ltac:(make_baseHasNatCorrect baseHasNatAndCorrect)
+            : @base.BaseHasNatCorrectT _ base_interp baseHasNat).
+
+  Ltac build_base_beq_and_reflect base :=
+    constr:(ltac:(unshelve eexists;
+                  [ let x := fresh "x" in
+                    let y := fresh "y" in
+                    intros x y; destruct x, y
+                  | apply reflect_of_beq;
+                    [ let x := fresh in
+                      let y := fresh in
+                      intros x y; destruct x, y; try reflexivity; instantiate (1:=Datatypes.false);
+                      intro; exfalso; apply diff_false_true; assumption
+                    | let x := fresh in
+                      let y := fresh in
+                      intros x y ?; subst y; destruct x; reflexivity ] ])
+            : { base_beq : _ & reflect_rel (@eq base) base_beq }).
+  Ltac make_base_beq_and_reflect base :=
+    let res := build_base_beq_and_reflect base in refine res.
+
+  Ltac build_base_beq base_beq_and_reflect := (eval cbv in (projT1 base_beq_and_reflect)).
+  Ltac make_base_beq base_beq_and_reflect :=
+    let res := build_base_beq base_beq_and_reflect in refine res.
+
+  Ltac make_reflect_base_beq base_beq_and_reflect := refine (projT2 base_beq_and_reflect).
+  Ltac build_reflect_base_beq base base_beq base_beq_and_reflect :=
+    constr:(ltac:(make_reflect_base_beq base_beq_and_reflect)
+            : reflect_rel (@eq base) base_beq).
 
   Ltac build_base_interp_beq base_interp :=
     (eval cbv beta in
@@ -75,35 +138,331 @@ Module Compilers.
          : forall t, base_interp t -> base_interp t -> Datatypes.bool)).
   Ltac make_base_interp_beq base_interp := let v := build_base_interp_beq base_interp in refine v.
 
-  Definition base_interp_beq : forall {t}, base_interp t -> base_interp t -> Datatypes.bool
-    := ltac:(make_base_interp_beq base_interp).
+  Ltac build_reflect_base_interp_eq base_interp base_interp_beq :=
+    constr:(ltac:(let t := fresh "t" in
+                  intro t; destruct t; cbv [base_interp base_interp_beq]; typeclasses eauto)
+            : forall t, reflect_rel (@eq (base_interp t)) (@base_interp_beq t)).
+  Ltac make_reflect_base_interp_eq base_interp base_interp_beq :=
+    let res := build_reflect_base_interp_eq base_interp base_interp_beq in refine res.
 
-  Notation base_type_interp := (base.interp base_interp).
+  Ltac build_try_make_base_transport_cps base_eq_dec eta_base_cps :=
+    constr:((fun (P : _ -> Type) (t1 t2 : _)
+             => @eta_base_cps
+                  _
+                  (fun t1
+                   => @eta_base_cps
+                        (fun t2 => ~> option (P t1 -> P t2))
+                        (fun t2
+                         => match base_eq_dec t1 t2 with
+                            | left pf => (return (Some (rew [fun t2 => P t1 -> P t2] pf in id)))
+                            | right _ => (return None)
+                            end)
+                        t2)
+                  t1)%cps
+            : @type.try_make_transport_cpsT _).
+  Ltac make_try_make_base_transport_cps base_eq_dec eta_base_cps :=
+    let res := build_try_make_base_transport_cps base_eq_dec eta_base_cps in
+    refine res.
 
-  Global Instance reflect_base_interp_eq {t} : reflect_rel (@eq (base_interp t)) (@base_interp_beq t) | 10.
-  Proof. destruct t; cbn [base_interp base_interp_beq]; eauto with typeclass_instances. Qed.
+  Ltac build_try_make_base_transport_cps_correct try_make_base_transport_cps reflect_base_beq :=
+    constr:(ltac:(let P := fresh "P" in
+                  let t1 := fresh "t1" in
+                  let t2 := fresh "t2" in
+                  intros P t1 t2; revert P t2; induction t1, t2; cbn;
+                  Reflect.reflect_beq_to_eq_using reflect_base_beq; reflexivity)
+            : @type.try_make_transport_cps_correctT _ _ try_make_base_transport_cps reflect_base_beq).
+  Ltac make_try_make_base_transport_cps_correct try_make_base_transport_cps reflect_base_beq :=
+    let res := build_try_make_base_transport_cps_correct try_make_base_transport_cps reflect_base_beq in
+    refine res.
 
-  Definition try_make_base_transport_cps : @type.try_make_transport_cpsT base
-    := (fun (P : base -> Type) (t1 t2 : base)
-        => eta_base_cps
-             (fun t1
-              => @eta_base_cps
-                   (fun t2 => ~> option (P t1 -> P t2))
-                   (fun t2
-                    => match base_eq_dec t1 t2 with
-                       | left pf => (return (Some (rew [fun t2 => P t1 -> P t2] pf in id)))
-                       | right _ => (return None)
-                       end)
-                   t2)
-             t1)%cps.
-  Global Existing Instance try_make_base_transport_cps | 5.
+  Ltac uneta_fun_push_eagerly term :=
+    let term := (eval cbv beta in term) in
+    lazymatch term with
+    | fun a => ?f a => uneta_fun_push_eagerly f
+    | (fun (a : ?A) => @?f a)
+      => lazymatch constr:(
+                     fun a : A
+                     => ltac:(let f' := uneta_fun_push_eagerly (f a) in
+                              exact f')) with
+         | fun a => ?f a => uneta_fun_push_eagerly f
+         | ?f => f
+         end
+    | ident.eagerly (?f ?x) => uneta_fun_push_eagerly (ident.eagerly f x)
+    | ?f ?x => let f' := uneta_fun_push_eagerly f in
+               let x' := uneta_fun_push_eagerly x in
+               (eval cbv beta in (f' x'))
+    | ?f => f
+    end.
+  Ltac build_buildEagerIdentAndInterpCorrect ident_gen_interp baseHasNat baseHasNatCorrect reify_ident :=
+    constr:(ltac:(let ident_gen_interp_head := head ident_gen_interp in
+                  let baseHasNat' := (eval hnf in baseHasNat) in
+                  let baseHasNatCorrect' := (eval hnf in baseHasNatCorrect) in
+                  change baseHasNatCorrect with baseHasNatCorrect';
+                  unshelve econstructor; [ econstructor; intros; shelve | constructor ]; intros;
+                  lazymatch goal with
+                  | [ |- ?ii ?id = ?v ]
+                    => let id' := (eval cbv in id) in
+                       change (ii id' = v); cbv [ident_gen_interp_head];
+                       change baseHasNat with baseHasNat'; cbv [base.of_nat base.to_nat];
+                       match goal with
+                       | [ |- ?LHS = ?v ] => let v' := uneta_fun_push_eagerly v in change (LHS = v')
+                       end;
+                       lazymatch goal with
+                       | [ |- _ = ?v ]
+                         => reify_ident v ltac:(fun idc => unify id' idc) ltac:(fun term => fail 0 "could not reify" term "as an ident") ltac:(fun _ => fail 0 "could not reify" v "as an ident")
+                       end
+                  end; reflexivity)
+            : { buildEagerIdent : _ & forall cast_outside_of_range, @ident.BuildInterpEagerIdentCorrectT _ _ _ (@ident_gen_interp cast_outside_of_range) baseHasNat buildEagerIdent baseHasNatCorrect }).
+  Ltac make_buildEagerIdentAndInterpCorrect ident_gen_interp baseHasNat baseHasNatCorrect reify_ident :=
+    let res := build_buildEagerIdentAndInterpCorrect ident_gen_interp baseHasNat baseHasNatCorrect reify_ident in refine res.
 
-  Global Instance try_make_base_transport_cps_correct
-    : type.try_make_transport_cps_correctT base.
-  Proof.
-    intros P t1 t2; revert P t2; induction t1, t2; cbn;
-      Reflect.reflect_beq_to_eq base_beq; reflexivity.
-  Qed.
+  Ltac make_buildEagerIdent buildEagerIdentAndInterpCorrect :=
+    let v := (eval hnf in (projT1 buildEagerIdentAndInterpCorrect)) in
+    exact v.
+  Ltac build_buildEagerIdent ident baseHasNat buildEagerIdentAndInterpCorrect :=
+    constr:(ltac:(make_buildEagerIdent buildEagerIdentAndInterpCorrect)
+            : @ident.BuildEagerIdentT _ ident baseHasNat).
+
+  Ltac make_buildInterpEagerIdentCorrect buildEagerIdentAndInterpCorrect :=
+    refine (projT2 buildEagerIdentAndInterpCorrect).
+  Ltac build_buildInterpEagerIdentCorrect ident_gen_interp buildEagerIdent baseHasNatCorrect buildEagerIdentAndInterpCorrect :=
+    constr:(ltac:(make_buildInterpEagerIdentCorrect buildEagerIdentAndInterpCorrect)
+            : forall cast_outside_of_range,
+               @ident.BuildInterpEagerIdentCorrectT _ _ _ (ident_gen_interp cast_outside_of_range) _ buildEagerIdent baseHasNatCorrect).
+
+  Ltac build_toRestrictedIdentAndCorrect baseHasNat buildEagerIdent :=
+    constr:(ltac:(unshelve eexists; hnf; [ | split ]; cbv;
+                  let idc := fresh "idc" in
+                  intros ? idc; destruct idc;
+                  try (((instantiate (1 := Datatypes.None) + idtac); reflexivity)))
+            : { toRestrictedIdent : _
+                                    & @ident.ToFromRestrictedIdentT _ _ baseHasNat buildEagerIdent toRestrictedIdent }).
+  Ltac make_toRestrictedIdentAndCorrect baseHasNat buildEagerIdent :=
+    let res := build_toRestrictedIdentAndCorrect baseHasNat buildEagerIdent in refine res.
+
+  Ltac make_toRestrictedIdent toRestrictedIdentAndCorrect :=
+    let v := (eval hnf in (projT1 toRestrictedIdentAndCorrect)) in
+    exact v.
+  Ltac build_toRestrictedIdent ident baseHasNat toRestrictedIdentAndCorrect :=
+    constr:(ltac:(make_toRestrictedIdent toRestrictedIdentAndCorrect)
+            : @ident.ToRestrictedIdentT _ ident baseHasNat).
+
+  Ltac make_toFromRestrictedIdent toRestrictedIdentAndCorrect :=
+    let v := (eval hnf in (projT2 toRestrictedIdentAndCorrect)) in
+    exact v.
+  Ltac build_toFromRestrictedIdent baseHasNat buildEagerIdent toRestrictedIdent toRestrictedIdentAndCorrect :=
+    constr:(ltac:(make_toFromRestrictedIdent toRestrictedIdentAndCorrect)
+            : @ident.ToFromRestrictedIdentT _ _ baseHasNat buildEagerIdent toRestrictedIdent).
+
+  Ltac build_buildIdentAndInterpCorrect ident_gen_interp reify_ident :=
+    constr:(ltac:(let ident_gen_interp_head := head ident_gen_interp in
+                  unshelve econstructor;
+                  [ econstructor; intros;
+                    lazymatch goal with
+                    | [ |- ?ident (type.base base.type.unit) ] => solve [ constructor ]
+                    | _ => shelve
+                    end
+                  | constructor ];
+                  intros;
+                  lazymatch goal with
+                  | [ |- ?ii ?id = ?v ]
+                    => let id' := (eval cbv in id) in
+                       change (ii id' = v); cbv [ident_gen_interp_head];
+                       fold (@base.interp);
+                       let v := match goal with |- _ = ?v => v end in
+                       reify_ident v ltac:(fun idc => unify id' idc) ltac:(fun term => fail 0 "could not reify" term "as an ident") ltac:(fun _ => fail 0 "could not reify" v "as an ident")
+                  end; reflexivity)
+            : { buildIdent : _
+                             & forall cast_outside_of_range,
+                    @ident.BuildInterpIdentCorrectT _ _ _ buildIdent (@ident_gen_interp cast_outside_of_range) }).
+  Ltac make_buildIdentAndInterpCorrect ident_gen_interp reify_ident :=
+    let res := build_buildIdentAndInterpCorrect ident_gen_interp reify_ident in refine res.
+
+  Ltac make_buildIdent buildIdentAndInterpCorrect :=
+    let v := (eval hnf in (projT1 buildIdentAndInterpCorrect)) in
+    exact v.
+  Ltac build_buildIdent base_interp ident buildIdentAndInterpCorrect :=
+    constr:(ltac:(make_buildIdent buildIdentAndInterpCorrect)
+            : @ident.BuildIdentT _ base_interp ident).
+
+  Ltac make_buildInterpIdentCorrect buildIdentAndInterpCorrect :=
+    refine (projT2 buildIdentAndInterpCorrect).
+  Ltac build_buildInterpIdentCorrect ident_gen_interp buildIdent buildIdentAndInterpCorrect :=
+    constr:(ltac:(make_buildInterpIdentCorrect buildIdentAndInterpCorrect)
+            : forall cast_outside_of_range,
+               @ident.BuildInterpIdentCorrectT _ _ _ buildIdent (ident_gen_interp cast_outside_of_range)).
+
+  Ltac build_ident_is_var_like ident ident_interp var_like_idents :=
+    (eval cbv beta zeta in
+        (ltac:(let t := fresh "t" in
+               let idc := fresh "idc" in
+               let idc' := fresh "idc'" in
+               let ident_interp_head := head (@ident_interp) in
+               intros t idc; pose (@ident_interp _ idc) as idc';
+               destruct idc; cbn [ident_interp_head] in idc';
+               let idcv := (eval cbv [idc'] in idc') in
+               let idc_head := head idcv in
+               lazymatch (eval hnf in var_like_idents) with
+               | context[GallinaIdentList.cons idc_head]
+                 => refine Datatypes.true
+               | _ => refine Datatypes.false
+               end)
+         : forall {t} (idc : ident t), Datatypes.bool)).
+  Ltac make_ident_is_var_like ident ident_interp var_like_idents :=
+    let res := build_ident_is_var_like ident ident_interp var_like_idents in refine res.
+
+  Ltac build_gen_eqv_Reflexive_Proper ident_gen_interp base_interp :=
+    constr:(ltac:(let idc := fresh in
+                  let ident_gen_interp_head := head ident_gen_interp in
+                  let base_interp_head := head base_interp in
+                  intros ? ? idc;
+                  destruct idc; cbn [type.eqv ident_gen_interp_head type.interp base.interp base_interp_head];
+                  cbv [ident.eagerly];
+                  try solve [ typeclasses eauto
+                            | cbv [respectful]; repeat intro; subst; cbv; break_innermost_match; eauto using eq_refl with nocore
+                            | cbv [respectful]; repeat intro; (apply nat_rect_Proper_nondep || apply list_rect_Proper || apply list_case_Proper || apply list_rect_arrow_Proper); repeat intro; eauto ];
+                  match goal with
+                  | [ |- ?G ] => idtac "WARNING: Could not automatically prove Proper lemma" G;
+                                 idtac "  Please ensure this goal can be solved by typeclasses eauto"
+                  end)
+            : forall cast_outside_of_range {t} idc, Proper type.eqv (@ident_gen_interp cast_outside_of_range t idc)).
+  Ltac make_gen_eqv_Reflexive_Proper ident_gen_interp base_interp :=
+    let res := build_gen_eqv_Reflexive_Proper ident_gen_interp base_interp in refine res.
+
+  Ltac make_eqv_Reflexive_Proper gen_eqv_Reflexive_Proper :=
+    apply gen_eqv_Reflexive_Proper.
+  Ltac build_eqv_Reflexive_Proper ident_interp gen_eqv_Reflexive_Proper :=
+    constr:(ltac:(make_eqv_Reflexive_Proper gen_eqv_Reflexive_Proper)
+                   : forall {t} idc, Proper type.eqv (@ident_interp t idc)).
+
+  Ltac make_ident_gen_interp_Proper gen_eqv_Reflexive_Proper :=
+    let idc := fresh "idc" in
+    let idc' := fresh "idc'" in
+    intros ? ? idc idc' ?; subst idc'; apply gen_eqv_Reflexive_Proper.
+  Ltac build_ident_gen_interp_Proper ident_gen_interp gen_eqv_Reflexive_Proper :=
+    constr:(ltac:(make_ident_gen_interp_Proper gen_eqv_Reflexive_Proper)
+            : forall {cast_outside_of_range} {t},
+               Proper (eq ==> type.eqv) (@ident_gen_interp cast_outside_of_range t)).
+
+  Ltac make_ident_interp_Proper ident_gen_interp_Proper :=
+    apply ident_gen_interp_Proper.
+  Ltac build_ident_interp_Proper ident_interp ident_gen_interp_Proper :=
+    constr:(ltac:(make_ident_interp_Proper ident_gen_interp_Proper)
+            : forall {t} idc, Proper (eq ==> type.eqv) (@ident_interp t)).
+
+  Ltac build_invertIdentAndCorrect base_type base_interp buildIdent reflect_base_beq :=
+    constr:(ltac:(pose proof reflect_base_beq;
+                  pose proof (_ : reflect_rel (@eq (type.type base_type)) _);
+                  unshelve
+                    (unshelve econstructor;
+                     [ constructor; let idc := fresh "idc" in intros ? idc; destruct idc; shelve
+                     | constructor;
+                       (let idc := fresh "idc" in
+                        intros ? idc;
+                        split;
+                        [ destruct idc; shelve
+                        | ]) ];
+                     repeat first [ match goal with
+                                    | [ |- match ?x with _ => _ end _ _ -> _ ] => is_var x; destruct x
+                                    | [ |- match ?x with _ => _ end _ -> _ ] => is_var x; destruct x
+                                    | [ |- False -> _ ] => intro; exfalso; assumption
+                                    | [ |- _ = _ -> _ ] => intro; subst
+                                    | [ H : existT _ _ ?idc = existT _ _ ?idc' |- _ ]
+                                      => is_var idc; destruct idc; try discriminate; []
+                                    end
+                                  | cbv; match goal with
+                                         | [ |- ?ev = ?x ]
+                                           => is_evar ev; tryif has_evar x then fail else reflexivity
+                                         end ]);
+                  try first [ exact Datatypes.None
+                            | exact Datatypes.false
+                            | cbv; intro; inversion_option; subst; solve [ reflexivity | exfalso; now apply diff_false_true ] ])
+            : { invertIdent : _
+                              & @invert_expr.BuildInvertIdentCorrectT _ base_interp _ invertIdent buildIdent }).
+  Ltac make_invertIdentAndCorrect base_type base_interp buildIdent reflect_base_beq :=
+    let res := build_invertIdentAndCorrect base_type base_interp buildIdent reflect_base_beq in refine res.
+
+  Ltac make_invertIdent invertIdentAndCorrect :=
+    let res := (eval cbv in (projT1 invertIdentAndCorrect)) in refine res.
+  Ltac build_invertIdent base_interp ident invertIdentAndCorrect :=
+    constr:(ltac:(make_invertIdent invertIdentAndCorrect)
+            : @invert_expr.InvertIdentT _ base_interp ident).
+
+  Ltac make_buildInvertIdentCorrect invertIdentAndCorrect :=
+    refine (projT2 invertIdentAndCorrect).
+  Ltac build_buildInvertIdentCorrect base_interp invertIdent buildIdent invertIdentAndCorrect :=
+    constr:(ltac:(make_buildInvertIdentCorrect invertIdentAndCorrect)
+            : @invert_expr.BuildInvertIdentCorrectT _ base_interp _ invertIdent buildIdent).
+
+  Ltac inhabit := (constructor; fail) + (constructor; inhabit).
+  Ltac build_base_default base_interp :=
+    constr:(ltac:(let t := fresh "t" in
+                  intro t; destruct t; hnf; inhabit)
+            : @DefaultValue.type.base.DefaultT _ base_interp).
+  Ltac make_base_default base_interp := let res := build_base_default base_interp in refine res.
+
+  Ltac make_exprInfoAndExprExtraInfo base ident base_interp ident_gen_interp base_default reflect_base_interp_eq try_make_base_transport_cps_correct toFromRestrictedIdent buildInvertIdentCorrect buildInterpIdentCorrect buildInterpEagerIdentCorrect ident_gen_interp_Proper :=
+    (exists {|
+          Classes.base := base;
+          Classes.ident := ident;
+          Classes.base_interp := base_interp;
+          Classes.ident_gen_interp := ident_gen_interp
+        |});
+    econstructor;
+    first [ exact base_default
+          | exact (@reflect_base_interp_eq)
+          | exact try_make_base_transport_cps_correct
+          | exact toFromRestrictedIdent
+          | exact buildInvertIdentCorrect
+          | exact (@buildInterpIdentCorrect)
+          | exact (@buildInterpEagerIdentCorrect)
+          | exact (@ident_gen_interp_Proper) ].
+  Ltac build_exprInfoAndExprExtraInfo base ident base_interp ident_gen_interp base_default reflect_base_interp_eq try_make_base_transport_cps_correct toFromRestrictedIdent buildInvertIdentCorrect buildInterpIdentCorrect buildInterpEagerIdentCorrect ident_gen_interp_Proper :=
+    let res := make_exprInfoAndExprExtraInfo base ident base_interp ident_gen_interp base_default reflect_base_interp_eq try_make_base_transport_cps_correct toFromRestrictedIdent buildInvertIdentCorrect buildInterpIdentCorrect buildInterpEagerIdentCorrect ident_gen_interp_Proper in refine res.
+
+  Ltac base_type_reified_hint base_type reify_type :=
+    lazymatch goal with
+    | [ |- @type.reified_of base_type _ ?T ?e ]
+      => solve [ let rT := reify_type T in unify e rT; reflexivity | idtac "ERROR: Failed to reify" T ]
+    end.
+
+  Ltac expr_reified_hint base_type ident reify_base_type reify_ident :=
+    lazymatch goal with
+    | [ |- @expr.Reified_of _ ident _ _ ?t ?v ?e ]
+      => solve [ let rv := expr.Reify constr:(base_type) ident ltac:(reify_base_type) ltac:(reify_ident) v in unify e rv; reflexivity | idtac "ERROR: Failed to reify" v "(of type" t "); try setting Reify.debug_level to see output" ]
+    end.
+
+
+  Definition var_like_idents : GallinaIdentList.t
+    := [@ident.literal
+        ; @Datatypes.nil
+        ; @Datatypes.cons
+        ; @Datatypes.pair
+        ; @Datatypes.fst
+        ; @Datatypes.snd
+        ; Z.opp
+        ; ident.cast
+        ; ident.cast2
+        ; Z.combine_at_bitwidth]%gi_list.
+
+  Definition base_type_list : TypeList.t
+    := [BinInt.Z; Datatypes.bool; Datatypes.nat; ZRange.zrange]%type_list.
+
+  Inductive base := Z | bool | nat | zrange. (* Not Variant because COQBUG(https://github.com/coq/coq/issues/7738) *)
+
+  Definition index_of_base : base -> Datatypes.nat
+    := ltac:(make_index_of_base base).
+
+  Local Notation base_type := (@base.type base).
+
+  Definition eta_base_cps_gen := ltac:(make_eta_base_cps_gen base).
+
+  Definition eta_base_cps : forall {P : base -> Type} (f : forall t, P t), forall t, P t
+    := ltac:(make_eta_base_cps eta_base_cps_gen).
+
+  Definition base_interp := ltac:(make_base_interp (@eta_base_cps) base_type_list index_of_base).
+
+  Local Notation base_type_interp := (base.interp base_interp).
 
   Ltac reify_base ty :=
     let __ := Reify.debug_enter_reify_base_type ty in
@@ -120,9 +479,6 @@ Module Compilers.
   Ltac reify_base_type ty := Language.Compilers.base.reify base reify_base ty.
   Ltac reify_type ty := Language.Compilers.type.reify reify_base_type constr:(base_type) ty.
 
-  Global Hint Extern 1 (@type.reified_of base_type _ ?T ?e)
-  => (solve [ let rT := reify_type T in unify e rT; reflexivity | idtac "ERROR: Failed to reify" T ])
-     : typeclass_instances.
   Bind Scope etype_scope with base.
 
   Section ident.
@@ -356,43 +712,6 @@ Module Compilers.
     End with_base.
   End ident.
 
-  Global Instance buildEagerIdent : ident.BuildEagerIdentT ident
-    := {
-        ident_nat_rect := @ident_nat_rect
-        ; ident_nat_rect_arrow := @ident_nat_rect_arrow
-        ; ident_list_rect := @ident_list_rect
-        ; ident_list_rect_arrow := @ident_list_rect_arrow
-        ; ident_List_nth_default := @ident_List_nth_default
-        ; ident_eager_nat_rect := @ident_eager_nat_rect
-        ; ident_eager_nat_rect_arrow := @ident_eager_nat_rect_arrow
-        ; ident_eager_list_rect := @ident_eager_list_rect
-        ; ident_eager_list_rect_arrow := @ident_eager_list_rect_arrow
-        ; ident_eager_List_nth_default := @ident_eager_List_nth_default
-      }.
-
-  Global Instance buildInterpEagerIdentCorrect
-         {cast_outside_of_range}
-    : ident.BuildInterpEagerIdentCorrectT (@ident_gen_interp cast_outside_of_range).
-  Proof. split; cbn; reflexivity. Defined.
-
-  Definition toRestrictedIdentAndCorrect
-    : { toRestrictedIdent : ident.ToRestrictedIdentT ident
-                            & ident.ToFromRestrictedIdentT ident }.
-  Proof.
-    unshelve eexists; hnf; [ | split ]; cbv;
-      let idc := fresh "idc" in
-      intros ? idc; destruct idc;
-        try (((instantiate (1 := Datatypes.None) + idtac); reflexivity)).
-  Defined.
-
-  Definition fromRestrictedIdent : ident.ToRestrictedIdentT ident
-    := Eval hnf in projT1 toRestrictedIdentAndCorrect.
-  Global Existing Instance fromRestrictedIdent.
-
-  Definition toFromRestrictedIdent : ident.ToFromRestrictedIdentT ident
-    := Eval hnf in projT2 toRestrictedIdentAndCorrect.
-  Global Existing Instance toFromRestrictedIdent.
-
   (** Interpret identifiers where [Z_cast] is an opaque identity
         function when the value is not inside the range *)
   Notation ident_interp := (@ident_gen_interp ident.cast_outside_of_range).
@@ -412,8 +731,6 @@ Module Compilers.
     | xI ?p => require_primitive_const p
     | xO ?p => require_primitive_const p
     | xH => idtac
-    | Datatypes.Some ?x => require_primitive_const x
-    | Datatypes.None => idtac
     | ZRange.Build_zrange ?x ?y
       => require_primitive_const x; require_primitive_const y
     | ident.literal ?x => idtac
@@ -708,6 +1025,7 @@ Module Compilers.
       | Z.rshi => then_tac ident_Z_rshi
       | Z.cc_m => then_tac ident_Z_cc_m
       | Z.combine_at_bitwidth => then_tac ident_Z_combine_at_bitwidth
+      | Datatypes.tt => then_tac ident_tt
       | ident.cast _ ?r => then_tac (ident_Z_cast r)
       | ident.cast2 _ ?r => then_tac (ident_Z_cast2 r)
       | @Some ?A
@@ -736,116 +1054,79 @@ Module Compilers.
       end
     end.
 
-  Global Instance buildIdent : @ident.BuildIdentT base base_interp ident | 5
-    := { ident_Literal := @ident_Literal
-         ; ident_nil := @ident_nil
-         ; ident_cons := @ident_cons
-         ; ident_Some := @ident_Some
-         ; ident_None := @ident_None
-         ; ident_pair := @ident_pair
-         ; ident_tt := @ident_tt
-       }.
+  Definition base_eq_dec := ltac:(make_base_eq_dec base).
 
-  Definition ident_is_var_like {t} (idc : ident t) : Datatypes.bool
-    := match idc with
-       | ident_Literal _ _
-       | ident_nil _
-       | ident_cons _
-       | ident_pair _ _
-       | ident_fst _ _
-       | ident_snd _ _
-       | ident_Z_opp
-       | ident_Z_cast _
-       | ident_Z_cast2 _
-       | ident_Z_combine_at_bitwidth
-         => Datatypes.true
-       | _ => Datatypes.false
-       end.
+  Definition base_beq_and_reflect := ltac:(make_base_beq_and_reflect base).
+  Definition base_beq := ltac:(make_base_beq base_beq_and_reflect).
+  Definition reflect_base_beq : reflect_rel (@eq base) base_beq := ltac:(make_reflect_base_beq base_beq_and_reflect).
 
-  Global Instance buildInterpIdentCorrect {cast_outside_of_range}
-    : @ident.BuildInterpIdentCorrectT base base_interp ident _ (@ident_gen_interp cast_outside_of_range).
-  Proof. constructor; cbn; reflexivity. Qed.
+  Definition baseHasNatAndCorrect := ltac:(make_baseHasNatAndCorrect base_interp).
+  Definition baseHasNat : base.type.BaseTypeHasNatT base := ltac:(make_baseHasNat baseHasNatAndCorrect).
+  Definition baseHasNatCorrect : base.BaseHasNatCorrectT base_interp := ltac:(make_baseHasNatCorrect baseHasNatAndCorrect).
+
+  Definition base_interp_beq : forall {t}, base_interp t -> base_interp t -> Datatypes.bool
+    := ltac:(make_base_interp_beq base_interp).
+
+  Definition reflect_base_interp_eq : forall {t}, reflect_rel (@eq (base_interp t)) (@base_interp_beq t)
+    := ltac:(make_reflect_base_interp_eq base_interp (@base_interp_beq)).
+
+  Definition try_make_base_transport_cps : @type.try_make_transport_cpsT base
+    := ltac:(make_try_make_base_transport_cps base_eq_dec (@eta_base_cps)).
+
+  Definition try_make_base_transport_cps_correct : @type.try_make_transport_cps_correctT base base_beq try_make_base_transport_cps reflect_base_beq
+    := ltac:(make_try_make_base_transport_cps_correct try_make_base_transport_cps reflect_base_beq).
+
+  Definition buildEagerIdentAndInterpCorrect := ltac:(make_buildEagerIdentAndInterpCorrect (@ident_gen_interp) baseHasNat baseHasNatCorrect ltac:(reify_ident)).
+
+  Definition buildEagerIdent : ident.BuildEagerIdentT ident
+    := ltac:(make_buildEagerIdent buildEagerIdentAndInterpCorrect).
+  Definition buildInterpEagerIdentCorrect : forall cast_outside_of_range, @ident.BuildInterpEagerIdentCorrectT _ _ _ (@ident_gen_interp cast_outside_of_range) _ buildEagerIdent baseHasNatCorrect
+    := ltac:(make_buildInterpEagerIdentCorrect buildEagerIdentAndInterpCorrect).
+
+  Definition toRestrictedIdentAndCorrect := ltac:(make_toRestrictedIdentAndCorrect baseHasNat buildEagerIdent).
+  Definition toRestrictedIdent : @ident.ToRestrictedIdentT _ ident baseHasNat
+    := ltac:(make_toRestrictedIdent toRestrictedIdentAndCorrect).
+  Definition toFromRestrictedIdent : @ident.ToFromRestrictedIdentT _ ident baseHasNat buildEagerIdent toRestrictedIdent
+    := ltac:(make_toFromRestrictedIdent toRestrictedIdentAndCorrect).
 
 
-  Global Instance gen_eqv_Reflexive_Proper cast_outside_of_range {t} (idc : ident t) : Proper type.eqv (ident_gen_interp cast_outside_of_range idc) | 1.
-  Proof.
-    destruct idc; cbn [type.eqv ident_gen_interp type.interp base.interp base_interp];
-      try solve [ typeclasses eauto
-                | cbv [respectful]; repeat intro; subst; destruct_head_hnf Datatypes.bool; destruct_head_hnf Datatypes.prod; destruct_head_hnf Datatypes.option; destruct_head_hnf ZRange.zrange; eauto
-                | cbv [respectful]; repeat intro; (apply nat_rect_Proper_nondep || apply list_rect_Proper || apply list_case_Proper || apply list_rect_arrow_Proper); repeat intro; eauto ].
-  Qed.
+  Definition buildIdentAndInterpCorrect
+    := ltac:(make_buildIdentAndInterpCorrect ident_gen_interp ltac:(reify_ident)).
+  Definition buildIdent : @ident.BuildIdentT base base_interp ident
+    := ltac:(make_buildIdent buildIdentAndInterpCorrect).
+  Definition buildInterpIdentCorrect
+    : forall {cast_outside_of_range}, @ident.BuildInterpIdentCorrectT base base_interp ident buildIdent (@ident_gen_interp cast_outside_of_range)
+    := ltac:(make_buildInterpIdentCorrect buildIdentAndInterpCorrect).
 
-  Global Instance eqv_Reflexive_Proper {t} (idc : ident t) : Proper type.eqv (ident_interp idc) | 1.
-  Proof. exact _. Qed.
+  Definition ident_is_var_like : forall {t} (idc : ident t), Datatypes.bool
+    := ltac:(make_ident_is_var_like ident (@ident_interp) var_like_idents).
 
-  Global Instance ident_gen_interp_Proper {cast_outside_of_range} {t} : Proper (@eq (ident t) ==> type.eqv) (ident_gen_interp cast_outside_of_range) | 1.
-  Proof. intros idc idc' ?; subst idc'; apply gen_eqv_Reflexive_Proper. Qed.
+  Definition gen_eqv_Reflexive_Proper : forall cast_outside_of_range {t} (idc : ident t), Proper type.eqv (@ident_gen_interp cast_outside_of_range t idc)
+    := ltac:(make_gen_eqv_Reflexive_Proper ident_gen_interp base_interp).
 
-  Global Instance ident_interp_Proper {t} : Proper (@eq (ident t) ==> type.eqv) ident_interp | 1.
-  Proof. exact _. Qed.
+  Definition eqv_Reflexive_Proper : forall {t} (idc : ident t), Proper type.eqv (ident_interp idc)
+    := ltac:(make_eqv_Reflexive_Proper gen_eqv_Reflexive_Proper).
+
+  Definition ident_gen_interp_Proper : forall {cast_outside_of_range} {t}, Proper (@eq (ident t) ==> type.eqv) (ident_gen_interp cast_outside_of_range)
+    := ltac:(make_ident_gen_interp_Proper gen_eqv_Reflexive_Proper).
+
+  Definition ident_interp_Proper : forall {t}, Proper (eq ==> type.eqv) (@ident_interp t)
+    := ltac:(make_ident_interp_Proper (@ident_gen_interp_Proper)).
+
+  Definition invertIdentAndCorrect := ltac:(make_invertIdentAndCorrect (@base_type) base_interp buildIdent reflect_base_beq).
+  Definition invertIdent : @invert_expr.InvertIdentT base base_interp ident
+    := ltac:(make_invertIdent invertIdentAndCorrect).
+  Definition buildInvertIdentCorrect : @invert_expr.BuildInvertIdentCorrectT base base_interp ident invertIdent buildIdent
+    := ltac:(make_buildInvertIdentCorrect invertIdentAndCorrect).
+
+  Definition base_default : @DefaultValue.type.base.DefaultT base base_interp
+    := ltac:(make_base_default base_interp).
+
+  Definition exprInfoAndExprExtraInfo : GoalType.package
+    := ltac:(make_exprInfoAndExprExtraInfo base ident base_interp ident_gen_interp base_default (@reflect_base_interp_eq) try_make_base_transport_cps_correct toFromRestrictedIdent buildInvertIdentCorrect (@buildInterpIdentCorrect) buildInterpEagerIdentCorrect (@ident_gen_interp_Proper)).
 
   Global Strategy -1000 [base_interp ident_gen_interp].
 
-  Definition invert_ident_Literal {t} (idc : ident t) : option (type.interp base_type_interp t)
-    := match idc with
-       | ident_Literal _ n => Datatypes.Some n
-       | _ => Datatypes.None
-       end.
-
-  Global Instance invertIdent : @invert_expr.InvertIdentT base base_interp ident
-    := {
-        invert_ident_Literal := @invert_ident_Literal
-        ; is_nil t idc := match idc with ident_nil _ => Datatypes.true | _ => Datatypes.false end
-        ; is_cons t idc := match idc with ident_cons _ => Datatypes.true | _ => Datatypes.false end
-        ; is_Some t idc := match idc with ident_Some _ => Datatypes.true | _ => Datatypes.false end
-        ; is_None t idc := match idc with ident_None _ => Datatypes.true | _ => Datatypes.false end
-        ; is_pair t idc := match idc with ident_pair _ _ => Datatypes.true | _ => Datatypes.false end
-        ; is_tt t idc := match idc with ident_tt => Datatypes.true | _ => Datatypes.false end
-      }.
-
-  Global Instance buildInvertIdentCorrect : @invert_expr.BuildInvertIdentCorrectT base base_interp ident _ _.
-  Proof.
-    constructor; intros t idc; destruct idc;
-      repeat first [ progress intros
-                   | progress cbn in *
-                   | apply conj
-                   | progress destruct_head'_False
-                   | progress inversion_option
-                   | discriminate
-                   | progress subst
-                   | reflexivity
-                   | break_innermost_match_hyps_step
-                   | match goal with
-                     | [ H : _ = _ :> ident _ |- _ ] => inversion H; clear H
-                     end ].
-  Qed.
-
-  Local Ltac inhabit := (constructor; fail) + (constructor; inhabit).
-  Local Ltac build_base_default base base_interp :=
-    constr:(ltac:(let t := fresh "t" in
-                  intro t; destruct t; hnf; inhabit)
-            : @DefaultValue.type.base.DefaultT base base_interp).
-  Local Ltac make_base_default base base_interp := let res := build_base_default base base_interp in refine res.
-  Global Instance base_default : @DefaultValue.type.base.DefaultT base base_interp
-    := ltac:(make_base_default base base_interp).
-
-  Module expr.
-    Global Hint Extern 1 (@expr.Reified_of _ ident _ _ ?t ?v ?e)
-    => solve [ let rv := expr.Reify constr:(base_type) ident ltac:(reify_base_type) ltac:(reify_ident) v in unify e rv; reflexivity | idtac "ERROR: Failed to reify" v "(of type" t "); try setting Reify.debug_level to see output" ]
-       : typeclass_instances.
-  End expr.
-
-  Import Language.Compilers.Classes.
-  Global Instance exprInfo : ExprInfoT :=
-    {
-      base := Compilers.base;
-      ident := Compilers.ident;
-      base_interp := Compilers.base_interp;
-      ident_gen_interp := Compilers.ident_gen_interp
-    }.
-
-  Definition exprExtraInfo : ExprExtraInfoT.
-  Proof.
-    econstructor; typeclasses eauto.
-  Defined.
+  Global Hint Extern 1 => base_type_reified_hint (@base_type) ltac:(reify_type) : typeclass_instances.
+  Global Hint Extern 1 => expr_reified_hint (@base_type) ident ltac:(reify_base_type) ltac:(reify_ident) : typeclass_instances.
 End Compilers.

--- a/src/Language/IdentifiersGENERATED.v
+++ b/src/Language/IdentifiersGENERATED.v
@@ -238,7 +238,7 @@ Module Compilers.
       .
 
       Definition package : @GoalType.package Compilers.base Compilers.ident.
-      Proof. Time Tactic.make_package Compilers.exprInfo Compilers.exprExtraInfo Compilers.ident Raw.ident.ident ident.ident. Defined.
+      Proof. Time Tactic.make_package Compilers.exprInfoAndExprExtraInfo Raw.ident.ident ident.ident. Defined.
     End ident.
   End pattern.
 End Compilers.

--- a/src/Language/IdentifiersGENERATEDProofs.v
+++ b/src/Language/IdentifiersGENERATEDProofs.v
@@ -32,7 +32,7 @@ Module Compilers.
       Import ProofTactic.Settings.
 
       Definition package_proofs : @ProofGoalType.package_proofs _ _ package.
-      Proof. ProofTactic.prove_package_proofs (). Qed.
+      Proof. ProofTactic.prove_package_proofs Identifier.Compilers.exprInfoAndExprExtraInfo. Qed.
     End ident.
   End pattern.
 End Compilers.

--- a/src/Language/Pre.v
+++ b/src/Language/Pre.v
@@ -139,3 +139,36 @@ Scheme Minimality for prod Sort Type.
 Scheme Minimality for nat Sort Type.
 Scheme Minimality for list Sort Type.
 Scheme Minimality for option Sort Type.
+
+Module GallinaIdentList.
+  Polymorphic Inductive t := nil | cons {T : Type} (v : T) (vs : t).
+  Module Export Notations.
+    Delimit Scope gallina_ident_list_scope with gi_list.
+    Bind Scope gallina_ident_list_scope with t.
+    Notation "[ ]" := nil (format "[ ]") : gallina_ident_list_scope.
+    Notation "[ x ]" := (cons x nil) : gallina_ident_list_scope.
+    Notation "[ x ; y ; .. ; z ]" :=  (cons x (cons y .. (cons z nil) ..)) : gallina_ident_list_scope.
+  End Notations.
+End GallinaIdentList.
+Export GallinaIdentList.Notations.
+
+Module TypeList.
+  Local Set Universe Polymorphism.
+  Inductive t := nil | cons (T : Type) (vs : t).
+
+  Fixpoint nth (n : nat) (l : t) (default : Type) {struct l} :=
+    match n, l with
+    | O, cons x _ => x
+    | S m, cons _ l => nth m l default
+    | _, _ => default
+    end.
+
+  Module Export Notations.
+    Delimit Scope type_list_scope with type_list.
+    Bind Scope type_list_scope with t.
+    Notation "[ ]" := nil (format "[ ]") : type_list_scope.
+    Notation "[ x ]" := (cons x nil) : type_list_scope.
+    Notation "[ x ; y ; .. ; z ]" :=  (cons x (cons y .. (cons z nil) ..)) : type_list_scope.
+  End Notations.
+End TypeList.
+Export TypeList.Notations.


### PR DESCRIPTION
This results in minor churn in API.v and Fancy/Compiler.v.

Timing diff coming soon.

Next up will probably be removing `cast_out_of_range`, then seeing if I can do reification in a less hand-written way, and then packaging up the tactics for identifiers separately from running them.  After that, I'll probably move all of the identifier inductives to a single file, and then each of the other GENERATED files will just be a single definition with a single tactic call (except I guess there will still be a couple of `Hint Extern`s in the `Identifier` one).  After that is the code to scrape identifiers from a list of rewrite lemmas, and then finally writing the OCaml code.