### PR TITLE
Allow widening carry bits

### DIFF
--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -78,6 +78,8 @@ Import
   MiscCompilerPasses.Compilers
   Stringification.Language.Compilers.
 
+Export Stringification.Language.Compilers.Options.
+
 Import Compilers.API.
 
 Definition round_up_bitwidth_gen (possible_values : list Z) (bitwidth : Z) : option Z
@@ -275,6 +277,7 @@ Module Pipeline.
                 => ((["Computed bounds " ++ show true computed_bounds ++ " are not tight enough (expected bounds not looser than " ++ show true expected_bounds ++ ")."]%string)
                       ++ [explain_too_loose_bounds (t:=type.base _) computed_bounds expected_bounds]
                       ++ match ToString.ToFunctionLines
+                                 (relax_zrange := fun r => r)
                                  false (* do extra bounds check *) false (* static *) "" "f" syntax_tree (fun _ _ => nil) None arg_bounds ZRange.type.base.option.None with
                          | inl (E_lines, types_used)
                            => ["When doing bounds analysis on the syntax tree:"]
@@ -399,6 +402,8 @@ Module Pipeline.
              (with_subst01 : bool)
              (translate_to_fancy : option to_fancy_args)
              (possible_values : list Z)
+             (relax_zrangef : relax_zrange_opt
+              := fun r => Option.value (relax_zrange_gen possible_values r) r)
              {t}
              (E : Expr t)
              (comment : type.for_each_lhs_of_arrow ToString.OfPHOAS.var_data t -> ToString.OfPHOAS.var_data (type.final_codomain t) -> list string)
@@ -430,7 +435,7 @@ Module Pipeline.
              (with_dead_code_elimination : bool := true)
              (with_subst01 : bool)
              (translate_to_fancy : option to_fancy_args)
-             relax_zrange
+             (possible_values : list Z)
              {t}
              (E : Expr t)
              (comment : type.for_each_lhs_of_arrow ToString.OfPHOAS.var_data t -> ToString.OfPHOAS.var_data (type.final_codomain t) -> list string)
@@ -442,7 +447,7 @@ Module Pipeline.
                   (*with_dead_code_elimination*)
                   with_subst01
                   translate_to_fancy
-                  relax_zrange
+                  possible_values
                   E comment arg_bounds out_bounds in
        match E with
        | Success (E, types_used) => Success (ToString.LinesToString E, types_used)
@@ -450,10 +455,13 @@ Module Pipeline.
        end.
 
   Local Notation arg_bounds_of_pipeline result
-    := ((fun a b c d t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d t E arg_bounds out_bounds = result') => arg_bounds) _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c possible_values t E arg_bounds out_bounds = result') => arg_bounds) _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Local Notation out_bounds_of_pipeline result
-    := ((fun a b c d t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d t E arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c possible_values t E arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ _ result eq_refl)
+         (only parsing).
+  Local Notation possible_values_of_pipeline result
+    := ((fun a b c possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c possible_values t E arg_bounds out_bounds = result') => possible_values) _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
 
   Notation FromPipelineToString prefix name result
@@ -462,6 +470,8 @@ Module Pipeline.
             match result with
             | Success E'
               => let E := ToString.ToFunctionLines
+                            (relax_zrange
+                             := fun r => Option.value (relax_zrange_gen (possible_values_of_pipeline result) r) r)
                             true (_ : static_opt) prefix (prefix ++ name)%string
                             E'
                             (comment (prefix ++ name)%string)

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -56,6 +56,8 @@ Section rbarrett_red.
     := [1; machine_wordsize / 2; machine_wordsize; 2 * machine_wordsize]%Z.
   Let possible_values := possible_values_of_machine_wordsize.
 
+  Local Instance widen_carry : widen_carry_opt := false.
+  Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance split_mul_to : split_mul_to_opt := None.
 
   Let fancy_args

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -63,6 +63,8 @@ Section rmontred.
 
   Let possible_values := possible_values_of_machine_wordsize.
 
+  Local Instance widen_carry : widen_carry_opt := false.
+  Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance split_mul_to : split_mul_to_opt := None.
 
   Let fancy_args

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -64,10 +64,12 @@ Section __.
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
           {widen_carry : widen_carry_opt}
-          {widen_bytes : widen_bytes_opt}
+          (widen_bytes : widen_bytes_opt := true) (* true, because we don't allow byte-sized things anyway, so we should not expect carries to be widened to byte-size when emitting C code *)
           (s : Z)
           (c : list (Z * Z))
           (machine_wordsize : Z).
+
+  Local Existing Instance widen_bytes.
 
   (* We include [0], so that even after bounds relaxation, we can
        notice where the constant 0s are, and remove them. *)

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -470,7 +470,9 @@ Module Compilers.
                :: (List.map (fun s => "  " ++ s)%string (to_strings prefix body)))
               ++ ["}"])%list.
 
-      Definition ToFunctionLines (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
+      Definition ToFunctionLines
+                 {relax_zrange : relax_zrange_opt}
+                 (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
                  {t}
                  (e : @Compilers.expr.Expr base.type ident.ident t)
                  (comment : type.for_each_lhs_of_arrow var_data t -> var_data (type.base (type.final_codomain t)) -> list string)
@@ -497,7 +499,9 @@ Module Compilers.
              => inr ("Errors in converting " ++ name ++ " to C:" ++ String.NewLine ++ String.concat String.NewLine errs)%string
            end.
 
-      Definition ToFunctionString (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
+      Definition ToFunctionString
+                 {relax_zrange : relax_zrange_opt}
+                 (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
                  {t}
                  (e : @Compilers.expr.Expr base.type ident.ident t)
                  (comment : type.for_each_lhs_of_arrow var_data t -> var_data (type.base (type.final_codomain t)) -> list string)
@@ -515,7 +519,7 @@ Module Compilers.
           comment_block s
           := List.map (fun line => "/* " ++ line ++ " */")%string s;
 
-          ToString.ToFunctionLines := ToFunctionLines;
+          ToString.ToFunctionLines := @ToFunctionLines;
 
           ToString.typedef_header := String.typedef_header
         |}.

--- a/src/Stringification/Language.v
+++ b/src/Stringification/Language.v
@@ -32,6 +32,12 @@ Module Compilers.
 
   Local Notation tZ := (base.type.type_base base.type.Z).
 
+  Module Export Options.
+    (** How to relax zranges *)
+    Class relax_zrange_opt := relax_zrange : zrange -> zrange.
+    Typeclasses Opaque relax_zrange_opt.
+  End Options.
+
   Module ToString.
     Local Open Scope string_scope.
     Local Open Scope Z_scope.
@@ -906,7 +912,8 @@ Module Compilers.
         (** Converts a PHOAS AST to lines of code * info on which
             primitive functions are called, or else an error string *)
         ToFunctionLines
-        : forall (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
+        : forall {relax_zrange : relax_zrange_opt}
+                 (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
                  {t}
                  (e : @Compilers.expr.Expr base.type ident.ident t)
                  (comment : type.for_each_lhs_of_arrow var_data t -> var_data (type.final_codomain t) -> list string)

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -15,6 +15,7 @@ Local Open Scope Z_scope.
 
 Module IR := IR.Compilers.ToString.IR.
 Module ToString := Stringification.Language.Compilers.ToString.
+Import Stringification.Language.Compilers.Options.
 
 Module Rust.
 
@@ -318,7 +319,9 @@ Module Rust.
       "(" ++ String.concat ", " (to_arg_list prefix Out rets ++ to_arg_list_for_each_lhs_of_arrow prefix args) ++
       ") -> () {")%string :: (List.map (fun s => "  " ++ s)%string (to_strings prefix body)) ++ ["}"%string]%list.
 
-  Definition ToFunctionLines (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
+  Definition ToFunctionLines
+             {relax_zrange : relax_zrange_opt}
+             (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
              {t}
              (e : API.Expr t)
              (comment : type.for_each_lhs_of_arrow var_data t -> var_data (type.base (type.final_codomain t)) -> list string)
@@ -347,7 +350,7 @@ Module Rust.
 
   Definition OutputRustAPI : ToString.OutputLanguageAPI :=
     {| ToString.comment_block := List.map (fun line => "/* " ++ line ++ " */")%string;
-       ToString.ToFunctionLines := ToFunctionLines;
+       ToString.ToFunctionLines := @ToFunctionLines;
        ToString.typedef_header := typedef_header |}.
 
 End Rust.


### PR DESCRIPTION
Note that this doesn't quite work yet; it still produces unused typedefs for unknown reasons, and it doesn't work for to_bytes, failing with the mysterious `Invalid identifier in arithmetic expression Z.zselect`.  But I think it's still worth merging, and I can finish making it work with to_bytes another time.