### PR TITLE
Be more systematic about opacity

### DIFF
--- a/src/AbstractInterpretation/Wf.v
+++ b/src/AbstractInterpretation/Wf.v
@@ -981,6 +981,7 @@ Module Compilers.
     End specialized.
   End partial.
   Hint Resolve Wf_Eval Wf_EvalWithBound Wf_EtaExpandWithBound Wf_EtaExpandWithListInfoFromBound : wf.
+  Hint Opaque partial.Eval partial.EvalWithBound partial.EtaExpandWithBound partial.EtaExpandWithListInfoFromBound : wf interp rewrite.
   Import API.
 
   Lemma Wf_PartialEvaluateWithListInfoFromBounds
@@ -991,6 +992,7 @@ Module Compilers.
     : Wf (PartialEvaluateWithListInfoFromBounds E b_in).
   Proof. cbv [PartialEvaluateWithListInfoFromBounds]; eauto with wf. Qed.
   Hint Resolve Wf_PartialEvaluateWithListInfoFromBounds : wf.
+  Hint Opaque PartialEvaluateWithListInfoFromBounds : wf interp rewrite.
 
   Lemma Wf_PartialEvaluateWithBounds
         {relax_zrange} {t} (E : Expr t)
@@ -1000,4 +1002,5 @@ Module Compilers.
     : Wf (PartialEvaluateWithBounds relax_zrange E b_in).
   Proof. cbv [PartialEvaluateWithBounds]; eauto with wf. Qed.
   Hint Resolve Wf_PartialEvaluateWithBounds : wf.
+  Hint Opaque PartialEvaluateWithBounds : wf interp rewrite.
 End Compilers.

--- a/src/AbstractInterpretation/WfExtra.v
+++ b/src/AbstractInterpretation/WfExtra.v
@@ -2,6 +2,7 @@ Require Import Rewriter.Language.Language.
 Require Import Rewriter.Language.Wf.
 Require Import Crypto.Language.API.
 Require Import Crypto.Language.WfExtra.
+Require Import Crypto.AbstractInterpretation.AbstractInterpretation.
 Require Import Crypto.AbstractInterpretation.Wf.
 
 Module Compilers.
@@ -10,14 +11,19 @@ Module Compilers.
   Import Language.Wf.Compilers.
   Import Language.API.Compilers.
   Import Language.WfExtra.Compilers.
+  Import AbstractInterpretation.AbstractInterpretation.Compilers.
   Import AbstractInterpretation.Wf.Compilers.
   Import Compilers.API.
 
+  Import AbstractInterpretation.AbstractInterpretation.Compilers.partial.
   Import AbstractInterpretation.Wf.Compilers.partial.
 
   Hint Resolve Wf_Eval Wf_EvalWithBound Wf_EtaExpandWithBound Wf_EtaExpandWithListInfoFromBound : wf_extra.
+  Hint Opaque partial.Eval EvalWithBound EtaExpandWithBound EtaExpandWithListInfoFromBound : wf_extra interp_extra.
 
   Hint Resolve Wf_PartialEvaluateWithListInfoFromBounds : wf_extra.
+  Hint Opaque PartialEvaluateWithListInfoFromBounds : wf_extra interp_extra.
 
   Hint Resolve Wf_PartialEvaluateWithBounds : wf_extra.
+  Hint Opaque PartialEvaluateWithBounds : wf_extra interp_extra.
 End Compilers.

--- a/src/Language/UnderLetsProofsExtra.v
+++ b/src/Language/UnderLetsProofsExtra.v
@@ -10,6 +10,7 @@ Module Compilers.
   Import Language.Wf.Compilers.
   Import Language.API.Compilers.
   Import Language.WfExtra.Compilers.
+  Import UnderLets.Compilers.
   Import UnderLetsProofs.Compilers.
   Import Compilers.API.
 
@@ -27,6 +28,7 @@ Module Compilers.
   End SubstVarLike.
 
   Hint Resolve SubstVarLike.Wf_SubstVar SubstVarLike.Wf_SubstVarLike SubstVarLike.Wf_SubstVarOrIdent : wf_extra.
+  Hint Opaque SubstVarLike.SubstVar SubstVarLike.SubstVarLike SubstVarLike.SubstVarOrIdent : wf_extra interp_extra.
   Hint Rewrite @SubstVarLike.Interp_SubstVar @SubstVarLike.Interp_SubstVarLike @SubstVarLike.Interp_SubstVarOrIdent : interp_extra.
 
   Module UnderLets.
@@ -54,5 +56,6 @@ Module Compilers.
   End UnderLets.
 
   Hint Resolve UnderLets.Wf_LetBindReturn : wf_extra.
+  Hint Opaque UnderLets.LetBindReturn : wf_extra interp_extra.
   Hint Rewrite @UnderLets.Interp_LetBindReturn : interp_extra.
 End Compilers.

--- a/src/Language/WfExtra.v
+++ b/src/Language/WfExtra.v
@@ -11,11 +11,16 @@ Module Compilers.
 
   Create HintDb wf_extra discriminated.
   Create HintDb interp_extra discriminated.
+  Hint Constants Opaque : wf_extra interp_extra.
+
+  Hint Opaque expr.interp expr.Interp : interp_extra.
+  Hint Opaque expr.Wf expr.Wf3 : wf_extra interp_extra.
 
   Module expr.
     Import Language.Wf.Compilers.expr.
     Global Hint Constructors wf : wf_extra.
     Global Hint Resolve @Wf_APP : wf_extra.
+    Global Hint Opaque expr.APP : wf_extra interp_extra.
     Hint Rewrite @expr.Interp_APP : interp_extra.
     Global Hint Resolve Wf_of_Wf3 : wf_extra.
 
@@ -46,6 +51,11 @@ Module Compilers.
 
   Hint Constructors expr.wf : wf_extra.
   Hint Resolve @expr.Wf_APP @expr.Wf_Reify_as @expr.Wf_reify : wf_extra.
+  (** Work around COQBUG(https://github.com/coq/coq/issues/11536) *)
+  Hint Extern 0 (expr.Wf (GallinaReify.base.Reify_as _ _)) => simple apply (@expr.Wf_Reify) : wf_extra.
+  (** Work around COQBUG(https://github.com/coq/coq/issues/11536) *)
+  Hint Extern 0 (expr.Wf (fun var => GallinaReify.base.reify _)) => simple apply (@expr.Wf_reify) : wf_extra.
+  Hint Opaque expr.APP GallinaReify.Reify_as GallinaReify.base.reify : wf_extra interp_extra.
   Hint Rewrite @expr.Interp_Reify_as @expr.interp_reify @expr.interp_reify_list @expr.interp_reify_option @expr.Interp_reify @expr.Interp_APP : interp_extra.
 
   Module GeneralizeVar.
@@ -72,6 +82,7 @@ Module Compilers.
 
   Global Hint Extern 0 (?x == ?x) => apply expr.Wf_Interp_Proper_gen : wf_extra interp_extra.
   Hint Resolve GeneralizeVar.Wf_FromFlat_ToFlat GeneralizeVar.Wf_GeneralizeVar : wf_extra.
+  Hint Opaque GeneralizeVar.FromFlat GeneralizeVar.ToFlat GeneralizeVar.GeneralizeVar : wf_extra interp_extra.
   Hint Resolve GeneralizeVar.Wf3_FromFlat_ToFlat GeneralizeVar.Wf3_GeneralizeVar : wf_extra.
   Hint Rewrite @GeneralizeVar.Interp_GeneralizeVar @GeneralizeVar.Interp_FromFlat_ToFlat : interp_extra.
 End Compilers.

--- a/src/MiscCompilerPassesProofs.v
+++ b/src/MiscCompilerPassesProofs.v
@@ -145,6 +145,7 @@ Module Compilers.
   End Subst01.
 
   Hint Resolve Subst01.Wf_Subst01 : wf.
+  Hint Opaque Subst01.Subst01 : wf interp rewrite.
   Hint Rewrite @Subst01.Interp_Subst01 : interp.
 
   Module DeadCodeElimination.
@@ -182,5 +183,6 @@ Module Compilers.
   End DeadCodeElimination.
 
   Hint Resolve DeadCodeElimination.Wf_EliminateDead : wf.
+  Hint Opaque DeadCodeElimination.EliminateDead : wf interp rewrite.
   Hint Rewrite @DeadCodeElimination.Interp_EliminateDead : interp.
 End Compilers.

--- a/src/MiscCompilerPassesProofsExtra.v
+++ b/src/MiscCompilerPassesProofsExtra.v
@@ -31,6 +31,7 @@ Module Compilers.
   End Subst01.
 
   Hint Resolve Subst01.Wf_Subst01 : wf_extra.
+  Hint Opaque Subst01.Subst01 : wf_extra interp_extra.
   Hint Rewrite @Subst01.Interp_Subst01 : interp_extra.
 
   Module DeadCodeElimination.
@@ -41,5 +42,6 @@ Module Compilers.
   End DeadCodeElimination.
 
   Hint Resolve DeadCodeElimination.Wf_EliminateDead : wf_extra.
+  Hint Opaque DeadCodeElimination.EliminateDead : wf_extra interp_extra.
   Hint Rewrite @DeadCodeElimination.Interp_EliminateDead : interp_extra.
 End Compilers.

--- a/src/Rewriter/Passes/Arith.v
+++ b/src/Rewriter/Passes/Arith.v
@@ -22,7 +22,7 @@ Module Compilers.
       Definition VerifiedRewriterArith : VerifiedRewriter_with_args false false (arith_rewrite_rules_proofs max_const_val).
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteArith {t} := Eval hnf in @Rewrite VerifiedRewriterArith t.
+      Definition RewriteArith {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterArith t.
 
       Lemma Wf_RewriteArith {t} e (Hwf : Wf e) : Wf (@RewriteArith t e).
       Proof. now apply VerifiedRewriterArith. Qed.
@@ -34,6 +34,7 @@ Module Compilers.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteArith : wf wf_extra.
+    Hint Opaque RewriteArith : wf wf_extra interp interp_extra rewrite.
     Hint Rewrite @Interp_RewriteArith : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/ArithWithCasts.v
+++ b/src/Rewriter/Passes/ArithWithCasts.v
@@ -19,7 +19,7 @@ Module Compilers.
       Definition VerifiedRewriterArithWithCasts : VerifiedRewriter_with_args false false arith_with_casts_rewrite_rules_proofs.
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteArithWithCasts {t} := Eval hnf in @Rewrite VerifiedRewriterArithWithCasts t.
+      Definition RewriteArithWithCasts {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterArithWithCasts t.
 
       Lemma Wf_RewriteArithWithCasts {t} e (Hwf : Wf e) : Wf (@RewriteArithWithCasts t e).
       Proof. now apply VerifiedRewriterArithWithCasts. Qed.
@@ -31,6 +31,7 @@ Module Compilers.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteArithWithCasts : wf wf_extra.
+    Hint Opaque RewriteArithWithCasts : wf wf_extra interp interp_extra rewrite.
     Hint Rewrite @Interp_RewriteArithWithCasts : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/MulSplit.v
+++ b/src/Rewriter/Passes/MulSplit.v
@@ -23,7 +23,7 @@ Module Compilers.
       Definition VerifiedRewriterMulSplit : VerifiedRewriter_with_args false false (mul_split_rewrite_rules_proofs bitwidth lgcarrymax).
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteMulSplit {t} := Eval hnf in @Rewrite VerifiedRewriterMulSplit t.
+      Definition RewriteMulSplit {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterMulSplit t.
 
       Lemma Wf_RewriteMulSplit {t} e (Hwf : Wf e) : Wf (@RewriteMulSplit t e).
       Proof. now apply VerifiedRewriterMulSplit. Qed.
@@ -35,6 +35,7 @@ Module Compilers.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteMulSplit : wf wf_extra.
+    Hint Opaque RewriteMulSplit : wf wf_extra interp interp_extra rewrite.
     Hint Rewrite @Interp_RewriteMulSplit : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/NBE.v
+++ b/src/Rewriter/Passes/NBE.v
@@ -19,7 +19,7 @@ Module Compilers.
       Definition VerifiedRewriterNBE : VerifiedRewriter_with_args true false nbe_rewrite_rules_proofs.
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteNBE {t} := Eval hnf in @Rewrite VerifiedRewriterNBE t.
+      Definition RewriteNBE {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterNBE t.
 
       Lemma Wf_RewriteNBE {t} e (Hwf : Wf e) : Wf (@RewriteNBE t e).
       Proof. now apply VerifiedRewriterNBE. Qed.
@@ -29,7 +29,7 @@ Module Compilers.
     End __.
   End RewriteRules.
 
-  Definition PartialEvaluate {t} (e : Expr t) : Expr t := RewriteRules.RewriteNBE e.
+  Definition PartialEvaluate {t : API.type} (e : Expr t) : Expr t := RewriteRules.RewriteNBE e.
 
   Lemma Wf_PartialEvaluate {t} e (Hwf : Wf e) : Wf (@PartialEvaluate t e).
   Proof. apply Wf_RewriteNBE, Hwf. Qed.
@@ -40,6 +40,7 @@ Module Compilers.
 
   Module Export Hints.
     Hint Resolve Wf_PartialEvaluate Wf_RewriteNBE : wf wf_extra.
+    Hint Opaque PartialEvaluate RewriteNBE : wf wf_extra interp interp_extra rewrite.
     Hint Rewrite @Interp_PartialEvaluate @Interp_RewriteNBE : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/StripLiteralCasts.v
+++ b/src/Rewriter/Passes/StripLiteralCasts.v
@@ -19,7 +19,7 @@ Module Compilers.
       Definition VerifiedRewriterStripLiteralCasts : VerifiedRewriter_with_args false false strip_literal_casts_rewrite_rules_proofs.
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteStripLiteralCasts {t} := Eval hnf in @Rewrite VerifiedRewriterStripLiteralCasts t.
+      Definition RewriteStripLiteralCasts {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterStripLiteralCasts t.
 
       Lemma Wf_RewriteStripLiteralCasts {t} e (Hwf : Wf e) : Wf (@RewriteStripLiteralCasts t e).
       Proof. now apply VerifiedRewriterStripLiteralCasts. Qed.
@@ -31,6 +31,7 @@ Module Compilers.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteStripLiteralCasts : wf wf_extra.
+    Hint Opaque RewriteStripLiteralCasts : wf wf_extra interp interp_extra rewrite.
     Hint Rewrite @Interp_RewriteStripLiteralCasts : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/ToFancy.v
+++ b/src/Rewriter/Passes/ToFancy.v
@@ -24,7 +24,7 @@ Module Compilers.
       Definition VerifiedRewriterToFancy : VerifiedRewriter_with_args false false fancy_rewrite_rules_proofs.
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteToFancy {t} : API.Expr t -> API.Expr t.
+      Definition RewriteToFancy {t : API.type} : API.Expr t -> API.Expr t.
       Proof using invert_low invert_high.
         let v := (eval hnf in (@Rewrite VerifiedRewriterToFancy t)) in exact v.
       Defined.
@@ -39,6 +39,7 @@ Module Compilers.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteToFancy : wf wf_extra.
+    Hint Opaque RewriteToFancy : wf wf_extra interp interp_extra rewrite.
     Hint Rewrite @Interp_RewriteToFancy : interp interp_extra.
   End Hints.
 End Compilers.

--- a/src/Rewriter/Passes/ToFancyWithCasts.v
+++ b/src/Rewriter/Passes/ToFancyWithCasts.v
@@ -26,7 +26,7 @@ Module Compilers.
       Definition VerifiedRewriterToFancyWithCasts : VerifiedRewriter_with_args false false (@fancy_with_casts_rewrite_rules_proofs invert_low invert_high value_range flag_range Hlow Hhigh).
       Proof using All. make_rewriter. Defined.
 
-      Definition RewriteToFancyWithCasts {t} : API.Expr t -> API.Expr t.
+      Definition RewriteToFancyWithCasts {t : API.type} : API.Expr t -> API.Expr t.
       Proof using invert_low invert_high value_range flag_range.
         let v := (eval hnf in (@Rewrite VerifiedRewriterToFancyWithCasts t)) in exact v.
       Defined.
@@ -41,6 +41,7 @@ Module Compilers.
 
   Module Export Hints.
     Hint Resolve Wf_RewriteToFancyWithCasts : wf wf_extra.
+    Hint Opaque RewriteToFancyWithCasts : wf wf_extra interp interp_extra rewrite.
     Hint Rewrite @Interp_RewriteToFancyWithCasts : interp interp_extra.
   End Hints.
 End Compilers.


### PR DESCRIPTION
Note that we now need to explicitly annotate the `type` argument to the
rewriter passes to ensure that we don't need to unfold `Classes.base
(exprInfo *VerifiedRewriter)`.

<details><summary>Timing Diff</summary>
<p>

```
After     | File Name                                                       | Before    || Change    | % Change
---------------------------------------------------------------------------------------------------------------
89m59.81s | Total                                                           | 90m54.22s || -0m54.41s | -0.99%
---------------------------------------------------------------------------------------------------------------
0m08.00s  | BoundsPipeline.vo                                               | 0m34.03s  || -0m26.03s | -76.49%
3m47.56s  | PushButtonSynthesis/WordByWordMontgomeryReificationCache.vo     | 3m34.94s  || +0m12.62s | +5.87%
8m16.86s  | Curves/Weierstrass/AffineProofs.vo                              | 8m08.78s  || +0m08.08s | +1.65%
0m49.42s  | PushButtonSynthesis/UnsaturatedSolinas.vo                       | 0m57.50s  || -0m08.07s | -14.05%
0m31.88s  | PushButtonSynthesis/WordByWordMontgomery.vo                     | 0m38.10s  || -0m06.22s | -16.32%
4m00.41s  | fiat-rust/src/p384_32.rs                                        | 4m04.81s  || -0m04.40s | -1.79%
2m18.63s  | Rewriter/Passes/ToFancyWithCasts.vo                             | 2m23.59s  || -0m04.96s | -3.45%
1m14.20s  | Curves/Weierstrass/Jacobian.vo                                  | 1m18.20s  || -0m04.00s | -5.11%
0m40.20s  | p521_32.c                                                       | 0m44.61s  || -0m04.40s | -9.88%
0m33.15s  | fiat-rust/src/p521_64.rs                                        | 0m36.58s  || -0m03.42s | -9.37%
4m03.10s  | p384_32.c                                                       | 4m05.23s  || -0m02.12s | -0.86%
3m29.43s  | Curves/Weierstrass/Projective.vo                                | 3m26.89s  || +0m02.54s | +1.22%
3m02.39s  | Curves/Montgomery/AffineProofs.vo                               | 3m05.03s  || -0m02.64s | -1.42%
0m17.45s  | fiat-rust/src/secp256k1_32.rs                                   | 0m19.61s  || -0m02.16s | -11.01%
1m53.09s  | Rewriter/Passes/ArithWithCasts.vo                               | 1m51.42s  || +0m01.67s | +1.49%
1m03.01s  | AbstractInterpretation/Proofs.vo                                | 1m04.22s  || -0m01.21s | -1.88%
0m42.98s  | PushButtonSynthesis/BarrettReductionReificationCache.vo         | 0m41.34s  || +0m01.63s | +3.96%
0m39.95s  | Arithmetic/BarrettReduction.vo                                  | 0m41.26s  || -0m01.30s | -3.17%
0m32.35s  | Rewriter/Passes/MulSplit.vo                                     | 0m31.27s  || +0m01.08s | +3.45%
0m18.56s  | fiat-rust/src/p256_32.rs                                        | 0m17.09s  || +0m01.46s | +8.60%
0m03.65s  | PushButtonSynthesis/FancyMontgomeryReduction.vo                 | 0m04.83s  || -0m01.18s | -24.43%
3m52.52s  | Curves/Montgomery/XZProofs.vo                                   | 3m52.76s  || -0m00.23s | -0.10%
3m34.16s  | Fancy/Compiler.vo                                               | 3m33.79s  || +0m00.37s | +0.17%
2m46.98s  | Rewriter/Passes/NBE.vo                                          | 2m47.53s  || -0m00.55s | -0.32%
2m42.81s  | PushButtonSynthesis/FancyMontgomeryReductionReificationCache.vo | 2m42.58s  || +0m00.23s | +0.14%
2m18.17s  | Fancy/Barrett256.vo                                             | 2m18.84s  || -0m00.66s | -0.48%
2m14.32s  | AbstractInterpretation/Wf.vo                                    | 2m13.94s  || +0m00.37s | +0.28%
2m10.57s  | Rewriter/Rewriter/Wf                                            | 2m11.27s  || -0m00.70s | -0.53%
1m28.56s  | Spec/Test/X25519.vo                                             | 1m28.36s  || +0m00.20s | +0.22%
1m09.16s  | AbstractInterpretation/ZRangeProofs.vo                          | 1m08.21s  || +0m00.94s | +1.39%
1m06.58s  | Fancy/Montgomery256.vo                                          | 1m06.23s  || +0m00.34s | +0.52%
1m02.10s  | Rewriter/Rewriter/InterpProofs                                  | 1m02.22s  || -0m00.11s | -0.19%
1m01.45s  | Arithmetic/Core.vo                                              | 1m00.61s  || +0m00.84s | +1.38%
1m01.00s  | PushButtonSynthesis/UnsaturatedSolinasReificationCache.vo       | 1m01.70s  || -0m00.70s | -1.13%
0m53.99s  | SlowPrimeSynthesisExamples.vo                                   | 0m53.18s  || +0m00.81s | +1.52%
0m53.62s  | Demo.vo                                                         | 0m53.95s  || -0m00.33s | -0.61%
0m52.05s  | Rewriter/Rewriter/ProofsCommon                                  | 0m51.95s  || +0m00.09s | +0.19%
0m48.67s  | Rewriter/Language/UnderLetsProofs                               | 0m49.01s  || -0m00.33s | -0.69%
0m47.77s  | Rewriter/RulesProofs.vo                                         | 0m48.66s  || -0m00.88s | -1.82%
0m46.70s  | Rewriter/Passes/Arith.vo                                        | 0m46.46s  || +0m00.24s | +0.51%
0m40.34s  | fiat-rust/src/p521_32.rs                                        | 0m40.33s  || +0m00.01s | +0.02%
0m38.51s  | Rewriter/Rewriter/Examples/SieveOfEratosthenes                  | 0m38.54s  || -0m00.03s | -0.07%
0m36.56s  | p521_64.c                                                       | 0m36.67s  || -0m00.10s | -0.29%
0m33.91s  | Rewriter/Rewriter/Examples                                      | 0m34.05s  || -0m00.14s | -0.41%
0m32.77s  | Arithmetic/Saturated.vo                                         | 0m32.59s  || +0m00.17s | +0.55%
0m31.50s  | Rewriter/Rewriter/Examples/PrefixSums                           | 0m31.37s  || +0m00.12s | +0.41%
0m30.86s  | Arithmetic/WordByWordMontgomery.vo                              | 0m30.83s  || +0m00.03s | +0.09%
0m27.43s  | ExtractionOCaml/word_by_word_montgomery                         | 0m27.33s  || +0m00.10s | +0.36%
0m23.15s  | Rewriter/Language/Wf                                            | 0m23.12s  || +0m00.02s | +0.12%
0m22.64s  | PushButtonSynthesis/BarrettReduction.vo                         | 0m22.85s  || -0m00.21s | -0.91%
0m20.05s  | Stringification/IR.vo                                           | 0m20.13s  || -0m00.07s | -0.39%
0m19.95s  | ExtractionOCaml/unsaturated_solinas                             | 0m20.21s  || -0m00.26s | -1.28%
0m19.01s  | secp256k1_32.c                                                  | 0m19.31s  || -0m00.29s | -1.55%
0m18.84s  | Rewriter/Rewriter/Examples/LiftLetsMap                          | 0m18.89s  || -0m00.05s | -0.26%
0m18.63s  | p256_32.c                                                       | 0m18.84s  || -0m00.21s | -1.11%
0m18.59s  | Curves/Edwards/XYZT/Basic.vo                                    | 0m19.33s  || -0m00.73s | -3.82%
0m17.97s  | ExtractionOCaml/perf_word_by_word_montgomery                    | 0m17.87s  || +0m00.09s | +0.55%
0m17.03s  | PushButtonSynthesis/BaseConversion.vo                           | 0m17.74s  || -0m00.70s | -4.00%
0m16.72s  | Algebra/Field.vo                                                | 0m16.72s  || +0m00.00s | +0.00%
0m16.65s  | Curves/Edwards/AffineProofs.vo                                  | 0m16.42s  || +0m00.22s | +1.40%
0m16.62s  | ExtractionOCaml/base_conversion                                 | 0m16.71s  || -0m00.08s | -0.53%
0m16.24s  | fiat-rust/src/p448_solinas_64.rs                                | 0m16.31s  || -0m00.07s | -0.42%
0m16.18s  | p448_solinas_64.c                                               | 0m16.26s  || -0m00.08s | -0.49%
0m16.02s  | ExtractionOCaml/perf_unsaturated_solinas                        | 0m16.11s  || -0m00.08s | -0.55%
0m15.76s  | p434_64.c                                                       | 0m16.39s  || -0m00.63s | -3.84%
0m15.67s  | Bedrock/Translation/Cmd.vo                                      | 0m15.61s  || +0m00.06s | +0.38%
0m15.65s  | Language/IdentifiersGENERATED.vo                                | 0m15.60s  || +0m00.05s | +0.32%
0m15.49s  | ExtractionOCaml/saturated_solinas                               | 0m16.23s  || -0m00.74s | -4.55%
0m15.48s  | ExtractionOCaml/word_by_word_montgomery.ml                      | 0m16.42s  || -0m00.94s | -5.72%
0m14.77s  | Rewriter/Rewriter/Examples/Plus0Tree                            | 0m14.79s  || -0m00.01s | -0.13%
0m14.55s  | fiat-rust/src/p434_64.rs                                        | 0m15.40s  || -0m00.84s | -5.51%
0m14.18s  | Rewriter/Rewriter/Examples/UnderLetsPlus0                       | 0m14.66s  || -0m00.48s | -3.27%
0m14.00s  | Arithmetic/FancyMontgomeryReduction.vo                          | 0m14.36s  || -0m00.35s | -2.50%
0m13.19s  | Util/ZRange/LandLorBounds.vo                                    | 0m13.63s  || -0m00.44s | -3.22%
0m12.83s  | Language/IdentifiersGENERATEDProofs.vo                          | 0m13.34s  || -0m00.50s | -3.82%
0m12.37s  | Primitives/MxDHRepChange.vo                                     | 0m13.10s  || -0m00.73s | -5.57%
0m11.86s  | ExtractionOCaml/unsaturated_solinas.ml                          | 0m11.18s  || +0m00.67s | +6.08%
0m10.99s  | Algebra/Ring.vo                                                 | 0m11.06s  || -0m00.07s | -0.63%
0m10.51s  | Util/ZRange/CornersMonotoneBounds.vo                            | 0m10.45s  || +0m00.06s | +0.57%
0m10.40s  | ExtractionOCaml/perf_word_by_word_montgomery.ml                 | 0m10.52s  || -0m00.11s | -1.14%
0m09.21s  | ExtractionOCaml/base_conversion.ml                              | 0m09.21s  || +0m00.00s | +0.00%
0m09.15s  | ExtractionOCaml/perf_unsaturated_solinas.ml                     | 0m09.16s  || -0m00.00s | -0.10%
0m09.12s  | fiat-rust/src/p224_32.rs                                        | 0m08.40s  || +0m00.71s | +8.57%
0m09.06s  | PushButtonSynthesis/SmallExamples.vo                            | 0m08.95s  || +0m00.11s | +1.22%
0m09.04s  | Arithmetic/BarrettReduction/RidiculousFish.vo                   | 0m08.96s  || +0m00.07s | +0.89%
0m09.03s  | p224_32.c                                                       | 0m09.14s  || -0m00.11s | -1.20%
0m08.79s  | ExtractionOCaml/saturated_solinas.ml                            | 0m09.28s  || -0m00.49s | -5.28%
0m08.34s  | Language/IdentifiersBasicGENERATED.vo                           | 0m08.30s  || +0m00.03s | +0.48%
0m07.87s  | Arithmetic/MontgomeryReduction/Proofs.vo                        | 0m07.68s  || +0m00.19s | +2.47%
0m07.62s  | p384_64.c                                                       | 0m07.92s  || -0m00.29s | -3.78%
0m07.58s  | fiat-rust/src/p384_64.rs                                        | 0m07.90s  || -0m00.32s | -4.05%
0m07.29s  | Util/ListUtil.vo                                                | 0m07.28s  || +0m00.00s | +0.13%
0m07.19s  | COperationSpecifications.vo                                     | 0m07.43s  || -0m00.23s | -3.23%
0m07.01s  | PushButtonSynthesis/SaturatedSolinasReificationCache.vo         | 0m07.00s  || +0m00.00s | +0.14%
0m06.72s  | Fancy/Prod.vo                                                   | 0m06.85s  || -0m00.12s | -1.89%
0m06.59s  | Util/ZUtil/ZSimplify/Autogenerated.vo                           | 0m06.59s  || +0m00.00s | +0.00%
0m06.52s  | Util/ZUtil/LandLorBounds.vo                                     | 0m06.34s  || +0m00.17s | +2.83%
0m06.34s  | Util/ZUtil/Modulo.vo                                            | 0m06.35s  || -0m00.00s | -0.15%
0m06.14s  | Util/ZUtil/Morphisms.vo                                         | 0m06.13s  || +0m00.00s | +0.16%
0m06.00s  | PushButtonSynthesis/Primitives.vo                               | 0m06.96s  || -0m00.96s | -13.79%
0m05.82s  | Arithmetic/BarrettReduction/Generalized.vo                      | 0m05.80s  || +0m00.02s | +0.34%
0m05.70s  | Curves/Edwards/Pre.vo                                           | 0m05.38s  || +0m00.32s | +5.94%
0m05.45s  | CastLemmas.vo                                                   | 0m05.47s  || -0m00.01s | -0.36%
0m05.42s  | Util/FsatzAutoLemmas.vo                                         | 0m05.63s  || -0m00.20s | -3.73%
0m05.28s  | Arithmetic/UniformWeight.vo                                     | 0m05.19s  || +0m00.08s | +1.73%
0m05.05s  | Algebra/Field_test.vo                                           | 0m05.04s  || +0m00.00s | +0.19%
0m04.77s  | Arithmetic/BarrettReduction/HAC.vo                              | 0m04.89s  || -0m00.12s | -2.45%
0m04.43s  | Language/InversionExtra.vo                                      | 0m04.69s  || -0m00.26s | -5.54%
0m04.22s  | Curves/Montgomery/Affine.vo                                     | 0m04.40s  || -0m00.18s | -4.09%
0m04.12s  | PushButtonSynthesis/SaturatedSolinas.vo                         | 0m04.97s  || -0m00.84s | -17.10%
0m03.79s  | Util/ZUtil/LandLorShiftBounds.vo                                | 0m03.77s  || +0m00.02s | +0.53%
0m03.70s  | Algebra/Group.vo                                                | 0m03.70s  || +0m00.00s | +0.00%
0m03.50s  | Util/ZUtil/Shift.vo                                             | 0m03.70s  || -0m00.20s | -5.40%
0m03.48s  | Arithmetic/Freeze.vo                                            | 0m03.36s  || +0m00.12s | +3.57%
0m03.44s  | PushButtonSynthesis/BaseConversionReificationCache.vo           | 0m03.60s  || -0m00.16s | -4.44%
0m03.26s  | Arithmetic/Primitives.vo                                        | 0m03.24s  || +0m00.01s | +0.61%
0m03.15s  | Util/ZUtil/Div.vo                                               | 0m03.17s  || -0m00.02s | -0.63%
0m03.00s  | Bedrock/Translation/ExprWithSet.vo                              | 0m02.69s  || +0m00.31s | +11.52%
0m02.96s  | MiscCompilerPassesProofs.vo                                     | 0m02.91s  || +0m00.04s | +1.71%
0m02.85s  | Bedrock/Varnames.vo                                             | 0m02.85s  || +0m00.00s | +0.00%
0m02.77s  | Spec/MontgomeryCurve.vo                                         | 0m02.78s  || -0m00.00s | -0.35%
0m02.73s  | Arithmetic/ModularArithmeticTheorems.vo                         | 0m02.75s  || -0m00.02s | -0.72%
0m02.70s  | Arithmetic/ModOps.vo                                            | 0m02.90s  || -0m00.19s | -6.89%
0m02.67s  | Bedrock/Translation/Expr.vo                                     | 0m02.71s  || -0m00.04s | -1.47%
0m02.55s  | fiat-rust/src/curve25519_32.rs                                  | 0m02.62s  || -0m00.07s | -2.67%
0m02.50s  | curve25519_32.c                                                 | 0m02.61s  || -0m00.10s | -4.21%
0m02.43s  | AbstractInterpretation/AbstractInterpretation.vo                | 0m02.37s  || +0m00.06s | +2.53%
0m02.37s  | Arithmetic/BaseConversion.vo                                    | 0m02.28s  || +0m00.09s | +3.94%
0m02.22s  | CLI.vo                                                          | 0m02.21s  || +0m00.01s | +0.45%
0m02.22s  | Util/ZRange/BasicLemmas.vo                                      | 0m02.19s  || +0m00.03s | +1.36%
0m02.18s  | Rewriter/Passes/StripLiteralCasts.vo                            | 0m02.06s  || +0m00.12s | +5.82%
0m02.15s  | Stringification/Rust.vo                                         | 0m02.21s  || -0m00.06s | -2.71%
0m02.14s  | Rewriter/PerfTesting/Core.vo                                    | 0m02.11s  || +0m00.03s | +1.42%
0m02.14s  | Util/ZUtil/Quot.vo                                              | 0m02.14s  || +0m00.00s | +0.00%
0m02.08s  | CompilersTestCases.vo                                           | 0m01.98s  || +0m00.10s | +5.05%
0m02.05s  | Util/ZRange/SplitBounds.vo                                      | 0m02.01s  || +0m00.04s | +1.99%
0m02.03s  | Rewriter/Passes/ToFancy.vo                                      | 0m01.88s  || +0m00.14s | +7.97%
0m01.95s  | Rewriter/PerfTesting/StandaloneOCamlMain.vo                     | 0m01.96s  || -0m00.01s | -0.51%
0m01.92s  | Stringification/Language.vo                                     | 0m01.91s  || +0m00.01s | +0.52%
0m01.91s  | Rewriter/Rewriter/Examples/PerfTesting/Harness                  | 0m01.94s  || -0m00.03s | -1.54%
0m01.88s  | Util/ZUtil/Pow2Mod.vo                                           | 0m01.75s  || +0m00.12s | +7.42%
0m01.87s  | Util/ZUtil/AddGetCarry.vo                                       | 0m01.90s  || -0m00.02s | -1.57%
0m01.83s  | Util/ZUtil/Ones.vo                                              | 0m01.70s  || +0m00.13s | +7.64%
0m01.82s  | Arithmetic/Partition.vo                                         | 0m01.96s  || -0m00.13s | -7.14%
0m01.82s  | Util/Tuple.vo                                                   | 0m01.91s  || -0m00.08s | -4.71%
0m01.79s  | Util/ZUtil/Rshi.vo                                              | 0m01.82s  || -0m00.03s | -1.64%
0m01.77s  | StandaloneHaskellMain.vo                                        | 0m01.72s  || +0m00.05s | +2.90%
0m01.74s  | Bedrock/Translation/Func.vo                                     | 0m01.75s  || -0m00.01s | -0.57%
0m01.73s  | StandaloneOCamlMain.vo                                          | 0m01.77s  || -0m00.04s | -2.25%
0m01.73s  | fiat-rust/src/curve25519_64.rs                                  | 0m01.73s  || +0m00.00s | +0.00%
0m01.72s  | curve25519_64.c                                                 | 0m01.71s  || +0m00.01s | +0.58%
0m01.71s  | Spec/WeierstrassCurve.vo                                        | 0m01.80s  || -0m00.09s | -5.00%
0m01.69s  | Util/NatUtil.vo                                                 | 0m01.70s  || -0m00.01s | -0.58%
0m01.63s  | Algebra/ScalarMult.vo                                           | 0m01.67s  || -0m00.04s | -2.39%
0m01.61s  | Util/ListUtil/Forall.vo                                         | 0m01.64s  || -0m00.02s | -1.82%
0m01.58s  | Arithmetic/BarrettReduction/Wikipedia.vo                        | 0m01.65s  || -0m00.06s | -4.24%
0m01.57s  | fiat-rust/src/secp256k1_64.rs                                   | 0m01.52s  || +0m00.05s | +3.28%
0m01.57s  | p224_64.c                                                       | 0m01.60s  || -0m00.03s | -1.87%
0m01.54s  | fiat-rust/src/p224_64.rs                                        | 0m01.61s  || -0m00.07s | -4.34%
0m01.54s  | secp256k1_64.c                                                  | 0m01.62s  || -0m00.08s | -4.93%
0m01.49s  | Curves/Edwards/XYZT/Precomputed.vo                              | 0m01.52s  || -0m00.03s | -1.97%
0m01.49s  | p256_64.c                                                       | 0m01.57s  || -0m00.08s | -5.09%
0m01.48s  | fiat-rust/src/p256_64.rs                                        | 0m01.54s  || -0m00.06s | -3.89%
0m01.40s  | Fancy/Spec.vo                                                   | 0m01.36s  || +0m00.03s | +2.94%
0m01.38s  | Arithmetic/PrimeFieldTheorems.vo                                | 0m01.47s  || -0m00.09s | -6.12%
0m01.38s  | Stringification/C.vo                                            | 0m01.47s  || -0m00.09s | -6.12%
0m01.37s  | Util/ZUtil/Testbit.vo                                           | 0m01.43s  || -0m00.05s | -4.19%
0m01.34s  | Language/APINotations.vo                                        | 0m01.34s  || +0m00.00s | +0.00%
0m01.31s  | MiscCompilerPassesProofsExtra.vo                                | 0m01.29s  || +0m00.02s | +1.55%
0m01.30s  | Util/QUtil.vo                                                   | 0m01.30s  || +0m00.00s | +0.00%
0m01.29s  | Curves/Montgomery/AffineInstances.vo                            | 0m01.34s  || -0m00.05s | -3.73%
0m01.26s  | Bedrock/Types.vo                                                | 0m01.34s  || -0m00.08s | -5.97%
0m01.22s  | AbstractInterpretation/WfExtra.vo                               | 0m01.20s  || +0m00.02s | +1.66%
0m01.22s  | Rewriter/All.vo                                                 | 0m01.33s  || -0m00.11s | -8.27%
0m01.21s  | Language/UnderLetsProofsExtra.vo                                | 0m01.15s  || +0m00.06s | +5.21%
0m01.20s  | Util/ZUtil/CC.vo                                                | 0m01.37s  || -0m00.17s | -12.40%
0m01.18s  | Rewriter/AllTacticsExtra.vo                                     | 0m01.17s  || +0m00.01s | +0.85%
0m01.12s  | Util/ZUtil/Modulo/PullPush.vo                                   | 0m01.05s  || +0m00.07s | +6.66%
0m01.10s  | Language/WfExtra.vo                                             | 0m01.25s  || -0m00.14s | -11.99%
0m01.10s  | Rewriter/Rewriter/AllTactics                                    | 0m01.12s  || -0m00.02s | -1.78%
0m01.09s  | ArithmeticCPS/WordByWordMontgomery.vo                           | 0m01.10s  || -0m00.01s | -0.90%
0m01.09s  | PushButtonSynthesis/ReificationCache.vo                         | 0m01.16s  || -0m00.06s | -6.03%
0m01.06s  | Language/API.vo                                                 | 0m01.18s  || -0m00.11s | -10.16%
0m01.06s  | Util/ZUtil/Combine.vo                                           | 0m00.95s  || +0m00.11s | +11.57%
0m01.06s  | Util/ZUtil/Stabilization.vo                                     | 0m01.12s  || -0m00.06s | -5.35%
0m01.04s  | Algebra/IntegralDomain.vo                                       | 0m01.01s  || +0m00.03s | +2.97%
0m01.00s  | Rewriter/Rewriter/ProofsCommonTactics                           | 0m01.03s  || -0m00.03s | -2.91%
0m00.98s  | ArithmeticCPS/Freeze.vo                                         | 0m00.94s  || +0m00.04s | +4.25%
0m00.98s  | MiscCompilerPasses.vo                                           | 0m01.00s  || -0m00.02s | -2.00%
0m00.96s  | Rewriter/Rewriter/Examples/PerfTesting/All                      | 0m01.00s  || -0m00.04s | -4.00%
0m00.95s  | ArithmeticCPS/Saturated.vo                                      | 0m01.01s  || -0m00.06s | -5.94%
0m00.94s  | Util/NumTheoryUtil.vo                                           | 0m00.97s  || -0m00.03s | -3.09%
0m00.93s  | ArithmeticCPS/BaseConversion.vo                                 | 0m00.94s  || -0m00.00s | -1.06%
0m00.91s  | Rewriter/Rewriter/Examples/PerfTesting/Settings                 | 0m00.95s  || -0m00.03s | -4.21%
0m00.90s  | Rewriter/Rules.vo                                               | 0m00.83s  || +0m00.07s | +8.43%
0m00.90s  | Util/ZUtil/EquivModulo.vo                                       | 0m00.81s  || +0m00.08s | +11.11%
0m00.89s  | ArithmeticCPS/Core.vo                                           | 0m00.91s  || -0m00.02s | -2.19%
0m00.89s  | Rewriter/Util/plugins/RewriterBuildRegistry                     | 0m00.90s  || -0m00.01s | -1.11%
0m00.88s  | Util/CPSUtil.vo                                                 | 0m00.88s  || +0m00.00s | +0.00%
0m00.87s  | Rewriter/Util/plugins/RewriterBuild                             | 0m00.88s  || -0m00.01s | -1.13%
0m00.87s  | Rewriter/Util/plugins/RewriterBuildRegistryImports              | 0m00.89s  || -0m00.02s | -2.24%
0m00.87s  | Util/ZUtil/TruncatingShiftl.vo                                  | 0m00.84s  || +0m00.03s | +3.57%
0m00.86s  | Util/ZUtil/Land.vo                                              | 0m00.84s  || +0m00.02s | +2.38%
0m00.85s  | Util/ZUtil/Le.vo                                                | 0m00.80s  || +0m00.04s | +6.24%
0m00.85s  | Util/ZUtil/Log2.vo                                              | 0m00.88s  || -0m00.03s | -3.40%
0m00.84s  | ArithmeticCPS/ModOps.vo                                         | 0m00.90s  || -0m00.06s | -6.66%
0m00.83s  | Util/Bool/Reflect.vo                                            | 0m00.87s  || -0m00.04s | -4.59%
0m00.82s  | UnsaturatedSolinasHeuristics.vo                                 | 0m00.93s  || -0m00.11s | -11.82%
0m00.82s  | Util/ZRange/OperationsBounds.vo                                 | 0m00.85s  || -0m00.03s | -3.52%
0m00.81s  | Util/PartiallyReifiedProp.vo                                    | 0m00.84s  || -0m00.02s | -3.57%
0m00.80s  | Util/ZUtil/Peano.vo                                             | 0m00.76s  || +0m00.04s | +5.26%
0m00.79s  | Util/ZUtil/Pow.vo                                               | 0m00.76s  || +0m00.03s | +3.94%
0m00.78s  | Util/Factorize.vo                                               | 0m00.78s  || +0m00.00s | +0.00%
0m00.77s  | Util/ZUtil/ZSimplify/Simple.vo                                  | 0m00.79s  || -0m00.02s | -2.53%
0m00.76s  | Util/ZUtil/Z2Nat.vo                                             | 0m00.83s  || -0m00.06s | -8.43%
0m00.72s  | Algebra/SubsetoidRing.vo                                        | 0m00.72s  || +0m00.00s | +0.00%
0m00.71s  | Util/ZUtil/Lnot.vo                                              | 0m00.70s  || +0m00.01s | +1.42%
0m00.68s  | Util/ZUtil/Mul.vo                                               | 0m00.70s  || -0m00.01s | -2.85%
0m00.64s  | Curves/Weierstrass/Affine.vo                                    | 0m00.70s  || -0m00.05s | -8.57%
0m00.64s  | Spec/CompleteEdwardsCurve.vo                                    | 0m00.69s  || -0m00.04s | -7.24%
0m00.62s  | Curves/Montgomery/XZ.vo                                         | 0m00.71s  || -0m00.08s | -12.67%
0m00.62s  | Util/Decidable/Decidable2Bool.vo                                | 0m00.63s  || -0m00.01s | -1.58%
0m00.61s  | Util/Decidable.vo                                               | 0m00.54s  || +0m00.06s | +12.96%
0m00.61s  | Util/ZUtil/Divide.vo                                            | 0m00.58s  || +0m00.03s | +5.17%
0m00.59s  | Arithmetic/ModularArithmeticPre.vo                              | 0m00.60s  || -0m00.01s | -1.66%
0m00.59s  | Util/HList.vo                                                   | 0m00.55s  || +0m00.03s | +7.27%
0m00.58s  | Language/IdentifierParameters.vo                                | 0m00.56s  || +0m00.01s | +3.57%
0m00.58s  | Util/ZRange.vo                                                  | 0m00.58s  || +0m00.00s | +0.00%
0m00.57s  | Util/Loops.vo                                                   | 0m00.58s  || -0m00.01s | -1.72%
0m00.57s  | Util/ZBounded.vo                                                | 0m00.56s  || +0m00.00s | +1.78%
0m00.57s  | Util/ZUtil/Tactics/RewriteModSmall.vo                           | 0m00.60s  || -0m00.03s | -5.00%
0m00.56s  | Util/MSetPositive/Facts.vo                                      | 0m00.52s  || +0m00.04s | +7.69%
0m00.54s  | Util/Strings/String_as_OT.vo                                    | 0m00.49s  || +0m00.05s | +10.20%
0m00.53s  | Util/Strings/ParseArithmeticToTaps.vo                           | 0m00.53s  || +0m00.00s | +0.00%
0m00.51s  | Util/Arg.vo                                                     | 0m00.51s  || +0m00.00s | +0.00%
0m00.50s  | Util/ZRange/Operations.vo                                       | 0m00.52s  || -0m00.02s | -3.84%
0m00.50s  | Util/ZUtil.vo                                                   | 0m00.48s  || +0m00.02s | +4.16%
0m00.49s  | Bedrock/Tactics.vo                                              | 0m00.49s  || +0m00.00s | +0.00%
0m00.48s  | Language/PreExtra.vo                                            | 0m00.53s  || -0m00.05s | -9.43%
0m00.47s  | Algebra/Nsatz.vo                                                | 0m00.49s  || -0m00.02s | -4.08%
0m00.47s  | Util/AdditionChainExponentiation.vo                             | 0m00.51s  || -0m00.04s | -7.84%
0m00.46s  | Spec/ModularArithmetic.vo                                       | 0m00.48s  || -0m00.01s | -4.16%
0m00.45s  | Util/IdfunWithAlt.vo                                            | 0m00.49s  || -0m00.03s | -8.16%
0m00.45s  | Util/ZUtil/Tactics/Ztestbit.vo                                  | 0m00.44s  || +0m00.01s | +2.27%
0m00.44s  | Util/NUtil/WithoutReferenceToZ.vo                               | 0m00.46s  || -0m00.02s | -4.34%
0m00.44s  | Util/Strings/String.vo                                          | 0m00.37s  || +0m00.07s | +18.91%
0m00.44s  | Util/ZUtil/N2Z.vo                                               | 0m00.47s  || -0m00.02s | -6.38%
0m00.43s  | Util/ZUtil/CPS.vo                                               | 0m00.44s  || -0m00.01s | -2.27%
0m00.43s  | Util/ZUtil/MulSplit.vo                                          | 0m00.46s  || -0m00.03s | -6.52%
0m00.42s  | Util/MSetPositive/Equality.vo                                   | 0m00.47s  || -0m00.04s | -10.63%
0m00.42s  | Util/Strings/ParseArithmetic.vo                                 | 0m00.41s  || +0m00.01s | +2.43%
0m00.40s  | Arithmetic/MontgomeryReduction/Definition.vo                    | 0m00.39s  || +0m00.01s | +2.56%
0m00.39s  | Util/ZUtil/Hints/Core.vo                                        | 0m00.39s  || +0m00.00s | +0.00%
0m00.39s  | Util/ZUtil/Tactics.vo                                           | 0m00.39s  || +0m00.00s | +0.00%
0m00.39s  | Util/ZUtil/Tactics/DivModToQuotRem.vo                           | 0m00.35s  || +0m00.04s | +11.42%
0m00.39s  | Util/ZUtil/Tactics/PullPush/Modulo.vo                           | 0m00.34s  || +0m00.04s | +14.70%
0m00.39s  | Util/ZUtil/Tactics/ZeroBounds.vo                                | 0m00.40s  || -0m00.01s | -2.50%
0m00.38s  | Util/ZRange/Show.vo                                             | 0m00.41s  || -0m00.02s | -7.31%
0m00.38s  | Util/ZUtil/Hints.vo                                             | 0m00.38s  || +0m00.00s | +0.00%
0m00.38s  | Util/ZUtil/Tactics/SimplifyFractionsLe.vo                       | 0m00.39s  || -0m00.01s | -2.56%
0m00.38s  | Util/ZUtil/ZSimplify/Core.vo                                    | 0m00.38s  || +0m00.00s | +0.00%
0m00.37s  | Util/ZUtil/Hints/Ztestbit.vo                                    | 0m00.35s  || +0m00.02s | +5.71%
0m00.37s  | Util/ZUtil/Modulo/Bootstrap.vo                                  | 0m00.34s  || +0m00.02s | +8.82%
0m00.37s  | Util/ZUtil/Odd.vo                                               | 0m00.37s  || +0m00.00s | +0.00%
0m00.37s  | Util/ZUtil/Opp.vo                                               | 0m00.31s  || +0m00.06s | +19.35%
0m00.37s  | Util/ZUtil/Tactics/PullPush.vo                                  | 0m00.38s  || -0m00.01s | -2.63%
0m00.36s  | Algebra/Monoid.vo                                               | 0m00.33s  || +0m00.02s | +9.09%
0m00.36s  | Util/Strings/HexString.vo                                       | 0m00.35s  || +0m00.01s | +2.85%
0m00.36s  | Util/Strings/StringMap.vo                                       | 0m00.35s  || +0m00.01s | +2.85%
0m00.36s  | Util/ZUtil/DistrIf.vo                                           | 0m00.35s  || +0m00.01s | +2.85%
0m00.36s  | Util/ZUtil/Hints/PullPush.vo                                    | 0m00.35s  || +0m00.01s | +2.85%
0m00.36s  | Util/ZUtil/Pow2.vo                                              | 0m00.32s  || +0m00.03s | +12.49%
0m00.36s  | Util/ZUtil/Sgn.vo                                               | 0m00.35s  || +0m00.01s | +2.85%
0m00.35s  | Util/ZUtil/Hints/ZArith.vo                                      | 0m00.36s  || -0m00.01s | -2.77%
0m00.35s  | Util/ZUtil/ZSimplify.vo                                         | 0m00.37s  || -0m00.02s | -5.40%
0m00.34s  | Util/ZUtil/Div/Bootstrap.vo                                     | 0m00.35s  || -0m00.00s | -2.85%
0m00.34s  | Util/ZUtil/Sorting.vo                                           | 0m00.35s  || -0m00.00s | -2.85%
0m00.33s  | Util/FMapPositive/Equality.vo                                   | 0m00.32s  || +0m00.01s | +3.12%
0m00.33s  | Util/ZUtil/Tactics/PeelLe.vo                                    | 0m00.41s  || -0m00.07s | -19.51%
0m00.32s  | Util/ZUtil/Definitions.vo                                       | 0m00.27s  || +0m00.04s | +18.51%
0m00.30s  | Util/Sum.vo                                                     | 0m00.30s  || +0m00.00s | +0.00%
0m00.29s  | Util/Strings/Show.vo                                            | 0m00.31s  || -0m00.02s | -6.45%
0m00.28s  | Util/Option.vo                                                  | 0m00.29s  || -0m00.00s | -3.44%
0m00.27s  | Util/ZUtil/Tactics/DivideExistsMul.vo                           | 0m00.24s  || +0m00.03s | +12.50%
0m00.27s  | Util/ZUtil/Tactics/LtbToLt.vo                                   | 0m00.30s  || -0m00.02s | -9.99%
0m00.26s  | Algebra/Hierarchy.vo                                            | 0m00.29s  || -0m00.02s | -10.34%
0m00.26s  | Util/OptionList.vo                                              | 0m00.25s  || +0m00.01s | +4.00%
0m00.26s  | Util/SideConditions/RingPackage.vo                              | 0m00.23s  || +0m00.03s | +13.04%
0m00.26s  | Util/ZUtil/AddModulo.vo                                         | 0m00.25s  || +0m00.01s | +4.00%
0m00.26s  | Util/ZUtil/Zselect.vo                                           | 0m00.26s  || +0m00.00s | +0.00%
0m00.25s  | TAPSort.vo                                                      | 0m00.27s  || -0m00.02s | -7.40%
0m00.25s  | Util/SideConditions/ModInvPackage.vo                            | 0m00.24s  || +0m00.01s | +4.16%
0m00.25s  | Util/Strings/BinaryString.vo                                    | 0m00.23s  || +0m00.01s | +8.69%
0m00.25s  | Util/Strings/OctalString.vo                                     | 0m00.26s  || -0m00.01s | -3.84%
0m00.25s  | Util/ZUtil/Tactics/CompareToSgn.vo                              | 0m00.22s  || +0m00.03s | +13.63%
0m00.25s  | Util/ZUtil/Tactics/LinearSubstitute.vo                          | 0m00.26s  || -0m00.01s | -3.84%
0m00.25s  | Util/ZUtil/Tactics/SplitMinMax.vo                               | 0m00.28s  || -0m00.03s | -10.71%
0m00.24s  | Util/ZUtil/Ge.vo                                                | 0m00.25s  || -0m00.01s | -4.00%
0m00.24s  | Util/ZUtil/Tactics/PrimeBound.vo                                | 0m00.24s  || +0m00.00s | +0.00%
0m00.24s  | Util/ZUtil/Tactics/ReplaceNegWithPos.vo                         | 0m00.26s  || -0m00.02s | -7.69%
0m00.23s  | Util/SideConditions/Autosolve.vo                                | 0m00.22s  || +0m00.01s | +4.54%
0m00.23s  | Util/Strings/Decimal.vo                                         | 0m00.23s  || +0m00.00s | +0.00%
0m00.23s  | Util/Strings/Equality.vo                                        | 0m00.21s  || +0m00.02s | +9.52%
0m00.23s  | Util/Strings/Parse/Common.vo                                    | 0m00.26s  || -0m00.03s | -11.53%
0m00.22s  | PushButtonSynthesis/InvertHighLow.vo                            | 0m00.26s  || -0m00.04s | -15.38%
0m00.22s  | Spec/MxDH.vo                                                    | 0m00.23s  || -0m00.01s | -4.34%
0m00.22s  | Util/PointedProp.vo                                             | 0m00.24s  || -0m00.01s | -8.33%
0m00.22s  | Util/ZUtil/ModInv.vo                                            | 0m00.25s  || -0m00.03s | -12.00%
0m00.21s  | Util/SideConditions/ReductionPackages.vo                        | 0m00.20s  || +0m00.00s | +4.99%
0m00.20s  | Util/Decidable/Bool2Prop.vo                                     | 0m00.19s  || +0m00.01s | +5.26%
0m00.20s  | Util/Strings/Ascii.vo                                           | 0m00.25s  || -0m00.04s | -19.99%
0m00.19s  | Util/ListUtil/FoldBool.vo                                       | 0m00.16s  || +0m00.03s | +18.75%
0m00.19s  | Util/ParseTaps.vo                                               | 0m00.18s  || +0m00.01s | +5.55%
0m00.18s  | Util/ZUtil/Notations.vo                                         | 0m00.16s  || +0m00.01s | +12.49%
0m00.17s  | Util/LetInMonad.vo                                              | 0m00.19s  || -0m00.01s | -10.52%
0m00.16s  | Util/ListUtil/SetoidList.vo                                     | 0m00.12s  || +0m00.04s | +33.33%
0m00.16s  | Util/Sigma.vo                                                   | 0m00.18s  || -0m00.01s | -11.11%
0m00.14s  | Util/ListUtil/ForallIn.vo                                       | 0m00.12s  || +0m00.02s | +16.66%
0m00.12s  | Util/Relations.vo                                               | 0m00.10s  || +0m00.01s | +19.99%
0m00.11s  | Util/PrimitiveHList.vo                                          | 0m00.09s  || +0m00.02s | +22.22%
0m00.11s  | Util/PrimitiveProd.vo                                           | 0m00.11s  || +0m00.00s | +0.00%
0m00.09s  | Util/Equality.vo                                                | 0m00.10s  || -0m00.01s | -10.00%
0m00.09s  | Util/PrimitiveSigma.vo                                          | 0m00.10s  || -0m00.01s | -10.00%
0m00.09s  | Util/Prod.vo                                                    | 0m00.11s  || -0m00.02s | -18.18%
0m00.09s  | Util/TagList.vo                                                 | 0m00.11s  || -0m00.02s | -18.18%
0m00.07s  | Util/Bool.vo                                                    | 0m00.08s  || -0m00.00s | -12.49%
0m00.07s  | Util/LetIn.vo                                                   | 0m00.05s  || +0m00.02s | +40.00%
0m00.07s  | Util/Logic/ExistsEqAnd.vo                                       | 0m00.05s  || +0m00.02s | +40.00%
0m00.07s  | Util/Sigma/Related.vo                                           | 0m00.08s  || -0m00.00s | -12.49%
0m00.06s  | Util/Bool/Equality.vo                                           | 0m00.06s  || +0m00.00s | +0.00%
0m00.06s  | Util/CPSNotations.vo                                            | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/ErrorT.vo                                                  | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Logic.vo                                                   | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Logic/ProdForall.vo                                        | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Tactics/DestructHead.vo                                    | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Tactics/DestructHyps.vo                                    | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Tactics/ETransitivity.vo                                   | 0m00.04s  || +0m00.01s | +49.99%
0m00.06s  | Util/Tactics/RewriteHyp.vo                                      | 0m00.04s  || +0m00.01s | +49.99%
0m00.06s  | Util/Tower.vo                                                   | 0m00.06s  || +0m00.00s | +0.00%
0m00.05s  | Util/DefaultedTypes.vo                                          | 0m00.02s  || +0m00.03s | +150.00%
0m00.05s  | Util/FixCoqMistakes.vo                                          | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/HProp.vo                                                   | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/IffT.vo                                                    | 0m00.07s  || -0m00.02s | -28.57%
0m00.05s  | Util/Isomorphism.vo                                             | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Notations.vo                                               | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/PER.vo                                                     | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Pointed.vo                                                 | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Sigma/MapProjections.vo                                    | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Sumbool.vo                                                 | 0m00.06s  || -0m00.00s | -16.66%
0m00.05s  | Util/Tactics/ClearAll.vo                                        | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/DoWithHyp.vo                                       | 0m00.03s  || +0m00.02s | +66.66%
0m00.05s  | Util/Tactics/ESpecialize.vo                                     | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/GetGoal.vo                                         | 0m00.03s  || +0m00.02s | +66.66%
0m00.05s  | Util/Tactics/Head.vo                                            | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/MoveLetIn.vo                                       | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/OnSubterms.vo                                      | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/RunTacticAsConstr.vo                               | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/SideConditionsBeforeToAfter.vo                     | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/SpecializeAllWays.vo                               | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/UnifyAbstractReflexivity.vo                        | 0m00.03s  || +0m00.02s | +66.66%
0m00.04s  | Util/AutoRewrite.vo                                             | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Bool/IsTrue.vo                                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/ChangeInAll.vo                                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Comparison.vo                                              | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Curry.vo                                                   | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/SideConditions/AdmitPackage.vo                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/SideConditions/CorePackages.vo                             | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Sigma/Lift.vo                                              | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/BreakMatch.vo                                      | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/CPSId.vo                                           | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Tactics/CacheTerm.vo                                       | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/ChangeInAll.vo                                     | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/DebugPrint.vo                                      | 0m00.07s  || -0m00.03s | -42.85%
0m00.04s  | Util/Tactics/DestructTrivial.vo                                 | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/EvarExists.vo                                      | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/Forward.vo                                         | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/HeadUnderBinders.vo                                | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Tactics/NormalizeCommutativeIdentifier.vo                  | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/PoseTermWithName.vo                                | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Tactics/PrintContext.vo                                    | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/SetEvars.vo                                        | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/SetoidSubst.vo                                     | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/SimplifyRepeatedIfs.vo                             | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/SpecializeBy.vo                                    | 0m00.06s  || -0m00.01s | -33.33%
0m00.04s  | Util/Tactics/SplitInContext.vo                                  | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/SubstLet.vo                                        | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/Test.vo                                            | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/UniquePose.vo                                      | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Tactics/VM.vo                                              | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Unit.vo                                                    | 0m00.04s  || +0m00.00s | +0.00%
0m00.03s  | Util/GlobalSettings.vo                                          | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Logic/ImplAnd.vo                                           | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Pos.vo                                                     | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Sigma/Associativity.vo                                     | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics.vo                                                 | 0m00.06s  || -0m00.03s | -50.00%
0m00.03s  | Util/Tactics/ClearDuplicates.vo                                 | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/ClearbodyAll.vo                                    | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/ConstrFail.vo                                      | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Tactics/Contains.vo                                        | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/ConvoyDestruct.vo                                  | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/EvarNormalize.vo                                   | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/HasBody.vo                                         | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/PrintGoal.vo                                       | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/Revert.vo                                          | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/SimplifyProjections.vo                             | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/SubstEvars.vo                                      | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/TransparentAssert.vo                               | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Tactics/UnfoldArg.vo                                       | 0m00.04s  || -0m00.01s | -25.00%
0m00.02s  | Util/Tactics/Not.vo                                             | 0m00.04s  || -0m00.02s | -50.00%
```
</p>