### PR TITLE
Remove cast_outside_of_range

### DIFF
--- a/src/AbstractInterpretation/ZRangeProofs.v
+++ b/src/AbstractInterpretation/ZRangeProofs.v
@@ -68,16 +68,14 @@ Module Compilers.
       Module option.
         (** First we prove relatedness for some particularly complicated identifiers separately *)
         Section interp_related.
-          Context (cast_outside_of_range : zrange -> Z -> Z).
-
           Local Notation interp_is_related idc
             := (type.related_hetero
                   (fun t st v => ZRange.type.base.option.is_bounded_by st v = true)
                   (ZRange.ident.option.interp idc)
-                  (ident.gen_interp cast_outside_of_range idc)).
+                  (ident.interp idc)).
 
           Local Ltac z_cast_t :=
-            cbn [type.related_hetero ZRange.ident.option.interp ident.interp ident.gen_interp respectful_hetero type.interp ZRange.type.base.option.interp ZRange.type.base.interp base.interp base.base_interp ZRange.type.base.option.Some];
+            cbn [type.related_hetero ZRange.ident.option.interp ident.interp respectful_hetero type.interp ZRange.type.base.option.interp ZRange.type.base.interp base.interp base.base_interp ZRange.type.base.option.Some];
             cbv [ZRange.ident.option.interp_Z_cast ZRange.type.base.option.is_bounded_by ZRange.type.base.is_bounded_by respectful_hetero];
             cbn [base.interp_beq base.base_interp_beq] in *;
             cbv [ident.cast2] in *; cbn [fst snd] in *;
@@ -501,9 +499,8 @@ Module Compilers.
           Local Lemma interp_related_fancy_rshi :
             interp_is_related ident.fancy_rshi.
           Proof.
-            cbn [type.related_hetero ZRange.ident.option.interp ident.interp ident.gen_interp respectful_hetero type.interp ZRange.type.base.option.interp ZRange.type.base.interp base.interp base.base_interp ZRange.type.base.option.Some ZRange.ident.option.of_literal].
+            cbn [type.related_hetero ZRange.ident.option.interp ident.interp respectful_hetero type.interp ZRange.type.base.option.interp ZRange.type.base.interp base.interp base.base_interp ZRange.type.base.option.Some ZRange.ident.option.of_literal].
             cbv [respectful_hetero option_map list_case].
-            clear cast_outside_of_range.
             intros.
             destruct_head_hnf' prod.
             handle_to_literal;
@@ -538,7 +535,7 @@ Module Compilers.
                  | [ |- context[ident.fancy_rshi] ] => apply interp_related_fancy_rshi
                  | _ => idtac
                  end.
-            all: cbn [type.related_hetero ZRange.ident.option.interp ident.interp ident.gen_interp respectful_hetero type.interp ZRange.type.base.option.interp ZRange.type.base.interp base.interp base.base_interp ZRange.type.base.option.Some ZRange.ident.option.of_literal].
+            all: cbn [type.related_hetero ZRange.ident.option.interp ident.interp respectful_hetero type.interp ZRange.type.base.option.interp ZRange.type.base.interp base.interp base.base_interp ZRange.type.base.option.Some ZRange.ident.option.of_literal].
             all: cbv [ident.cast2 ident.literal prod_rect_nodep ident.eagerly] in *.
             all: change (@zrange_rect_nodep) with (fun T => @zrange_rect (fun _ => T)) in *.
             all: change (@ident.Thunked.nat_rect) with (fun P P0 => @nat_rect (fun _ => P) (P0 Datatypes.tt)) in *.
@@ -585,7 +582,6 @@ Module Compilers.
                                 end
                               | progress Z.ltb_to_lt
                               | progress rewrite ?Z.mul_split_div, ?Z.mul_split_mod, ?Z.add_get_carry_full_div, ?Z.add_get_carry_full_mod, ?Z.add_with_get_carry_full_div, ?Z.add_with_get_carry_full_mod, ?Z.sub_get_borrow_full_div, ?Z.sub_get_borrow_full_mod, ?Z.sub_with_get_borrow_full_div, ?Z.sub_with_get_borrow_full_mod, ?Z.zselect_correct, ?Z.add_modulo_correct, ?Z.rshi_correct_full, ?Z.truncating_shiftl_correct_land_ones ].
-            all: clear cast_outside_of_range.
             all: repeat lazymatch goal with
                         | [ |- is_bounded_by_bool (Z.land _ _) (ZRange.land_bounds _ _) = true ]
                           => apply ZRange.is_bounded_by_bool_land_bounds; auto

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -476,7 +476,7 @@ Module Pipeline.
 
   Local Ltac wf_interp_t :=
     repeat first [ progress destruct_head'_and
-                 | progress cbv [Classes.ident_gen_interp Classes.base Classes.ident Classes.ident_interp Classes.base_interp Classes.exprInfo] in *
+                 | progress cbv [Classes.base Classes.ident Classes.ident_interp Classes.base_interp Classes.exprInfo] in *
                  | progress autorewrite with interp
                  | solve [ eauto with nocore interp_extra wf_extra ]
                  | solve [ typeclasses eauto ]
@@ -503,13 +503,13 @@ Module Pipeline.
 
   Global Hint Resolve @Wf_RewriteAndEliminateDeadAndInline : wf wf_extra.
 
-  Lemma Interp_RewriteAndEliminateDeadAndInline {cast_outside_of_range} {t} DoRewrite with_dead_code_elimination with_subst01
-        (Interp_DoRewrite : forall E, Wf E -> expr.gen_Interp cast_outside_of_range (DoRewrite E) == expr.gen_Interp cast_outside_of_range E)
+  Lemma Interp_RewriteAndEliminateDeadAndInline {t} DoRewrite with_dead_code_elimination with_subst01
+        (Interp_DoRewrite : forall E, Wf E -> Interp (DoRewrite E) == Interp E)
         (Wf_DoRewrite : forall E, Wf E -> Wf (DoRewrite E))
         E
         (Hwf : Wf E)
-    : expr.gen_Interp cast_outside_of_range (@RewriteAndEliminateDeadAndInline t DoRewrite with_dead_code_elimination with_subst01 E)
-      == expr.gen_Interp cast_outside_of_range E.
+    : Interp (@RewriteAndEliminateDeadAndInline t DoRewrite with_dead_code_elimination with_subst01 E)
+      == Interp E.
   Proof.
     cbv [RewriteAndEliminateDeadAndInline Let_In];
       repeat (wf_interp_t || rewrite !Interp_DoRewrite).
@@ -549,8 +549,7 @@ Module Pipeline.
               (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
               (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) arg_bounds arg1 = true),
           ZRange.type.base.option.is_bounded_by out_bounds (type.app_curried (Interp rv) arg1) = true
-          /\ forall cast_outside_of_range, type.app_curried (expr.gen_Interp cast_outside_of_range rv) arg1
-                                           = type.app_curried (Interp e) arg2)
+          /\ type.app_curried (Interp rv) arg1 = type.app_curried (Interp e) arg2)
       /\ Wf rv.
   Proof.
     assert (Hbounds_Proper : bounds_goodT arg_bounds) by (apply type.and_eqv_for_each_lhs_of_arrow_not_higher_order, type_good).
@@ -605,8 +604,7 @@ Module Pipeline.
                (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
                (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) arg_bounds arg1 = true),
            ZRange.type.base.option.is_bounded_by out_bounds (type.app_curried (Interp rv) arg1) = true
-           /\ forall cast_outside_of_range, type.app_curried (expr.gen_Interp cast_outside_of_range rv) arg1
-                                            = type.app_curried InterpE arg2)
+           /\ type.app_curried (Interp rv) arg1 = type.app_curried InterpE arg2)
        /\ Wf rv.
 
   Lemma BoundsPipeline_correct_trans

--- a/src/CastLemmas.v
+++ b/src/CastLemmas.v
@@ -37,9 +37,7 @@ Import EqNotations.
 Module ident.
   Local Transparent ident.cast.
   Section with_cast.
-    Context {cast_outside_of_range : zrange -> Z -> Z}.
-
-    Local Notation cast := (@ident.cast cast_outside_of_range).
+    Local Notation cast := ident.cast (only parsing).
 
     Lemma cast_opp' r v : (-cast (-r) (-v) = cast r v)%Z.
     Proof.
@@ -131,82 +129,6 @@ Module ident.
       edestruct is_bounded_by_bool; tauto.
     Qed.
 
-    (*
-    Lemma cast_out_of_bounds_in_range_pos r v
-      : ident.is_more_pos_than_neg (ZRange.normalize r) v = true
-        -> is_bounded_by_bool v (ZRange.normalize r) = false
-        -> is_bounded_by_bool (cast_outside_of_range (ZRange.normalize r) v) (ZRange.normalize r) = true
-        -> cast r v = cast_outside_of_range (ZRange.normalize r) v.
-    Proof.
-      cbv [cast is_bounded_by_bool]; break_innermost_match; try congruence; intros.
-      pose proof (ZRange.goodb_normalize r); cbv [ZRange.goodb] in *.
-      split_andb; Z.ltb_to_lt; try lia.
-      match goal with
-      | [ |- context[(?a mod ?b)%Z] ]
-        => cut ((a / b) = 0)%Z
-      end.
-      all: Z.div_mod_to_quot_rem; nia.
-    Qed.
-     *)
-
-    (*
-    Lemma cast_out_of_bounds_in_range_neg r v
-      : ident.is_more_pos_than_neg (ZRange.normalize r) v = false
-        -> is_bounded_by_bool v (ZRange.normalize r) = false
-        -> is_bounded_by_bool (-cast_outside_of_range (-ZRange.normalize r) (-v)) (ZRange.normalize r) = true
-        -> cast r v = (-cast_outside_of_range (-ZRange.normalize r) (-v))%Z.
-    Proof.
-      cbv [cast is_bounded_by_bool]; break_innermost_match; try congruence; intros.
-      pose proof (ZRange.goodb_normalize r); cbv [ZRange.goodb] in *.
-      split_andb; Z.ltb_to_lt; try lia.
-      repeat change (lower (-?r)) with (-upper r)%Z.
-      repeat change (upper (-?r)) with (-lower r)%Z.
-      match goal with
-      | [ |- context[(?a mod ?b)%Z] ]
-        => cut ((a / b) = 0)%Z
-      end.
-      all: Z.div_mod_to_quot_rem; nia.
-    Qed.
-     *)
-
-    (*
-    Lemma cast_out_of_bounds_in_range r v
-      : is_bounded_by_bool v (ZRange.normalize r) = false
-        -> (ident.is_more_pos_than_neg (ZRange.normalize r) v = true -> is_bounded_by_bool (cast_outside_of_range (ZRange.normalize r) v) (ZRange.normalize r) = true)
-        -> (ident.is_more_pos_than_neg (ZRange.normalize r) v = false -> is_bounded_by_bool (-cast_outside_of_range (-ZRange.normalize r) (-v)) (ZRange.normalize r) = true)
-        -> cast r v = if ident.is_more_pos_than_neg (ZRange.normalize r) v
-                      then cast_outside_of_range (ZRange.normalize r) v
-                      else (-cast_outside_of_range (-ZRange.normalize r) (-v))%Z.
-    Proof.
-      pose proof (cast_out_of_bounds_in_range_pos r v).
-      pose proof (cast_out_of_bounds_in_range_neg r v).
-      break_innermost_match; intros; auto.
-    Qed.
-     *)
-
-    (*
-    Lemma cast_out_of_bounds_simple r v
-      : (is_bounded_by_bool v (ZRange.normalize r) = true -> cast_outside_of_range (ZRange.normalize r) v = v)
-        -> (ident.is_more_pos_than_neg (ZRange.normalize r) v = false -> (is_bounded_by_bool (-v) (-ZRange.normalize r))%Z = true -> (-cast_outside_of_range (-ZRange.normalize r) (-v) = v)%Z)
-        -> (ident.is_more_pos_than_neg (ZRange.normalize r) v = true -> is_bounded_by_bool (cast_outside_of_range (ZRange.normalize r) v) (ZRange.normalize r) = true)
-        -> (ident.is_more_pos_than_neg (ZRange.normalize r) v = false -> is_bounded_by_bool (-cast_outside_of_range (-ZRange.normalize r) (-v)) (ZRange.normalize r) = true)
-        -> cast r v = if ident.is_more_pos_than_neg (ZRange.normalize r) v
-                      then cast_outside_of_range (ZRange.normalize r) v
-                      else (-cast_outside_of_range (-ZRange.normalize r) (-v))%Z.
-    Proof.
-      pose proof (cast_out_of_bounds_in_range r v).
-      assert (is_bounded_by_bool (-v) (-ZRange.normalize r) = is_bounded_by_bool v (ZRange.normalize r)).
-      { cbv [is_bounded_by_bool].
-        repeat change (lower (-?r)) with (-upper r)%Z.
-        repeat change (upper (-?r)) with (-lower r)%Z.
-        cbv [andb]; break_innermost_match; Z.ltb_to_lt; break_match; Z.ltb_to_lt; try lia; try reflexivity.
-        symmetry; Z.ltb_to_lt; lia. }
-      destruct (is_bounded_by_bool v (ZRange.normalize r)) eqn:?.
-      { rewrite cast_in_normalized_bounds by assumption; intros; symmetry; break_innermost_match; auto. }
-      { auto. }
-    Qed.
-     *)
-
     Lemma is_more_pos_then_neg_0_u u v
       : (0 <= u)%Z
         -> ident.is_more_pos_than_neg (ZRange.normalize r[0~>u]) v = true.
@@ -220,28 +142,9 @@ Module ident.
       cbv [andb orb]; break_innermost_match; Z.ltb_to_lt; try lia; reflexivity.
     Qed.
 
-    (*
-    Lemma cast_out_of_bounds_simple_0 u v
-      : (0 <= u)%Z
-        -> ((0 <= v <= u)%Z -> cast_outside_of_range r[0~>u] v = v)
-        -> (0 <= cast_outside_of_range r[0~>u] v <= u)%Z
-        -> cast r[0~>u] v = cast_outside_of_range r[0~>u] v.
-    Proof.
-      pose proof (cast_out_of_bounds_simple r[0~>u] v) as H.
-      intro H0.
-      pose proof (is_more_pos_then_neg_0_u u v H0) as H1.
-      rewrite H1 in *.
-      rewrite (proj1 ZRange.normalize_id_iff_goodb) in H
-        by (cbv [ZRange.goodb lower upper]; Z.ltb_to_lt; assumption).
-      cbv [is_bounded_by_bool ZRange.opp] in *; cbn [lower upper] in *; rewrite ?Bool.andb_true_iff, ?Z.leb_le in *.
-      intros; apply H; intros; destruct_head'_and; repeat apply conj; Z.ltb_to_lt; auto; try congruence.
-    Qed.
-     *)
-    (*
     Lemma cast_out_of_bounds_simple_0_mod u v
       : (0 <= u)%Z
-        -> ((0 <= v <= u)%Z -> cast_outside_of_range r[0~>u] v = v)
-        -> (cast r[0~>u] v = (cast_outside_of_range r[0~>u] v) mod (u + 1))%Z.
+        -> (cast r[0~>u] v = v mod (u + 1))%Z.
     Proof.
       intro H0.
       pose proof (is_more_pos_then_neg_0_u u v H0) as H1.
@@ -250,25 +153,8 @@ Module ident.
         by (cbv [ZRange.goodb lower upper]; Z.ltb_to_lt; assumption).
       cbn [lower upper].
       rewrite !Z.sub_0_r, !Z.add_0_r.
-      break_innermost_match; split_andb; Z.ltb_to_lt; intro H';
-        rewrite ?H' by lia; Z.rewrite_mod_small; reflexivity.
-    Qed.
-     *)
-
-    Lemma cast_out_of_bounds_simple_0_mod u v
-      : (0 <= u)%Z
-        -> ((cast_outside_of_range r[0~>u] v) mod (u + 1) = v mod (u + 1))%Z
-        -> (cast r[0~>u] v = (cast_outside_of_range r[0~>u] v) mod (u + 1))%Z.
-    Proof.
-      intro H0.
-      pose proof (is_more_pos_then_neg_0_u u v H0) as H1.
-      cbv [cast]; rewrite H1.
-      rewrite (proj1 ZRange.normalize_id_iff_goodb)
-        by (cbv [ZRange.goodb lower upper]; Z.ltb_to_lt; assumption).
-      cbn [lower upper].
-      rewrite !Z.sub_0_r, !Z.add_0_r.
-      break_innermost_match; split_andb; Z.ltb_to_lt; intro H';
-        rewrite ?H' by lia; Z.rewrite_mod_small; reflexivity.
+      break_innermost_match; split_andb; Z.ltb_to_lt;
+        Z.rewrite_mod_small; reflexivity.
     Qed.
 
     (* N.B. This lemma depends on the hard-coded behavior of casting
@@ -294,20 +180,20 @@ Module ident.
     Qed.
   End with_cast.
 
-  Lemma cast_idempotent_gen {cast_outside_of_range1 cast_outside_of_range2}
+  Lemma cast_idempotent_gen
         r1 r2 v
     : is_tighter_than_bool (ZRange.normalize r1) (ZRange.normalize r2) = true
-      -> ident.cast cast_outside_of_range2 r2 (ident.cast cast_outside_of_range1 r1 v)
-         = ident.cast cast_outside_of_range1 r1 v.
+      -> ident.cast r2 (ident.cast r1 v)
+         = ident.cast r1 v.
   Proof.
-    intro H; apply (@cast_in_normalized_bounds _ r2).
+    intro H; apply (@cast_in_normalized_bounds r2).
     eapply ZRange.is_bounded_by_of_is_tighter_than, cast_always_bounded; assumption.
   Qed.
 
-  Lemma cast_idempotent {cast_outside_of_range1 cast_outside_of_range2}
+  Lemma cast_idempotent
         r v
-    : ident.cast cast_outside_of_range2 r (ident.cast cast_outside_of_range1 r v)
-      = ident.cast cast_outside_of_range1 r v.
+    : ident.cast r (ident.cast r v)
+      = ident.cast r v.
   Proof.
     apply cast_idempotent_gen; change (is_true (is_tighter_than_bool (ZRange.normalize r) (ZRange.normalize r))); reflexivity.
   Qed.

--- a/src/Fancy/Barrett256.v
+++ b/src/Fancy/Barrett256.v
@@ -27,7 +27,7 @@ Module Barrett256.
   Proof. lazy; reflexivity. Qed.
 
   Lemma barrett_red256_correct :
-    COperationSpecifications.BarrettReduction.barrett_red_correct machine_wordsize M (expr.gen_Interp cast_oor barrett_red256).
+    COperationSpecifications.BarrettReduction.barrett_red_correct machine_wordsize M (API.Interp barrett_red256).
   Proof.
     apply barrett_red_correct with (machine_wordsize:=machine_wordsize).
     { lazy. reflexivity. }

--- a/src/Fancy/Montgomery256.v
+++ b/src/Fancy/Montgomery256.v
@@ -30,7 +30,7 @@ Module Montgomery256.
   Proof. lazy; reflexivity. Qed.
 
   Lemma montred256_correct :
-    COperationSpecifications.MontgomeryReduction.montred_correct N R R' (expr.gen_Interp cast_oor montred256).
+    COperationSpecifications.MontgomeryReduction.montred_correct N R R' (API.Interp montred256).
   Proof.
     apply montred_correct with (n:=2%nat) (machine_wordsize:=machine_wordsize) (N':=N').
     { lazy. reflexivity. }

--- a/src/Language/API.v
+++ b/src/Language/API.v
@@ -38,8 +38,6 @@ Compute API.type. (* to figure out what goes into a type *)
     Notation Interp := (@expr.Interp base.type ident base.interp (@ident_interp)).
     (** [interp : forall {t}, @expr interp_type t -> interp_type t] is the [expr] denotation function *)
     Notation interp := (@expr.interp base.type ident base.interp (@ident_interp)).
-    Notation gen_Interp cast_outside_of_range := (@expr.Interp base.type ident base.interp (@ident.gen_interp cast_outside_of_range)).
-    Notation gen_interp cast_outside_of_range := (@expr.interp base.type ident base.interp (@ident.gen_interp cast_outside_of_range)).
 
     Ltac reify_type ty := type.reify ltac:(reify_base_type) constr:(base.type) ty.
     Notation reify_type t := (ltac:(let rt := reify_type t in exact rt)) (only parsing).

--- a/src/Language/APINotations.v
+++ b/src/Language/APINotations.v
@@ -53,9 +53,7 @@ Module Compilers.
   Global Existing Instance reflect_base_interp_eq | 10.
   Global Existing Instance try_make_base_transport_cps | 5.
   Global Existing Instance buildIdent | 5.
-  Global Existing Instance gen_eqv_Reflexive_Proper | 1.
   Global Existing Instance eqv_Reflexive_Proper | 1.
-  Global Existing Instance ident_gen_interp_Proper | 1.
   Global Existing Instance ident_interp_Proper | 1.
 
 
@@ -207,8 +205,7 @@ Module Compilers.
     Notation option_Some := Compilers.ident_Some (only parsing).
     Notation option_None := Compilers.ident_None (only parsing).
 
-    Notation gen_interp := Compilers.ident_gen_interp (only parsing).
-    Notation interp := (@Compilers.ident_gen_interp ident.cast_outside_of_range) (only parsing).
+    Notation interp := Compilers.ident_interp (only parsing).
 
     Notation buildEagerIdent := Compilers.buildEagerIdent (only parsing).
     Notation buildInterpEagerIdentCorrect := Compilers.buildInterpEagerIdentCorrect (only parsing).
@@ -220,16 +217,14 @@ Module Compilers.
     Notation buildIdent := Compilers.buildIdent (only parsing).
     Notation is_var_like := Compilers.ident_is_var_like (only parsing).
     Notation buildInterpIdentCorrect := Compilers.buildInterpIdentCorrect (only parsing).
-    Notation gen_eqv_Reflexive_Proper := Compilers.gen_eqv_Reflexive_Proper (only parsing).
     Notation eqv_Reflexive_Proper := Compilers.eqv_Reflexive_Proper (only parsing).
-    Notation gen_interp_Proper := Compilers.ident_gen_interp_Proper (only parsing).
     Notation interp_Proper := Compilers.ident_interp_Proper (only parsing).
 
     Module Export Notations.
       Export Language.Compilers.ident.Notations.
       Delimit Scope ident_scope with ident.
       Bind Scope ident_scope with ident.
-      Notation interp := (@Compilers.ident_gen_interp ident.cast_outside_of_range) (only parsing).
+      Notation interp := Compilers.ident_interp (only parsing).
       Global Arguments expr.Ident {base_type%type ident%function var%function t%etype} idc%ident.
       Notation "## x" := (Compilers.ident_Literal x) (only printing) : ident_scope.
       Notation "## x" := (Compilers.ident_Literal (t:=base.reify_base_type_of x) x) (only parsing) : ident_scope.
@@ -260,16 +255,11 @@ Module Compilers.
       Notation "x || y" := (#Compilers.ident_Z_lor @ x @ y)%expr : expr_scope.
       Notation "x 'mod' y" := (#Compilers.ident_Z_modulo @ x @ y)%expr : expr_scope.
       Notation "- x" := (#Compilers.ident_Z_opp @ x)%expr : expr_scope.
-      Global Arguments ident_gen_interp _ _ !_.
+      Global Arguments ident_interp _ !_.
     End Notations.
   End ident.
   Export ident.Notations.
   Notation ident := Identifier.Compilers.ident (only parsing).
-
-  Module expr.
-    Notation gen_Interp cast_outside_of_range := (@expr.Interp base.type ident base.interp (@ident.gen_interp cast_outside_of_range)).
-    Notation gen_interp cast_outside_of_range := (@expr.interp base.type ident base.interp (@ident.gen_interp cast_outside_of_range)).
-  End expr.
 
   Ltac reify var term :=
     expr.reify constr:(base.type) ident ltac:(reify_base_type) ltac:(reify_ident) var term.

--- a/src/Language/Language.v
+++ b/src/Language/Language.v
@@ -1765,8 +1765,7 @@ Module Compilers.
         base : Type;
         ident : type (base.type base) -> Type;
         base_interp : base -> Type;
-        ident_gen_interp : (zrange -> Z -> Z) -> forall t, ident t -> type.interp (base.interp base_interp) t;
-        ident_interp := ident_gen_interp ident.cast_outside_of_range
+        ident_interp : forall t, ident t -> type.interp (base.interp base_interp) t
       }.
 
     Class ExprExtraInfoT {exprInfo : ExprInfoT} :=
@@ -1786,9 +1785,9 @@ Module Compilers.
         baseHasNatCorrect :> base.BaseHasNatCorrectT base_interp;
         toFromRestrictedIdent :> ident.ToFromRestrictedIdentT ident;
         buildInvertIdentCorrect :> BuildInvertIdentCorrectT;
-        buildInterpIdentCorrect :> forall cast_outside_of_range, ident.BuildInterpIdentCorrectT (ident_gen_interp cast_outside_of_range);
-        buildInterpEagerIdentCorrect :> forall cast_outside_of_range, ident.BuildInterpEagerIdentCorrectT (ident_gen_interp cast_outside_of_range);
-        ident_gen_interp_Proper :> forall cast_outside_of_range t, Proper (eq ==> type.eqv) (ident_gen_interp cast_outside_of_range t)
+        buildInterpIdentCorrect :> ident.BuildInterpIdentCorrectT ident_interp;
+        buildInterpEagerIdentCorrect :> ident.BuildInterpEagerIdentCorrectT ident_interp;
+        ident_interp_Proper :> forall t, Proper (eq ==> type.eqv) (ident_interp t)
       }.
   End Classes.
 End Compilers.

--- a/src/Language/Pre.v
+++ b/src/Language/Pre.v
@@ -13,8 +13,6 @@ Module ident.
   Definition gets_inlined (real_val : bool) {T} (v : T) : bool := real_val.
 
   Section cast.
-    Context (cast_outside_of_range : zrange -> BinInt.Z -> BinInt.Z).
-
     Definition is_more_pos_than_neg (r : zrange) (v : BinInt.Z) : bool
       := ((Z.abs (lower r) <? Z.abs (upper r)) (* if more of the range is above 0 than below 0 *)
           || ((lower r =? upper r) && (0 <=? lower r))
@@ -22,31 +20,24 @@ Module ident.
 
     (** We ensure that [ident.cast] is symmetric under [Z.opp], as
         this makes some rewrite rules much, much easier to prove. *)
-    (** We actually ignore [cast_outside_of_range] and hard-code it to
-        the identity.  This is needed for one of our rewrite rules.
-
-        XXX TODO: Come up with a good way of proving boundedness for
+    (** XXX TODO: Come up with a good way of proving boundedness for
           the abstract interpreter, now that we no longer can even
           guarantee that we have the same behavior independent of
           overflow behavior. *)
-    Let cast_outside_of_range' (r : zrange) (v : BinInt.Z) : BinInt.Z
-      := let v' := let dummy := cast_outside_of_range r v in v in
-         ((v' - lower r) mod (upper r - lower r + 1)) + lower r.
+    Let cast_outside_of_range (r : zrange) (v : BinInt.Z) : BinInt.Z
+      := ((v - lower r) mod (upper r - lower r + 1)) + lower r.
 
     Definition cast (r : zrange) (x : BinInt.Z)
       := let r := ZRange.normalize r in
          if (lower r <=? x) && (x <=? upper r)
          then x
          else if is_more_pos_than_neg r x
-              then cast_outside_of_range' r x
-              else -cast_outside_of_range' (-r) (-x).
+              then cast_outside_of_range r x
+              else -cast_outside_of_range (-r) (-x).
     Definition cast2 (r : zrange * zrange) (x : BinInt.Z * BinInt.Z)
       := (cast (Datatypes.fst r) (Datatypes.fst x),
           cast (Datatypes.snd r) (Datatypes.snd x)).
   End cast.
-
-  Definition cast_outside_of_range (r : zrange) (v : BinInt.Z) : BinInt.Z.
-  Proof. exact v. Qed.
 
   Module fancy.
     Module with_wordmax.

--- a/src/Language/UnderLetsProofs.v
+++ b/src/Language/UnderLetsProofs.v
@@ -141,27 +141,10 @@ Module Compilers.
         Proof. apply interp_subst_var_like_gen_nil, Hwf. Qed.
       End interp.
     End with_ident.
-
-    (*
-    Lemma Wf_SubstVarFstSndPairOppCast {t} (e : expr.Expr t)
-      : expr.Wf e -> expr.Wf (SubstVarLike.SubstVarFstSndPairOppCast e).
-    Proof. apply Wf_SubstVarOrIdent. Qed.
-
-    Section with_cast.
-      Context {cast_outside_of_range : ZRange.zrange -> BinInt.Z -> BinInt.Z}.
-      Local Notation ident_interp := (@ident.gen_interp cast_outside_of_range).
-      Local Notation interp := (@expr.interp _ _ _ (@ident_interp)).
-      Local Notation Interp := (@expr.Interp _ _ _ (@ident_interp)).
-
-      Lemma Interp_SubstVarFstSndPairOppCast {t} (e : expr.Expr t) (Hwf : expr.Wf e)
-        : Interp (SubstVarLike.SubstVarFstSndPairOppCast e) == Interp e.
-      Proof. apply Interp_SubstVarOrIdent, Hwf. Qed.
-    End with_cast.
-     *)
   End SubstVarLike.
 
-  Hint Resolve SubstVarLike.Wf_SubstVar (*SubstVarLike.Wf_SubstVarFstSndPairOppCast*) SubstVarLike.Wf_SubstVarLike SubstVarLike.Wf_SubstVarOrIdent : wf.
-  Hint Rewrite @SubstVarLike.Interp_SubstVar (*@SubstVarLike.Interp_SubstVarFstSndPairOppCast*) @SubstVarLike.Interp_SubstVarLike @SubstVarLike.Interp_SubstVarOrIdent : interp.
+  Hint Resolve SubstVarLike.Wf_SubstVar SubstVarLike.Wf_SubstVarLike SubstVarLike.Wf_SubstVarOrIdent : wf.
+  Hint Rewrite @SubstVarLike.Interp_SubstVar @SubstVarLike.Interp_SubstVarLike @SubstVarLike.Interp_SubstVarOrIdent : interp.
 
   Module UnderLets.
     Import UnderLets.Compilers.UnderLets.
@@ -1238,7 +1221,7 @@ Module Compilers.
                        | progress destruct_head'_ex
                        | progress destruct_head'_and
                        | progress inversion_type
-                       | progress cbn [(*invert_Var invert_Literal ident.invert_Literal*) eq_rect f_equal f_equal2 type.decode fst snd projT1 projT2 invert_pair Option.bind to_expr expr.interp (*ident.interp ident.gen_interp*) type.eqv length list_rect combine In] in *
+                       | progress cbn [eq_rect f_equal f_equal2 type.decode fst snd projT1 projT2 invert_pair Option.bind to_expr expr.interp type.eqv length list_rect combine In] in *
                        | progress cbv [CPSNotations.cps_option_bind CPSNotations.cpsreturn CPSNotations.cpsbind CPSNotations.cpscall id] in *
                        | progress rewrite_type_transport_correct
                        | progress type_beq_to_eq

--- a/src/Language/UnderLetsProofsExtra.v
+++ b/src/Language/UnderLetsProofsExtra.v
@@ -16,18 +16,18 @@ Module Compilers.
   Module SubstVarLike.
     Import UnderLetsProofs.Compilers.SubstVarLike.
 
-    Definition Interp_gen_SubstVar {cast_outside_of_range} {t} e Hwf
-      := @Interp_SubstVar _ ident _ (@ident.gen_interp cast_outside_of_range) (@ident.gen_interp_Proper cast_outside_of_range) t e Hwf.
+    Definition Interp_SubstVar {t} e Hwf
+      := @Interp_SubstVar _ ident _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
 
-    Definition Interp_gen_SubstVarLike {cast_outside_of_range} {t} e Hwf
-      := @Interp_SubstVarLike _ ident _ (@ident.gen_interp cast_outside_of_range) (@ident.gen_interp_Proper cast_outside_of_range) t e Hwf.
+    Definition Interp_SubstVarLike {t} e Hwf
+      := @Interp_SubstVarLike _ ident _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
 
-    Definition Interp_gen_SubstVarOrIdent {cast_outside_of_range} {t} e Hwf
-      := @Interp_SubstVarOrIdent _ ident _ (@ident.gen_interp cast_outside_of_range) (@ident.gen_interp_Proper cast_outside_of_range) t e Hwf.
+    Definition Interp_SubstVarOrIdent {t} e Hwf
+      := @Interp_SubstVarOrIdent _ ident _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
   End SubstVarLike.
 
   Hint Resolve SubstVarLike.Wf_SubstVar SubstVarLike.Wf_SubstVarLike SubstVarLike.Wf_SubstVarOrIdent : wf_extra.
-  Hint Rewrite @SubstVarLike.Interp_gen_SubstVar @SubstVarLike.Interp_gen_SubstVarLike @SubstVarLike.Interp_gen_SubstVarOrIdent : interp_extra.
+  Hint Rewrite @SubstVarLike.Interp_SubstVar @SubstVarLike.Interp_SubstVarLike @SubstVarLike.Interp_SubstVarOrIdent : interp_extra.
 
   Module UnderLets.
     Import UnderLetsProofs.Compilers.UnderLets.
@@ -41,7 +41,7 @@ Module Compilers.
            base.try_make_base_transport_cps_correct
            ident_is_var_like t e Hwf.
 
-    Definition Interp_gen_LetBindReturn {cast_outside_of_range} {ident_is_var_like} {t} e Hwf
+    Definition Interp_LetBindReturn {ident_is_var_like} {t} e Hwf
       := @Interp_LetBindReturn
            base.type.base ident.ident
            base.base_interp base.type.base_beq base.reflect_base_beq
@@ -49,10 +49,10 @@ Module Compilers.
            invert_expr.ident.buildInvertIdentCorrect
            base.try_make_base_transport_cps_correct
            ident_is_var_like
-           (@ident.gen_interp cast_outside_of_range) (@ident.gen_interp_Proper cast_outside_of_range)
+           (@ident.interp) (@ident.interp_Proper)
            t e Hwf.
   End UnderLets.
 
   Hint Resolve UnderLets.Wf_LetBindReturn : wf_extra.
-  Hint Rewrite @UnderLets.Interp_gen_LetBindReturn : interp_extra.
+  Hint Rewrite @UnderLets.Interp_LetBindReturn : interp_extra.
 End Compilers.

--- a/src/Language/Wf.v
+++ b/src/Language/Wf.v
@@ -1562,20 +1562,6 @@ Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [
           : type.related R (expr.Interp ident_interp (GeneralizeVar (e _))) (expr.Interp ident_interp e).
         Proof. apply @Interp_gen2_GeneralizeVar; eassumption. Qed.
       End gen1.
-
-      (*
-      Section with_cast.
-        Context {cast_outside_of_range : zrange -> Z -> Z}.
-
-        Local Notation Interp := (expr.Interp (@ident.gen_interp cast_outside_of_range)).
-
-        Lemma Interp_FromFlat_ToFlat {t} (e : Expr t) (Hwf : expr.Wf e) : Interp (FromFlat (ToFlat e)) == Interp e.
-        Proof. apply @Interp_gen1_FromFlat_ToFlat; eauto using ident.gen_interp_Proper. Qed.
-
-        Lemma Interp_GeneralizeVar {t} (e : Expr t) (Hwf : expr.Wf e) : Interp (GeneralizeVar (e _)) == Interp e.
-        Proof. apply Interp_FromFlat_ToFlat, Hwf. Qed.
-      End with_cast.
-       *)
     End with_base_type.
   End GeneralizeVar.
 

--- a/src/Language/WfExtra.v
+++ b/src/Language/WfExtra.v
@@ -27,28 +27,28 @@ Module Compilers.
     Definition Wf_reify {t} v
       := @Wf_reify base.type.base base.base_interp base.type.base_beq ident ident.buildIdent base.reflect_base_beq t v.
 
-    Definition Interp_gen_Reify_as {cast_outside_of_range} {t} v
-      := @Interp_Reify_as base.type.base base.base_interp ident ident.buildIdent (@ident.gen_interp cast_outside_of_range) ident.buildInterpIdentCorrect t v.
+    Definition Interp_Reify_as {t} v
+      := @Interp_Reify_as base.type.base base.base_interp ident ident.buildIdent (@ident.interp) ident.buildInterpIdentCorrect t v.
 
-    Definition Interp_gen_reify {cast_outside_of_range} {t} v
-      := @Interp_reify base.type.base base.base_interp ident ident.buildIdent (@ident.gen_interp cast_outside_of_range) ident.buildInterpIdentCorrect t v.
+    Definition Interp_reify {t} v
+      := @Interp_reify base.type.base base.base_interp ident ident.buildIdent (@ident.interp) ident.buildInterpIdentCorrect t v.
 
-    Definition interp_gen_reify {cast_outside_of_range} {t} v
-      := @interp_reify base.type.base base.base_interp ident ident.buildIdent (@ident.gen_interp cast_outside_of_range) ident.buildInterpIdentCorrect t v.
+    Definition interp_reify {t} v
+      := @interp_reify base.type.base base.base_interp ident ident.buildIdent (@ident.interp) ident.buildInterpIdentCorrect t v.
 
-    Definition interp_gen_reify_list {cast_outside_of_range} {t} v
-      := @interp_reify_list base.type.base base.base_interp ident ident.buildIdent (@ident.gen_interp cast_outside_of_range) ident.buildInterpIdentCorrect t v.
+    Definition interp_reify_list {t} v
+      := @interp_reify_list base.type.base base.base_interp ident ident.buildIdent (@ident.interp) ident.buildInterpIdentCorrect t v.
 
-    Definition interp_gen_reify_option {cast_outside_of_range} {t} v
-      := @interp_reify_option base.type.base base.base_interp ident ident.buildIdent (@ident.gen_interp cast_outside_of_range) ident.buildInterpIdentCorrect t v.
+    Definition interp_reify_option {t} v
+      := @interp_reify_option base.type.base base.base_interp ident ident.buildIdent (@ident.interp) ident.buildInterpIdentCorrect t v.
 
-    Definition Wf_Interp_Proper_gen {cast_outside_of_range} {t} e Hwf
-      := @Wf_Interp_Proper_gen _ ident _ _ (@ident.gen_interp cast_outside_of_range) (@ident.gen_interp_Proper cast_outside_of_range) t e Hwf.
+    Definition Wf_Interp_Proper {t} e Hwf
+      := @Wf_Interp_Proper_gen _ ident _ _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
   End expr.
 
   Hint Constructors expr.wf : wf_extra.
   Hint Resolve @expr.Wf_APP @expr.Wf_Reify_as @expr.Wf_reify : wf_extra.
-  Hint Rewrite @expr.Interp_gen_Reify_as @expr.interp_gen_reify @expr.interp_gen_reify_list @expr.interp_gen_reify_option @expr.Interp_gen_reify @expr.Interp_APP : interp_extra.
+  Hint Rewrite @expr.Interp_Reify_as @expr.interp_reify @expr.interp_reify_list @expr.interp_reify_option @expr.Interp_reify @expr.Interp_APP : interp_extra.
 
   Module GeneralizeVar.
     Import Language.Wf.Compilers.GeneralizeVar.
@@ -65,15 +65,15 @@ Module Compilers.
     Definition Wf3_GeneralizeVar {t} e Hwf
       := @Wf3_GeneralizeVar _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ t e Hwf.
 
-    Definition Interp_gen1_FromFlat_ToFlat {cast_outside_of_range} {t} e Hwf
-      := @Interp_gen1_FromFlat_ToFlat _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ _ (@ident.gen_interp cast_outside_of_range) _ (@ident.gen_interp_Proper cast_outside_of_range) t e Hwf.
+    Definition Interp_FromFlat_ToFlat {t} e Hwf
+      := @Interp_gen1_FromFlat_ToFlat _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ _ (@ident.interp) _ (@ident.interp_Proper) t e Hwf.
 
-    Definition Interp_gen1_GeneralizeVar {cast_outside_of_range} {t} e Hwf
-      := @Interp_gen1_GeneralizeVar _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ _ (@ident.gen_interp cast_outside_of_range) _ (@ident.gen_interp_Proper cast_outside_of_range) t e Hwf.
+    Definition Interp_GeneralizeVar {t} e Hwf
+      := @Interp_gen1_GeneralizeVar _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ _ (@ident.interp) _ (@ident.interp_Proper) t e Hwf.
   End GeneralizeVar.
 
   Global Hint Extern 0 (?x == ?x) => apply expr.Wf_Interp_Proper_gen : wf_extra interp_extra.
   Hint Resolve GeneralizeVar.Wf_FromFlat_ToFlat GeneralizeVar.Wf_GeneralizeVar : wf_extra.
   Hint Resolve GeneralizeVar.Wf3_FromFlat_ToFlat GeneralizeVar.Wf3_GeneralizeVar : wf_extra.
-  Hint Rewrite @GeneralizeVar.Interp_gen1_GeneralizeVar @GeneralizeVar.Interp_gen1_FromFlat_ToFlat : interp_extra.
+  Hint Rewrite @GeneralizeVar.Interp_GeneralizeVar @GeneralizeVar.Interp_FromFlat_ToFlat : interp_extra.
 End Compilers.

--- a/src/MiscCompilerPassesProofsExtra.v
+++ b/src/MiscCompilerPassesProofsExtra.v
@@ -28,20 +28,20 @@ Module Compilers.
   Module Subst01.
     Import MiscCompilerPassesProofs.Compilers.Subst01.
 
-    Definition Interp_gen_Subst01 {cast_outside_of_range} {t} e Hwf
-      := @Interp_Subst01 _ ident _ (@ident.gen_interp cast_outside_of_range) (@ident.gen_interp_Proper cast_outside_of_range) t e Hwf.
+    Definition Interp_Subst01 {t} e Hwf
+      := @Interp_Subst01 _ ident _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
   End Subst01.
 
   Hint Resolve Subst01.Wf_Subst01 : wf_extra.
-  Hint Rewrite @Subst01.Interp_gen_Subst01 : interp_extra.
+  Hint Rewrite @Subst01.Interp_Subst01 : interp_extra.
 
   Module DeadCodeElimination.
     Import MiscCompilerPassesProofs.Compilers.DeadCodeElimination.
 
-    Definition Interp_gen_EliminateDead {cast_outside_of_range} {t} e Hwf
-      := @Interp_EliminateDead _ ident _ (@ident.gen_interp cast_outside_of_range) (@ident.gen_interp_Proper cast_outside_of_range) t e Hwf.
+    Definition Interp_EliminateDead {t} e Hwf
+      := @Interp_EliminateDead _ ident _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
   End DeadCodeElimination.
 
   Hint Resolve DeadCodeElimination.Wf_EliminateDead : wf_extra.
-  Hint Rewrite @DeadCodeElimination.Interp_gen_EliminateDead : interp_extra.
+  Hint Rewrite @DeadCodeElimination.Interp_EliminateDead : interp_extra.
 End Compilers.

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -190,7 +190,7 @@ Section rbarrett_red.
 
   Local Strategy -100 [barrett_red]. (* needed for making Qed not take forever *)
   Lemma barrett_red_correct res (Hres : barrett_red = Success res)
-    : barrett_red_correct machine_wordsize M (API.gen_Interp cast_oor res).
+    : barrett_red_correct machine_wordsize M (API.Interp res).
   Proof using M curve_good.
     cbv [barrett_red_correct]; intros.
     assert (1 < machine_wordsize) by apply use_curve_good.

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -179,7 +179,7 @@ Section rmontred.
   Local Strategy -100 [montred]. (* needed for making Qed not take forever *)
   Local Strategy -100 [montred' reified_montred_gen]. (* needed for making prove_correctness not take forever *)
   Lemma montred_correct res (Hres : montred = Success res)
-    : montred_correct N R R' (API.gen_Interp cast_oor res).
+    : montred_correct N R R' (API.Interp res).
   Proof using n curve_good.
     cbv [montred_correct]; intros.
     rewrite <- MontgomeryReduction.montred'_correct with (R:=R) (N':=N') (Zlog2R:=machine_wordsize) (n:=n) (lo:=lo) (hi:=hi) by solve_montred_preconditions.

--- a/src/Rewriter/AllTactics.v
+++ b/src/Rewriter/AllTactics.v
@@ -154,31 +154,31 @@ Module Compilers.
         | lazymatch do_rhs with true => idtac | false => reflexivity end ].
 
       Ltac do_reify_rhs ident ident_interp := notypeclasses refine (@expr.Reify_rhs _ ident _ ident_interp _ _ _ _ _ _); [ typeclasses eauto | ].
+
       Ltac do_rewrite_with verified_rewriter_package :=
         refine (eq_trans_eqv_Interp _ _);
-        [ refine (@Interp_gen_Rewrite verified_rewriter_package _ _ _ _);
+        [ refine (@Interp_Rewrite verified_rewriter_package _ _ _);
           [ .. | prove_Wf () ]
         | lazymatch goal with
           | [ |- ?ev = ?RHS ] => let RHS' := (eval vm_compute in RHS) in
                                  unify ev RHS'; vm_cast_no_check (eq_refl RHS)
           end ].
 
-      Ltac do_final_cbv base_interp ident_gen_interp :=
+      Ltac do_final_cbv base_interp ident_interp :=
         let base_interp_head := head base_interp in
-        let ident_gen_interp_head := head ident_gen_interp in
-        cbv [expr.Interp expr.interp Classes.ident_gen_interp Classes.ident_interp type.interp base.interp base_interp_head ident_gen_interp_head ident.literal ident.eagerly ident.cast2].
+        let ident_interp_head := head ident_interp in
+        cbv [expr.Interp expr.interp Classes.ident_interp type.interp base.interp base_interp_head ident_interp_head ident.literal ident.eagerly ident.cast2].
 
       Ltac Rewrite_for_gen verified_rewriter_package do_lhs do_rhs :=
         lazymatch (eval hnf in (exprInfo verified_rewriter_package)) with
         | {| base := ?base
              ; ident := ?ident
              ; base_interp := ?base_interp
-             ; ident_gen_interp := ?ident_gen_interp
+             ; ident_interp := ?ident_interp
           |}
           => let base_type := constr:(base.type base) in
              let base_type_interp := constr:(base.interp base_interp) in
              let reify_type := type.reify_via_tc base_type base_type_interp in
-             let ident_interp := constr:(@ident_gen_interp ident.cast_outside_of_range) in
              unshelve (
                  solve [
                      etransitivity_for_sides do_lhs do_rhs;
@@ -186,7 +186,7 @@ Module Compilers.
                      do_reify_rhs ident ident_interp;
                      do_rewrite_with verified_rewriter_package
                ]);
-             do_final_cbv base_interp ident_gen_interp
+             do_final_cbv base_interp ident_interp
         end.
     End FinalTacticHelpers.
 

--- a/src/Rewriter/Passes/Arith.v
+++ b/src/Rewriter/Passes/Arith.v
@@ -27,18 +27,13 @@ Module Compilers.
       Lemma Wf_RewriteArith {t} e (Hwf : Wf e) : Wf (@RewriteArith t e).
       Proof. now apply VerifiedRewriterArith. Qed.
 
-      Lemma Interp_gen_RewriteArith {cast_outside_of_range t} e (Hwf : Wf e)
-        : API.gen_Interp cast_outside_of_range (@RewriteArith t e)
-          == API.gen_Interp cast_outside_of_range e.
-      Proof. now apply VerifiedRewriterArith. Qed.
-
       Lemma Interp_RewriteArith {t} e (Hwf : Wf e) : API.Interp (@RewriteArith t e) == API.Interp e.
-      Proof. apply Interp_gen_RewriteArith; assumption. Qed.
+      Proof. now apply VerifiedRewriterArith. Qed.
     End __.
   End RewriteRules.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteArith : wf wf_extra.
-    Hint Rewrite @Interp_gen_RewriteArith @Interp_RewriteArith : interp interp_extra.
+    Hint Rewrite @Interp_RewriteArith : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/ArithWithCasts.v
+++ b/src/Rewriter/Passes/ArithWithCasts.v
@@ -24,18 +24,13 @@ Module Compilers.
       Lemma Wf_RewriteArithWithCasts {t} e (Hwf : Wf e) : Wf (@RewriteArithWithCasts t e).
       Proof. now apply VerifiedRewriterArithWithCasts. Qed.
 
-      Lemma Interp_gen_RewriteArithWithCasts {cast_outside_of_range t} e (Hwf : Wf e)
-        : API.gen_Interp cast_outside_of_range (@RewriteArithWithCasts t e)
-          == API.gen_Interp cast_outside_of_range e.
-      Proof. now apply VerifiedRewriterArithWithCasts. Qed.
-
       Lemma Interp_RewriteArithWithCasts {t} e (Hwf : Wf e) : API.Interp (@RewriteArithWithCasts t e) == API.Interp e.
-      Proof. apply Interp_gen_RewriteArithWithCasts; assumption. Qed.
+      Proof. now apply VerifiedRewriterArithWithCasts. Qed.
     End __.
   End RewriteRules.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteArithWithCasts : wf wf_extra.
-    Hint Rewrite @Interp_gen_RewriteArithWithCasts @Interp_RewriteArithWithCasts : interp interp_extra.
+    Hint Rewrite @Interp_RewriteArithWithCasts : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/MulSplit.v
+++ b/src/Rewriter/Passes/MulSplit.v
@@ -28,18 +28,13 @@ Module Compilers.
       Lemma Wf_RewriteMulSplit {t} e (Hwf : Wf e) : Wf (@RewriteMulSplit t e).
       Proof. now apply VerifiedRewriterMulSplit. Qed.
 
-      Lemma Interp_gen_RewriteMulSplit {cast_outside_of_range t} e (Hwf : Wf e)
-        : API.gen_Interp cast_outside_of_range (@RewriteMulSplit t e)
-          == API.gen_Interp cast_outside_of_range e.
-      Proof. now apply VerifiedRewriterMulSplit. Qed.
-
       Lemma Interp_RewriteMulSplit {t} e (Hwf : Wf e) : API.Interp (@RewriteMulSplit t e) == API.Interp e.
-      Proof. apply Interp_gen_RewriteMulSplit; assumption. Qed.
+      Proof. now apply VerifiedRewriterMulSplit. Qed.
     End __.
   End RewriteRules.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteMulSplit : wf wf_extra.
-    Hint Rewrite @Interp_gen_RewriteMulSplit @Interp_RewriteMulSplit : interp interp_extra.
+    Hint Rewrite @Interp_RewriteMulSplit : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/NBE.v
+++ b/src/Rewriter/Passes/NBE.v
@@ -24,13 +24,8 @@ Module Compilers.
       Lemma Wf_RewriteNBE {t} e (Hwf : Wf e) : Wf (@RewriteNBE t e).
       Proof. now apply VerifiedRewriterNBE. Qed.
 
-      Lemma Interp_gen_RewriteNBE {cast_outside_of_range t} e (Hwf : Wf e)
-        : API.gen_Interp cast_outside_of_range (@RewriteNBE t e)
-          == API.gen_Interp cast_outside_of_range e.
-      Proof. now apply VerifiedRewriterNBE. Qed.
-
       Lemma Interp_RewriteNBE {t} e (Hwf : Wf e) : API.Interp (@RewriteNBE t e) == API.Interp e.
-      Proof. apply Interp_gen_RewriteNBE; assumption. Qed.
+      Proof. now apply VerifiedRewriterNBE. Qed.
     End __.
   End RewriteRules.
 
@@ -39,16 +34,12 @@ Module Compilers.
   Lemma Wf_PartialEvaluate {t} e (Hwf : Wf e) : Wf (@PartialEvaluate t e).
   Proof. apply Wf_RewriteNBE, Hwf. Qed.
 
-  Lemma Interp_gen_PartialEvaluate {cast_outside_of_range} {t} e (Hwf : Wf e)
-    : API.gen_Interp cast_outside_of_range (@PartialEvaluate t e) == API.gen_Interp cast_outside_of_range e.
-  Proof. apply Interp_gen_RewriteNBE, Hwf. Qed.
-
   Lemma Interp_PartialEvaluate {t} e (Hwf : Wf e)
     : API.Interp (@PartialEvaluate t e) == API.Interp e.
-  Proof. apply Interp_gen_PartialEvaluate; assumption. Qed.
+  Proof. apply Interp_RewriteNBE, Hwf. Qed.
 
   Module Export Hints.
     Hint Resolve Wf_PartialEvaluate Wf_RewriteNBE : wf wf_extra.
-    Hint Rewrite @Interp_gen_PartialEvaluate @Interp_gen_RewriteNBE @Interp_PartialEvaluate @Interp_RewriteNBE : interp interp_extra.
+    Hint Rewrite @Interp_PartialEvaluate @Interp_RewriteNBE : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/StripLiteralCasts.v
+++ b/src/Rewriter/Passes/StripLiteralCasts.v
@@ -24,18 +24,13 @@ Module Compilers.
       Lemma Wf_RewriteStripLiteralCasts {t} e (Hwf : Wf e) : Wf (@RewriteStripLiteralCasts t e).
       Proof. now apply VerifiedRewriterStripLiteralCasts. Qed.
 
-      Lemma Interp_gen_RewriteStripLiteralCasts {cast_outside_of_range t} e (Hwf : Wf e)
-        : API.gen_Interp cast_outside_of_range (@RewriteStripLiteralCasts t e)
-          == API.gen_Interp cast_outside_of_range e.
-      Proof. now apply VerifiedRewriterStripLiteralCasts. Qed.
-
       Lemma Interp_RewriteStripLiteralCasts {t} e (Hwf : Wf e) : expr.Interp (@Compilers.ident_interp) (@RewriteStripLiteralCasts t e) == expr.Interp (@Compilers.ident_interp) e.
-      Proof. apply Interp_gen_RewriteStripLiteralCasts; assumption. Qed.
+      Proof. now apply VerifiedRewriterStripLiteralCasts. Qed.
     End __.
   End RewriteRules.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteStripLiteralCasts : wf wf_extra.
-    Hint Rewrite @Interp_gen_RewriteStripLiteralCasts @Interp_RewriteStripLiteralCasts : interp interp_extra.
+    Hint Rewrite @Interp_RewriteStripLiteralCasts : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/ToFancy.v
+++ b/src/Rewriter/Passes/ToFancy.v
@@ -32,18 +32,13 @@ Module Compilers.
       Lemma Wf_RewriteToFancy {t} e (Hwf : Wf e) : Wf (@RewriteToFancy t e).
       Proof using All. now apply VerifiedRewriterToFancy. Qed.
 
-      Lemma Interp_gen_RewriteToFancy {cast_outside_of_range t} e (Hwf : Wf e)
-        : API.gen_Interp cast_outside_of_range (@RewriteToFancy t e)
-          == API.gen_Interp cast_outside_of_range e.
-      Proof using All. now apply VerifiedRewriterToFancy. Qed.
-
       Lemma Interp_RewriteToFancy {t} e (Hwf : Wf e) : API.Interp (@RewriteToFancy t e) == API.Interp e.
-      Proof using All. apply Interp_gen_RewriteToFancy; assumption. Qed.
+      Proof using All. now apply VerifiedRewriterToFancy. Qed.
     End __.
   End RewriteRules.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteToFancy : wf wf_extra.
-    Hint Rewrite @Interp_gen_RewriteToFancy @Interp_RewriteToFancy : interp interp_extra.
+    Hint Rewrite @Interp_RewriteToFancy : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/ToFancyWithCasts.v
+++ b/src/Rewriter/Passes/ToFancyWithCasts.v
@@ -34,18 +34,13 @@ Module Compilers.
       Lemma Wf_RewriteToFancyWithCasts {t} e (Hwf : Wf e) : Wf (@RewriteToFancyWithCasts t e).
       Proof using All. now apply VerifiedRewriterToFancyWithCasts. Qed.
 
-      Lemma Interp_gen_RewriteToFancyWithCasts {cast_outside_of_range t} e (Hwf : Wf e)
-        : API.gen_Interp cast_outside_of_range (@RewriteToFancyWithCasts t e)
-          == API.gen_Interp cast_outside_of_range e.
-      Proof using All. now apply VerifiedRewriterToFancyWithCasts. Qed.
-
       Lemma Interp_RewriteToFancyWithCasts {t} e (Hwf : Wf e) : API.Interp (@RewriteToFancyWithCasts t e) == API.Interp e.
-      Proof using All. apply Interp_gen_RewriteToFancyWithCasts; assumption. Qed.
+      Proof using All. now apply VerifiedRewriterToFancyWithCasts. Qed.
     End __.
   End RewriteRules.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteToFancyWithCasts : wf wf_extra.
-    Hint Rewrite @Interp_gen_RewriteToFancyWithCasts @Interp_RewriteToFancyWithCasts : interp interp_extra.
+    Hint Rewrite @Interp_RewriteToFancyWithCasts : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/ProofsCommon.v
+++ b/src/Rewriter/ProofsCommon.v
@@ -2669,7 +2669,7 @@ Module Compilers.
                            rewrite_rules_interp_goodT_curried_cps_folded snd hd tl projT1 projT2 rewrite_rule_data_interp_goodT_curried
                            rewrite_rule_data_interp_goodT_curried under_with_unification_resultT_relation_hetero under_with_unification_resultT'_relation_hetero wf_with_unification_resultT under_type_of_list_relation_cps under_type_of_list_relation1_cps pattern.pattern_of_anypattern pattern.type_of_anypattern rew_replacement rew_should_do_again rew_with_opt rew_under_lets wf_with_unification_resultT pattern_default_interp pattern.type.under_forall_vars_relation pattern.type.under_forall_vars_relation1 deep_rewrite_ruleTP_gen with_unification_resultT' pattern.ident.arg_types pattern.type.lam_forall_vars Compilers.pattern.type.lam_forall_vars_gen pattern_default_interp' pattern.collect_vars PositiveMap.empty pattern.type.collect_vars PositiveSet.elements PositiveSet.union pattern.base.collect_vars PositiveSet.empty PositiveSet.xelements lam_type_of_list id pattern.ident.to_typed under_type_of_list_relation_cps deep_rewrite_ruleTP_gen_good_relation normalize_deep_rewrite_rule pattern.type.subst_default PositiveSet.add PositiveSet.rev PositiveSet.rev_append PositiveMap.add option_bind' wf_value value pattern.base.subst_default pattern.base.lookup_default PositiveMap.find rewrite_ruleTP ident.smart_Literal value_interp_related
                            Reify.expr_value_to_rewrite_rule_replacement UnderLets.flat_map reify_expr_beta_iota reflect_expr_beta_iota reflect_ident_iota Compile.reify_to_UnderLets UnderLets.of_expr Compile.Base_value
-                           Classes.ident_gen_interp Classes.base Classes.ident Classes.base_interp Classes.ident_interp
+                           Classes.base Classes.ident Classes.base_interp Classes.ident_interp
                            List.map List.fold_right List.rev list_rect orb List.app
                         ] in
                 rewrite_rules_interp_goodT_curried_cps_folded.
@@ -3342,15 +3342,14 @@ Module Compilers.
 
           Lemma expr_value_to_rewrite_rule_replacement_interp_related
                 (should_do_again : bool)
-                {cast_outside_of_range}
                 {t} e v
-                (He : expr.interp_related_gen (ident_gen_interp cast_outside_of_range) (fun t => value_interp_related (ident_gen_interp cast_outside_of_range)) e v)
+                (He : expr.interp_related_gen ident_interp (fun t => value_interp_related ident_interp) e v)
             : UnderLets.interp_related
-                (ident_gen_interp cast_outside_of_range)
+                ident_interp
                 (if should_do_again
                     return (@expr.expr base_type ident (if should_do_again then @value _ ident var else var) t) -> type.interp (base.interp base_interp) t -> Prop
-                 then expr.interp_related_gen (ident_gen_interp cast_outside_of_range) (fun t => value_interp_related (ident_gen_interp cast_outside_of_range))
-                 else expr.interp_related (ident_gen_interp cast_outside_of_range))
+                 then expr.interp_related_gen ident_interp (fun t => value_interp_related ident_interp)
+                 else expr.interp_related ident_interp)
                 (@expr_value_to_rewrite_rule_replacement _ ident var (fun t => reflect_ident_iota) should_do_again t e)
                 v.
           Proof using Type.
@@ -3389,11 +3388,10 @@ Module Compilers.
           := (match y return _ with x => z end).
 
         Definition Interp_GoalT {exprInfo : ExprInfoT} {exprExtraInfo : ExprExtraInfoT} {pkg : package} (Rewriter : RewriterT) : Prop
-          := forall (cast_outside_of_range : zrange -> Z -> Z),
-            plet data := Rewriter_data Rewriter in
+          := plet data := Rewriter_data Rewriter in
                    specT data
                    -> @Compile.rewrite_rules_interp_goodT
-                        base _ ident pattern_ident arg_types to_typed base_interp (ident_gen_interp cast_outside_of_range)
+                        base _ ident pattern_ident arg_types to_typed base_interp ident_interp
                         (Make.GoalType.rewrite_rules data _).
       End GoalType.
     End InterpTactics.
@@ -3407,13 +3405,8 @@ Module Compilers.
 
           Rewrite : forall {t} (e : expr.Expr (ident:=ident) t), expr.Expr (ident:=ident) t;
           Wf_Rewrite : forall {t} e (Hwf : Wf e), Wf (@Rewrite t e);
-          Interp_gen_Rewrite
-          : forall {cast_outside_of_range t} e (Hwf : Wf e),
-              expr.Interp (ident_gen_interp cast_outside_of_range) (@Rewrite t e)
-              == expr.Interp (ident_gen_interp cast_outside_of_range) e;
           Interp_Rewrite {t} e
-          : forall (Hwf : Wf e), expr.Interp ident_interp (@Rewrite t e) == expr.Interp ident_interp e
-          := Interp_gen_Rewrite e;
+          : forall (Hwf : Wf e), expr.Interp ident_interp (@Rewrite t e) == expr.Interp ident_interp e;
 
           check_wf : forall {t}, expr.Expr (ident:=ident) t -> bool;
           generalize_for_wf : forall {t}, expr.Expr (ident:=ident) t -> expr.Expr (ident:=ident) t;

--- a/src/Rewriter/Reify.v
+++ b/src/Rewriter/Reify.v
@@ -917,17 +917,15 @@ Module Compilers.
         let exprExtraInfo := (eval hnf in exprExtraInfo) in
         let pident_pair := build_pident_pair exprExtraInfo pkg in
         let ident_interp := (eval cbv [Classes.ident_interp] in (@Classes.ident_interp exprInfo)) in
-        let ident_gen_interp := (eval cbv [Classes.ident_gen_interp] in (@Classes.ident_gen_interp exprInfo)) in
         let ident_interp_head := head ident_interp in
-        let ident_gen_interp_head := head ident_gen_interp in
         let base_interp_beq := (eval cbv [Classes.base_interp_beq] in (@Classes.base_interp_beq exprInfo exprExtraInfo)) in
         let base_interp_beq_head := head base_interp_beq in
         let x := fresh "x" in
-        let v := (eval cbv -[ident_interp_head ident_gen_interp_head ident.smart_Literal base_interp_beq_head] in
+        let v := (eval cbv -[ident_interp_head ident.smart_Literal base_interp_beq_head] in
                      (fun var
                       => @interp_rewrite_rules_folded
                            exprInfo exprExtraInfo pkg var pident_pair (fun evm t x => Datatypes.fst x))) in
-        let v := (eval cbv [ident_interp_head ident_gen_interp_head ident.smart_Literal ident.ident_Literal ident.ident_tt ident.ident_pair] in v) in
+        let v := (eval cbv [ident_interp_head ident.smart_Literal ident.ident_Literal ident.ident_tt ident.ident_pair] in v) in
         v.
 
       Module Import AdjustRewriteRulesForReduction.

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -178,16 +178,16 @@ Local Ltac interp_good_t_step_arith :=
             => rewrite ZRange.is_bounded_by_bool_move_opp_normalize in H
           | [ |- context[is_bounded_by_bool _ (ZRange.normalize (-_))] ]
             => rewrite ZRange.is_bounded_by_bool_move_opp_normalize
-          | [ H : is_bounded_by_bool ?v (ZRange.normalize ?r) = true |- context[ident.cast _ ?r ?v] ]
-            => rewrite (@ident.cast_in_normalized_bounds _ r v) by exact H
-          | [ H : is_bounded_by_bool ?v (ZRange.normalize ?r) = true |- context[ident.cast _ (-?r) (-?v)] ]
-            => rewrite (@ident.cast_in_normalized_bounds _ (-r) (-v));
+          | [ H : is_bounded_by_bool ?v (ZRange.normalize ?r) = true |- context[ident.cast ?r ?v] ]
+            => rewrite (@ident.cast_in_normalized_bounds r v) by exact H
+          | [ H : is_bounded_by_bool ?v (ZRange.normalize ?r) = true |- context[ident.cast (-?r) (-?v)] ]
+            => rewrite (@ident.cast_in_normalized_bounds (-r) (-v));
                [ | clear -H ]
-          | [ |- context[ident.cast _ ?r (-ident.cast _ (-?r) ?v)] ]
-            => rewrite (ident.cast_in_normalized_bounds r (-ident.cast _ (-r) v))
+          | [ |- context[ident.cast ?r (-ident.cast (-?r) ?v)] ]
+            => rewrite (ident.cast_in_normalized_bounds r (-ident.cast (-r) v))
               by (rewrite <- ZRange.is_bounded_by_bool_move_opp_normalize; apply ident.cast_always_bounded)
-          | [ |- context[ident.cast _ ?r (ident.cast _ ?r _)] ]
-            => rewrite (@ident.cast_idempotent _ _ r)
+          | [ |- context[ident.cast ?r (ident.cast ?r _)] ]
+            => rewrite (@ident.cast_idempotent r)
           | [ H : is_bounded_by_bool _ ?r = true |- _]
             => is_var r; unique pose proof (ZRange.is_bounded_by_normalize _ _ H)
           | [ H : lower ?x = upper ?x |- _ ] => is_var x; destruct x; cbn [upper lower] in *
@@ -211,15 +211,15 @@ Local Ltac interp_good_t_step_arith :=
         | break_innermost_match_hyps_step
         | progress destruct_head'_or
         | match goal with
-          | [ |- context[-ident.cast _ (-?r) (-?v)] ] => rewrite (ident.cast_opp' r v)
-          | [ |- context[ident.cast ?coor ?r ?v] ]
+          | [ |- context[-ident.cast (-?r) (-?v)] ] => rewrite (ident.cast_opp' r v)
+          | [ |- context[ident.cast ?r ?v] ]
             => is_var v;
-               pose proof (@ident.cast_always_bounded coor r v);
-               generalize dependent (ident.cast coor r v); clear v; intro v; intros
-          | [ |- context[ident.cast ?coor ?r ?v] ]
-            => is_var v; is_var coor;
-               pose proof (@ident.cast_cases coor r v);
-               generalize dependent (ident.cast coor r v); intros
+               pose proof (@ident.cast_always_bounded r v);
+               generalize dependent (ident.cast r v); clear v; intro v; intros
+          | [ |- context[ident.cast ?r ?v] ]
+            => is_var v;
+               pose proof (@ident.cast_cases r v);
+               generalize dependent (ident.cast r v); intros
           | [ H : is_bounded_by_bool ?v ?r = true, H' : is_tighter_than_bool ?r ?r' = true |- _ ]
             => unique assert (is_bounded_by_bool v r' = true) by (eauto 2 using ZRange.is_bounded_by_of_is_tighter_than)
           | [ H : is_bounded_by_bool (-?v) ?r = true, H' : (-?r <=? ?r')%zrange = true |- _ ]
@@ -309,28 +309,28 @@ Local Ltac interp_good_t_step_arith :=
                | [ |- context[y + z + x] ]
                  => progress replace (y + z + x) with (x + y + z) by (clear; lia)
                end
-          | [ |- - ident.cast _ (-?r) (- (?x / ?y)) = ident.cast _ ?r (?x' / ?y) ]
+          | [ |- - ident.cast (-?r) (- (?x / ?y)) = ident.cast ?r (?x' / ?y) ]
             => tryif constr_eq x x' then fail else replace x with x' by lia
           | [ |- _ = _ :> BinInt.Z ] => progress autorewrite with zsimplify_fast
           end ].
 
 Local Ltac remove_casts :=
   repeat match goal with
-         | [ |- context[ident.cast _ r[?x~>?x] ?x] ]
+         | [ |- context[ident.cast r[?x~>?x] ?x] ]
            => rewrite (ident.cast_in_bounds r[x~>x] x) by apply ZRange.is_bounded_by_bool_constant
-         | [ |- context[ident.cast _ ?r (ident.cast _ ?r _)] ]
+         | [ |- context[ident.cast ?r (ident.cast ?r _)] ]
            => rewrite ident.cast_idempotent
-         | [ H : context[ident.cast _ ?r (ident.cast _ ?r _)] |- _ ]
+         | [ H : context[ident.cast ?r (ident.cast ?r _)] |- _ ]
            => rewrite ident.cast_idempotent in H
-         | [ |- context[ident.cast ?coor ?r ?v] ]
+         | [ |- context[ident.cast ?r ?v] ]
            => is_var v;
-              pose proof (@ident.cast_always_bounded coor r v);
-              generalize dependent (ident.cast coor r v);
+              pose proof (@ident.cast_always_bounded r v);
+              generalize dependent (ident.cast r v);
               clear v; intro v; intros
-         | [ H : context[ident.cast ?coor ?r ?v] |- _ ]
+         | [ H : context[ident.cast ?r ?v] |- _ ]
            => is_var v;
-              pose proof (@ident.cast_always_bounded coor r v);
-              generalize dependent (ident.cast coor r v);
+              pose proof (@ident.cast_always_bounded r v);
+              generalize dependent (ident.cast r v);
               clear v; intro v; intros
          | [ H : context[ZRange.constant ?v] |- _ ] => unique pose proof (ZRange.is_bounded_by_bool_normalize_constant v)
          | [ H : is_tighter_than_bool (?ZRf ?r1 ?r2) (ZRange.normalize ?rs) = true,
@@ -338,11 +338,11 @@ Local Ltac remove_casts :=
                       H2 : is_bounded_by_bool ?v2 ?r2 = true
              |- _ ]
            => let cst := multimatch goal with
-                         | [ |- context[ident.cast ?coor rs (?Zf v1 v2)] ] => constr:(ident.cast coor rs (Zf v1 v2))
-                         | [ H : context[ident.cast ?coor rs (?Zf v1 v2)] |- _ ] => constr:(ident.cast coor rs (Zf v1 v2))
+                         | [ |- context[ident.cast rs (?Zf v1 v2)] ] => constr:(ident.cast rs (Zf v1 v2))
+                         | [ H : context[ident.cast rs (?Zf v1 v2)] |- _ ] => constr:(ident.cast rs (Zf v1 v2))
                          end in
               lazymatch cst with
-              | ident.cast ?coor rs (?Zf v1 v2)
+              | ident.cast rs (?Zf v1 v2)
                 => let lem := lazymatch constr:((ZRf, Zf)%core) with
                               | (ZRange.shiftl, Z.shiftl)%core => constr:(@ZRange.is_bounded_by_bool_shiftl v1 r1 v2 r2 H1 H2)
                               | (ZRange.shiftr, Z.shiftr)%core => constr:(@ZRange.is_bounded_by_bool_shiftr v1 r1 v2 r2 H1 H2)
@@ -350,28 +350,28 @@ Local Ltac remove_casts :=
                               end in
                    try unique pose proof (@ZRange.is_bounded_by_of_is_tighter_than _ _ H _ lem);
                    clear H;
-                   rewrite (@ident.cast_in_normalized_bounds coor rs (Zf v1 v2)) in * by assumption
+                   rewrite (@ident.cast_in_normalized_bounds rs (Zf v1 v2)) in * by assumption
               end
          | [ H : is_tighter_than_bool (?ZRf ?r1) (ZRange.normalize ?rs) = true,
                  H1 : is_bounded_by_bool ?v1 ?r1 = true
              |- _ ]
            => let cst := multimatch goal with
-                         | [ |- context[ident.cast ?coor rs (?Zf v1)] ] => constr:(ident.cast coor rs (Zf v1))
-                         | [ H : context[ident.cast ?coor rs (?Zf v1)] |- _ ] => constr:(ident.cast coor rs (Zf v1))
+                         | [ |- context[ident.cast rs (?Zf v1)] ] => constr:(ident.cast rs (Zf v1))
+                         | [ H : context[ident.cast rs (?Zf v1)] |- _ ] => constr:(ident.cast rs (Zf v1))
                          end in
               lazymatch cst with
-              | ident.cast ?coor rs (?Zf v1)
+              | ident.cast rs (?Zf v1)
                 => let lem := lazymatch constr:((ZRf, Zf)%core) with
                               | (ZRange.cc_m ?s, Z.cc_m ?s)%core => constr:(@ZRange.is_bounded_by_bool_cc_m s v1 r1 H1)
                               end in
                    try unique pose proof (@ZRange.is_bounded_by_of_is_tighter_than _ _ H _ lem);
                    clear H;
-                   rewrite (@ident.cast_in_normalized_bounds coor rs (Zf v1)) in * by assumption
+                   rewrite (@ident.cast_in_normalized_bounds rs (Zf v1)) in * by assumption
               end
-         | [ H : is_bounded_by_bool ?v (ZRange.normalize ?r) = true |- context[ident.cast ?coor ?r ?v] ]
-           => rewrite (@ident.cast_in_normalized_bounds coor r v) in * by assumption
-         | [ H : is_bounded_by_bool ?v (ZRange.normalize ?r) = true, H' : context[ident.cast ?coor ?r ?v] |- _ ]
-           => rewrite (@ident.cast_in_normalized_bounds coor r v) in * by assumption
+         | [ H : is_bounded_by_bool ?v (ZRange.normalize ?r) = true |- context[ident.cast ?r ?v] ]
+           => rewrite (@ident.cast_in_normalized_bounds r v) in * by assumption
+         | [ H : is_bounded_by_bool ?v (ZRange.normalize ?r) = true, H' : context[ident.cast ?r ?v] |- _ ]
+           => rewrite (@ident.cast_in_normalized_bounds r v) in * by assumption
          | [ H : is_bounded_by_bool ?v ?r = true,
                  H' : is_tighter_than_bool ?r r[0~>?x-1]%zrange = true,
                       H'' : Z.eqb ?x ?m = true
@@ -441,7 +441,7 @@ Local Ltac systematically_handle_casts :=
 
 Local Ltac fin_with_nia :=
   lazymatch goal with
-  | [ |- ident.cast _ ?r _ = ident.cast _ ?r _ ] => apply f_equal; Z.div_mod_to_quot_rem; nia
+  | [ |- ident.cast ?r _ = ident.cast ?r _ ] => apply f_equal; Z.div_mod_to_quot_rem; nia
   | _ => reflexivity || (Z.div_mod_to_quot_rem; (lia + nia))
   end.
 
@@ -492,7 +492,7 @@ End fancy.
 
 Local Ltac cast_to_arith r v :=
   match goal with
-  | [ |- context[ident.cast ?coor r v] ]
+  | [ |- context[ident.cast r v] ]
     => let H := fresh in
        eassert (H : _);
        [ | rewrite (ident.cast_in_bounds r v) by exact H ]
@@ -566,13 +566,13 @@ Proof using Type.
   (* special case to match on a particular rule that is way easier to prove this
      way; this is hacky and should ideally be removed eventually *)
   all: try match goal with
-           | |- ident.cast _ r[0 ~> 2 ^ ?b * 2 ^ ?b - 1] (_ >> _) = _ =>
+           | |- ident.cast r[0 ~> 2 ^ ?b * 2 ^ ?b - 1] (_ >> _) = _ =>
              f_equal
            end.
 
   (* remove whatever bounds [bounds_arith_hammer] solves *)
   all:repeat match goal with
-             | [ |- context[ident.cast ?coor ?r ?v] ]
+             | [ |- context[ident.cast ?r ?v] ]
                => cast_to_arith r v; [ solve [bounds_arith_hammer] .. | ]
              end.
 


### PR DESCRIPTION
On top of #599

It was unused, since 99df34f

```
After     | File Name                                                       | Before    || Change    | % Change
---------------------------------------------------------------------------------------------------------------
55m16.13s | Total                                                           | 55m14.28s || +0m01.84s | +0.05%
---------------------------------------------------------------------------------------------------------------
4m24.81s  | p384_32.c                                                       | 4m14.59s  || +0m10.21s | +4.01%
4m17.30s  | fiat-rust/src/p384_32.rs                                        | 4m07.30s  || +0m10.00s | +4.04%
0m28.84s  | BoundsPipeline.vo                                               | 0m34.56s  || -0m05.72s | -16.55%
0m33.82s  | p521_64.c                                                       | 0m37.99s  || -0m04.17s | -10.97%
1m02.42s  | Rewriter/Examples.vo                                            | 1m05.97s  || -0m03.54s | -5.38%
3m26.94s  | PushButtonSynthesis/WordByWordMontgomeryReificationCache.vo     | 3m29.73s  || -0m02.78s | -1.33%
2m41.64s  | PushButtonSynthesis/FancyMontgomeryReductionReificationCache.vo | 2m44.21s  || -0m02.57s | -1.56%
2m28.71s  | Rewriter/Passes/NBE.vo                                          | 2m26.38s  || +0m02.33s | +1.59%
0m39.00s  | Rewriter/Passes/Arith.vo                                        | 0m41.02s  || -0m02.02s | -4.92%
0m00.82s  | Rewriter/Rules.vo                                               | 0m03.13s  || -0m02.31s | -73.80%
2m29.64s  | Rewriter/Passes/ToFancyWithCasts.vo                             | 2m27.90s  || +0m01.73s | +1.17%
2m04.75s  | Fancy/Barrett256.vo                                             | 2m02.82s  || +0m01.93s | +1.57%
1m52.24s  | Rewriter/Passes/ArithWithCasts.vo                               | 1m51.12s  || +0m01.12s | +1.00%
1m08.99s  | AbstractInterpretation/Wf.vo                                    | 1m07.51s  || +0m01.47s | +2.19%
1m04.18s  | AbstractInterpretation/ZRangeProofs.vo                          | 1m05.71s  || -0m01.52s | -2.32%
0m55.78s  | Language/UnderLetsProofs.vo                                     | 0m56.88s  || -0m01.10s | -1.93%
0m50.48s  | Fancy/Montgomery256.vo                                          | 0m51.95s  || -0m01.47s | -2.82%
0m42.32s  | Rewriter/RulesProofs.vo                                         | 0m44.01s  || -0m01.68s | -3.84%
0m37.77s  | fiat-rust/src/p521_64.rs                                        | 0m36.14s  || +0m01.63s | +4.51%
0m35.88s  | AbstractInterpretation/Proofs.vo                                | 0m37.37s  || -0m01.48s | -3.98%
0m32.72s  | ExtractionOCaml/word_by_word_montgomery                         | 0m31.68s  || +0m01.03s | +3.28%
0m17.60s  | p256_32.c                                                       | 0m18.69s  || -0m01.08s | -5.83%
0m15.56s  | p434_64.c                                                       | 0m16.85s  || -0m01.29s | -7.65%
0m15.40s  | fiat-rust/src/p434_64.rs                                        | 0m16.53s  || -0m01.13s | -6.83%
3m28.70s  | Fancy/Compiler.vo                                               | 3m29.44s  || -0m00.74s | -0.35%
2m37.14s  | Rewriter/Wf.vo                                                  | 2m37.64s  || -0m00.50s | -0.31%
1m07.70s  | Rewriter/InterpProofs.vo                                        | 1m08.08s  || -0m00.37s | -0.55%
1m02.12s  | Rewriter/ProofsCommon.vo                                        | 1m01.75s  || +0m00.36s | +0.59%
0m55.91s  | PushButtonSynthesis/UnsaturatedSolinas.vo                       | 0m55.42s  || +0m00.48s | +0.88%
0m50.95s  | SlowPrimeSynthesisExamples.vo                                   | 0m50.41s  || +0m00.54s | +1.07%
0m46.93s  | PushButtonSynthesis/UnsaturatedSolinasReificationCache.vo       | 0m47.10s  || -0m00.17s | -0.36%
0m45.68s  | p521_32.c                                                       | 0m45.62s  || +0m00.06s | +0.13%
0m45.64s  | fiat-rust/src/p521_32.rs                                        | 0m45.49s  || +0m00.14s | +0.32%
0m41.38s  | PushButtonSynthesis/WordByWordMontgomery.vo                     | 0m41.42s  || -0m00.03s | -0.09%
0m38.23s  | PushButtonSynthesis/BarrettReductionReificationCache.vo         | 0m38.51s  || -0m00.28s | -0.72%
0m25.94s  | Rewriter/Passes/MulSplit.vo                                     | 0m25.00s  || +0m00.94s | +3.76%
0m25.66s  | ExtractionOCaml/unsaturated_solinas                             | 0m25.17s  || +0m00.48s | +1.94%
0m24.91s  | Language/Wf.vo                                                  | 0m24.93s  || -0m00.01s | -0.08%
0m23.76s  | PushButtonSynthesis/BarrettReduction.vo                         | 0m22.91s  || +0m00.85s | +3.71%
0m23.10s  | Language/Identifier.vo                                          | 0m23.13s  || -0m00.02s | -0.12%
0m21.83s  | Language/Inversion.vo                                           | 0m21.91s  || -0m00.08s | -0.36%
0m19.82s  | fiat-rust/src/secp256k1_32.rs                                   | 0m19.14s  || +0m00.67s | +3.55%
0m19.82s  | secp256k1_32.c                                                  | 0m19.30s  || +0m00.51s | +2.69%
0m19.63s  | fiat-rust/src/p256_32.rs                                        | 0m19.20s  || +0m00.42s | +2.23%
0m18.93s  | ExtractionOCaml/word_by_word_montgomery.ml                      | 0m18.83s  || +0m00.10s | +0.53%
0m16.61s  | p448_solinas_64.c                                               | 0m17.10s  || -0m00.49s | -2.86%
0m16.53s  | Stringification/IR.vo                                           | 0m16.51s  || +0m00.01s | +0.12%
0m16.22s  | fiat-rust/src/p448_solinas_64.rs                                | 0m16.81s  || -0m00.58s | -3.50%
0m15.27s  | Language/IdentifiersGENERATED.vo                                | 0m15.36s  || -0m00.08s | -0.58%
0m14.78s  | Language/IdentifiersGENERATEDProofs.vo                          | 0m14.68s  || +0m00.09s | +0.68%
0m14.76s  | ExtractionOCaml/unsaturated_solinas.ml                          | 0m15.14s  || -0m00.38s | -2.50%
0m14.67s  | Language/IdentifiersLibraryProofs.vo                            | 0m14.59s  || +0m00.08s | +0.54%
0m09.58s  | fiat-rust/src/p224_32.rs                                        | 0m09.21s  || +0m00.36s | +4.01%
0m09.48s  | p224_32.c                                                       | 0m09.14s  || +0m00.33s | +3.71%
0m08.21s  | fiat-rust/src/p384_64.rs                                        | 0m08.06s  || +0m00.15s | +1.86%
0m08.04s  | p384_64.c                                                       | 0m07.49s  || +0m00.54s | +7.34%
0m06.44s  | PushButtonSynthesis/SmallExamples.vo                            | 0m06.24s  || +0m00.20s | +3.20%
0m06.14s  | Fancy/Prod.vo                                                   | 0m06.04s  || +0m00.09s | +1.65%
0m05.44s  | PushButtonSynthesis/Primitives.vo                               | 0m05.36s  || +0m00.08s | +1.49%
0m05.42s  | PushButtonSynthesis/SaturatedSolinasReificationCache.vo         | 0m05.47s  || -0m00.04s | -0.91%
0m05.02s  | CastLemmas.vo                                                   | 0m05.10s  || -0m00.08s | -1.56%
0m04.35s  | PushButtonSynthesis/SaturatedSolinas.vo                         | 0m04.30s  || +0m00.04s | +1.16%
0m04.26s  | PushButtonSynthesis/FancyMontgomeryReduction.vo                 | 0m04.23s  || +0m00.02s | +0.70%
0m04.20s  | Language/InversionExtra.vo                                      | 0m04.29s  || -0m00.08s | -2.09%
0m02.83s  | fiat-rust/src/curve25519_32.rs                                  | 0m02.76s  || +0m00.07s | +2.53%
0m02.78s  | MiscCompilerPassesProofs.vo                                     | 0m02.88s  || -0m00.10s | -3.47%
0m02.71s  | curve25519_32.c                                                 | 0m02.76s  || -0m00.04s | -1.81%
0m01.99s  | Rewriter/Passes/StripLiteralCasts.vo                            | 0m01.88s  || +0m00.11s | +5.85%
0m01.88s  | Rewriter/PerfTesting/Core.vo                                    | 0m01.81s  || +0m00.06s | +3.86%
0m01.87s  | curve25519_64.c                                                 | 0m01.88s  || -0m00.00s | -0.53%
0m01.87s  | fiat-rust/src/curve25519_64.rs                                  | 0m01.84s  || +0m00.03s | +1.63%
0m01.83s  | CLI.vo                                                          | 0m01.89s  || -0m00.05s | -3.17%
0m01.82s  | Language/IdentifiersLibrary.vo                                  | 0m01.83s  || -0m00.01s | -0.54%
0m01.81s  | Stringification/Rust.vo                                         | 0m01.82s  || -0m00.01s | -0.54%
0m01.79s  | Rewriter/Passes/ToFancy.vo                                      | 0m01.84s  || -0m00.05s | -2.71%
0m01.78s  | AbstractInterpretation/AbstractInterpretation.vo                | 0m01.77s  || +0m00.01s | +0.56%
0m01.77s  | fiat-rust/src/secp256k1_64.rs                                   | 0m01.72s  || +0m00.05s | +2.90%
0m01.76s  | p224_64.c                                                       | 0m01.61s  || +0m00.14s | +9.31%
0m01.76s  | secp256k1_64.c                                                  | 0m01.68s  || +0m00.08s | +4.76%
0m01.72s  | fiat-rust/src/p224_64.rs                                        | 0m01.58s  || +0m00.13s | +8.86%
0m01.71s  | Rewriter/PerfTesting/StandaloneOCamlMain.vo                     | 0m01.64s  || +0m00.07s | +4.26%
0m01.69s  | fiat-rust/src/p256_64.rs                                        | 0m01.58s  || +0m00.10s | +6.96%
0m01.54s  | StandaloneOCamlMain.vo                                          | 0m01.38s  || +0m00.16s | +11.59%
0m01.52s  | p256_64.c                                                       | 0m01.64s  || -0m00.11s | -7.31%
0m01.50s  | CompilersTestCases.vo                                           | 0m01.51s  || -0m00.01s | -0.66%
0m01.42s  | Rewriter/Rewriter.vo                                            | 0m01.32s  || +0m00.09s | +7.57%
0m01.40s  | StandaloneHaskellMain.vo                                        | 0m01.43s  || -0m00.03s | -2.09%
0m01.37s  | Rewriter/Reify.vo                                               | 0m01.32s  || +0m00.05s | +3.78%
0m01.35s  | Stringification/Language.vo                                     | 0m01.28s  || +0m00.07s | +5.46%
0m01.26s  | Language/Language.vo                                            | 0m01.24s  || +0m00.02s | +1.61%
0m01.04s  | Stringification/C.vo                                            | 0m01.04s  || +0m00.00s | +0.00%
0m01.02s  | Rewriter/AllTactics.vo                                          | 0m01.02s  || +0m00.00s | +0.00%
0m00.95s  | Rewriter/All.vo                                                 | 0m00.91s  || +0m00.03s | +4.39%
0m00.91s  | Rewriter/ProofsCommonTactics.vo                                 | 0m00.92s  || -0m00.01s | -1.08%
0m00.89s  | MiscCompilerPassesProofsExtra.vo                                | 0m00.84s  || +0m00.05s | +5.95%
0m00.88s  | Rewriter/AllTacticsExtra.vo                                     | 0m00.93s  || -0m00.05s | -5.37%
0m00.85s  | Language/IdentifiersGenerate.vo                                 | 0m00.90s  || -0m00.05s | -5.55%
0m00.82s  | Language/IdentifiersGenerateProofs.vo                           | 0m00.85s  || -0m00.03s | -3.52%
0m00.80s  | MiscCompilerPasses.vo                                           | 0m00.83s  || -0m00.02s | -3.61%
0m00.62s  | Language/WfExtra.vo                                             | 0m00.67s  || -0m00.05s | -7.46%
0m00.60s  | Language/APINotations.vo                                        | 0m00.70s  || -0m00.09s | -14.28%
0m00.60s  | Language/UnderLets.vo                                           | 0m00.58s  || +0m00.02s | +3.44%
0m00.59s  | AbstractInterpretation/WfExtra.vo                               | 0m00.52s  || +0m00.06s | +13.46%
0m00.58s  | PushButtonSynthesis/ReificationCache.vo                         | 0m00.56s  || +0m00.01s | +3.57%
0m00.57s  | Language/UnderLetsProofsExtra.vo                                | 0m00.58s  || -0m00.01s | -1.72%
0m00.48s  | Language/API.vo                                                 | 0m00.53s  || -0m00.05s | -9.43%
0m00.39s  | Language/Pre.vo                                                 | 0m00.46s  || -0m00.07s | -15.21%
```