### PR TITLE
Automatically publish the fiat-rust crate using a release-triggered Github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  release:
+    types: [published] # Only publish to crates.io when we formally publish a release
+  # For more on how to formally release on Github, read https://help.github.com/en/articles/creating-releases
+
+jobs:
+  publish:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
+    - uses: actions/checkout@master
+    - name: Login to crates.io
+      run: cargo login $CRATES_IO_TOKEN
+      env:
+        CRATES_IO_TOKEN: ${{ secrets.crates_io_token }} # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets
+    - name: Dry run publish
+      run: cargo publish --dry-run --manifest-path fiat-rust/Cargo.toml
+    - name: Publish
+      run: cargo publish --manifest-path fiat-rust/Cargo.toml
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}

--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Andres Erbsen <andreser@mit.edu>
 Google Inc.
 Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>
 Massachusetts Institute of Technology
+Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>

--- a/fiat-rust/AUTHORS
+++ b/fiat-rust/AUTHORS
@@ -1,0 +1,17 @@
+# This is the official list of fiat-crypto authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as one of
+#     Organization's name
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+# See CONTRIBUTORS for the meaning of multiple email addresses.
+
+# Please keep the list sorted.
+
+Andres Erbsen <andreser@mit.edu>
+Google Inc.
+Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>
+Massachusetts Institute of Technology
+Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>

--- a/fiat-rust/Cargo.toml
+++ b/fiat-rust/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
-name = "fiat-rust"
+name = "fiat-crypto"
 version = "0.1.0"
-authors = ["Zoe Paraskevopoulou <zoopar@fb.com>"]
+authors = ["Fiat Crypto library authors <jgross@mit.edu>"]
 edition = "2018"
+description = "Fiat-crypto generated Rust"
+homepage = "https://github.com/mit-plv/fiat-crypto"
+repository = "https://github.com/mit-plv/fiat-crypto"
+readme = "README.md"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fiat-rust/LICENSE
+++ b/fiat-rust/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 the fiat-crypto authors (see the AUTHORS file).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/fiat-rust/README.md
+++ b/fiat-rust/README.md
@@ -1,0 +1,8 @@
+## Fiat-crypto
+
+This crate provides the extracted Rust code from the Coq
+[fiat-crypto](https://github.com/mit-plv/fiat-crypto) libraries.
+
+
+## License
+This project is licensed under the terms of the [MIT license](LICENSE).


### PR DESCRIPTION
This publishes the fiat-rust crate, under its name/version as declared in the `Cargo.toml` manifest, when the project publishes a [release](https://help.github.com/en/github/administering-a-repository/creating-releases).

This will require:
- creating an account for the project on [crates.io](https://crates.io/), 
- [getting a token](https://crates.io/me) there, 
- [registering it as a secret named `crates_io_token`](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) on this project's Github settings,

Contributes to #647  (minus setup)