### PR TITLE
Bump rewriter - Allow specifying more rewriter options

### DIFF
--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -78,6 +78,10 @@ Import
   MiscCompilerPasses.Compilers
   Stringification.Language.Compilers.
 
+Import
+  ProofsCommon.Compilers.RewriteRules.GoalType
+  ProofsCommon.Compilers.RewriteRules.GoalType.DefaultOptionType.
+
 Export Stringification.Language.Compilers.Options.
 
 Import Compilers.API.
@@ -128,6 +132,14 @@ Proof.
         try (rewrite <- Z.log2_up_le_pow2_full in *; omega).
 Qed.
 
+(** Which of the rewriter methods do we use? *)
+(** Note that we don't currently generate a precomputed naive method, because it eats too much RAM to do so. *)
+Inductive low_level_rewriter_method_opt :=
+  precomputed_decision_tree | unreduced_decision_tree | unreduced_naive.
+Existing Class low_level_rewriter_method_opt.
+(** We make this an instance later *)
+Definition default_low_level_rewriter_method : low_level_rewriter_method_opt
+  := precomputed_decision_tree.
 (** Prefix function definitions with static/non-public? *)
 Class static_opt := static : bool.
 Typeclasses Opaque static_opt.
@@ -186,6 +198,12 @@ Module Pipeline.
   Section show.
     Context {output_api : ToString.OutputLanguageAPI}.
     Local Open Scope string_scope.
+    Global Instance show_low_level_rewriter_method_opt : Show low_level_rewriter_method_opt
+      := fun _ v => match v with
+                    | precomputed_decision_tree => "precomputed_decision_tree"
+                    | unreduced_decision_tree => "unreduced_decision_tree"
+                    | unreduced_naive => "unreduced_naive"
+                    end.
     Fixpoint find_too_loose_base_bounds {t}
       : ZRange.type.base.option.interp t -> ZRange.type.base.option.interp t-> bool * list (nat * nat) * list (zrange * zrange)
       := match t return ZRange.type.base.option.interp t -> ZRange.type.option.interp t-> bool * list (nat * nat) * list (zrange * zrange) with
@@ -347,7 +365,23 @@ Module Pipeline.
        let E := if with_dead_code_elimination then DeadCodeElimination.EliminateDead E else E in
        E.
 
+  Definition opts_of_method
+             {low_level_rewriter_method : low_level_rewriter_method_opt}
+    := {| use_decision_tree
+          := match low_level_rewriter_method with
+             | precomputed_decision_tree => true
+             | unreduced_decision_tree => true
+             | unreduced_naive => false
+             end;
+          use_precomputed_functions
+          := match low_level_rewriter_method with
+             | precomputed_decision_tree => true
+             | unreduced_decision_tree => false
+             | unreduced_naive => false
+             end; |}.
+
   Definition BoundsPipeline
+             {low_level_rewriter_method : low_level_rewriter_method_opt}
              {split_mul_to : split_mul_to_opt}
              (with_dead_code_elimination : bool := true)
              (with_subst01 : bool)
@@ -360,12 +394,13 @@ Module Pipeline.
              out_bounds
   : ErrorT (Expr t)
     := (*let E := expr.Uncurry E in*)
+      let opts := opts_of_method in
       let E := PartialEvaluateWithListInfoFromBounds E arg_bounds in
-      let E := PartialEvaluate E in
-      let E := RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArith 0) with_dead_code_elimination with_subst01 E in
-      let E := RewriteRules.RewriteArith (2^8) E in (* reassociate small consts *)
+      let E := PartialEvaluate opts E in
+      let E := RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArith 0 opts) with_dead_code_elimination with_subst01 E in
+      let E := RewriteRules.RewriteArith (2^8) opts E in (* reassociate small consts *)
       let E := match translate_to_fancy with
-               | Some {| invert_low := invert_low ; invert_high := invert_high |} => RewriteRules.RewriteToFancy invert_low invert_high E
+               | Some {| invert_low := invert_low ; invert_high := invert_high |} => RewriteRules.RewriteToFancy invert_low invert_high opts E
                | None => E
                end in
       dlet_nd e := ToFlat E in
@@ -373,18 +408,18 @@ Module Pipeline.
       let E' := CheckedPartialEvaluateWithBounds relax_zrange E arg_bounds out_bounds in
       match E' with
       | inl E
-        => let E := RewriteAndEliminateDeadAndInline RewriteRules.RewriteArithWithCasts with_dead_code_elimination with_subst01 E in
+        => let E := RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArithWithCasts opts) with_dead_code_elimination with_subst01 E in
            let E := match split_mul_to with
                     | Some (max_bitwidth, lgcarrymax)
-                      => RewriteRules.RewriteMulSplit max_bitwidth lgcarrymax E
+                      => RewriteRules.RewriteMulSplit max_bitwidth lgcarrymax opts E
                     | None => E
                     end in
            let E := match translate_to_fancy with
                     | Some {| invert_low := invert_low ; invert_high := invert_high ; value_range := value_range ; flag_range := flag_range |}
-                      => RewriteRules.RewriteToFancyWithCasts invert_low invert_high value_range flag_range E
+                      => RewriteRules.RewriteToFancyWithCasts invert_low invert_high value_range flag_range opts E
                     | None => E
                     end in
-           let E := RewriteRules.RewriteStripLiteralCasts E in
+           let E := RewriteRules.RewriteStripLiteralCasts opts E in
            Success E
       | inr (inl (b, E))
         => Error (Computed_bounds_are_not_tight_enough b out_bounds E arg_bounds)
@@ -395,6 +430,7 @@ Module Pipeline.
   Definition BoundsPipelineToStrings
              {output_language_api : ToString.OutputLanguageAPI}
              {static : static_opt}
+             {low_level_rewriter_method : low_level_rewriter_method_opt}
              {split_mul_to : split_mul_to_opt}
              (type_prefix : string)
              (name : string)
@@ -429,6 +465,7 @@ Module Pipeline.
   Definition BoundsPipelineToString
              {output_language_api : ToString.OutputLanguageAPI}
              {static : static_opt}
+             {low_level_rewriter_method : low_level_rewriter_method_opt}
              {split_mul_to : split_mul_to_opt}
              (type_prefix : string)
              (name : string)
@@ -455,13 +492,13 @@ Module Pipeline.
        end.
 
   Local Notation arg_bounds_of_pipeline result
-    := ((fun a b c possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c possible_values t E arg_bounds out_bounds = result') => arg_bounds) _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c d possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d possible_values t E arg_bounds out_bounds = result') => arg_bounds) _ _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Local Notation out_bounds_of_pipeline result
-    := ((fun a b c possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c possible_values t E arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c d possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d possible_values t E arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Local Notation possible_values_of_pipeline result
-    := ((fun a b c possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c possible_values t E arg_bounds out_bounds = result') => possible_values) _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c d possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d possible_values t E arg_bounds out_bounds = result') => possible_values) _ _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
 
   Notation FromPipelineToString prefix name result
@@ -515,6 +552,7 @@ Module Pipeline.
   Proof. cbv [RewriteAndEliminateDeadAndInline Let_In]; wf_interp_t. Qed.
 
   Global Hint Resolve @Wf_RewriteAndEliminateDeadAndInline : wf wf_extra.
+  Global Hint Opaque RewriteAndEliminateDeadAndInline : wf wf_extra.
 
   Lemma Interp_RewriteAndEliminateDeadAndInline {t} DoRewrite with_dead_code_elimination with_subst01
         (Interp_DoRewrite : forall E, Wf E -> Interp (DoRewrite E) == Interp E)
@@ -531,6 +569,7 @@ Module Pipeline.
   Hint Rewrite @Interp_RewriteAndEliminateDeadAndInline : interp interp_extra.
 
   Lemma BoundsPipeline_correct
+             {low_level_rewriter_method : low_level_rewriter_method_opt}
              {split_mul_to : split_mul_to_opt}
              (with_dead_code_elimination : bool := true)
              (with_subst01 : bool)
@@ -605,6 +644,7 @@ Module Pipeline.
        /\ Wf rv.
 
   Lemma BoundsPipeline_correct_trans
+        {low_level_rewriter_method : low_level_rewriter_method_opt}
         {split_mul_to : split_mul_to_opt}
         (with_dead_code_elimination : bool := true)
         (with_subst01 : bool)
@@ -648,6 +688,8 @@ Module Pipeline.
                  | exact eq_refl ].
 
   Module Export Instances.
+    (*Global Existing Instance default_low_level_rewriter_method.*)
+
     Global Instance bounds0_good {t : base.type} {bounds} : @bounds_goodT t bounds.
     Proof. solve_bounds_good. Qed.
 

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -252,6 +252,9 @@ Module ForExtraction.
       ; widen_carry :> widen_carry_opt
       (** Should we widen the byte type to the full bitwidth? *)
       ; widen_bytes :> widen_bytes_opt
+      (** What method should we use for rewriting? *)
+      ; low_level_rewriter_method :> low_level_rewriter_method_opt
+        := default_low_level_rewriter_method
     }.
 
   (** We define a class for the various operations that are specific to a pipeline *)

--- a/src/CompilersTestCases.v
+++ b/src/CompilersTestCases.v
@@ -36,7 +36,7 @@ Proof.
   let v := Reify ((fun x => 2^x) 255)%Z in
   pose v as E.
   vm_compute in E.
-  pose (PartialEvaluate E) as E'.
+  pose (PartialEvaluate RewriteRules.default_opts E) as E'.
   vm_compute in E'.
   lazymatch (eval cbv delta [E'] in E') with
   | (fun var => expr.Ident (ident.Literal ?v)) => idtac
@@ -47,21 +47,21 @@ Module testrewrite.
   Import expr.
   Import ident.
 
-  Redirect "log" Eval compute in RewriteRules.RewriteNBE (fun var =>
+  Redirect "log" Eval compute in RewriteRules.RewriteNBE RewriteRules.default_opts (fun var =>
                           (#ident.fst @ (expr_let x := ##10 in ($x, $x)))%expr).
 
   Notation "x + y" := (@expr.Ident base.type ident _ _ ident.Z_add @ x @ y)%expr : expr_scope.
 
-  Redirect "log" Eval compute in RewriteRules.RewriteNBE (fun var =>
+  Redirect "log" Eval compute in RewriteRules.RewriteNBE RewriteRules.default_opts (fun var =>
                           ((\ x , expr_let y := ##5 in #ident.fst @ $x + (#ident.fst @ $x + ($y + $y)))
                              @ (##1, ##1))%expr).
 
-  Redirect "log" Eval compute in RewriteRules.RewriteNBE (fun var =>
+  Redirect "log" Eval compute in RewriteRules.RewriteNBE RewriteRules.default_opts (fun var =>
                           ((\ x , expr_let y := ##5 in $y + ($y + (#ident.fst @ $x + #ident.snd @ $x)))
                              @ (##1, ##7))%expr).
 
   Redirect "log" Eval cbv in partial.eval_with_bound partial.default_relax_zrange
-                                      (RewriteRules.RewriteNBE (fun var =>
+                                      (RewriteRules.RewriteNBE RewriteRules.default_opts (fun var =>
                 (\z , ((\ x , expr_let y := ##5 in $y + ($z + (#ident.fst @ $x + #ident.snd @ $x)))
                          @ (##1, ##7)))%expr) _)
                 (Datatypes.Some r[0~>100]%zrange, Datatypes.tt).
@@ -197,7 +197,7 @@ Module test4.
     pose (partial.EtaExpandWithListInfoFromBound E' bound) as E''.
     lazy in E''.
     clear E'.
-    pose (PartialEvaluate E'') as E'''.
+    pose (PartialEvaluate RewriteRules.default_opts E'') as E'''.
     lazy in E'''.
     pose (partial.EvalWithBound partial.default_relax_zrange E''' bound) as E''''.
     lazy in E''''.
@@ -224,7 +224,7 @@ Module test5.
                         x) in
     pose v as E.
     vm_compute in E.
-    pose (RewriteRules.RewriteArith (2^8) (partial.Eval E)) as E'.
+    pose (RewriteRules.RewriteArith (2^8) RewriteRules.default_opts (partial.Eval E)) as E'.
     lazy in E'.
     clear E.
     lazymatch (eval cbv delta [E'] in E') with
@@ -244,7 +244,7 @@ Module test5.
                         x) in
     pose v as E.
     vm_compute in E.
-    pose (RewriteRules.RewriteArith (2^8) (partial.Eval E)) as E'.
+    pose (RewriteRules.RewriteArith (2^8) RewriteRules.default_opts (partial.Eval E)) as E'.
     lazy in E'.
     clear E.
     lazymatch (eval cbv delta [E'] in E') with
@@ -268,7 +268,7 @@ Module test6.
                        else y) in
     pose v as E.
     vm_compute in E.
-    pose (PartialEvaluate E) as E''.
+    pose (PartialEvaluate RewriteRules.default_opts E) as E''.
     lazy in E''.
     lazymatch eval cbv delta [E''] in E'' with
     | fun var : type -> Type => (λ x : var _, $x)%expr
@@ -320,7 +320,7 @@ Module test9.
     let v := Reify (fun y : list Z => (hd 0%Z y, tl y)) in
     pose v as E.
     vm_compute in E.
-    pose (PartialEvaluate E) as E'.
+    pose (PartialEvaluate RewriteRules.default_opts E) as E'.
     lazy in E'.
     clear E.
     lazymatch (eval cbv delta [E'] in E') with
@@ -388,7 +388,7 @@ Module test12.
     pose v as E.
     vm_compute in E.
     pose (Some (repeat (@None zrange) 3), Datatypes.tt) as bound.
-    pose (PartialEvaluate (partial.EtaExpandWithListInfoFromBound E bound)) as E'.
+    pose (PartialEvaluate RewriteRules.default_opts (partial.EtaExpandWithListInfoFromBound E bound)) as E'.
     lazy in E'.
     clear E.
     lazymatch (eval cbv delta [E'] in E') with
@@ -408,7 +408,7 @@ Module test13.
       pose v0 as exp.
     vm_compute in E.
     vm_compute in exp.
-    pose (PartialEvaluate E) as E'.
+    pose (PartialEvaluate RewriteRules.default_opts E) as E'.
     vm_compute in E'.
     clear E.
     let r := Reify exp in

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -59,6 +59,7 @@ Section rbarrett_red.
   Local Instance widen_carry : widen_carry_opt := false.
   Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance split_mul_to : split_mul_to_opt := None.
+  Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
 
   Let fancy_args
     := (Some {| Pipeline.invert_low log2wordsize := invert_low log2wordsize consts_list;

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -66,6 +66,7 @@ Local Opaque
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {low_level_rewriter_method : low_level_rewriter_method_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -66,6 +66,7 @@ Section rmontred.
   Local Instance widen_carry : widen_carry_opt := false.
   Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance split_mul_to : split_mul_to_opt := None.
+  Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
 
   Let fancy_args
     := (Some {| Pipeline.invert_low log2wordsize := invert_low log2wordsize consts_list;

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -631,6 +631,7 @@ Notation "'docstring_with_summary_from_lemma!' summary correctness"
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {low_level_rewriter_method : low_level_rewriter_method_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -60,6 +60,7 @@ Local Opaque expr.Interp.
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {low_level_rewriter_method : low_level_rewriter_method_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -21,6 +21,7 @@ Import Compilers.API.
 Import Associational Positional.
 
 Local Instance : split_mul_to_opt := None.
+Local Existing Instance default_low_level_rewriter_method.
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -75,6 +75,7 @@ Local Opaque
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {low_level_rewriter_method : low_level_rewriter_method_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -91,6 +91,7 @@ Local Opaque
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
           {static : static_opt}
+          {low_level_rewriter_method : low_level_rewriter_method_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}

--- a/src/Rewriter/Passes/Arith.v
+++ b/src/Rewriter/Passes/Arith.v
@@ -19,15 +19,18 @@ Module Compilers.
     Section __.
       Context (max_const_val : Z).
 
-      Definition VerifiedRewriterArith : VerifiedRewriter_with_args false false (arith_rewrite_rules_proofs max_const_val).
+      Definition VerifiedRewriterArith : VerifiedRewriter_with_args false false true (arith_rewrite_rules_proofs max_const_val).
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteArith {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterArith t.
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterArith.
+      Let optsT := Eval hnf in optsT VerifiedRewriterArith.
 
-      Lemma Wf_RewriteArith {t} e (Hwf : Wf e) : Wf (@RewriteArith t e).
+      Definition RewriteArith (opts : optsT) {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterArith opts t.
+
+      Lemma Wf_RewriteArith opts {t} e (Hwf : Wf e) : Wf (@RewriteArith opts t e).
       Proof. now apply VerifiedRewriterArith. Qed.
 
-      Lemma Interp_RewriteArith {t} e (Hwf : Wf e) : API.Interp (@RewriteArith t e) == API.Interp e.
+      Lemma Interp_RewriteArith opts {t} e (Hwf : Wf e) : API.Interp (@RewriteArith opts t e) == API.Interp e.
       Proof. now apply VerifiedRewriterArith. Qed.
     End __.
   End RewriteRules.

--- a/src/Rewriter/Passes/ArithWithCasts.v
+++ b/src/Rewriter/Passes/ArithWithCasts.v
@@ -16,15 +16,18 @@ Module Compilers.
 
   Module Import RewriteRules.
     Section __.
-      Definition VerifiedRewriterArithWithCasts : VerifiedRewriter_with_args false false arith_with_casts_rewrite_rules_proofs.
+      Definition VerifiedRewriterArithWithCasts : VerifiedRewriter_with_args false false true arith_with_casts_rewrite_rules_proofs.
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteArithWithCasts {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterArithWithCasts t.
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterArithWithCasts.
+      Let optsT := Eval hnf in optsT VerifiedRewriterArithWithCasts.
 
-      Lemma Wf_RewriteArithWithCasts {t} e (Hwf : Wf e) : Wf (@RewriteArithWithCasts t e).
+      Definition RewriteArithWithCasts (opts : optsT) {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterArithWithCasts opts t.
+
+      Lemma Wf_RewriteArithWithCasts opts {t} e (Hwf : Wf e) : Wf (@RewriteArithWithCasts opts t e).
       Proof. now apply VerifiedRewriterArithWithCasts. Qed.
 
-      Lemma Interp_RewriteArithWithCasts {t} e (Hwf : Wf e) : API.Interp (@RewriteArithWithCasts t e) == API.Interp e.
+      Lemma Interp_RewriteArithWithCasts opts {t} e (Hwf : Wf e) : API.Interp (@RewriteArithWithCasts opts t e) == API.Interp e.
       Proof. now apply VerifiedRewriterArithWithCasts. Qed.
     End __.
   End RewriteRules.

--- a/src/Rewriter/Passes/MulSplit.v
+++ b/src/Rewriter/Passes/MulSplit.v
@@ -20,15 +20,18 @@ Module Compilers.
       Context (bitwidth : Z)
               (lgcarrymax : Z).
 
-      Definition VerifiedRewriterMulSplit : VerifiedRewriter_with_args false false (mul_split_rewrite_rules_proofs bitwidth lgcarrymax).
+      Definition VerifiedRewriterMulSplit : VerifiedRewriter_with_args false false true (mul_split_rewrite_rules_proofs bitwidth lgcarrymax).
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteMulSplit {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterMulSplit t.
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterMulSplit.
+      Let optsT := Eval hnf in optsT VerifiedRewriterMulSplit.
 
-      Lemma Wf_RewriteMulSplit {t} e (Hwf : Wf e) : Wf (@RewriteMulSplit t e).
+      Definition RewriteMulSplit (opts : optsT) {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterMulSplit opts t.
+
+      Lemma Wf_RewriteMulSplit opts {t} e (Hwf : Wf e) : Wf (@RewriteMulSplit opts t e).
       Proof. now apply VerifiedRewriterMulSplit. Qed.
 
-      Lemma Interp_RewriteMulSplit {t} e (Hwf : Wf e) : API.Interp (@RewriteMulSplit t e) == API.Interp e.
+      Lemma Interp_RewriteMulSplit opts {t} e (Hwf : Wf e) : API.Interp (@RewriteMulSplit opts t e) == API.Interp e.
       Proof. now apply VerifiedRewriterMulSplit. Qed.
     End __.
   End RewriteRules.

--- a/src/Rewriter/Passes/NBE.v
+++ b/src/Rewriter/Passes/NBE.v
@@ -16,26 +16,29 @@ Module Compilers.
 
   Module Import RewriteRules.
     Section __.
-      Definition VerifiedRewriterNBE : VerifiedRewriter_with_args true false nbe_rewrite_rules_proofs.
+      Definition VerifiedRewriterNBE : VerifiedRewriter_with_args true false true nbe_rewrite_rules_proofs.
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteNBE {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterNBE t.
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterNBE.
+      Let optsT := Eval hnf in optsT VerifiedRewriterNBE.
 
-      Lemma Wf_RewriteNBE {t} e (Hwf : Wf e) : Wf (@RewriteNBE t e).
+      Definition RewriteNBE (opts : optsT) {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterNBE opts t.
+
+      Lemma Wf_RewriteNBE opts {t} e (Hwf : Wf e) : Wf (@RewriteNBE opts t e).
       Proof. now apply VerifiedRewriterNBE. Qed.
 
-      Lemma Interp_RewriteNBE {t} e (Hwf : Wf e) : API.Interp (@RewriteNBE t e) == API.Interp e.
+      Lemma Interp_RewriteNBE opts {t} e (Hwf : Wf e) : API.Interp (@RewriteNBE opts t e) == API.Interp e.
       Proof. now apply VerifiedRewriterNBE. Qed.
     End __.
   End RewriteRules.
 
-  Definition PartialEvaluate {t : API.type} (e : Expr t) : Expr t := RewriteRules.RewriteNBE e.
+  Definition PartialEvaluate opts {t : API.type} (e : Expr t) : Expr t := RewriteRules.RewriteNBE opts e.
 
-  Lemma Wf_PartialEvaluate {t} e (Hwf : Wf e) : Wf (@PartialEvaluate t e).
+  Lemma Wf_PartialEvaluate opts {t} e (Hwf : Wf e) : Wf (@PartialEvaluate opts t e).
   Proof. apply Wf_RewriteNBE, Hwf. Qed.
 
-  Lemma Interp_PartialEvaluate {t} e (Hwf : Wf e)
-    : API.Interp (@PartialEvaluate t e) == API.Interp e.
+  Lemma Interp_PartialEvaluate opts {t} e (Hwf : Wf e)
+    : API.Interp (@PartialEvaluate opts t e) == API.Interp e.
   Proof. apply Interp_RewriteNBE, Hwf. Qed.
 
   Module Export Hints.

--- a/src/Rewriter/Passes/StripLiteralCasts.v
+++ b/src/Rewriter/Passes/StripLiteralCasts.v
@@ -16,15 +16,18 @@ Module Compilers.
 
   Module Import RewriteRules.
     Section __.
-      Definition VerifiedRewriterStripLiteralCasts : VerifiedRewriter_with_args false false strip_literal_casts_rewrite_rules_proofs.
+      Definition VerifiedRewriterStripLiteralCasts : VerifiedRewriter_with_args false false true strip_literal_casts_rewrite_rules_proofs.
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteStripLiteralCasts {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterStripLiteralCasts t.
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterStripLiteralCasts.
+      Let optsT := Eval hnf in optsT VerifiedRewriterStripLiteralCasts.
 
-      Lemma Wf_RewriteStripLiteralCasts {t} e (Hwf : Wf e) : Wf (@RewriteStripLiteralCasts t e).
+      Definition RewriteStripLiteralCasts (opts : optsT) {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterStripLiteralCasts opts t.
+
+      Lemma Wf_RewriteStripLiteralCasts opts {t} e (Hwf : Wf e) : Wf (@RewriteStripLiteralCasts opts t e).
       Proof. now apply VerifiedRewriterStripLiteralCasts. Qed.
 
-      Lemma Interp_RewriteStripLiteralCasts {t} e (Hwf : Wf e) : expr.Interp (@Compilers.ident_interp) (@RewriteStripLiteralCasts t e) == expr.Interp (@Compilers.ident_interp) e.
+      Lemma Interp_RewriteStripLiteralCasts opts {t} e (Hwf : Wf e) : expr.Interp (@Compilers.ident_interp) (@RewriteStripLiteralCasts opts t e) == expr.Interp (@Compilers.ident_interp) e.
       Proof. now apply VerifiedRewriterStripLiteralCasts. Qed.
     End __.
   End RewriteRules.

--- a/src/Rewriter/Passes/ToFancy.v
+++ b/src/Rewriter/Passes/ToFancy.v
@@ -21,18 +21,21 @@ Module Compilers.
               (Hlow : forall s v v', invert_low s v = Some v' -> v = Z.land v' (2^(s/2)-1))
               (Hhigh : forall s v v', invert_high s v = Some v' -> v = Z.shiftr v' (s/2)).
 
-      Definition VerifiedRewriterToFancy : VerifiedRewriter_with_args false false fancy_rewrite_rules_proofs.
+      Definition VerifiedRewriterToFancy : VerifiedRewriter_with_args false false true fancy_rewrite_rules_proofs.
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteToFancy {t : API.type} : API.Expr t -> API.Expr t.
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterToFancy.
+      Let optsT := Eval hnf in optsT VerifiedRewriterToFancy.
+
+      Definition RewriteToFancy (opts : optsT) {t : API.type} : API.Expr t -> API.Expr t.
       Proof using invert_low invert_high.
-        let v := (eval hnf in (@Rewrite VerifiedRewriterToFancy t)) in exact v.
+        let v := (eval hnf in (@Rewrite VerifiedRewriterToFancy opts t)) in exact v.
       Defined.
 
-      Lemma Wf_RewriteToFancy {t} e (Hwf : Wf e) : Wf (@RewriteToFancy t e).
+      Lemma Wf_RewriteToFancy opts {t} e (Hwf : Wf e) : Wf (@RewriteToFancy opts t e).
       Proof using All. now apply VerifiedRewriterToFancy. Qed.
 
-      Lemma Interp_RewriteToFancy {t} e (Hwf : Wf e) : API.Interp (@RewriteToFancy t e) == API.Interp e.
+      Lemma Interp_RewriteToFancy opts {t} e (Hwf : Wf e) : API.Interp (@RewriteToFancy opts t e) == API.Interp e.
       Proof using All. now apply VerifiedRewriterToFancy. Qed.
     End __.
   End RewriteRules.

--- a/src/Rewriter/Passes/ToFancyWithCasts.v
+++ b/src/Rewriter/Passes/ToFancyWithCasts.v
@@ -23,18 +23,21 @@ Module Compilers.
               (Hlow : forall s v v', invert_low s v = Some v' -> v = Z.land v' (2^(s/2)-1))
               (Hhigh : forall s v v', invert_high s v = Some v' -> v = Z.shiftr v' (s/2)).
 
-      Definition VerifiedRewriterToFancyWithCasts : VerifiedRewriter_with_args false false (@fancy_with_casts_rewrite_rules_proofs invert_low invert_high value_range flag_range Hlow Hhigh).
+      Definition VerifiedRewriterToFancyWithCasts : VerifiedRewriter_with_args false false true (@fancy_with_casts_rewrite_rules_proofs invert_low invert_high value_range flag_range Hlow Hhigh).
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteToFancyWithCasts {t : API.type} : API.Expr t -> API.Expr t.
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterToFancyWithCasts.
+      Let optsT := Eval hnf in optsT VerifiedRewriterToFancyWithCasts.
+
+      Definition RewriteToFancyWithCasts (opts : optsT) {t : API.type} : API.Expr t -> API.Expr t.
       Proof using invert_low invert_high value_range flag_range.
-        let v := (eval hnf in (@Rewrite VerifiedRewriterToFancyWithCasts t)) in exact v.
+        let v := (eval hnf in (@Rewrite VerifiedRewriterToFancyWithCasts opts t)) in exact v.
       Defined.
 
-      Lemma Wf_RewriteToFancyWithCasts {t} e (Hwf : Wf e) : Wf (@RewriteToFancyWithCasts t e).
+      Lemma Wf_RewriteToFancyWithCasts opts {t} e (Hwf : Wf e) : Wf (@RewriteToFancyWithCasts opts t e).
       Proof using All. now apply VerifiedRewriterToFancyWithCasts. Qed.
 
-      Lemma Interp_RewriteToFancyWithCasts {t} e (Hwf : Wf e) : API.Interp (@RewriteToFancyWithCasts t e) == API.Interp e.
+      Lemma Interp_RewriteToFancyWithCasts opts {t} e (Hwf : Wf e) : API.Interp (@RewriteToFancyWithCasts opts t e) == API.Interp e.
       Proof using All. now apply VerifiedRewriterToFancyWithCasts. Qed.
     End __.
   End RewriteRules.

--- a/src/Rewriter/PerfTesting/Specific/to_csv.py
+++ b/src/Rewriter/PerfTesting/Specific/to_csv.py
@@ -38,6 +38,7 @@ def eval_numexpr(numexpr):
 REGS = {'kind': r'(UnsaturatedSolinas|WordByWordMontgomery)',
         'bitwidth': r'bitwidth = ([0-9]+)',
         'prime': r'(?:UnsaturatedSolinas|WordByWordMontgomery)[\s"]*([^" ]+)',
+        'method': r'method = ([a-zA-Z0-9_-]+)',
         'descr': r'\|}\s*\)[\s"]*([^:]+)',
         'real': r'(?:ran for |real:\s*)([0-9\.]*) s',
         'user': r'(?:secs \(|user:\s*)([0-9\.]*)(?:u,| s)',
@@ -75,7 +76,7 @@ def get_data_for_graph(lines, key_is_good):
         if line is None: continue
         prime = line['prime']
         if not prime in data.keys(): data[prime] = {}
-        key = ('%(kind)s x%(bitwidth)s %(index)s | %(descr1)s with %(descr2)s' % line).strip()
+        key = ('%(kind)s x%(bitwidth)s %(index)s | %(descr1)s with %(descr2)s using %(method)s' % line).strip()
         new_data = {'real': line['real'], 'user': line['user']}
         if key in data[prime]: warn('Overwriting (%s) data[%s][%s] = %s with %s' % (line['prime_str'], prime, key, str(data[prime][key]), str(new_data)))
         data[prime][key] = new_data
@@ -126,10 +127,10 @@ def lines_to_rows(lines, for_graph=False, real_or_user='real', only=None, **kwar
             if p is None or t is None or '' in (p, t): return
             return [format_prime(p), format_time(t)]
         arg_to_key_filter = {
-            'perf_old_vm_times': (lambda short_key: 'Pipeline' not in short_key and 'vm_compute' in short_key),
-            'perf_new_vm_times': (lambda short_key: 'Pipeline' in short_key and 'vm_compute' in short_key),
-            'perf_new_extraction_times': (lambda short_key: 'Pipeline' in short_key and 'extraction' in short_key),
-            'perf_old_cbv_times': (lambda short_key: 'Pipeline' not in short_key and 'cbv' in short_key)
+            'perf_old_vm_times': (lambda short_key: 'Pipeline' not in short_key and 'vm_compute' in short_key and 'precomputed_decision_tree' in short_key),
+            'perf_new_vm_times': (lambda short_key: 'Pipeline' in short_key and 'vm_compute' in short_key and 'precomputed_decision_tree' in short_key),
+            'perf_new_extraction_times': (lambda short_key: 'Pipeline' in short_key and 'extraction' in short_key and 'precomputed_decision_tree' in short_key),
+            'perf_old_cbv_times': (lambda short_key: 'Pipeline' not in short_key and 'cbv' in short_key and 'precomputed_decision_tree' in short_key)
         }
         div_arg_to_key_filters = dict(
             (key, (arg_to_key_filter['perf_' + n_key + '_times'], arg_to_key_filter['perf_' + d_key + '_times']))
@@ -151,7 +152,7 @@ def lines_to_rows(lines, for_graph=False, real_or_user='real', only=None, **kwar
                                           *[v for short_key, v in extra_args if d_key_filter(short_key)])
                         if row is not None: yield row
     else:
-        keys = ['prime', 'user', 'real', 'kind', 'bitwidth', 'descr1', 'descr2', 'index', 'prime_str']
+        keys = ['prime', 'user', 'real', 'kind', 'bitwidth', 'descr1', 'descr2', 'method', 'index', 'prime_str']
         yield list(keys)
         for data in map(get_data, lines):
             if data is None: continue

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -33,6 +33,7 @@ Local Existing Instance ToString.C.OutputCAPI.
 Local Instance static : static_opt := true.
 Local Instance : use_mul_for_cmovznz_opt := false.
 Local Instance : emit_primitives_opt := true.
+Local Existing Instance default_low_level_rewriter_method.
 
 Module debugging_remove_mul_split_to_C_uint1_carry.
   Section __.
@@ -828,7 +829,7 @@ Module debugging_remove_mul_split2.
       end.
       cbv beta iota in k.
       set (v := Pipeline.RewriteAndEliminateDeadAndInline _ _ _ _) in (value of k).
-      set (v'' := MulSplit.Compilers.RewriteRules.RewriteMulSplit _ _ _) in (value of k).
+      set (v'' := MulSplit.Compilers.RewriteRules.RewriteMulSplit _ _ _ _) in (value of k).
       vm_compute in v; clear v';
       lazymatch (eval cbv [v] in v) with
       | ?x => pose (id x) as v'; change v with v' in (value of v''); clear v


### PR DESCRIPTION
Allow specifying more rewriter options

We can now more easily disable use of pre-reduced constants, and can
also more easily disable use of the decision tree.

Unfortunately the extra arguments make things a bit slower in
PushButtonSynthesis.

<details><summary>Timing Diff</summary>
<p>

```
After     | File Name                                                       | Before    || Change    | % Change
---------------------------------------------------------------------------------------------------------------
91m02.00s | Total                                                           | 88m48.62s || +2m13.38s | +2.50%
---------------------------------------------------------------------------------------------------------------
0m58.79s  | PushButtonSynthesis/WordByWordMontgomery.vo                     | 0m31.80s  || +0m26.98s | +84.87%
1m10.24s  | PushButtonSynthesis/UnsaturatedSolinas.vo                       | 0m49.17s  || +0m21.06s | +42.85%
8m17.74s  | Curves/Weierstrass/AffineProofs.vo                              | 8m06.93s  || +0m10.81s | +2.22%
2m00.45s  | Rewriter/Rewriter/Wf                                            | 2m11.01s  || -0m10.55s | -8.06%
2m38.18s  | Rewriter/Passes/NBE.vo                                          | 2m47.31s  || -0m09.12s | -5.45%
0m24.77s  | ExtractionOCaml/perf_word_by_word_montgomery                    | 0m17.24s  || +0m07.53s | +43.67%
3m39.89s  | PushButtonSynthesis/WordByWordMontgomeryReificationCache.vo     | 3m46.66s  || -0m06.77s | -2.98%
0m33.34s  | ExtractionOCaml/word_by_word_montgomery                         | 0m27.24s  || +0m06.10s | +22.39%
0m22.93s  | ExtractionOCaml/saturated_solinas                               | 0m16.34s  || +0m06.58s | +40.33%
0m22.71s  | ExtractionOCaml/perf_unsaturated_solinas                        | 0m15.95s  || +0m06.76s | +42.38%
3m31.58s  | Curves/Weierstrass/Projective.vo                                | 3m26.31s  || +0m05.26s | +2.55%
0m25.79s  | ExtractionOCaml/unsaturated_solinas                             | 0m20.15s  || +0m05.64s | +27.99%
0m13.95s  | ExtractionOCaml/base_conversion.ml                              | 0m08.72s  || +0m05.22s | +59.97%
1m53.50s  | Rewriter/Passes/ArithWithCasts.vo                               | 1m49.24s  || +0m04.25s | +3.89%
1m06.99s  | Rewriter/Rewriter/InterpProofs                                  | 1m02.20s  || +0m04.78s | +7.70%
0m40.49s  | p521_32.c                                                       | 0m44.64s  || -0m04.14s | -9.29%
0m21.19s  | ExtractionOCaml/word_by_word_montgomery.ml                      | 0m16.51s  || +0m04.67s | +28.34%
0m20.81s  | ExtractionOCaml/base_conversion                                 | 0m16.73s  || +0m04.07s | +24.38%
0m16.60s  | ExtractionOCaml/unsaturated_solinas.ml                          | 0m11.80s  || +0m04.80s | +40.67%
0m15.31s  | ExtractionOCaml/perf_word_by_word_montgomery.ml                 | 0m10.52s  || +0m04.79s | +45.53%
0m13.96s  | ExtractionOCaml/saturated_solinas.ml                            | 0m09.33s  || +0m04.63s | +49.62%
0m13.95s  | ExtractionOCaml/perf_unsaturated_solinas.ml                     | 0m09.33s  || +0m04.61s | +49.51%
2m16.35s  | Fancy/Barrett256.vo                                             | 2m19.47s  || -0m03.12s | -2.23%
2m14.94s  | AbstractInterpretation/Wf.vo                                    | 2m11.54s  || +0m03.40s | +2.58%
0m47.51s  | Rewriter/Passes/Arith.vo                                        | 0m44.15s  || +0m03.35s | +7.61%
0m36.82s  | p521_64.c                                                       | 0m33.18s  || +0m03.64s | +10.97%
0m09.35s  | PushButtonSynthesis/Primitives.vo                               | 0m06.31s  || +0m03.04s | +48.17%
0m07.26s  | PushButtonSynthesis/SaturatedSolinas.vo                         | 0m04.22s  || +0m03.04s | +72.03%
3m59.69s  | fiat-rust/src/p384_32.rs                                        | 4m01.91s  || -0m02.21s | -0.91%
3m53.51s  | Curves/Montgomery/XZProofs.vo                                   | 3m50.74s  || +0m02.76s | +1.20%
2m21.04s  | Rewriter/Passes/ToFancyWithCasts.vo                             | 2m18.17s  || +0m02.86s | +2.07%
1m01.16s  | PushButtonSynthesis/UnsaturatedSolinasReificationCache.vo       | 0m58.67s  || +0m02.48s | +4.24%
2m42.96s  | PushButtonSynthesis/FancyMontgomeryReductionReificationCache.vo | 2m41.68s  || +0m01.28s | +0.79%
1m09.50s  | AbstractInterpretation/ZRangeProofs.vo                          | 1m08.12s  || +0m01.37s | +2.02%
1m00.18s  | AbstractInterpretation/Proofs.vo                                | 1m01.88s  || -0m01.70s | -2.74%
0m52.01s  | SlowPrimeSynthesisExamples.vo                                   | 0m53.12s  || -0m01.10s | -2.08%
0m41.20s  | PushButtonSynthesis/BarrettReductionReificationCache.vo         | 0m43.11s  || -0m01.90s | -4.43%
0m40.18s  | Arithmetic/BarrettReduction.vo                                  | 0m41.38s  || -0m01.20s | -2.89%
0m18.58s  | PushButtonSynthesis/BaseConversion.vo                           | 0m17.31s  || +0m01.26s | +7.33%
0m17.40s  | fiat-rust/src/p256_32.rs                                        | 0m18.56s  || -0m01.16s | -6.25%
4m05.33s  | p384_32.c                                                       | 4m04.37s  || +0m00.96s | +0.39%
3m33.84s  | Fancy/Compiler.vo                                               | 3m33.79s  || +0m00.05s | +0.02%
3m05.40s  | Curves/Montgomery/AffineProofs.vo                               | 3m04.52s  || +0m00.87s | +0.47%
1m28.21s  | Spec/Test/X25519.vo                                             | 1m28.31s  || -0m00.09s | -0.11%
1m18.32s  | Curves/Weierstrass/Jacobian.vo                                  | 1m17.94s  || +0m00.37s | +0.48%
1m06.54s  | Fancy/Montgomery256.vo                                          | 1m06.68s  || -0m00.14s | -0.20%
1m02.52s  | Arithmetic/Core.vo                                              | 1m02.09s  || +0m00.42s | +0.69%
0m53.85s  | Demo.vo                                                         | 0m53.76s  || +0m00.09s | +0.16%
0m52.77s  | Rewriter/Rewriter/ProofsCommon                                  | 0m52.27s  || +0m00.50s | +0.95%
0m47.52s  | Rewriter/RulesProofs.vo                                         | 0m48.00s  || -0m00.47s | -0.99%
0m44.97s  | fiat-rust/src/p521_32.rs                                        | 0m44.64s  || +0m00.32s | +0.73%
0m39.33s  | Rewriter/Rewriter/Examples/SieveOfEratosthenes                  | 0m38.46s  || +0m00.86s | +2.26%
0m36.97s  | fiat-rust/src/p521_64.rs                                        | 0m36.65s  || +0m00.32s | +0.87%
0m34.70s  | Rewriter/Rewriter/Examples                                      | 0m34.02s  || +0m00.67s | +1.99%
0m33.02s  | Arithmetic/Saturated.vo                                         | 0m32.62s  || +0m00.40s | +1.22%
0m32.32s  | Rewriter/Passes/MulSplit.vo                                     | 0m31.49s  || +0m00.83s | +2.63%
0m32.15s  | Rewriter/Rewriter/Examples/PrefixSums                           | 0m31.42s  || +0m00.72s | +2.32%
0m30.83s  | Arithmetic/WordByWordMontgomery.vo                              | 0m30.99s  || -0m00.16s | -0.51%
0m22.50s  | PushButtonSynthesis/BarrettReduction.vo                         | 0m23.06s  || -0m00.55s | -2.42%
0m19.42s  | Curves/Edwards/XYZT/Basic.vo                                    | 0m19.25s  || +0m00.17s | +0.88%
0m19.40s  | Rewriter/Rewriter/Examples/LiftLetsMap                          | 0m18.87s  || +0m00.52s | +2.80%
0m19.15s  | fiat-rust/src/secp256k1_32.rs                                   | 0m19.15s  || +0m00.00s | +0.00%
0m18.97s  | Stringification/IR.vo                                           | 0m18.36s  || +0m00.60s | +3.32%
0m18.95s  | secp256k1_32.c                                                  | 0m19.14s  || -0m00.19s | -0.99%
0m18.82s  | p256_32.c                                                       | 0m18.73s  || +0m00.08s | +0.48%
0m17.66s  | Curves/Edwards/AffineProofs.vo                                  | 0m17.34s  || +0m00.32s | +1.84%
0m16.69s  | Algebra/Field.vo                                                | 0m16.67s  || +0m00.01s | +0.11%
0m16.34s  | p448_solinas_64.c                                               | 0m15.63s  || +0m00.70s | +4.54%
0m16.32s  | fiat-rust/src/p448_solinas_64.rs                                | 0m16.28s  || +0m00.03s | +0.24%
0m16.07s  | fiat-rust/src/p434_64.rs                                        | 0m15.97s  || +0m00.09s | +0.62%
0m15.92s  | Bedrock/Translation/Cmd.vo                                      | 0m15.62s  || +0m00.30s | +1.92%
0m15.65s  | Language/IdentifiersGENERATED.vo                                | 0m15.72s  || -0m00.07s | -0.44%
0m15.16s  | Rewriter/Rewriter/Examples/Plus0Tree                            | 0m14.79s  || +0m00.37s | +2.50%
0m14.63s  | p434_64.c                                                       | 0m15.60s  || -0m00.96s | -6.21%
0m14.57s  | Rewriter/Rewriter/Examples/UnderLetsPlus0                       | 0m14.73s  || -0m00.16s | -1.08%
0m14.27s  | Arithmetic/FancyMontgomeryReduction.vo                          | 0m14.33s  || -0m00.06s | -0.41%
0m13.66s  | Util/ZRange/LandLorBounds.vo                                    | 0m13.64s  || +0m00.01s | +0.14%
0m13.38s  | Language/IdentifiersGENERATEDProofs.vo                          | 0m13.33s  || +0m00.05s | +0.37%
0m12.91s  | Primitives/MxDHRepChange.vo                                     | 0m13.17s  || -0m00.25s | -1.97%
0m10.59s  | Algebra/Ring.vo                                                 | 0m11.03s  || -0m00.43s | -3.98%
0m10.45s  | Util/ZRange/CornersMonotoneBounds.vo                            | 0m10.53s  || -0m00.08s | -0.75%
0m09.21s  | PushButtonSynthesis/SmallExamples.vo                            | 0m09.07s  || +0m00.14s | +1.54%
0m09.04s  | Arithmetic/BarrettReduction/RidiculousFish.vo                   | 0m09.05s  || -0m00.01s | -0.11%
0m08.71s  | BoundsPipeline.vo                                               | 0m08.35s  || +0m00.36s | +4.31%
0m08.64s  | fiat-rust/src/p224_32.rs                                        | 0m09.14s  || -0m00.50s | -5.47%
0m08.42s  | Language/IdentifiersBasicGENERATED.vo                           | 0m08.12s  || +0m00.30s | +3.69%
0m08.35s  | p224_32.c                                                       | 0m08.35s  || +0m00.00s | +0.00%
0m07.90s  | Arithmetic/MontgomeryReduction/Proofs.vo                        | 0m07.90s  || +0m00.00s | +0.00%
0m07.89s  | fiat-rust/src/p384_64.rs                                        | 0m07.11s  || +0m00.77s | +10.97%
0m07.67s  | p384_64.c                                                       | 0m07.67s  || +0m00.00s | +0.00%
0m07.47s  | COperationSpecifications.vo                                     | 0m07.54s  || -0m00.07s | -0.92%
0m07.25s  | Util/ListUtil.vo                                                | 0m07.15s  || +0m00.09s | +1.39%
0m06.99s  | PushButtonSynthesis/SaturatedSolinasReificationCache.vo         | 0m06.99s  || +0m00.00s | +0.00%
0m06.83s  | Fancy/Prod.vo                                                   | 0m06.87s  || -0m00.04s | -0.58%
0m06.63s  | Util/ZUtil/ZSimplify/Autogenerated.vo                           | 0m06.58s  || +0m00.04s | +0.75%
0m06.54s  | Util/ZUtil/LandLorBounds.vo                                     | 0m06.55s  || -0m00.00s | -0.15%
0m06.19s  | Util/ZUtil/Morphisms.vo                                         | 0m05.88s  || +0m00.31s | +5.27%
0m06.15s  | Util/ZUtil/Modulo.vo                                            | 0m06.35s  || -0m00.19s | -3.14%
0m05.68s  | Curves/Edwards/Pre.vo                                           | 0m05.66s  || +0m00.01s | +0.35%
0m05.65s  | Arithmetic/BarrettReduction/Generalized.vo                      | 0m05.86s  || -0m00.20s | -3.58%
0m05.63s  | Util/FsatzAutoLemmas.vo                                         | 0m05.67s  || -0m00.04s | -0.70%
0m05.32s  | CastLemmas.vo                                                   | 0m05.37s  || -0m00.04s | -0.93%
0m05.24s  | Arithmetic/UniformWeight.vo                                     | 0m05.18s  || +0m00.06s | +1.15%
0m04.79s  | Arithmetic/BarrettReduction/HAC.vo                              | 0m04.91s  || -0m00.12s | -2.44%
0m04.78s  | Algebra/Field_test.vo                                           | 0m05.05s  || -0m00.26s | -5.34%
0m04.72s  | Language/InversionExtra.vo                                      | 0m04.92s  || -0m00.20s | -4.06%
0m04.45s  | Curves/Montgomery/Affine.vo                                     | 0m04.45s  || +0m00.00s | +0.00%
0m03.71s  | Algebra/Group.vo                                                | 0m03.68s  || +0m00.02s | +0.81%
0m03.67s  | Util/ZUtil/LandLorShiftBounds.vo                                | 0m03.82s  || -0m00.14s | -3.92%
0m03.65s  | Util/ZUtil/Shift.vo                                             | 0m03.51s  || +0m00.14s | +3.98%
0m03.56s  | PushButtonSynthesis/BaseConversionReificationCache.vo           | 0m03.56s  || +0m00.00s | +0.00%
0m03.52s  | Arithmetic/Freeze.vo                                            | 0m03.54s  || -0m00.02s | -0.56%
0m03.37s  | PushButtonSynthesis/FancyMontgomeryReduction.vo                 | 0m03.70s  || -0m00.33s | -8.91%
0m03.35s  | Arithmetic/Primitives.vo                                        | 0m03.31s  || +0m00.04s | +1.20%
0m03.20s  | Util/ZUtil/Div.vo                                               | 0m03.07s  || +0m00.13s | +4.23%
0m02.94s  | Bedrock/Translation/ExprWithSet.vo                              | 0m02.95s  || -0m00.01s | -0.33%
0m02.88s  | Bedrock/Varnames.vo                                             | 0m02.65s  || +0m00.23s | +8.67%
0m02.83s  | Arithmetic/ModOps.vo                                            | 0m02.82s  || +0m00.01s | +0.35%
0m02.82s  | MiscCompilerPassesProofs.vo                                     | 0m02.94s  || -0m00.12s | -4.08%
0m02.78s  | Spec/MontgomeryCurve.vo                                         | 0m02.76s  || +0m00.02s | +0.72%
0m02.74s  | Arithmetic/ModularArithmeticTheorems.vo                         | 0m02.81s  || -0m00.06s | -2.49%
0m02.67s  | Bedrock/Translation/Expr.vo                                     | 0m02.71s  || -0m00.04s | -1.47%
0m02.66s  | curve25519_32.c                                                 | 0m02.60s  || +0m00.06s | +2.30%
0m02.64s  | fiat-rust/src/curve25519_32.rs                                  | 0m02.63s  || +0m00.01s | +0.38%
0m02.47s  | Rewriter/Passes/StripLiteralCasts.vo                            | 0m02.19s  || +0m00.28s | +12.78%
0m02.46s  | AbstractInterpretation/AbstractInterpretation.vo                | 0m02.31s  || +0m00.14s | +6.49%
0m02.33s  | Arithmetic/BaseConversion.vo                                    | 0m02.35s  || -0m00.02s | -0.85%
0m02.23s  | CLI.vo                                                          | 0m02.30s  || -0m00.06s | -3.04%
0m02.22s  | Util/ZRange/BasicLemmas.vo                                      | 0m02.04s  || +0m00.18s | +8.82%
0m02.21s  | Rewriter/Passes/ToFancy.vo                                      | 0m01.99s  || +0m00.21s | +11.05%
0m02.17s  | Rewriter/PerfTesting/Core.vo                                    | 0m02.11s  || +0m00.06s | +2.84%
0m02.17s  | Stringification/Rust.vo                                         | 0m02.15s  || +0m00.02s | +0.93%
0m02.15s  | Util/ZUtil/Quot.vo                                              | 0m02.18s  || -0m00.03s | -1.37%
0m02.10s  | CompilersTestCases.vo                                           | 0m02.06s  || +0m00.04s | +1.94%
0m02.08s  | Util/ZRange/SplitBounds.vo                                      | 0m02.06s  || +0m00.02s | +0.97%
0m02.00s  | Arithmetic/Partition.vo                                         | 0m01.89s  || +0m00.11s | +5.82%
0m01.98s  | Rewriter/PerfTesting/StandaloneOCamlMain.vo                     | 0m01.94s  || +0m00.04s | +2.06%
0m01.93s  | Rewriter/Rewriter/Examples/PerfTesting/Harness                  | 0m01.97s  || -0m00.04s | -2.03%
0m01.92s  | Util/Tuple.vo                                                   | 0m01.87s  || +0m00.04s | +2.67%
0m01.91s  | Util/ZUtil/AddGetCarry.vo                                       | 0m01.80s  || +0m00.10s | +6.11%
0m01.90s  | Stringification/Language.vo                                     | 0m01.77s  || +0m00.12s | +7.34%
0m01.85s  | Util/ZUtil/Ones.vo                                              | 0m01.83s  || +0m00.02s | +1.09%
0m01.85s  | Util/ZUtil/Pow2Mod.vo                                           | 0m01.79s  || +0m00.06s | +3.35%
0m01.82s  | Util/ZUtil/Rshi.vo                                              | 0m01.81s  || +0m00.01s | +0.55%
0m01.80s  | Bedrock/Translation/Func.vo                                     | 0m01.72s  || +0m00.08s | +4.65%
0m01.75s  | StandaloneHaskellMain.vo                                        | 0m01.79s  || -0m00.04s | -2.23%
0m01.75s  | StandaloneOCamlMain.vo                                          | 0m01.80s  || -0m00.05s | -2.77%
0m01.74s  | fiat-rust/src/curve25519_64.rs                                  | 0m01.73s  || +0m00.01s | +0.57%
0m01.72s  | Spec/WeierstrassCurve.vo                                        | 0m01.82s  || -0m00.10s | -5.49%
0m01.72s  | curve25519_64.c                                                 | 0m01.70s  || +0m00.02s | +1.17%
0m01.68s  | Algebra/ScalarMult.vo                                           | 0m01.64s  || +0m00.04s | +2.43%
0m01.67s  | Util/NatUtil.vo                                                 | 0m01.62s  || +0m00.04s | +3.08%
0m01.66s  | Util/ListUtil/Forall.vo                                         | 0m01.72s  || -0m00.06s | -3.48%
0m01.64s  | fiat-rust/src/p224_64.rs                                        | 0m01.52s  || +0m00.11s | +7.89%
0m01.61s  | fiat-rust/src/secp256k1_64.rs                                   | 0m01.59s  || +0m00.02s | +1.25%
0m01.56s  | Arithmetic/BarrettReduction/Wikipedia.vo                        | 0m01.64s  || -0m00.07s | -4.87%
0m01.56s  | p224_64.c                                                       | 0m01.55s  || +0m00.01s | +0.64%
0m01.55s  | fiat-rust/src/p256_64.rs                                        | 0m01.51s  || +0m00.04s | +2.64%
0m01.55s  | secp256k1_64.c                                                  | 0m01.45s  || +0m00.10s | +6.89%
0m01.53s  | p256_64.c                                                       | 0m01.49s  || +0m00.04s | +2.68%
0m01.51s  | Stringification/C.vo                                            | 0m01.48s  || +0m00.03s | +2.02%
0m01.45s  | Curves/Edwards/XYZT/Precomputed.vo                              | 0m01.52s  || -0m00.07s | -4.60%
0m01.44s  | Util/ZUtil/Testbit.vo                                           | 0m01.45s  || -0m00.01s | -0.68%
0m01.43s  | Fancy/Spec.vo                                                   | 0m01.41s  || +0m00.02s | +1.41%
0m01.42s  | Rewriter/Rewriter/Rewriter                                      | 0m01.40s  || +0m00.02s | +1.42%
0m01.36s  | Arithmetic/PrimeFieldTheorems.vo                                | 0m01.42s  || -0m00.05s | -4.22%
0m01.34s  | Curves/Montgomery/AffineInstances.vo                            | 0m01.28s  || +0m00.06s | +4.68%
0m01.32s  | MiscCompilerPassesProofsExtra.vo                                | 0m01.29s  || +0m00.03s | +2.32%
0m01.32s  | Rewriter/All.vo                                                 | 0m01.35s  || -0m00.03s | -2.22%
0m01.30s  | Bedrock/Types.vo                                                | 0m01.20s  || +0m00.10s | +8.33%
0m01.28s  | Rewriter/Rewriter/Reify                                         | 0m01.22s  || +0m00.06s | +4.91%
0m01.28s  | Util/QUtil.vo                                                   | 0m01.25s  || +0m00.03s | +2.40%
0m01.26s  | Util/ZUtil/CC.vo                                                | 0m01.31s  || -0m00.05s | -3.81%
0m01.23s  | Language/UnderLetsProofsExtra.vo                                | 0m01.16s  || +0m00.07s | +6.03%
0m01.22s  | Language/APINotations.vo                                        | 0m01.34s  || -0m00.12s | -8.95%
0m01.21s  | Rewriter/Rewriter/AllTactics                                    | 0m01.14s  || +0m00.07s | +6.14%
0m01.18s  | Rewriter/AllTacticsExtra.vo                                     | 0m01.03s  || +0m00.14s | +14.56%
0m01.14s  | AbstractInterpretation/WfExtra.vo                               | 0m01.21s  || -0m00.07s | -5.78%
0m01.14s  | PushButtonSynthesis/ReificationCache.vo                         | 0m01.12s  || +0m00.01s | +1.78%
0m01.13s  | Language/API.vo                                                 | 0m01.17s  || -0m00.04s | -3.41%
0m01.12s  | ArithmeticCPS/WordByWordMontgomery.vo                           | 0m01.07s  || +0m00.05s | +4.67%
0m01.10s  | Util/ZUtil/Modulo/PullPush.vo                                   | 0m01.14s  || -0m00.03s | -3.50%
0m01.09s  | Algebra/IntegralDomain.vo                                       | 0m01.01s  || +0m00.08s | +7.92%
0m01.08s  | Language/WfExtra.vo                                             | 0m01.23s  || -0m00.14s | -12.19%
0m01.06s  | Util/ZUtil/Stabilization.vo                                     | 0m01.06s  || +0m00.00s | +0.00%
0m01.05s  | ArithmeticCPS/Freeze.vo                                         | 0m01.02s  || +0m00.03s | +2.94%
0m01.05s  | ArithmeticCPS/Saturated.vo                                      | 0m00.96s  || +0m00.09s | +9.37%
0m01.05s  | Util/ZUtil/Combine.vo                                           | 0m01.06s  || -0m00.01s | -0.94%
0m01.00s  | Rewriter/Rewriter/ProofsCommonTactics                           | 0m01.01s  || -0m00.01s | -0.99%
0m00.97s  | Rewriter/Rewriter/Examples/PerfTesting/All                      | 0m00.97s  || +0m00.00s | +0.00%
0m00.97s  | Rewriter/Rules.vo                                               | 0m00.84s  || +0m00.13s | +15.47%
0m00.96s  | UnsaturatedSolinasHeuristics.vo                                 | 0m00.84s  || +0m00.12s | +14.28%
0m00.95s  | Util/NumTheoryUtil.vo                                           | 0m00.95s  || +0m00.00s | +0.00%
0m00.94s  | ArithmeticCPS/BaseConversion.vo                                 | 0m00.93s  || +0m00.00s | +1.07%
0m00.94s  | MiscCompilerPasses.vo                                           | 0m00.98s  || -0m00.04s | -4.08%
0m00.94s  | Rewriter/Rewriter/Examples/PerfTesting/Settings                 | 0m00.92s  || +0m00.01s | +2.17%
0m00.93s  | Util/CPSUtil.vo                                                 | 0m00.89s  || +0m00.04s | +4.49%
0m00.92s  | ArithmeticCPS/ModOps.vo                                         | 0m00.94s  || -0m00.01s | -2.12%
0m00.89s  | Util/ZUtil/TruncatingShiftl.vo                                  | 0m00.83s  || +0m00.06s | +7.22%
0m00.88s  | ArithmeticCPS/Core.vo                                           | 0m00.91s  || -0m00.03s | -3.29%
0m00.88s  | Rewriter/Util/plugins/RewriterBuildRegistry                     | 0m00.86s  || +0m00.02s | +2.32%
0m00.87s  | Rewriter/Util/plugins/RewriterBuild                             | 0m00.90s  || -0m00.03s | -3.33%
0m00.86s  | Util/ZUtil/EquivModulo.vo                                       | 0m00.87s  || -0m00.01s | -1.14%
0m00.85s  | Rewriter/Util/plugins/RewriterBuildRegistryImports              | 0m00.89s  || -0m00.04s | -4.49%
0m00.84s  | Util/ZUtil/Land.vo                                              | 0m00.83s  || +0m00.01s | +1.20%
0m00.84s  | Util/ZUtil/Peano.vo                                             | 0m00.79s  || +0m00.04s | +6.32%
0m00.84s  | Util/ZUtil/ZSimplify/Simple.vo                                  | 0m00.84s  || +0m00.00s | +0.00%
0m00.83s  | Util/Bool/Reflect.vo                                            | 0m00.82s  || +0m00.01s | +1.21%
0m00.83s  | Util/ZUtil/Le.vo                                                | 0m00.87s  || -0m00.04s | -4.59%
0m00.81s  | Util/PartiallyReifiedProp.vo                                    | 0m00.79s  || +0m00.02s | +2.53%
0m00.81s  | Util/ZUtil/Log2.vo                                              | 0m00.92s  || -0m00.10s | -11.95%
0m00.81s  | Util/ZUtil/Pow.vo                                               | 0m00.82s  || -0m00.00s | -1.21%
0m00.81s  | Util/ZUtil/Z2Nat.vo                                             | 0m00.74s  || +0m00.07s | +9.45%
0m00.78s  | Util/Factorize.vo                                               | 0m00.80s  || -0m00.02s | -2.50%
0m00.77s  | Util/ZRange/OperationsBounds.vo                                 | 0m00.86s  || -0m00.08s | -10.46%
0m00.71s  | Util/ZUtil/Lnot.vo                                              | 0m00.67s  || +0m00.03s | +5.97%
0m00.70s  | Spec/CompleteEdwardsCurve.vo                                    | 0m00.68s  || +0m00.01s | +2.94%
0m00.68s  | Algebra/SubsetoidRing.vo                                        | 0m00.69s  || -0m00.00s | -1.44%
0m00.67s  | Curves/Montgomery/XZ.vo                                         | 0m00.67s  || +0m00.00s | +0.00%
0m00.66s  | Util/ZUtil/Mul.vo                                               | 0m00.71s  || -0m00.04s | -7.04%
0m00.65s  | Curves/Weierstrass/Affine.vo                                    | 0m00.68s  || -0m00.03s | -4.41%
0m00.63s  | Util/ZBounded.vo                                                | 0m00.60s  || +0m00.03s | +5.00%
0m00.60s  | Util/Decidable.vo                                               | 0m00.64s  || -0m00.04s | -6.25%
0m00.59s  | Util/HList.vo                                                   | 0m00.58s  || +0m00.01s | +1.72%
0m00.57s  | Util/ZRange.vo                                                  | 0m00.58s  || -0m00.01s | -1.72%
0m00.57s  | Util/ZUtil/Divide.vo                                            | 0m00.59s  || -0m00.02s | -3.38%
0m00.57s  | Util/ZUtil/Tactics/RewriteModSmall.vo                           | 0m00.59s  || -0m00.02s | -3.38%
0m00.56s  | Util/Decidable/Decidable2Bool.vo                                | 0m00.62s  || -0m00.05s | -9.67%
0m00.55s  | Arithmetic/ModularArithmeticPre.vo                              | 0m00.59s  || -0m00.03s | -6.77%
0m00.55s  | Util/Loops.vo                                                   | 0m00.60s  || -0m00.04s | -8.33%
0m00.54s  | Language/IdentifierParameters.vo                                | 0m00.56s  || -0m00.02s | -3.57%
0m00.53s  | Util/MSetPositive/Facts.vo                                      | 0m00.55s  || -0m00.02s | -3.63%
0m00.52s  | Util/Arg.vo                                                     | 0m00.50s  || +0m00.02s | +4.00%
0m00.52s  | Util/ZRange/Operations.vo                                       | 0m00.47s  || +0m00.05s | +10.63%
0m00.51s  | Language/PreExtra.vo                                            | 0m00.53s  || -0m00.02s | -3.77%
0m00.51s  | Util/Strings/ParseArithmeticToTaps.vo                           | 0m00.51s  || +0m00.00s | +0.00%
0m00.51s  | Util/ZUtil/MulSplit.vo                                          | 0m00.49s  || +0m00.02s | +4.08%
0m00.49s  | Util/AdditionChainExponentiation.vo                             | 0m00.49s  || +0m00.00s | +0.00%
0m00.49s  | Util/MSetPositive/Equality.vo                                   | 0m00.47s  || +0m00.02s | +4.25%
0m00.49s  | Util/NUtil/WithoutReferenceToZ.vo                               | 0m00.49s  || +0m00.00s | +0.00%
0m00.48s  | Bedrock/Tactics.vo                                              | 0m00.53s  || -0m00.05s | -9.43%
0m00.48s  | Util/ZUtil.vo                                                   | 0m00.50s  || -0m00.02s | -4.00%
0m00.47s  | Algebra/Nsatz.vo                                                | 0m00.51s  || -0m00.04s | -7.84%
0m00.47s  | Util/IdfunWithAlt.vo                                            | 0m00.45s  || +0m00.01s | +4.44%
0m00.47s  | Util/Strings/String_as_OT.vo                                    | 0m00.49s  || -0m00.02s | -4.08%
0m00.47s  | Util/ZUtil/Tactics.vo                                           | 0m00.41s  || +0m00.06s | +14.63%
0m00.45s  | Spec/ModularArithmetic.vo                                       | 0m00.45s  || +0m00.00s | +0.00%
0m00.43s  | Util/ZUtil/CPS.vo                                               | 0m00.44s  || -0m00.01s | -2.27%
0m00.43s  | Util/ZUtil/N2Z.vo                                               | 0m00.45s  || -0m00.02s | -4.44%
0m00.43s  | Util/ZUtil/Tactics/Ztestbit.vo                                  | 0m00.44s  || -0m00.01s | -2.27%
0m00.42s  | Util/Strings/String.vo                                          | 0m00.41s  || +0m00.01s | +2.43%
0m00.42s  | Util/ZUtil/Tactics/ZeroBounds.vo                                | 0m00.40s  || +0m00.01s | +4.99%
0m00.40s  | Arithmetic/MontgomeryReduction/Definition.vo                    | 0m00.39s  || +0m00.01s | +2.56%
0m00.40s  | Util/ZUtil/Hints/Core.vo                                        | 0m00.35s  || +0m00.05s | +14.28%
0m00.39s  | Util/Strings/HexString.vo                                       | 0m00.34s  || +0m00.04s | +14.70%
0m00.39s  | Util/Strings/ParseArithmetic.vo                                 | 0m00.41s  || -0m00.01s | -4.87%
0m00.39s  | Util/Strings/StringMap.vo                                       | 0m00.38s  || +0m00.01s | +2.63%
0m00.39s  | Util/ZUtil/Modulo/Bootstrap.vo                                  | 0m00.33s  || +0m00.06s | +18.18%
0m00.39s  | Util/ZUtil/Sgn.vo                                               | 0m00.38s  || +0m00.01s | +2.63%
0m00.39s  | Util/ZUtil/Tactics/SimplifyFractionsLe.vo                       | 0m00.39s  || +0m00.00s | +0.00%
0m00.38s  | Util/ZUtil/Div/Bootstrap.vo                                     | 0m00.33s  || +0m00.04s | +15.15%
0m00.37s  | Algebra/Monoid.vo                                               | 0m00.36s  || +0m00.01s | +2.77%
0m00.37s  | Util/ZUtil/Hints/ZArith.vo                                      | 0m00.35s  || +0m00.02s | +5.71%
0m00.37s  | Util/ZUtil/Opp.vo                                               | 0m00.35s  || +0m00.02s | +5.71%
0m00.37s  | Util/ZUtil/Tactics/DivModToQuotRem.vo                           | 0m00.39s  || -0m00.02s | -5.12%
0m00.37s  | Util/ZUtil/Tactics/PeelLe.vo                                    | 0m00.36s  || +0m00.01s | +2.77%
0m00.37s  | Util/ZUtil/Tactics/PullPush.vo                                  | 0m00.41s  || -0m00.03s | -9.75%
0m00.36s  | Util/ZRange/Show.vo                                             | 0m00.37s  || -0m00.01s | -2.70%
0m00.36s  | Util/ZUtil/Hints/Ztestbit.vo                                    | 0m00.36s  || +0m00.00s | +0.00%
0m00.36s  | Util/ZUtil/Tactics/PullPush/Modulo.vo                           | 0m00.38s  || -0m00.02s | -5.26%
0m00.35s  | Util/ZUtil/DistrIf.vo                                           | 0m00.39s  || -0m00.04s | -10.25%
0m00.35s  | Util/ZUtil/Hints.vo                                             | 0m00.35s  || +0m00.00s | +0.00%
0m00.35s  | Util/ZUtil/Odd.vo                                               | 0m00.36s  || -0m00.01s | -2.77%
0m00.35s  | Util/ZUtil/Sorting.vo                                           | 0m00.33s  || +0m00.01s | +6.06%
0m00.34s  | Util/Strings/Show.vo                                            | 0m00.33s  || +0m00.01s | +3.03%
0m00.34s  | Util/ZUtil/Pow2.vo                                              | 0m00.34s  || +0m00.00s | +0.00%
0m00.33s  | Util/Sum.vo                                                     | 0m00.30s  || +0m00.03s | +10.00%
0m00.33s  | Util/ZUtil/Hints/PullPush.vo                                    | 0m00.37s  || -0m00.03s | -10.81%
0m00.32s  | Util/FMapPositive/Equality.vo                                   | 0m00.32s  || +0m00.00s | +0.00%
0m00.32s  | Util/ZUtil/ZSimplify.vo                                         | 0m00.37s  || -0m00.04s | -13.51%
0m00.32s  | Util/ZUtil/ZSimplify/Core.vo                                    | 0m00.35s  || -0m00.02s | -8.57%
0m00.30s  | Util/ZUtil/Tactics/LtbToLt.vo                                   | 0m00.27s  || +0m00.02s | +11.11%
0m00.29s  | Util/ZUtil/Definitions.vo                                       | 0m00.29s  || +0m00.00s | +0.00%
0m00.28s  | Algebra/Hierarchy.vo                                            | 0m00.26s  || +0m00.02s | +7.69%
0m00.28s  | Util/Option.vo                                                  | 0m00.32s  || -0m00.03s | -12.49%
0m00.28s  | Util/ZUtil/Tactics/ReplaceNegWithPos.vo                         | 0m00.26s  || +0m00.02s | +7.69%
0m00.27s  | TAPSort.vo                                                      | 0m00.24s  || +0m00.03s | +12.50%
0m00.27s  | Util/Strings/Ascii.vo                                           | 0m00.24s  || +0m00.03s | +12.50%
0m00.27s  | Util/ZUtil/Zselect.vo                                           | 0m00.32s  || -0m00.04s | -15.62%
0m00.26s  | Util/Strings/Parse/Common.vo                                    | 0m00.29s  || -0m00.02s | -10.34%
0m00.26s  | Util/ZUtil/AddModulo.vo                                         | 0m00.26s  || +0m00.00s | +0.00%
0m00.26s  | Util/ZUtil/Tactics/LinearSubstitute.vo                          | 0m00.26s  || +0m00.00s | +0.00%
0m00.25s  | PushButtonSynthesis/InvertHighLow.vo                            | 0m00.25s  || +0m00.00s | +0.00%
0m00.25s  | Util/ZUtil/Ge.vo                                                | 0m00.23s  || +0m00.01s | +8.69%
0m00.25s  | Util/ZUtil/ModInv.vo                                            | 0m00.26s  || -0m00.01s | -3.84%
0m00.25s  | Util/ZUtil/Tactics/PrimeBound.vo                                | 0m00.27s  || -0m00.02s | -7.40%
0m00.24s  | Util/SideConditions/ReductionPackages.vo                        | 0m00.21s  || +0m00.03s | +14.28%
0m00.24s  | Util/Strings/BinaryString.vo                                    | 0m00.25s  || -0m00.01s | -4.00%
0m00.24s  | Util/Strings/OctalString.vo                                     | 0m00.27s  || -0m00.03s | -11.11%
0m00.24s  | Util/ZUtil/Tactics/CompareToSgn.vo                              | 0m00.22s  || +0m00.01s | +9.09%
0m00.23s  | Spec/MxDH.vo                                                    | 0m00.20s  || +0m00.03s | +15.00%
0m00.23s  | Util/OptionList.vo                                              | 0m00.24s  || -0m00.00s | -4.16%
0m00.23s  | Util/SideConditions/ModInvPackage.vo                            | 0m00.27s  || -0m00.04s | -14.81%
0m00.23s  | Util/SideConditions/RingPackage.vo                              | 0m00.23s  || +0m00.00s | +0.00%
0m00.23s  | Util/Strings/Decimal.vo                                         | 0m00.19s  || +0m00.04s | +21.05%
0m00.23s  | Util/ZUtil/Tactics/DivideExistsMul.vo                           | 0m00.22s  || +0m00.01s | +4.54%
0m00.23s  | Util/ZUtil/Tactics/SplitMinMax.vo                               | 0m00.25s  || -0m00.01s | -7.99%
0m00.22s  | Util/PointedProp.vo                                             | 0m00.23s  || -0m00.01s | -4.34%
0m00.22s  | Util/SideConditions/Autosolve.vo                                | 0m00.22s  || +0m00.00s | +0.00%
0m00.22s  | Util/Strings/Equality.vo                                        | 0m00.25s  || -0m00.03s | -12.00%
0m00.20s  | Util/Decidable/Bool2Prop.vo                                     | 0m00.20s  || +0m00.00s | +0.00%
0m00.20s  | Util/LetInMonad.vo                                              | 0m00.23s  || -0m00.03s | -13.04%
0m00.18s  | Util/ListUtil/FoldBool.vo                                       | 0m00.21s  || -0m00.03s | -14.28%
0m00.18s  | Util/ZUtil/Notations.vo                                         | 0m00.15s  || +0m00.03s | +20.00%
0m00.15s  | Util/ListUtil/ForallIn.vo                                       | 0m00.13s  || +0m00.01s | +15.38%
0m00.15s  | Util/ListUtil/SetoidList.vo                                     | 0m00.14s  || +0m00.00s | +7.14%
0m00.15s  | Util/ParseTaps.vo                                               | 0m00.16s  || -0m00.01s | -6.25%
0m00.13s  | Util/Prod.vo                                                    | 0m00.11s  || +0m00.02s | +18.18%
0m00.12s  | Util/Sigma.vo                                                   | 0m00.15s  || -0m00.03s | -20.00%
0m00.12s  | Util/TagList.vo                                                 | 0m00.10s  || +0m00.01s | +19.99%
0m00.11s  | Util/Equality.vo                                                | 0m00.10s  || +0m00.00s | +9.99%
0m00.11s  | Util/PrimitiveProd.vo                                           | 0m00.10s  || +0m00.00s | +9.99%
0m00.11s  | Util/Relations.vo                                               | 0m00.13s  || -0m00.02s | -15.38%
0m00.10s  | Util/PrimitiveSigma.vo                                          | 0m00.12s  || -0m00.01s | -16.66%
0m00.09s  | Util/PrimitiveHList.vo                                          | 0m00.09s  || +0m00.00s | +0.00%
0m00.09s  | Util/Sigma/Related.vo                                           | 0m00.08s  || +0m00.00s | +12.49%
0m00.08s  | Util/Bool.vo                                                    | 0m00.08s  || +0m00.00s | +0.00%
0m00.07s  | Util/HProp.vo                                                   | 0m00.07s  || +0m00.00s | +0.00%
0m00.07s  | Util/Logic/ExistsEqAnd.vo                                       | 0m00.05s  || +0m00.02s | +40.00%
0m00.07s  | Util/Notations.vo                                               | 0m00.04s  || +0m00.03s | +75.00%
0m00.07s  | Util/Sumbool.vo                                                 | 0m00.05s  || +0m00.02s | +40.00%
0m00.07s  | Util/Tactics/DestructHead.vo                                    | 0m00.05s  || +0m00.02s | +40.00%
0m00.06s  | Util/Comparison.vo                                              | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Curry.vo                                                   | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/LetIn.vo                                                   | 0m00.06s  || +0m00.00s | +0.00%
0m00.06s  | Util/Pointed.vo                                                 | 0m00.07s  || -0m00.01s | -14.28%
0m00.06s  | Util/Sigma/Lift.vo                                              | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Tactics/ConstrFail.vo                                      | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Tactics/EvarNormalize.vo                                   | 0m00.04s  || +0m00.01s | +49.99%
0m00.06s  | Util/Tactics/Head.vo                                            | 0m00.04s  || +0m00.01s | +49.99%
0m00.06s  | Util/Tactics/MoveLetIn.vo                                       | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Tactics/RewriteHyp.vo                                      | 0m00.06s  || +0m00.00s | +0.00%
0m00.06s  | Util/Tower.vo                                                   | 0m00.05s  || +0m00.00s | +19.99%
0m00.05s  | Util/AutoRewrite.vo                                             | 0m00.06s  || -0m00.00s | -16.66%
0m00.05s  | Util/ErrorT.vo                                                  | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/FixCoqMistakes.vo                                          | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/GlobalSettings.vo                                          | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/IffT.vo                                                    | 0m00.06s  || -0m00.00s | -16.66%
0m00.05s  | Util/Isomorphism.vo                                             | 0m00.03s  || +0m00.02s | +66.66%
0m00.05s  | Util/Logic/ProdForall.vo                                        | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Sigma/MapProjections.vo                                    | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics.vo                                                 | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/BreakMatch.vo                                      | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/CPSId.vo                                           | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/CacheTerm.vo                                       | 0m00.03s  || +0m00.02s | +66.66%
0m00.05s  | Util/Tactics/ClearDuplicates.vo                                 | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/DoWithHyp.vo                                       | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/ETransitivity.vo                                   | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/EvarExists.vo                                      | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/PrintGoal.vo                                       | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/RunTacticAsConstr.vo                               | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/SpecializeAllWays.vo                               | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/UniquePose.vo                                      | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Unit.vo                                                    | 0m00.04s  || +0m00.01s | +25.00%
0m00.04s  | Util/Bool/Equality.vo                                           | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/ChangeInAll.vo                                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/DefaultedTypes.vo                                          | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/PER.vo                                                     | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/SideConditions/AdmitPackage.vo                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/ChangeInAll.vo                                     | 0m00.02s  || +0m00.02s | +100.00%
0m00.04s  | Util/Tactics/Contains.vo                                        | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/ConvoyDestruct.vo                                  | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/DestructHyps.vo                                    | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/ESpecialize.vo                                     | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/Forward.vo                                         | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/GetGoal.vo                                         | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/HeadUnderBinders.vo                                | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/Not.vo                                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/OnSubterms.vo                                      | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Tactics/PoseTermWithName.vo                                | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/SimplifyProjections.vo                             | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/SimplifyRepeatedIfs.vo                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/SpecializeBy.vo                                    | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/SplitInContext.vo                                  | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/SubstLet.vo                                        | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Tactics/Test.vo                                            | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Tactics/TransparentAssert.vo                               | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/UnifyAbstractReflexivity.vo                        | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/VM.vo                                              | 0m00.05s  || -0m00.01s | -20.00%
0m00.03s  | Util/Bool/IsTrue.vo                                             | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/CPSNotations.vo                                            | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Logic.vo                                                   | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Logic/ImplAnd.vo                                           | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Pos.vo                                                     | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/SideConditions/CorePackages.vo                             | 0m00.06s  || -0m00.03s | -50.00%
0m00.03s  | Util/Sigma/Associativity.vo                                     | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/ClearAll.vo                                        | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/ClearbodyAll.vo                                    | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/DebugPrint.vo                                      | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Tactics/DestructTrivial.vo                                 | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/HasBody.vo                                         | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/NormalizeCommutativeIdentifier.vo                  | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/PrintContext.vo                                    | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/Revert.vo                                          | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/SetEvars.vo                                        | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/SetoidSubst.vo                                     | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Tactics/SideConditionsBeforeToAfter.vo                     | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/SubstEvars.vo                                      | 0m00.03s  || +0m00.00s | +0.00%
0m00.02s  | Util/Tactics/UnfoldArg.vo                                       | 0m00.04s  || -0m00.02s | -50.00%
```
</p>