### PR TITLE
Adjust maker tactics to not need arguments

### DIFF
--- a/src/Language/IdentifierParameters.v
+++ b/src/Language/IdentifierParameters.v
@@ -120,3 +120,7 @@ Definition all_ident_named_interped : GallinaIdentList.t
       ; with_name ident_fancy_sell ident.fancy.sell
       ; with_name ident_fancy_addm ident.fancy.addm
      ]%gi_list.
+
+Definition scraped_data : ScrapedData.t
+  := {| ScrapedData.base_type_list_named := base_type_list_named
+        ; ScrapedData.all_ident_named_interped := all_ident_named_interped |}.

--- a/src/Language/IdentifiersBasicGENERATED.v
+++ b/src/Language/IdentifiersBasicGENERATED.v
@@ -326,8 +326,8 @@ Module Compilers.
   | raw_ident_fancy_addm : raw_ident
   .
 
-  Definition package : GoalType.package.
-  Proof. Tactic.make_package base ident base_type_list_named var_like_idents all_ident_named_interped. Defined.
+  Definition package : GoalType.package_with_args scraped_data var_like_idents base ident.
+  Proof. Tactic.make_package. Defined.
 
   Global Strategy -1000 [base_interp ident_interp].
 End Compilers.

--- a/src/Language/IdentifiersBasicLibrary.v
+++ b/src/Language/IdentifiersBasicLibrary.v
@@ -20,6 +20,12 @@ Module Compilers.
           ; exprReifyInfo : @ExprReifyInfoT exprInfo
           ; ident_is_var_like : forall t (idc : Classes.ident t), Datatypes.bool
         }.
+
+      Definition package_with_args (scraped_data : ScrapedData.t) (var_like_idents : GallinaIdentList.t) (base : Type) (ident : type.type (base.type base) -> Type)
+        := package.
+
+      Definition base_elim_with_args (scraped_data : ScrapedData.t) := Type.
+      Definition ident_elim_with_args (scraped_data : ScrapedData.t) (base : Type) := Type.
     End GoalType.
   End Basic.
 End Compilers.

--- a/src/Language/IdentifiersGENERATED.v
+++ b/src/Language/IdentifiersGENERATED.v
@@ -10,8 +10,8 @@ Module Compilers.
     Module ident.
       Export IdentifiersGenerate.Compilers.pattern.ident.
 
-      Definition package : @GoalType.package Compilers.base Compilers.ident.
-      Proof. Time Tactic.make_package IdentifiersBasicGENERATED.Compilers.package IdentifiersBasicGENERATED.Compilers.raw_ident IdentifiersBasicGENERATED.Compilers.pattern_ident. Defined.
+      Definition package : @GoalType.package_with_args Compilers.base Compilers.ident IdentifiersBasicGENERATED.Compilers.package IdentifiersBasicGENERATED.Compilers.raw_ident IdentifiersBasicGENERATED.Compilers.pattern_ident.
+      Proof. Time Tactic.make_package. Defined.
     End ident.
   End pattern.
 End Compilers.

--- a/src/Language/IdentifiersGENERATEDProofs.v
+++ b/src/Language/IdentifiersGENERATEDProofs.v
@@ -32,8 +32,8 @@ Module Compilers.
 
       Import ProofTactic.Settings.
 
-      Definition package_proofs : @ProofGoalType.package_proofs _ _ package.
-      Proof. ProofTactic.prove_package_proofs IdentifiersBasicGENERATED.Compilers.package. Qed.
+      Definition package_proofs : @ProofGoalType.package_proofs_with_args Compilers.base Compilers.ident package IdentifiersBasicGENERATED.Compilers.package.
+      Proof. ProofTactic.prove_package_proofs. Qed.
     End ident.
   End pattern.
 End Compilers.

--- a/src/Language/IdentifiersGenerate.v
+++ b/src/Language/IdentifiersGenerate.v
@@ -755,8 +755,15 @@ Module Compilers.
                     arg_types_of_typed_ident_unfolded
                     unify
                     unify_unknown).
-        Ltac make_package ident_package raw_ident pattern_ident :=
+        Ltac make_package_via ident_package raw_ident pattern_ident :=
           let res := build_package ident_package raw_ident pattern_ident in refine res.
+        Ltac make_package :=
+          idtac;
+          lazymatch goal with
+          | [ |- GoalType.package_with_args ?ident_package ?raw_ident ?pattern_ident ]
+            => cbv [GoalType.package_with_args];
+               make_package_via ident_package raw_ident pattern_ident
+          end.
         Ltac cache_build_package ident_package raw_ident pattern_ident :=
           let name := fresh "pattern_package" in
           let term := build_package ident_package raw_ident pattern_ident in

--- a/src/Language/IdentifiersGenerateProofs.v
+++ b/src/Language/IdentifiersGenerateProofs.v
@@ -120,7 +120,7 @@ Module Compilers.
       Module Export Settings.
         Export ident.GoalType.Settings.
       End Settings.
-      Ltac prove_package_proofs ident_package :=
+      Ltac prove_package_proofs_via ident_package :=
         idtac;
         let time_if_debug1 := Tactics.time_if_debug1 in
         let pkg := lazymatch goal with |- @package_proofs _ _ ?pkg => pkg end in
@@ -149,6 +149,13 @@ Module Compilers.
           time_if_debug1 Raw.ident.prove_eq_invert_bind_args_unknown; fail 0 "A goal remains"
         | let __ := Tactics.debug1 ltac:(fun _ => idtac "Proving eq_unify_unknown...") in
           time_if_debug1 ident.prove_eq_unify_unknown; fail 0 "A goal remains" ].
+      Ltac prove_package_proofs :=
+        idtac;
+        lazymatch goal with
+        | [ |- ProofGoalType.package_proofs_with_args ?ident_package ]
+          => cbv [ProofGoalType.package_proofs_with_args];
+             prove_package_proofs_via ident_package
+        end.
       Ltac cache_build_package_proofs ident_package package :=
         let name := fresh "ident_package_proofs" in
         cache_proof_with_type_by (@package_proofs _ _ package) ltac:(prove_package_proofs ident_package) name.

--- a/src/Language/IdentifiersLibrary.v
+++ b/src/Language/IdentifiersLibrary.v
@@ -11,6 +11,7 @@ Require Import Crypto.Util.PrimitiveSigma.
 Require Import Crypto.Util.Bool.Reflect.
 Require Import Crypto.Util.Notations.
 Require Import Crypto.Language.Language.
+Require Import Crypto.Language.IdentifiersBasicLibrary.
 Require Import Crypto.Util.Tactics.Head.
 Require Import Crypto.Util.Tactics.ConstrFail.
 Require Import Crypto.Util.Tactics.CacheTerm.
@@ -23,6 +24,7 @@ Module Compilers.
   Set Boolean Equality Schemes.
   Set Decidable Equality Schemes.
   Local Set Primitive Projections.
+  Import IdentifiersBasicLibrary.Compilers.
   Export Language.Compilers.
 
   Local Notation type_of_list := (fold_right (fun A B => prod A B) unit).
@@ -808,6 +810,9 @@ Module Compilers.
             unify_unknown : forall {t t'} (pidc : pattern_ident t) (idc : ident t') (*evm : EvarMap*), Datatypes.option (type_of_list (@ident.arg_types base ident raw_ident raw_ident_infos_of pattern_ident eta_pattern_ident_cps_gen split_types t pidc))
           }.
 
+        Definition package_with_args {base} {ident} (ident_package : Basic.GoalType.package) (raw_ident : Type) (pattern_ident : type.type (pattern.base.type base) -> Type)
+          := @package base ident.
+
         Ltac red_proj :=
           cbv [
               all_idents
@@ -843,38 +848,38 @@ Module Compilers.
             ] in *.
 
         Module Export Settings.
-          Strategy -100 [
-                        all_idents
-                          ident_index
-                          eta_ident_cps_gen
-                          eta_ident_cps_gen_expand_literal
-                          eta_ident_cps
-                          simple_idents
-                          raw_ident
-                          all_raw_idents
-                          raw_ident_index
-                          raw_ident_index_idempotent
-                          eta_raw_ident_cps_gen
-                          raw_ident_infos_of
-                          split_raw_ident_gen
-                          invert_bind_args
-                          invert_bind_args_unknown
-                          pattern_ident
-                          all_pattern_idents
-                          eta_pattern_ident_cps_gen
-                          eta_pattern_ident_cps_gen_expand_literal
-                          split_types
-                          add_types_from_raw_sig
-                          to_type_split_types_subst_default_eq
-                          projT1_add_types_from_raw_sig_eq
-                          arg_types_unfolded
-                          to_typed_unfolded
-                          type_of_list_arg_types_beq_unfolded
-                          of_typed_ident_unfolded
-                          arg_types_of_typed_ident_unfolded
-                          unify
-                          unify_unknown
-                      ].
+          Global Strategy -100 [
+                               all_idents
+                                 ident_index
+                                 eta_ident_cps_gen
+                                 eta_ident_cps_gen_expand_literal
+                                 eta_ident_cps
+                                 simple_idents
+                                 raw_ident
+                                 all_raw_idents
+                                 raw_ident_index
+                                 raw_ident_index_idempotent
+                                 eta_raw_ident_cps_gen
+                                 raw_ident_infos_of
+                                 split_raw_ident_gen
+                                 invert_bind_args
+                                 invert_bind_args_unknown
+                                 pattern_ident
+                                 all_pattern_idents
+                                 eta_pattern_ident_cps_gen
+                                 eta_pattern_ident_cps_gen_expand_literal
+                                 split_types
+                                 add_types_from_raw_sig
+                                 to_type_split_types_subst_default_eq
+                                 projT1_add_types_from_raw_sig_eq
+                                 arg_types_unfolded
+                                 to_typed_unfolded
+                                 type_of_list_arg_types_beq_unfolded
+                                 of_typed_ident_unfolded
+                                 arg_types_of_typed_ident_unfolded
+                                 unify
+                                 unify_unknown
+                             ].
         End Settings.
 
         Notation eta_ident_cps_gen2_of p := (@pattern.eta_ident_cps_gen2 _ _ (@eta_ident_cps_gen _ _ p)).

--- a/src/Language/IdentifiersLibraryProofs.v
+++ b/src/Language/IdentifiersLibraryProofs.v
@@ -15,6 +15,7 @@ Require Import Crypto.Util.Tactics.SpecializeBy.
 Require Import Crypto.Util.Tactics.CacheTerm.
 Require Import Crypto.Language.Language.
 Require Import Crypto.Language.Inversion.
+Require Import Crypto.Language.IdentifiersBasicLibrary.
 Require Import Crypto.Language.IdentifiersLibrary.
 Require Import Crypto.Util.FixCoqMistakes.
 
@@ -22,6 +23,7 @@ Import EqNotations.
 Module Compilers.
   Import Language.Compilers.
   Import Language.Inversion.Compilers.
+  Import IdentifiersBasicLibrary.Compilers.
   Import IdentifiersLibrary.Compilers.
   Local Set Primitive Projections.
 
@@ -222,6 +224,9 @@ Module Compilers.
           eq_invert_bind_args_unknown : @invert_bind_args_unknown _ _ pkg = @invert_bind_args _ _ pkg;
           eq_unify_unknown : @unify_unknown _ _ pkg = @unify _ _ pkg
         }.
+
+      Definition package_proofs_with_args {base ident} {pkg : @package base ident} (ident_package : Basic.GoalType.package)
+        := @package_proofs base ident pkg.
     End ProofGoalType.
 
     Module Raw.

--- a/src/Language/Pre.v
+++ b/src/Language/Pre.v
@@ -4,6 +4,7 @@ Require Import Crypto.Util.ZRange.
 Require Import Crypto.Util.ZRange.Operations.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Notations.
+Require Crypto.Util.PrimitiveHList.
 Local Open Scope bool_scope.
 Local Open Scope Z_scope.
 
@@ -200,4 +201,6 @@ Module ScrapedData.
       base_type_list_named : GallinaIdentList.t
       ; all_ident_named_interped : GallinaIdentList.t
     }.
+
+  Definition t_with_args {rewrite_rulesT} (rules_proofs : PrimitiveHList.hlist (@snd bool Prop) rewrite_rulesT) := t.
 End ScrapedData.

--- a/src/Rewriter/AllTacticsExtra.v
+++ b/src/Rewriter/AllTacticsExtra.v
@@ -1,4 +1,5 @@
 Require Import Crypto.Rewriter.AllTactics.
+Require Import Crypto.Rewriter.ProofsCommon.
 Require Import Crypto.Language.IdentifiersBasicGENERATED.
 Require Import Crypto.Language.IdentifiersGENERATEDProofs.
 
@@ -7,14 +8,19 @@ Module Compilers.
   Import Rewriter.AllTactics.Compilers.
 
   Module RewriteRules.
+    Module GoalType.
+      Export ProofsCommon.Compilers.RewriteRules.GoalType.
+      Notation VerifiedRewriter_with_args := (VerifiedRewriter_with_args IdentifiersBasicGENERATED.Compilers.package IdentifiersGENERATEDProofs.Compilers.pattern.ident.package_proofs) (only parsing).
+    End GoalType.
+
     Module Export Tactic.
       Export Rewriter.AllTactics.Compilers.RewriteRules.Tactic.Settings.
 
-      Ltac make_rewriter include_interp specs_proofs :=
-        Rewriter.AllTactics.Compilers.RewriteRules.Tactic.make_rewriter IdentifiersBasicGENERATED.Compilers.package IdentifiersGENERATEDProofs.Compilers.pattern.ident.package_proofs include_interp specs_proofs.
+      Ltac make_rewriter_via include_interp specs_proofs :=
+        Rewriter.AllTactics.Compilers.RewriteRules.Tactic.make_rewriter_via IdentifiersBasicGENERATED.Compilers.package IdentifiersGENERATEDProofs.Compilers.pattern.ident.package_proofs include_interp specs_proofs.
 
-      Tactic Notation "make_rewriter" constr(include_interp) constr(specs_proofs) :=
-        make_rewriter include_interp specs_proofs.
+      Tactic Notation "make_rewriter_via" constr(include_interp) constr(specs_proofs) :=
+        make_rewriter_via include_interp specs_proofs.
     End Tactic.
   End RewriteRules.
 End Compilers.

--- a/src/Rewriter/Examples.v
+++ b/src/Rewriter/Examples.v
@@ -12,6 +12,7 @@ Import ListNotations. Local Open Scope bool_scope. Local Open Scope Z_scope.
 
 Import Rewriter.AllTactics.Compilers.RewriteRules.GoalType.
 Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
+Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
 Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.Tactic.
 
 (** We first define some helper notations, and then define the list of
@@ -34,8 +35,8 @@ Proof. repeat constructor. Qed.
 
 (** Next we define the rewriter package *)
 
-Definition norules : VerifiedRewriter.
-Proof using All. make_rewriter false noruleproofs. Defined.
+Definition norules : VerifiedRewriter_with_args false noruleproofs.
+Proof using All. make_rewriter. Defined.
 
 (** Now we show some simple examples. *)
 
@@ -92,8 +93,8 @@ Qed.
 
 (** Next we define the rewriter package *)
 
-Definition myrules : VerifiedRewriter.
-Proof using All. make_rewriter true myruleproofs. Defined.
+Definition myrules : VerifiedRewriter_with_args true myruleproofs.
+Proof using All. make_rewriter. Defined.
 
 (** Now we show some simple examples. *)
 

--- a/src/Rewriter/Passes/Arith.v
+++ b/src/Rewriter/Passes/Arith.v
@@ -11,16 +11,16 @@ Module Compilers.
   Import Language.API.Compilers.
   Import Language.Wf.Compilers.
   Import Language.WfExtra.Compilers.
-  Import Rewriter.AllTactics.Compilers.RewriteRules.GoalType.
-  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.Tactic.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
   Import Compilers.Classes.
 
   Module Import RewriteRules.
     Section __.
       Context (max_const_val : Z).
 
-      Definition VerifiedRewriterArith : VerifiedRewriter.
-      Proof using All. make_rewriter false (arith_rewrite_rules_proofs max_const_val). Defined.
+      Definition VerifiedRewriterArith : VerifiedRewriter_with_args false (arith_rewrite_rules_proofs max_const_val).
+      Proof using All. make_rewriter. Defined.
 
       Definition RewriteArith {t} := Eval hnf in @Rewrite VerifiedRewriterArith t.
 

--- a/src/Rewriter/Passes/ArithWithCasts.v
+++ b/src/Rewriter/Passes/ArithWithCasts.v
@@ -10,14 +10,14 @@ Module Compilers.
   Import Language.API.Compilers.
   Import Language.Wf.Compilers.
   Import Language.WfExtra.Compilers.
-  Import Rewriter.AllTactics.Compilers.RewriteRules.GoalType.
-  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.Tactic.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
   Import Compilers.Classes.
 
   Module Import RewriteRules.
     Section __.
-      Definition VerifiedRewriterArithWithCasts : VerifiedRewriter.
-      Proof using All. make_rewriter false arith_with_casts_rewrite_rules_proofs. Defined.
+      Definition VerifiedRewriterArithWithCasts : VerifiedRewriter_with_args false arith_with_casts_rewrite_rules_proofs.
+      Proof using All. make_rewriter. Defined.
 
       Definition RewriteArithWithCasts {t} := Eval hnf in @Rewrite VerifiedRewriterArithWithCasts t.
 

--- a/src/Rewriter/Passes/MulSplit.v
+++ b/src/Rewriter/Passes/MulSplit.v
@@ -11,8 +11,8 @@ Module Compilers.
   Import Language.API.Compilers.
   Import Language.Wf.Compilers.
   Import Language.WfExtra.Compilers.
-  Import Rewriter.AllTactics.Compilers.RewriteRules.GoalType.
-  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.Tactic.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
   Import Compilers.Classes.
 
   Module Import RewriteRules.
@@ -20,8 +20,8 @@ Module Compilers.
       Context (bitwidth : Z)
               (lgcarrymax : Z).
 
-      Definition VerifiedRewriterMulSplit : VerifiedRewriter.
-      Proof using All. make_rewriter false (mul_split_rewrite_rules_proofs bitwidth lgcarrymax). Defined.
+      Definition VerifiedRewriterMulSplit : VerifiedRewriter_with_args false (mul_split_rewrite_rules_proofs bitwidth lgcarrymax).
+      Proof using All. make_rewriter. Defined.
 
       Definition RewriteMulSplit {t} := Eval hnf in @Rewrite VerifiedRewriterMulSplit t.
 

--- a/src/Rewriter/Passes/NBE.v
+++ b/src/Rewriter/Passes/NBE.v
@@ -10,14 +10,14 @@ Module Compilers.
   Import Language.API.Compilers.
   Import Language.Wf.Compilers.
   Import Language.WfExtra.Compilers.
-  Import Rewriter.AllTactics.Compilers.RewriteRules.GoalType.
-  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.Tactic.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
   Import Compilers.Classes.
 
   Module Import RewriteRules.
     Section __.
-      Definition VerifiedRewriterNBE : VerifiedRewriter.
-      Proof using All. make_rewriter true nbe_rewrite_rules_proofs. Defined.
+      Definition VerifiedRewriterNBE : VerifiedRewriter_with_args true nbe_rewrite_rules_proofs.
+      Proof using All. make_rewriter. Defined.
 
       Definition RewriteNBE {t} := Eval hnf in @Rewrite VerifiedRewriterNBE t.
 

--- a/src/Rewriter/Passes/StripLiteralCasts.v
+++ b/src/Rewriter/Passes/StripLiteralCasts.v
@@ -10,14 +10,14 @@ Module Compilers.
   Import Language.API.Compilers.
   Import Language.Wf.Compilers.
   Import Language.WfExtra.Compilers.
-  Import Rewriter.AllTactics.Compilers.RewriteRules.GoalType.
-  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.Tactic.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
   Import Compilers.Classes.
 
   Module Import RewriteRules.
     Section __.
-      Definition VerifiedRewriterStripLiteralCasts : VerifiedRewriter.
-      Proof using All. make_rewriter false strip_literal_casts_rewrite_rules_proofs. Defined.
+      Definition VerifiedRewriterStripLiteralCasts : VerifiedRewriter_with_args false strip_literal_casts_rewrite_rules_proofs.
+      Proof using All. make_rewriter. Defined.
 
       Definition RewriteStripLiteralCasts {t} := Eval hnf in @Rewrite VerifiedRewriterStripLiteralCasts t.
 

--- a/src/Rewriter/Passes/ToFancy.v
+++ b/src/Rewriter/Passes/ToFancy.v
@@ -11,8 +11,8 @@ Module Compilers.
   Import Language.API.Compilers.
   Import Language.Wf.Compilers.
   Import Language.WfExtra.Compilers.
-  Import Rewriter.AllTactics.Compilers.RewriteRules.GoalType.
-  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.Tactic.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
   Import Compilers.Classes.
 
   Module Import RewriteRules.
@@ -21,8 +21,8 @@ Module Compilers.
               (Hlow : forall s v v', invert_low s v = Some v' -> v = Z.land v' (2^(s/2)-1))
               (Hhigh : forall s v v', invert_high s v = Some v' -> v = Z.shiftr v' (s/2)).
 
-      Definition VerifiedRewriterToFancy : VerifiedRewriter.
-      Proof using All. make_rewriter false fancy_rewrite_rules_proofs. Defined.
+      Definition VerifiedRewriterToFancy : VerifiedRewriter_with_args false fancy_rewrite_rules_proofs.
+      Proof using All. make_rewriter. Defined.
 
       Definition RewriteToFancy {t} : API.Expr t -> API.Expr t.
       Proof using invert_low invert_high.

--- a/src/Rewriter/Passes/ToFancyWithCasts.v
+++ b/src/Rewriter/Passes/ToFancyWithCasts.v
@@ -12,8 +12,8 @@ Module Compilers.
   Import Language.API.Compilers.
   Import Language.Wf.Compilers.
   Import Language.WfExtra.Compilers.
-  Import Rewriter.AllTactics.Compilers.RewriteRules.GoalType.
-  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.Tactic.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
   Import Compilers.Classes.
 
   Module Import RewriteRules.
@@ -23,8 +23,8 @@ Module Compilers.
               (Hlow : forall s v v', invert_low s v = Some v' -> v = Z.land v' (2^(s/2)-1))
               (Hhigh : forall s v v', invert_high s v = Some v' -> v = Z.shiftr v' (s/2)).
 
-      Definition VerifiedRewriterToFancyWithCasts : VerifiedRewriter.
-      Proof using All. make_rewriter false (@fancy_with_casts_rewrite_rules_proofs invert_low invert_high value_range flag_range Hlow Hhigh). Defined.
+      Definition VerifiedRewriterToFancyWithCasts : VerifiedRewriter_with_args false (@fancy_with_casts_rewrite_rules_proofs invert_low invert_high value_range flag_range Hlow Hhigh).
+      Proof using All. make_rewriter. Defined.
 
       Definition RewriteToFancyWithCasts {t} : API.Expr t -> API.Expr t.
       Proof using invert_low invert_high value_range flag_range.

--- a/src/Rewriter/ProofsCommon.v
+++ b/src/Rewriter/ProofsCommon.v
@@ -3417,6 +3417,24 @@ Module Compilers.
           generalize_for_wf : forall {t}, expr.Expr (ident:=ident) t -> expr.Expr (ident:=ident) t;
           prove_Wf : forall {t} (e : expr.Expr (ident:=ident) t), (e = generalize_for_wf e /\ check_wf e = true) -> expr.Wf e;
         }.
+
+      Definition VerifiedRewriter_with_args
+                 (basic_package : Basic.GoalType.package)
+                 {base ident pkg} (pkg_proofs : @pattern.ProofGoalType.package_proofs base ident pkg)
+                 (include_interp : bool)
+                 {rewrite_rulesT} (rules_proofs : PrimitiveHList.hlist (@snd bool Prop) rewrite_rulesT)
+        := VerifiedRewriter.
+
+      Definition VerifiedRewriter_with_ind_args
+                 (scraped_data : ScrapedData.t)
+                 (var_like_idents : GallinaIdentList.t)
+                 (base : Type)
+                 (ident : type.type (base.type base) -> Type)
+                 (raw_ident : type.type (pattern.base.type base) -> Type)
+                 (pattern_ident : type.type (pattern.base.type base) -> Type)
+                 (include_interp : bool)
+                 {rewrite_rulesT} (rules_proofs : PrimitiveHList.hlist (@snd bool Prop) rewrite_rulesT)
+        := VerifiedRewriter.
     End GoalType.
   End RewriteRules.
 End Compilers.


### PR DESCRIPTION
The arguments to the various package making tactics are now carried in
the goal type.  This will make it easier to call the tactics from OCaml.