### PR TITLE
Use an auto-generated version of the ident inductive

### DIFF
--- a/src/AbstractInterpretation/ZRangeProofs.v
+++ b/src/AbstractInterpretation/ZRangeProofs.v
@@ -537,6 +537,7 @@ Module Compilers.
                  end.
             all: cbn [type.related_hetero ZRange.ident.option.interp ident.interp respectful_hetero type.interp ZRange.type.base.option.interp ZRange.type.base.interp base.interp base.base_interp ZRange.type.base.option.Some ZRange.ident.option.of_literal].
             all: cbv [ident.cast2 ident.literal prod_rect_nodep ident.eagerly] in *.
+            all: cbv [nat_rect_arrow_nodep list_rect_arrow_nodep] in *.
             all: change (@zrange_rect_nodep) with (fun T => @zrange_rect (fun _ => T)) in *.
             all: change (@ident.Thunked.nat_rect) with (fun P P0 => @nat_rect (fun _ => P) (P0 Datatypes.tt)) in *.
             all: change (@nat_rect_nodep) with (fun P => @nat_rect (fun _ => P)).

--- a/src/Language/APINotations.v
+++ b/src/Language/APINotations.v
@@ -56,6 +56,43 @@ Module Compilers.
   Global Existing Instance eqv_Reflexive_Proper | 1.
   Global Existing Instance ident_interp_Proper | 1.
 
+  Bind Scope etype_scope with base.
+
+  Global Arguments ident_Literal {_} _ : assert.
+  Global Arguments ident_nil {_} : assert.
+  Global Arguments ident_cons {_} : assert.
+  Global Arguments ident_pair {_ _} : assert.
+  Global Arguments ident_fst {_ _} : assert.
+  Global Arguments ident_snd {_ _} : assert.
+  Global Arguments ident_prod_rect {_ _ _} : assert.
+  Global Arguments ident_bool_rect {_} : assert.
+  Global Arguments ident_nat_rect {_} : assert.
+  Global Arguments ident_nat_rect_arrow {_ _} : assert.
+  Global Arguments ident_eager_nat_rect {_} : assert.
+  Global Arguments ident_eager_nat_rect_arrow {_ _} : assert.
+  Global Arguments ident_list_rect {_ _} : assert.
+  Global Arguments ident_list_rect_arrow {_ _ _} : assert.
+  Global Arguments ident_eager_list_rect {_ _} : assert.
+  Global Arguments ident_eager_list_rect_arrow {_ _ _} : assert.
+  Global Arguments ident_list_case {_ _} : assert.
+  Global Arguments ident_List_length {_} : assert.
+  Global Arguments ident_List_firstn {_} : assert.
+  Global Arguments ident_List_skipn {_} : assert.
+  Global Arguments ident_List_repeat {_} : assert.
+  Global Arguments ident_List_combine {_ _} : assert.
+  Global Arguments ident_List_map {_ _} : assert.
+  Global Arguments ident_List_app {_} : assert.
+  Global Arguments ident_List_rev {_} : assert.
+  Global Arguments ident_List_flat_map {_ _} : assert.
+  Global Arguments ident_List_partition {_} : assert.
+  Global Arguments ident_List_fold_right {_ _} : assert.
+  Global Arguments ident_List_update_nth {_} : assert.
+  Global Arguments ident_List_nth_default {_} : assert.
+  Global Arguments ident_eager_List_nth_default {_} : assert.
+  Global Arguments ident_Some {_} : assert.
+  Global Arguments ident_None {_} : assert.
+  Global Arguments ident_option_rect {_ _} : assert.
+  Global Arguments ident_zrange_rect {_} : assert.
 
   (** This file defines some convenience notations and definitions. *)
   Module base.

--- a/src/Language/IdentifiersGENERATED.v
+++ b/src/Language/IdentifiersGENERATED.v
@@ -40,12 +40,12 @@ Module Compilers.
         | ident_prod_rect
         | ident_bool_rect
         | ident_nat_rect
-        | ident_nat_rect_arrow
         | ident_eager_nat_rect
+        | ident_nat_rect_arrow
         | ident_eager_nat_rect_arrow
         | ident_list_rect
-        | ident_list_rect_arrow
         | ident_eager_list_rect
+        | ident_list_rect_arrow
         | ident_eager_list_rect_arrow
         | ident_list_case
         | ident_List_length
@@ -70,13 +70,13 @@ Module Compilers.
         | ident_Z_opp
         | ident_Z_div
         | ident_Z_modulo
-        | ident_Z_log2
-        | ident_Z_log2_up
         | ident_Z_eqb
         | ident_Z_leb
         | ident_Z_ltb
         | ident_Z_geb
         | ident_Z_gtb
+        | ident_Z_log2
+        | ident_Z_log2_up
         | ident_Z_of_nat
         | ident_Z_to_nat
         | ident_Z_shiftr
@@ -85,9 +85,6 @@ Module Compilers.
         | ident_Z_lor
         | ident_Z_min
         | ident_Z_max
-        | ident_Z_bneg
-        | ident_Z_lnot_modulo
-        | ident_Z_truncating_shiftl
         | ident_Z_mul_split
         | ident_Z_add_get_carry
         | ident_Z_add_with_carry
@@ -96,6 +93,9 @@ Module Compilers.
         | ident_Z_sub_with_get_borrow
         | ident_Z_zselect
         | ident_Z_add_modulo
+        | ident_Z_truncating_shiftl
+        | ident_Z_bneg
+        | ident_Z_lnot_modulo
         | ident_Z_rshi
         | ident_Z_cc_m
         | ident_Z_combine_at_bitwidth
@@ -150,35 +150,35 @@ Module Compilers.
       | ident_nil : (forall t : pattern.base.type.type base, ident (type.base (pattern.base.type.list t)))
       | ident_cons : (forall t : pattern.base.type.type base, ident (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.list t)))))
       | ident_tt : (ident (type.base pattern.base.type.unit))
-      | ident_pair : (forall A B : pattern.base.type.type base, ident (type.arrow (type.base A) (type.arrow (type.base B) (type.base (pattern.base.type.prod A B)))))
-      | ident_fst : (forall A B : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.prod A B)) (type.base A)))
-      | ident_snd : (forall A B : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.prod A B)) (type.base B)))
-      | ident_prod_rect : (forall A B T : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base A) (type.arrow (type.base B) (type.base T))) (type.arrow (type.base (pattern.base.type.prod A B)) (type.base T))))
-      | ident_bool_rect : (forall T : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base T)) (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base T)) (type.arrow (type.base (pattern.base.type.type_base Compilers.bool)) (type.base T)))))
-      | ident_nat_rect : (forall P : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base P)) (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base P) (type.base P))) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base P)))))
-      | ident_nat_rect_arrow : (forall P Q : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base P) (type.base Q)) (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.arrow (type.base P) (type.base Q)) (type.arrow (type.base P) (type.base Q)))) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base P) (type.base Q))))))
-      | ident_eager_nat_rect : (forall P : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base P)) (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base P) (type.base P))) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base P)))))
-      | ident_eager_nat_rect_arrow : (forall P Q : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base P) (type.base Q)) (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.arrow (type.base P) (type.base Q)) (type.arrow (type.base P) (type.base Q)))) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base P) (type.base Q))))))
-      | ident_list_rect : (forall A P : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base P)) (type.arrow (type.arrow (type.base A) (type.arrow (type.base (pattern.base.type.list A)) (type.arrow (type.base P) (type.base P)))) (type.arrow (type.base (pattern.base.type.list A)) (type.base P)))))
-      | ident_list_rect_arrow : (forall A P Q : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base P) (type.base Q)) (type.arrow (type.arrow (type.base A) (type.arrow (type.base (pattern.base.type.list A)) (type.arrow (type.arrow (type.base P) (type.base Q)) (type.arrow (type.base P) (type.base Q))))) (type.arrow (type.base (pattern.base.type.list A)) (type.arrow (type.base P) (type.base Q))))))
-      | ident_eager_list_rect : (forall A P : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base P)) (type.arrow (type.arrow (type.base A) (type.arrow (type.base (pattern.base.type.list A)) (type.arrow (type.base P) (type.base P)))) (type.arrow (type.base (pattern.base.type.list A)) (type.base P)))))
-      | ident_eager_list_rect_arrow : (forall A P Q : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base P) (type.base Q)) (type.arrow (type.arrow (type.base A) (type.arrow (type.base (pattern.base.type.list A)) (type.arrow (type.arrow (type.base P) (type.base Q)) (type.arrow (type.base P) (type.base Q))))) (type.arrow (type.base (pattern.base.type.list A)) (type.arrow (type.base P) (type.base Q))))))
-      | ident_list_case : (forall A P : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base P)) (type.arrow (type.arrow (type.base A) (type.arrow (type.base (pattern.base.type.list A)) (type.base P))) (type.arrow (type.base (pattern.base.type.list A)) (type.base P)))))
-      | ident_List_length : (forall T : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.list T)) (type.base (pattern.base.type.type_base Compilers.nat))))
+      | ident_pair : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.base t) (type.arrow (type.base t0) (type.base (pattern.base.type.prod t t0)))))
+      | ident_fst : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.prod t t0)) (type.base t)))
+      | ident_snd : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.prod t t0)) (type.base t0)))
+      | ident_prod_rect : (forall t t0 t1 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t) (type.arrow (type.base t0) (type.base t1))) (type.arrow (type.base (pattern.base.type.prod t t0)) (type.base t1))))
+      | ident_bool_rect : (forall t : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base t)) (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base t)) (type.arrow (type.base (pattern.base.type.type_base Compilers.bool)) (type.base t)))))
+      | ident_nat_rect : (forall t : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base t)) (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base t) (type.base t))) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base t)))))
+      | ident_eager_nat_rect : (forall t : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base t)) (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base t) (type.base t))) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base t)))))
+      | ident_nat_rect_arrow : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t) (type.base t0)) (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.arrow (type.base t) (type.base t0)) (type.arrow (type.base t) (type.base t0)))) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base t) (type.base t0))))))
+      | ident_eager_nat_rect_arrow : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t) (type.base t0)) (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.arrow (type.base t) (type.base t0)) (type.arrow (type.base t) (type.base t0)))) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base t) (type.base t0))))))
+      | ident_list_rect : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base t0)) (type.arrow (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.base t0) (type.base t0)))) (type.arrow (type.base (pattern.base.type.list t)) (type.base t0)))))
+      | ident_eager_list_rect : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base t0)) (type.arrow (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.base t0) (type.base t0)))) (type.arrow (type.base (pattern.base.type.list t)) (type.base t0)))))
+      | ident_list_rect_arrow : (forall t t0 t1 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t0) (type.base t1)) (type.arrow (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.arrow (type.base t0) (type.base t1)) (type.arrow (type.base t0) (type.base t1))))) (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.base t0) (type.base t1))))))
+      | ident_eager_list_rect_arrow : (forall t t0 t1 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t0) (type.base t1)) (type.arrow (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.arrow (type.base t0) (type.base t1)) (type.arrow (type.base t0) (type.base t1))))) (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.base t0) (type.base t1))))))
+      | ident_list_case : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base t0)) (type.arrow (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t)) (type.base t0))) (type.arrow (type.base (pattern.base.type.list t)) (type.base t0)))))
+      | ident_List_length : (forall t : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.type_base Compilers.nat))))
       | ident_List_seq : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base (pattern.base.type.list (pattern.base.type.type_base Compilers.nat))))))
-      | ident_List_firstn : (forall A : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base (pattern.base.type.list A)) (type.base (pattern.base.type.list A)))))
-      | ident_List_skipn : (forall A : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base (pattern.base.type.list A)) (type.base (pattern.base.type.list A)))))
-      | ident_List_repeat : (forall A : pattern.base.type.type base, ident (type.arrow (type.base A) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base (pattern.base.type.list A)))))
-      | ident_List_combine : (forall A B : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.list A)) (type.arrow (type.base (pattern.base.type.list B)) (type.base (pattern.base.type.list (pattern.base.type.prod A B))))))
-      | ident_List_map : (forall A B : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base A) (type.base B)) (type.arrow (type.base (pattern.base.type.list A)) (type.base (pattern.base.type.list B)))))
-      | ident_List_app : (forall A : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.list A)) (type.arrow (type.base (pattern.base.type.list A)) (type.base (pattern.base.type.list A)))))
-      | ident_List_rev : (forall A : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.list A)) (type.base (pattern.base.type.list A))))
-      | ident_List_flat_map : (forall A B : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base A) (type.base (pattern.base.type.list B))) (type.arrow (type.base (pattern.base.type.list A)) (type.base (pattern.base.type.list B)))))
-      | ident_List_partition : (forall A : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base A) (type.base (pattern.base.type.type_base Compilers.bool))) (type.arrow (type.base (pattern.base.type.list A)) (type.base (pattern.base.type.prod (pattern.base.type.list A) (pattern.base.type.list A))))))
-      | ident_List_fold_right : (forall A B : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base B) (type.arrow (type.base A) (type.base A))) (type.arrow (type.base A) (type.arrow (type.base (pattern.base.type.list B)) (type.base A)))))
-      | ident_List_update_nth : (forall T : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.arrow (type.base T) (type.base T)) (type.arrow (type.base (pattern.base.type.list T)) (type.base (pattern.base.type.list T))))))
-      | ident_List_nth_default : (forall T : pattern.base.type.type base, ident (type.arrow (type.base T) (type.arrow (type.base (pattern.base.type.list T)) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base T)))))
-      | ident_eager_List_nth_default : (forall T : pattern.base.type.type base, ident (type.arrow (type.base T) (type.arrow (type.base (pattern.base.type.list T)) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base T)))))
+      | ident_List_firstn : (forall t : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.list t)))))
+      | ident_List_skipn : (forall t : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.list t)))))
+      | ident_List_repeat : (forall t : pattern.base.type.type base, ident (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base (pattern.base.type.list t)))))
+      | ident_List_combine : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.base (pattern.base.type.list t0)) (type.base (pattern.base.type.list (pattern.base.type.prod t t0))))))
+      | ident_List_map : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t) (type.base t0)) (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.list t0)))))
+      | ident_List_app : (forall t : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.list t)))))
+      | ident_List_rev : (forall t : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.list t))))
+      | ident_List_flat_map : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t) (type.base (pattern.base.type.list t0))) (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.list t0)))))
+      | ident_List_partition : (forall t : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t) (type.base (pattern.base.type.type_base Compilers.bool))) (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.prod (pattern.base.type.list t) (pattern.base.type.list t))))))
+      | ident_List_fold_right : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t0) (type.arrow (type.base t) (type.base t))) (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t0)) (type.base t)))))
+      | ident_List_update_nth : (forall t : pattern.base.type.type base, ident (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.arrow (type.arrow (type.base t) (type.base t)) (type.arrow (type.base (pattern.base.type.list t)) (type.base (pattern.base.type.list t))))))
+      | ident_List_nth_default : (forall t : pattern.base.type.type base, ident (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base t)))))
+      | ident_eager_List_nth_default : (forall t : pattern.base.type.type base, ident (type.arrow (type.base t) (type.arrow (type.base (pattern.base.type.list t)) (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base t)))))
       | ident_Z_add : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
       | ident_Z_mul : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
       | ident_Z_pow : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
@@ -186,13 +186,13 @@ Module Compilers.
       | ident_Z_opp : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))
       | ident_Z_div : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
       | ident_Z_modulo : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
-      | ident_Z_log2 : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))
-      | ident_Z_log2_up : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))
       | ident_Z_eqb : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.bool)))))
       | ident_Z_leb : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.bool)))))
       | ident_Z_ltb : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.bool)))))
       | ident_Z_geb : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.bool)))))
       | ident_Z_gtb : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.bool)))))
+      | ident_Z_log2 : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))
+      | ident_Z_log2_up : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))
       | ident_Z_of_nat : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.nat)) (type.base (pattern.base.type.type_base Compilers.Z))))
       | ident_Z_to_nat : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.nat))))
       | ident_Z_shiftr : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
@@ -201,9 +201,6 @@ Module Compilers.
       | ident_Z_lor : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
       | ident_Z_min : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
       | ident_Z_max : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
-      | ident_Z_bneg : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))
-      | ident_Z_lnot_modulo : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
-      | ident_Z_truncating_shiftl : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))))
       | ident_Z_mul_split : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)))))))
       | ident_Z_add_get_carry : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)))))))
       | ident_Z_add_with_carry : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))))
@@ -212,16 +209,19 @@ Module Compilers.
       | ident_Z_sub_with_get_borrow : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z))))))))
       | ident_Z_zselect : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))))
       | ident_Z_add_modulo : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))))
+      | ident_Z_truncating_shiftl : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))))
+      | ident_Z_bneg : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))
+      | ident_Z_lnot_modulo : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
       | ident_Z_rshi : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))))
       | ident_Z_cc_m : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
       | ident_Z_combine_at_bitwidth : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z))))))
       | ident_Z_cast : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.zrange)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.Z)))))
       | ident_Z_cast2 : (ident (type.arrow (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.zrange) (pattern.base.type.type_base Compilers.zrange))) (type.arrow (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z))) (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z))))))
-      | ident_Some : (forall A : pattern.base.type.type base, ident (type.arrow (type.base A) (type.base (pattern.base.type.option A))))
-      | ident_None : (forall A : pattern.base.type.type base, ident (type.base (pattern.base.type.option A)))
-      | ident_option_rect : (forall A P : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base A) (type.base P)) (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base P)) (type.arrow (type.base (pattern.base.type.option A)) (type.base P)))))
+      | ident_Some : (forall t : pattern.base.type.type base, ident (type.arrow (type.base t) (type.base (pattern.base.type.option t))))
+      | ident_None : (forall t : pattern.base.type.type base, ident (type.base (pattern.base.type.option t)))
+      | ident_option_rect : (forall t t0 : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base t) (type.base t0)) (type.arrow (type.arrow (type.base pattern.base.type.unit) (type.base t0)) (type.arrow (type.base (pattern.base.type.option t)) (type.base t0)))))
       | ident_Build_zrange : (ident (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base (pattern.base.type.type_base Compilers.zrange)))))
-      | ident_zrange_rect : (forall P : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base P))) (type.arrow (type.base (pattern.base.type.type_base Compilers.zrange)) (type.base P))))
+      | ident_zrange_rect : (forall t : pattern.base.type.type base, ident (type.arrow (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.arrow (type.base (pattern.base.type.type_base Compilers.Z)) (type.base t))) (type.arrow (type.base (pattern.base.type.type_base Compilers.zrange)) (type.base t))))
       | ident_fancy_add : (ident (type.arrow (type.base (pattern.base.type.prod (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)) (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)))) (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)))))
       | ident_fancy_addc : (ident (type.arrow (type.base (pattern.base.type.prod (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)) (pattern.base.type.prod (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)) (pattern.base.type.type_base Compilers.Z)))) (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)))))
       | ident_fancy_sub : (ident (type.arrow (type.base (pattern.base.type.prod (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)) (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)))) (type.base (pattern.base.type.prod (pattern.base.type.type_base Compilers.Z) (pattern.base.type.type_base Compilers.Z)))))

--- a/src/Language/IdentifiersGenerate.v
+++ b/src/Language/IdentifiersGenerate.v
@@ -400,7 +400,7 @@ Module Compilers.
               let all_idents := Compilers.pattern.Tactics.build_all_idents ident in
               idtac "        Inductive ident :=";
               let v := all_idents in
-              map_projT2 ltac:(fun v => let v := fill_forall_args v in idtac "        |" v) v;
+              map_projT2 ltac:(fun v => (*let v := fill_forall_args v in*) idtac "        |" v) v;
               idtac "        .".
             Import Compilers.ident.
             Local Unset Printing Notations.
@@ -690,7 +690,7 @@ Module Compilers.
                                 let T := Set_to_Type T in
                                 let T := (eval cbv beta in
                                              (T base.type.type (@base.type.prod) (@base.type.list) (@base.type.option) (@base.type.unit) (@base.type.type_base) (@ident))) in
-                                let v := fill_forall_args v in
+                                (*let v := fill_forall_args v in*)
                                 idtac "        |" v ":" T) v;
             idtac "      .".
           Import Compilers.ident.

--- a/src/Language/Pre.v
+++ b/src/Language/Pre.v
@@ -131,8 +131,27 @@ Scheme Minimality for nat Sort Type.
 Scheme Minimality for list Sort Type.
 Scheme Minimality for option Sort Type.
 
+Definition nat_rect_arrow_nodep P Q := @nat_rect_nodep (P -> Q).
+Definition list_rect_arrow_nodep A P Q := @list_rect_nodep A (P -> Q).
+
 Module GallinaIdentList.
-  Polymorphic Inductive t := nil | cons {T : Type} (v : T) (vs : t).
+  Local Set Universe Polymorphism.
+  Inductive t := nil | cons {T : Type} (v : T) (vs : t).
+
+  Fixpoint nth_type (n : nat) (l : t) (default : Type) {struct l} :=
+    match n, l with
+    | O, @cons T _ _ => T
+    | S m, @cons _ _ l => nth_type m l default
+    | _, _ => default
+    end.
+
+  Fixpoint nth (n : nat) (l : t) {T} (default : T) {struct l} : nth_type n l T :=
+    match n, l return nth_type n l T with
+    | O, @cons _ x _ => x
+    | S m, @cons _ _ l => nth m l default
+    | _, _ => default
+    end.
+
   Module Export Notations.
     Delimit Scope gallina_ident_list_scope with gi_list.
     Bind Scope gallina_ident_list_scope with t.
@@ -163,3 +182,17 @@ Module TypeList.
   End Notations.
 End TypeList.
 Export TypeList.Notations.
+
+Module Named.
+  Local Set Universe Polymorphism.
+  Local Set Primitive Projections.
+  Inductive maybe_name := no_name | a_name (_ : forall P : Prop, P -> P).
+  Record t := { type : Type ; value : type ; naming : maybe_name }.
+End Named.
+Notation with_name name v := (@Named.Build_t _ v (Named.a_name (fun (P : Prop) (name : P) => name))) (only parsing).
+Notation without_name v := (@Named.Build_t _ v Named.no_name) (only parsing).
+
+Module GallinaAndReifiedIdentList.
+  Local Set Universe Polymorphism.
+  Inductive t := nil | cons {T1 T2 : Type} (v1 : T1) (v2 : T2) (vs : t).
+End GallinaAndReifiedIdentList.

--- a/src/Rewriter/ProofsCommon.v
+++ b/src/Rewriter/ProofsCommon.v
@@ -3118,6 +3118,7 @@ Module Compilers.
                          | break_innermost_match_step
                          | progress ident.rewrite_interp ident_interp
                          | progress cbv [ident.literal ident.eagerly] in * ].
+            all: cbv [nat_rect_arrow_nodep list_rect_arrow_nodep] in *.
             all: change (@nat_rect_nodep) with (fun P => @nat_rect (fun _ => P)) in *.
             all: change (@list_rect_nodep) with (fun A P => @list_rect A (fun _ => P)) in *.
             all: repeat


### PR DESCRIPTION
On top of #600 

Note that the type of ident_Literal has changed; the type of the second
argument is now more unfolded.  Hopefully this won't slow things down.
We do it this way so that when we eventually move to OCaml code, all of
the identifier inductives can be created without needing to emit
definitions in the middle, and then we can create all the definitions
in one fell swoop with a tactic.

```
After     | File Name                                                       | Before    || Change    | % Change
---------------------------------------------------------------------------------------------------------------
55m48.98s | Total                                                           | 55m44.49s || +0m04.48s | +0.13%
---------------------------------------------------------------------------------------------------------------
3m17.00s  | Fancy/Compiler.vo                                               | 3m37.24s  || -0m20.24s | -9.31%
4m10.35s  | p384_32.c                                                       | 3m58.44s  || +0m11.90s | +4.99%
4m03.89s  | fiat-rust/src/p384_32.rs                                        | 4m12.25s  || -0m08.36s | -3.31%
3m42.67s  | PushButtonSynthesis/WordByWordMontgomeryReificationCache.vo     | 3m34.37s  || +0m08.30s | +3.87%
1m56.16s  | Fancy/Barrett256.vo                                             | 2m03.79s  || -0m07.63s | -6.16%
2m36.12s  | Rewriter/Passes/ToFancyWithCasts.vo                             | 2m30.52s  || +0m05.59s | +3.72%
0m47.65s  | Fancy/Montgomery256.vo                                          | 0m53.25s  || -0m05.60s | -10.51%
0m59.29s  | PushButtonSynthesis/UnsaturatedSolinasReificationCache.vo       | 0m54.68s  || +0m04.60s | +8.43%
0m46.02s  | fiat-rust/src/p521_32.rs                                        | 0m41.24s  || +0m04.78s | +11.59%
0m53.12s  | SlowPrimeSynthesisExamples.vo                                   | 0m49.87s  || +0m03.25s | +6.51%
0m42.99s  | Rewriter/Passes/Arith.vo                                        | 0m39.73s  || +0m03.26s | +8.20%
0m42.50s  | PushButtonSynthesis/BarrettReductionReificationCache.vo         | 0m38.79s  || +0m03.71s | +9.56%
0m41.56s  | p521_32.c                                                       | 0m45.38s  || -0m03.82s | -8.41%
0m37.59s  | fiat-rust/src/p521_64.rs                                        | 0m33.88s  || +0m03.71s | +10.95%
0m34.30s  | p521_64.c                                                       | 0m37.60s  || -0m03.30s | -8.77%
0m26.42s  | Language/Identifier.vo                                          | 0m23.36s  || +0m03.06s | +13.09%
2m48.76s  | PushButtonSynthesis/FancyMontgomeryReductionReificationCache.vo | 2m51.50s  || -0m02.74s | -1.59%
2m30.08s  | Rewriter/Passes/NBE.vo                                          | 2m27.44s  || +0m02.63s | +1.79%
1m02.22s  | Rewriter/ProofsCommon.vo                                        | 1m04.25s  || -0m02.03s | -3.15%
0m17.75s  | fiat-rust/src/secp256k1_32.rs                                   | 0m20.10s  || -0m02.35s | -11.69%
1m10.97s  | Rewriter/Examples.vo                                            | 1m09.01s  || +0m01.95s | +2.84%
0m56.49s  | Language/UnderLetsProofs.vo                                     | 0m58.44s  || -0m01.94s | -3.33%
0m27.00s  | Rewriter/Passes/MulSplit.vo                                     | 0m25.23s  || +0m01.76s | +7.01%
0m20.23s  | p256_32.c                                                       | 0m18.27s  || +0m01.96s | +10.72%
0m18.14s  | secp256k1_32.c                                                  | 0m20.13s  || -0m01.98s | -9.88%
0m17.62s  | fiat-rust/src/p434_64.rs                                        | 0m16.05s  || +0m01.57s | +9.78%
2m41.51s  | Rewriter/Wf.vo                                                  | 2m40.77s  || +0m00.73s | +0.46%
1m54.74s  | Rewriter/Passes/ArithWithCasts.vo                               | 1m53.79s  || +0m00.95s | +0.83%
1m12.51s  | AbstractInterpretation/Wf.vo                                    | 1m11.99s  || +0m00.52s | +0.72%
1m08.94s  | Rewriter/InterpProofs.vo                                        | 1m09.17s  || -0m00.23s | -0.33%
1m08.21s  | AbstractInterpretation/ZRangeProofs.vo                          | 1m07.28s  || +0m00.93s | +1.38%
0m55.81s  | PushButtonSynthesis/UnsaturatedSolinas.vo                       | 0m55.91s  || -0m00.09s | -0.17%
0m43.10s  | Rewriter/RulesProofs.vo                                         | 0m42.98s  || +0m00.12s | +0.27%
0m41.58s  | PushButtonSynthesis/WordByWordMontgomery.vo                     | 0m41.40s  || +0m00.17s | +0.43%
0m36.30s  | AbstractInterpretation/Proofs.vo                                | 0m36.40s  || -0m00.10s | -0.27%
0m32.64s  | ExtractionOCaml/word_by_word_montgomery                         | 0m32.33s  || +0m00.31s | +0.95%
0m28.75s  | BoundsPipeline.vo                                               | 0m28.82s  || -0m00.07s | -0.24%
0m24.96s  | Language/Wf.vo                                                  | 0m25.63s  || -0m00.66s | -2.61%
0m24.60s  | ExtractionOCaml/unsaturated_solinas                             | 0m25.30s  || -0m00.69s | -2.76%
0m23.65s  | PushButtonSynthesis/BarrettReduction.vo                         | 0m23.69s  || -0m00.04s | -0.16%
0m22.03s  | Language/Inversion.vo                                           | 0m22.12s  || -0m00.08s | -0.40%
0m19.86s  | ExtractionOCaml/word_by_word_montgomery.ml                      | 0m19.58s  || +0m00.28s | +1.43%
0m19.29s  | fiat-rust/src/p256_32.rs                                        | 0m19.67s  || -0m00.38s | -1.93%
0m16.96s  | fiat-rust/src/p448_solinas_64.rs                                | 0m16.80s  || +0m00.16s | +0.95%
0m16.94s  | p448_solinas_64.c                                               | 0m16.60s  || +0m00.33s | +2.04%
0m16.68s  | Stringification/IR.vo                                           | 0m16.98s  || -0m00.30s | -1.76%
0m15.80s  | p434_64.c                                                       | 0m15.59s  || +0m00.21s | +1.34%
0m15.50s  | ExtractionOCaml/unsaturated_solinas.ml                          | 0m15.36s  || +0m00.14s | +0.91%
0m15.05s  | Language/IdentifiersGENERATEDProofs.vo                          | 0m14.89s  || +0m00.16s | +1.07%
0m15.04s  | Language/IdentifiersGENERATED.vo                                | 0m15.79s  || -0m00.75s | -4.74%
0m15.02s  | Language/IdentifiersLibraryProofs.vo                            | 0m15.05s  || -0m00.03s | -0.19%
0m10.02s  | p224_32.c                                                       | 0m09.72s  || +0m00.29s | +3.08%
0m08.59s  | fiat-rust/src/p224_32.rs                                        | 0m08.81s  || -0m00.22s | -2.49%
0m07.91s  | p384_64.c                                                       | 0m07.82s  || +0m00.08s | +1.15%
0m07.55s  | fiat-rust/src/p384_64.rs                                        | 0m07.81s  || -0m00.25s | -3.32%
0m06.83s  | PushButtonSynthesis/SmallExamples.vo                            | 0m06.25s  || +0m00.58s | +9.28%
0m06.32s  | PushButtonSynthesis/SaturatedSolinasReificationCache.vo         | 0m05.66s  || +0m00.66s | +11.66%
0m06.19s  | Fancy/Prod.vo                                                   | 0m06.10s  || +0m00.09s | +1.47%
0m05.34s  | PushButtonSynthesis/Primitives.vo                               | 0m05.27s  || +0m00.07s | +1.32%
0m05.04s  | CastLemmas.vo                                                   | 0m05.06s  || -0m00.01s | -0.39%
0m04.42s  | PushButtonSynthesis/SaturatedSolinas.vo                         | 0m04.49s  || -0m00.07s | -1.55%
0m04.38s  | PushButtonSynthesis/FancyMontgomeryReduction.vo                 | 0m04.06s  || +0m00.32s | +7.88%
0m04.08s  | Language/InversionExtra.vo                                      | 0m04.47s  || -0m00.38s | -8.72%
0m02.78s  | MiscCompilerPassesProofs.vo                                     | 0m02.84s  || -0m00.06s | -2.11%
0m02.69s  | curve25519_32.c                                                 | 0m02.76s  || -0m00.06s | -2.53%
0m02.57s  | fiat-rust/src/curve25519_32.rs                                  | 0m02.68s  || -0m00.11s | -4.10%
0m02.04s  | Rewriter/Passes/StripLiteralCasts.vo                            | 0m01.99s  || +0m00.05s | +2.51%
0m01.90s  | CLI.vo                                                          | 0m01.76s  || +0m00.13s | +7.95%
0m01.86s  | Language/IdentifiersLibrary.vo                                  | 0m01.81s  || +0m00.05s | +2.76%
0m01.86s  | Rewriter/PerfTesting/Core.vo                                    | 0m01.86s  || +0m00.00s | +0.00%
0m01.82s  | curve25519_64.c                                                 | 0m01.85s  || -0m00.03s | -1.62%
0m01.81s  | Rewriter/Passes/ToFancy.vo                                      | 0m01.84s  || -0m00.03s | -1.63%
0m01.78s  | fiat-rust/src/curve25519_64.rs                                  | 0m01.79s  || -0m00.01s | -0.55%
0m01.76s  | Stringification/Rust.vo                                         | 0m01.93s  || -0m00.16s | -8.80%
0m01.76s  | p256_64.c                                                       | 0m01.63s  || +0m00.13s | +7.97%
0m01.68s  | AbstractInterpretation/AbstractInterpretation.vo                | 0m01.87s  || -0m00.19s | -10.16%
0m01.67s  | secp256k1_64.c                                                  | 0m01.72s  || -0m00.05s | -2.90%
0m01.60s  | p224_64.c                                                       | 0m01.60s  || +0m00.00s | +0.00%
0m01.58s  | fiat-rust/src/p256_64.rs                                        | 0m01.68s  || -0m00.09s | -5.95%
0m01.57s  | fiat-rust/src/secp256k1_64.rs                                   | 0m01.60s  || -0m00.03s | -1.87%
0m01.54s  | CompilersTestCases.vo                                           | 0m01.50s  || +0m00.04s | +2.66%
0m01.54s  | fiat-rust/src/p224_64.rs                                        | 0m01.78s  || -0m00.24s | -13.48%
0m01.49s  | Rewriter/PerfTesting/StandaloneOCamlMain.vo                     | 0m01.57s  || -0m00.08s | -5.09%
0m01.44s  | Rewriter/Rewriter.vo                                            | 0m01.50s  || -0m00.06s | -4.00%
0m01.42s  | Stringification/Language.vo                                     | 0m01.36s  || +0m00.05s | +4.41%
0m01.40s  | StandaloneHaskellMain.vo                                        | 0m01.45s  || -0m00.05s | -3.44%
0m01.38s  | StandaloneOCamlMain.vo                                          | 0m01.45s  || -0m00.07s | -4.82%
0m01.30s  | Rewriter/Reify.vo                                               | 0m01.35s  || -0m00.05s | -3.70%
0m01.27s  | Language/Language.vo                                            | 0m01.16s  || +0m00.11s | +9.48%
0m01.14s  | Rewriter/ProofsCommonTactics.vo                                 | 0m01.06s  || +0m00.07s | +7.54%
0m01.09s  | Stringification/C.vo                                            | 0m01.09s  || +0m00.00s | +0.00%
0m01.03s  | Rewriter/AllTactics.vo                                          | 0m00.98s  || +0m00.05s | +5.10%
0m01.00s  | MiscCompilerPassesProofsExtra.vo                                | 0m00.96s  || +0m00.04s | +4.16%
0m00.98s  | MiscCompilerPasses.vo                                           | 0m00.78s  || +0m00.19s | +25.64%
0m00.98s  | Rewriter/All.vo                                                 | 0m00.97s  || +0m00.01s | +1.03%
0m00.92s  | Language/IdentifiersGenerate.vo                                 | 0m00.89s  || +0m00.03s | +3.37%
0m00.92s  | Rewriter/AllTacticsExtra.vo                                     | 0m00.85s  || +0m00.07s | +8.23%
0m00.91s  | Language/IdentifiersGenerateProofs.vo                           | 0m00.89s  || +0m00.02s | +2.24%
0m00.84s  | Rewriter/Rules.vo                                               | 0m00.80s  || +0m00.03s | +4.99%
0m00.68s  | Language/APINotations.vo                                        | 0m00.69s  || -0m00.00s | -1.44%
0m00.66s  | Language/UnderLetsProofsExtra.vo                                | 0m00.66s  || +0m00.00s | +0.00%
0m00.62s  | Language/WfExtra.vo                                             | 0m00.57s  || +0m00.05s | +8.77%
0m00.58s  | Language/UnderLets.vo                                           | 0m00.57s  || +0m00.01s | +1.75%
0m00.55s  | Language/API.vo                                                 | 0m00.57s  || -0m00.01s | -3.50%
0m00.53s  | AbstractInterpretation/WfExtra.vo                               | 0m00.61s  || -0m00.07s | -13.11%
0m00.51s  | PushButtonSynthesis/ReificationCache.vo                         | 0m00.60s  || -0m00.08s | -14.99%
0m00.50s  | Language/Pre.vo                                                 | 0m00.41s  || +0m00.09s | +21.95%
```