### PR TITLE
Improve expressivity of parsing

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -55,8 +55,8 @@ src/ArithmeticCPS/Freeze.v
 src/ArithmeticCPS/ModOps.v
 src/ArithmeticCPS/Saturated.v
 src/ArithmeticCPS/WordByWordMontgomery.v
-src/Bedrock/Types.v
 src/Bedrock/Tactics.v
+src/Bedrock/Types.v
 src/Bedrock/Varnames.v
 src/Bedrock/Translation/Cmd.v
 src/Bedrock/Translation/Expr.v
@@ -223,6 +223,7 @@ src/Util/Strings/Show.v
 src/Util/Strings/String.v
 src/Util/Strings/StringMap.v
 src/Util/Strings/String_as_OT.v
+src/Util/Strings/Parse/Common.v
 src/Util/Tactics/BreakMatch.v
 src/Util/Tactics/CPSId.v
 src/Util/Tactics/CacheTerm.v

--- a/src/Arithmetic/Saturated.v
+++ b/src/Arithmetic/Saturated.v
@@ -888,7 +888,7 @@ Module Rows.
       Lemma conditional_add_partitions n mask cond p q :
         length p = n -> length q = n -> map (Z.land mask) q = q ->
         fst (conditional_add n mask cond p q)
-        = Partition.partition weight n (Positional.eval weight n p + if dec (cond = 0) then 0 else Positional.eval weight n q).
+        = Partition.partition weight n (Positional.eval weight n p + (if dec (cond = 0) then 0 else Positional.eval weight n q)).
       Proof using wprops.
         cbv [conditional_add]; intros; rewrite add_partitions by (distr_length; auto).
         autorewrite with push_eval; reflexivity.
@@ -896,7 +896,7 @@ Module Rows.
 
       Lemma conditional_add_div n mask cond p q :
         length p = n -> length q = n -> map (Z.land mask) q = q ->
-        snd (conditional_add n mask cond p q) = (Positional.eval weight n p + if dec (cond = 0) then 0 else Positional.eval weight n q) / weight n.
+        snd (conditional_add n mask cond p q) = (Positional.eval weight n p + (if dec (cond = 0) then 0 else Positional.eval weight n q)) / weight n.
       Proof using wprops.
         cbv [conditional_add]; intros; rewrite add_div by (distr_length; auto).
         autorewrite with push_eval; auto.

--- a/src/Arithmetic/WordByWordMontgomery.v
+++ b/src/Arithmetic/WordByWordMontgomery.v
@@ -348,7 +348,7 @@ Module WordByWordMontgomery.
       split; try apply partition_eq_mod; auto; rewrite uweight_eq_alt by omega; subst r; Z.rewrite_mod_small; auto with zarith.
     Qed.
 
-    Local Lemma conditional_sub_correct : forall v, small v -> 0 <= eval v < eval N + R -> canon_rep (eval v + if eval N <=? eval v then -eval N else 0) (conditional_sub v N).
+    Local Lemma conditional_sub_correct : forall v, small v -> 0 <= eval v < eval N + R -> canon_rep (eval v + (if eval N <=? eval v then -eval N else 0)) (conditional_sub v N).
     Proof using small_N lgr_big N_nz N_lt_R.
       pose proof R_plusR_le as R_plusR_le.
       clear - small_N lgr_big N_nz N_lt_R R_plusR_le.
@@ -370,7 +370,7 @@ Module WordByWordMontgomery.
       { split; auto using Z.mod_small with lia. }
     Qed.
 
-    Local Lemma sub_then_maybe_add_correct : forall a b, small a -> small b -> 0 <= eval a < eval N -> 0 <= eval b < eval N -> canon_rep (eval a - eval b + if eval a - eval b <? 0 then eval N else 0) (sub_then_maybe_add a b).
+    Local Lemma sub_then_maybe_add_correct : forall a b, small a -> small b -> 0 <= eval a < eval N -> 0 <= eval b < eval N -> canon_rep (eval a - eval b + (if eval a - eval b <? 0 then eval N else 0)) (sub_then_maybe_add a b).
     Proof using small_N lgr_big R_numlimbs_nz N_nz N_lt_R.
       pose proof mask_r_sub1 as mask_r_sub1.
       clear - small_N lgr_big R_numlimbs_nz N_nz N_lt_R mask_r_sub1.
@@ -397,11 +397,11 @@ Module WordByWordMontgomery.
     Proof using lgr_big. eauto using drop_high_addT'_correct, eval_canon_rep. Qed.
     Local Lemma small_drop_high_addT' : forall n a b, small a -> small b -> small (@drop_high_addT' n a b).
     Proof using lgr_big. eauto using drop_high_addT'_correct, small_canon_rep. Qed.
-    Local Lemma eval_conditional_sub : forall v, small v -> 0 <= eval v < eval N + R -> eval (conditional_sub v N) = eval v + if eval N <=? eval v then -eval N else 0.
+    Local Lemma eval_conditional_sub : forall v, small v -> 0 <= eval v < eval N + R -> eval (conditional_sub v N) = eval v + (if eval N <=? eval v then -eval N else 0).
     Proof using small_N lgr_big R_numlimbs_nz N_nz N_lt_R. eauto using conditional_sub_correct, eval_canon_rep. Qed.
     Local Lemma small_conditional_sub : forall v, small v -> 0 <= eval v < eval N + R -> small (conditional_sub v N).
     Proof using small_N lgr_big R_numlimbs_nz N_nz N_lt_R. eauto using conditional_sub_correct, small_canon_rep. Qed.
-    Local Lemma eval_sub_then_maybe_add : forall a b, small a -> small b -> 0 <= eval a < eval N -> 0 <= eval b < eval N -> eval (sub_then_maybe_add a b) = eval a - eval b + if eval a - eval b <? 0 then eval N else 0.
+    Local Lemma eval_sub_then_maybe_add : forall a b, small a -> small b -> 0 <= eval a < eval N -> 0 <= eval b < eval N -> eval (sub_then_maybe_add a b) = eval a - eval b + (if eval a - eval b <? 0 then eval N else 0).
     Proof using small_N lgr_big R_numlimbs_nz N_nz N_lt_R. eauto using sub_then_maybe_add_correct, eval_canon_rep. Qed.
     Local Lemma small_sub_then_maybe_add : forall a b, small a -> small b -> 0 <= eval a < eval N -> 0 <= eval b < eval N -> small (sub_then_maybe_add a b).
     Proof using small_N lgr_big R_numlimbs_nz N_nz N_lt_R. eauto using sub_then_maybe_add_correct, small_canon_rep. Qed.
@@ -852,7 +852,7 @@ Module WordByWordMontgomery.
 
       Lemma redc_bound_tight A_numlimbs (A : T A_numlimbs)
             (small_A : small A)
-        : 0 <= eval (redc A) < eval N + eval B + if eval N <=? eval (pre_redc A) then -eval N else 0.
+        : 0 <= eval (redc A) < eval N + eval B + (if eval N <=? eval (pre_redc A) then -eval N else 0).
       Proof using small_N small_B lgr_big R_numlimbs_nz N_nz N_lt_R B_bounds.
         clear -small_N small_B lgr_big R_numlimbs_nz N_nz N_lt_R B_bounds r_big' partition_Proper small_A sub_then_maybe_add.
         pose proof (@small_pre_redc _ A small_A).
@@ -920,12 +920,12 @@ Module WordByWordMontgomery.
       Lemma small_opp : small (opp Av).
       Proof using small_N small_Bv small_Av partition_Proper lgr_big R_numlimbs_nz N_nz N_lt_R Av_bound. unfold opp, sub; t_small. Qed.
 
-      Lemma eval_add : eval (add Av Bv) = eval Av + eval Bv + if (eval N <=? eval Av + eval Bv) then -eval N else 0.
+      Lemma eval_add : eval (add Av Bv) = eval Av + eval Bv + (if (eval N <=? eval Av + eval Bv) then -eval N else 0).
       Proof using small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound small_N ri k R_numlimbs_nz N_nz B_bounds B.
         clear -small_Bv small_Av lgr_big N_lt_R Bv_bound Av_bound partition_Proper r_big' small_N ri k R_numlimbs_nz N_nz B_bounds B sub_then_maybe_add.
         unfold add; autorewrite with push_mont_eval; reflexivity.
       Qed.
-      Lemma eval_sub : eval (sub Av Bv) = eval Av - eval Bv + if (eval Av - eval Bv <? 0) then eval N else 0.
+      Lemma eval_sub : eval (sub Av Bv) = eval Av - eval Bv + (if (eval Av - eval Bv <? 0) then eval N else 0).
       Proof using small_Bv small_Av Bv_bound Av_bound small_N partition_Proper lgr_big R_numlimbs_nz N_nz N_lt_R. unfold sub; autorewrite with push_mont_eval; reflexivity. Qed.
       Lemma eval_opp : eval (opp Av) = (if (eval Av =? 0) then 0 else eval N) - eval Av.
       Proof using small_Av Av_bound small_N partition_Proper lgr_big R_numlimbs_nz N_nz N_lt_R.

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -26,28 +26,10 @@ Import
   Stringification.C.Compilers.
 
 Module ForExtraction.
-  Definition parse_Z (s : string) : option Z
-    := z <- ParseArithmetic.parse_Z s;
-         match snd z with
-         | EmptyString => Some (fst z)
-         | _ => None
-         end.
-  Definition parse_N (s : string) : option N
-    := match parse_Z s with
-       | Some Z0 => Some N0
-       | Some (Zpos p) => Some (Npos p)
-       | _ => None
-       end.
-  Definition parse_nat (s : string) : option nat
-    := option_map N.to_nat (parse_N s).
-  Definition parse_Q (s : string) : option Q
-    := match parseQ_arith s, List.map parse_Z (String.split "." s), List.map String.length (String.split "." s) with
-       | _, [Some int_part; Some dec_part], [_; digits]
-         => let den := 10 ^ (Z.of_nat digits) in
-            Some (Qmake (int_part * den + dec_part) (Z.to_pos den))
-       | Some num, _, _ => Some num
-       | _, _, _ => None
-       end.
+  Definition parse_Z (s : string) : option Z := parseZ_arith_strict s.
+  Definition parse_N (s : string) : option N := parseN_arith_strict s.
+  Definition parse_nat (s : string) : option nat := parsenat_arith_strict s.
+  Definition parse_Q (s : string) : option Q := parseQ_arith_strict s.
   Definition parse_bool (s : string) : option bool
     := if string_dec s "true"
        then Some true
@@ -81,12 +63,12 @@ Module ForExtraction.
   Definition parse_machine_wordsize (s : string) : option Z
     := parse_Z s.
   Definition parse_m (s : string) : option Z
-    := parseZ_arith s.
+    := parse_Z s.
 
   Definition parse_src_n : string -> option nat := parse_nat.
   Definition parse_limbwidth : string -> option Q := parse_Q.
   Definition parse_max (s : string) : option (option Z)
-    := option_map (@Some _) (parseZ_arith s).
+    := option_map (@Some _) (parse_Z s).
   Definition parse_inbounds_multiplier (s : string) : option (option Q)
     := option_map (@Some _) (parse_Q s).
 

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -64,21 +64,6 @@ Module ModOpsDef := ModOps.ModOps Core.RuntimeDefinitions.
 Module Import WordByWordMontgomeryAx := ArithmeticCPS.WordByWordMontgomery.WordByWordMontgomery Core.RuntimeAxioms.
 Module Import WordByWordMontgomeryDef := ArithmeticCPS.WordByWordMontgomery.WordByWordMontgomery Core.RuntimeDefinitions.
 
-Definition parse_Z (s : string) : option Z
-  := z <- ParseArithmetic.parse_Z s;
-       match snd z with
-       | EmptyString => Some (fst z)
-       | _ => None
-       end.
-Definition parse_N (s : string) : option N
-  := match parse_Z s with
-     | Some Z0 => Some N0
-     | Some (Zpos p) => Some (Npos p)
-     | _ => None
-     end.
-Definition parse_nat (s : string) : option nat
-  := option_map N.to_nat (parse_N s).
-
 Module Import UnsaturatedSolinas.
   Class params :=
     { n : nat;
@@ -143,7 +128,7 @@ Module Import UnsaturatedSolinas.
     : R
     := let str_bitwidth := bitwidth in
        let str_index := index in
-       match parse_Z bitwidth, parse_nat index with
+       match parseZ_arith_strict bitwidth, parsenat_arith_strict index with
        | Some bitwidth, Some index
          => match List.nth_error (of_string prime bitwidth) index with
             | Some p
@@ -293,7 +278,7 @@ Module Import WordByWordMontgomery.
     := fun _ p => ("{| m := " ++ show false m ++ "; machine_wordsize := " ++ show false machine_wordsize ++ "|}")%string.
 
   Definition of_string (p : string) (bitwidth : Z) : option params
-    := match parseZ_arith p with
+    := match parseZ_arith_strict p with
        | Some v => Some {| m := v ; machine_wordsize := bitwidth |}
        | None => None
        end.
@@ -341,7 +326,7 @@ Module Import WordByWordMontgomery.
              (error : list string -> R)
     : R
     := let str_bitwidth := bitwidth in
-       match parse_Z bitwidth with
+       match parseZ_arith_strict bitwidth with
        | Some bitwidth
          => match of_string prime bitwidth with
             | Some p

--- a/src/Util/Notations.v
+++ b/src/Util/Notations.v
@@ -32,6 +32,10 @@ Reserved Infix "=ₙ?" (at level 70, no associativity).
 Reserved Infix "=ℤ?" (at level 70, no associativity).
 Reserved Infix "=ᶻ?" (at level 70, no associativity).
 Reserved Infix "=ⁿ?" (at level 70, no associativity).
+Reserved Notation "f ?" (at level 9, format "f ?").
+Reserved Notation "f [ ? ]" (at level 9, format "f [ ? ]").
+Reserved Notation "f +" (at level 50, format "f +").
+Reserved Notation "f *" (at level 40, format "f *").
 (* to match with ssreflect *)
 Reserved Notation "x \in A"
   (at level 70, format "'[hv' x '/ '  \in  A ']'", no associativity).
@@ -100,6 +104,9 @@ Reserved Infix "≡₂₅₆" (at level 70, no associativity).
 Reserved Infix "≢₂₅₆" (at level 70, no associativity).
 Reserved Infix "≡₅₁₂" (at level 70, no associativity).
 Reserved Infix "≢₅₁₂" (at level 70, no associativity).
+Reserved Infix "|||" (at level 50, left associativity).
+Reserved Notation "A ||->{ f } B" (at level 50, left associativity). (* would be nice to make these Reserved Infix, but but it doesn't work; cf COQBUG(https://github.com/coq/coq/issues/11402) *)
+Reserved Notation "A |||->{ f } B" (at level 50, left associativity). (* would be nice to make these Reserved Infix, but but it doesn't work; cf COQBUG(https://github.com/coq/coq/issues/11402) *)
 (* Put these at level 71 so they don't conflict with the infix notations at level 70 *)
 Reserved Notation "<" (at level 71).
 Reserved Notation ">" (at level 71).
@@ -118,6 +125,7 @@ Reserved Notation "A <--- X ; B" (at level 70, X at next level, right associativ
 Reserved Notation "A <---- X ; B" (at level 70, X at next level, right associativity, format "'[v' A  <----  X ; '/' B ']'").
 Reserved Notation "A <----- X ; B" (at level 70, X at next level, right associativity, format "'[v' A  <-----  X ; '/' B ']'").
 Reserved Notation "A ;; B" (at level 70, right associativity, format "'[v' A ;; '/' B ']'").
+Reserved Notation "A ;;->{ f } B" (at level 70, right associativity, format "'[v' A ;;->{ f } '/' B ']'").
 Reserved Notation "A ;;; B" (at level 70, right associativity, format "'[v' A ;;; '/' B ']'").
 Reserved Notation "u [ i ]" (at level 30).
 Reserved Notation "v [[ i ]]" (at level 30).

--- a/src/Util/Strings/Ascii.v
+++ b/src/Util/Strings/Ascii.v
@@ -1,6 +1,10 @@
+Require Import Coq.NArith.NArith.
 Require Import Crypto.Util.Strings.Equality.
 Require Import Coq.Strings.Ascii.
+Require Import Crypto.Util.Notations.
 
+Local Open Scope bool_scope.
+Local Open Scope N_scope.
 Local Open Scope char_scope.
 
 (** Special characters *)
@@ -13,3 +17,18 @@ Example NewPage := "012".
 Example CR := "013".
 Example Escape := "027".
 Example NewLine := "010".
+
+Local Coercion N_of_ascii : ascii >-> N.
+Definition ltb (x y : ascii) : bool := N.ltb x y.
+Definition leb (x y : ascii) : bool := N.leb x y.
+Infix "<?" := ltb : char_scope.
+Infix "<=?" := leb : char_scope.
+
+Definition to_lower (ch : ascii) : ascii
+  := if ("A" <=? ch) && (ch <=? "Z")
+     then ascii_of_N ("a" + ch - "A")
+     else ch.
+Definition to_upper (ch : ascii) : ascii
+  := if ("a" <=? ch) && (ch <=? "z")
+     then ascii_of_N ("A" + ch - "a")
+     else ch.

--- a/src/Util/Strings/Parse/Common.v
+++ b/src/Util/Strings/Parse/Common.v
@@ -1,0 +1,181 @@
+Require Import Coq.Strings.Ascii Coq.Strings.String Coq.Lists.List.
+Require Import Crypto.Util.Option.
+Require Import Crypto.Util.Strings.String.
+Require Import Crypto.Util.Strings.Equality.
+Require Import Crypto.Util.Notations.
+Import ListNotations.
+Local Open Scope list_scope.
+Local Open Scope option_scope.
+Local Open Scope char_scope.
+Local Open Scope string_scope.
+
+Definition ParserAction T := string -> list (T * string).
+Delimit Scope parse_scope with parse.
+Bind Scope parse_scope with ParserAction.
+Definition parse_impossible {T} : ParserAction T
+  := fun s => [].
+Definition parse_empty : ParserAction unit
+  := fun s
+     => if s =? ""
+        then [(tt, "")]
+        else [].
+Definition parse_seq_gen {A B C} (f : A -> B -> C) (p1 : ParserAction A) (p2 : ParserAction B) : ParserAction C
+  := fun s
+     => flat_map
+          (fun '(a, s) => List.map (fun '(b, s) => (f a b, s)) (p2 s))
+          (p1 s).
+Definition parse_alt_gen {A B C} (f : A + B -> C) (p1 : ParserAction A) (p2 : ParserAction B) : ParserAction C
+  := fun s
+     => ((List.map (fun '(v, s) => (f (inl v), s)) (p1 s))
+           ++ List.map (fun '(v, s) => (f (inr v), s)) (p2 s))%list.
+Definition parse_alt {A} (p1 p2 : ParserAction A) : ParserAction A
+  := parse_alt_gen (fun aa => match aa with inl a => a | inr a => a end) p1 p2.
+
+Notation ε := parse_empty.
+Infix "||" := parse_alt : parse_scope.
+Infix "||->{ f }" := (parse_alt_gen f) : parse_scope.
+Infix ";;->{ f }" := (parse_seq_gen f) : parse_scope.
+Infix ";;" := (parse_seq_gen (@pair _ _)) : parse_scope.
+
+Definition parse_ascii (prefix : ascii) : ParserAction ascii
+  := fun s
+     => match s with
+        | EmptyString => []
+        | String ch s' => if ascii_beq ch prefix
+                          then [(ch, s')]
+                          else []
+        end.
+
+Coercion parse_ascii : ascii >-> ParserAction.
+
+Definition parse_str (prefix : string) : ParserAction string
+  := fun s
+     => if startswith prefix s
+        then [(prefix, substring (String.length prefix) (String.length s) s)]
+        else [].
+
+Coercion parse_str : string >-> ParserAction.
+
+Definition parse_map {A B} (f : A -> B) : ParserAction A -> ParserAction B
+  := fun p s
+     => List.map (fun '(v, s) => (f v, s)) (p s).
+
+Definition parse_maybe {A} (p : ParserAction A) : ParserAction (option A)
+  := (p ||->{ fun v => match v with inl v => Some v | inr _ => None end } "")%parse.
+
+Notation "f ?" := (parse_maybe f) : parse_scope.
+
+Definition option_to_list {A} (v : option A) : list A
+  := match v with
+     | Some v => [v]
+     | None => []
+     end.
+
+Definition option_list_to_list {A} (v : option (list A)) : list A
+  := match v with
+     | Some v => v
+     | None => []
+     end.
+
+Definition fuel {A} (p : nat -> ParserAction A) : ParserAction A
+  := fun s => p (S (String.length s)) s.
+
+Fixpoint parse_plus_fueled {A} (p : ParserAction A) (fuel : nat) : ParserAction (list A)
+  := (p ;;->{ @cons _ } (match fuel with
+                         | O => fun s => []
+                         | S fuel => parse_map option_list_to_list ((parse_plus_fueled p fuel)?)
+                         end)).
+
+Definition parse_plus {A} (p : ParserAction A) : ParserAction (list A)
+  := fuel (parse_plus_fueled p).
+
+Definition parse_star {A} (p : ParserAction A) : ParserAction (list A)
+  := parse_map option_list_to_list ((parse_plus p)?).
+
+Notation "p +" := (parse_plus p) : parse_scope.
+Notation "p *" := (parse_star p) : parse_scope.
+
+Definition whitespace : list ascii
+  := [" "; "009" (* \t *); "010" (* \n *); "013" (* \r *); "012" (* \f *); "011" (* \v *)]%char.
+Definition whitespace_strs : list string
+  := Eval compute in List.map (fun ch => String ch "") whitespace.
+
+Definition parse_strs {T} (ls : list (string * T)) : ParserAction T
+  := List.fold_left ((fun p2 '(s1, v1) => (s1:string) ||->{ fun v => match v with inl _ => v1 | inr v => v end } p2)%parse)
+                    ls
+                    parse_impossible.
+
+
+
+Definition parse_any_whitespace : ParserAction (list string)
+  := Eval cbv [List.fold_right List.fold_left whitespace whitespace_strs List.tl List.hd parse_strs List.combine] in
+      (List.fold_left (B:=string) parse_alt (tl whitespace_strs) (hd " " whitespace_strs))*.
+
+Definition strip_whitespace_around {A} (p : ParserAction A) : ParserAction A
+  := parse_any_whitespace ;;->{ fun _ v => v }
+                          p ;;->{ fun v _ => v }
+                          parse_any_whitespace.
+
+Definition parse_list_gen {A} (leftbr sep rightbr : string) (parse : ParserAction A) : ParserAction (list A)
+  := (strip_whitespace_around leftbr)
+       ;;->{ fun _ v => v }
+       ((parse ;;->{ @cons _ }
+               (strip_whitespace_around sep ;;->{ fun _ tl => tl } parse)* ))?
+       ;;->{ fun v _ => match v with None => [] | Some ls => ls end }
+       strip_whitespace_around rightbr.
+
+Definition parse_list {A} (parse : ParserAction A) : ParserAction (list A)
+  := parse_list_gen "[" ";" "]" parse.
+
+Definition parse_list_Python_style {A} (parse : ParserAction A) : ParserAction (list A)
+  := parse_list_gen "[" "," "]" parse.
+
+Definition parse_list_Mathematica_style {A} (parse : ParserAction A) : ParserAction (list A)
+  := parse_list_gen "{" "," "}" parse.
+
+Definition parse_comma_list {A} (parse : ParserAction A) : ParserAction (list A)
+  := parse_list_gen "" "," "" parse.
+
+Definition parse_semicolon_list {A} (parse : ParserAction A) : ParserAction (list A)
+  := parse_list_gen "" ";" "" parse.
+
+Definition parse_any_list {A} (parse : ParserAction A) : ParserAction (list A)
+  := parse_list parse || parse_list_Python_style parse || parse_list_Mathematica_style parse || parse_comma_list parse || parse_semicolon_list parse.
+
+Fixpoint split_before_first (f : ascii -> bool) (s : string) : string * string
+  := match s with
+     | EmptyString => (EmptyString, EmptyString)
+     | String ch rest
+       => if f ch
+          then (EmptyString, s)
+          else let '(s1, s2) := split_before_first f rest in
+               (String ch s1, s2)
+     end.
+
+Fixpoint split_before_first_skip (f : ascii -> bool) (s : string) (skip : nat) : string * string
+  := match skip, s with
+     | 0, _ => split_before_first f s
+     | _, EmptyString => (EmptyString, EmptyString)
+     | S skip', String ch rest
+       => let '(s1, s2) := split_before_first_skip f rest skip' in
+          (String ch s1, s2)
+     end.
+
+Definition finalize {A} (p : ParserAction A) : string -> option A
+  := fun s => match (p ;;->{fun v _ => v} ε)%parse s with
+              | [(v, _)] => Some v
+              | _ => None
+              end.
+
+(*
+Definition parse_ch {T} (ls : list (ascii * T)) (s : string) : option (T * string)
+  := match s with
+     | EmptyString => None
+     | String ch s
+       => List.fold_right
+            (fun '(ch', t) default
+             => if ascii_beq ch ch' then Some (t, s) else default)
+            None
+            ls
+     end.
+*)

--- a/src/Util/Strings/String.v
+++ b/src/Util/Strings/String.v
@@ -56,6 +56,11 @@ Lemma map_step f s
               end.
 Proof. destruct s; reflexivity. Qed.
 
+
+(** *** Lower and upper case *)
+Definition to_lower (s : string) : string := map Ascii.to_lower s.
+Definition to_upper (s : string) : string := map Ascii.to_upper s.
+
 (** *** string reversal *)
 (** [rev s] reverses the string [s] *)
 Definition rev : string -> string
@@ -130,6 +135,19 @@ Definition contains (n : nat) (s1 s2 : string) : bool :=
   | Some _ => true
   | None => false
   end.
+
+(** [startswith prefix s] returns [true] iff [s] starts with [prefix] *)
+Definition startswith (prefix s : string) : bool
+  := (prefix =? (substring 0 (length prefix) s))%string.
+
+Lemma startswith_correct prefix s
+  : startswith prefix s = true <-> substring 0 (length prefix) s = prefix.
+Proof.
+  cbv [startswith].
+  split; intro H.
+  { apply internal_string_dec_bl in H; congruence. }
+  { apply internal_string_dec_lb; congruence. }
+Qed.
 
 Section strip_prefix_cps.
   Context {R} (found : string -> R)


### PR DESCRIPTION
Perhaps it is overkill, but Fiat-Crypto now includes a small parser
combinator library for parsing command-line options.  We can now parse
things like `2^(1.1 * 255) + 0xF + 0o1 + 0b1010.1010 + 2^(255/10)`.

The actual impetus for this change was to allow parsing of lists, to be
used to parse lists of bounds.