### PR TITLE
Add support for splitting apart multireturn functions

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -114,6 +114,7 @@ src/Rewriter/RulesProofs.v
 src/Rewriter/Passes/Arith.v
 src/Rewriter/Passes/ArithWithCasts.v
 src/Rewriter/Passes/MulSplit.v
+src/Rewriter/Passes/MultiRetSplit.v
 src/Rewriter/Passes/NBE.v
 src/Rewriter/Passes/StripLiteralCasts.v
 src/Rewriter/Passes/ToFancy.v

--- a/src/AbstractInterpretation/AbstractInterpretation.v
+++ b/src/AbstractInterpretation/AbstractInterpretation.v
@@ -462,6 +462,11 @@ Module Compilers.
                              | Some x, Some y => of_literal (ident.interp idc x y)
                              | _, _ => ZRange.type.base.option.None
                              end
+             | ident.Z_ltz as idc
+               => fun x y => match to_literal x, to_literal y with
+                             | Some x, Some y => of_literal (ident.interp idc x y)
+                             | _, _ => Some r[0~>1]
+                             end
              | ident.Z_bneg as idc
                => fun x => match to_literal x with
                            | Some x => of_literal (ident.interp idc x)
@@ -634,6 +639,15 @@ Module Compilers.
                          (ZRange.split_bounds (ZRange.four_corners Z.mul x y) split_at)
                    | _, _, _ => ZRange.type.base.option.None
                    end
+             | ident.Z_mul_high
+               => fun split_at x y
+                 => match to_literal split_at, x, y with
+                   | Some split_at, Some x, Some y
+                     => ZRange.type.base.option.Some
+                         (t:=tZ)
+                         (snd (ZRange.split_bounds (ZRange.four_corners Z.mul x y) split_at))
+                   | _, _, _ => ZRange.type.base.option.None
+                    end
              | ident.Z_add_get_carry
                => fun split_at x y
                  => match to_literal split_at, x, y with

--- a/src/AbstractInterpretation/ZRangeProofs.v
+++ b/src/AbstractInterpretation/ZRangeProofs.v
@@ -576,6 +576,8 @@ Module Compilers.
                                 | [ |- andb (is_bounded_by_bool (_ mod ?m) (fst (Operations.ZRange.split_bounds _ ?m)))
                                            (is_bounded_by_bool (_ / ?m) (snd (Operations.ZRange.split_bounds _ ?m))) = true ]
                                   => apply ZRange.is_bounded_by_bool_split_bounds
+                                | [ |- is_bounded_by_bool (_ / ?m) (snd (Operations.ZRange.split_bounds _ ?m)) = true ]
+                                  => apply ZRange.is_bounded_by_bool_split_bounds_and
                                 | [ |- is_bounded_by_bool (_ mod _) r[_ ~> _] = true ] => cbv [is_bounded_by_bool]; rewrite Bool.andb_true_iff
                                 | [ H : is_bounded_by_bool ?v ?r1 = true, H' : is_tighter_than_bool ?r1 ?r2 = true |- _ ]
                                   => pose proof (@ZRange.is_bounded_by_of_is_tighter_than r1 r2 H' v H);
@@ -584,9 +586,11 @@ Module Compilers.
                                   => break_innermost_match
                                 | [ |- context[ZRange.constant ?x] ] => unique pose proof (ZRange.is_bounded_by_bool_constant x)
                                 | [ |- context[r[?x~>?x]%zrange] ] => unique pose proof (ZRange.is_bounded_by_bool_constant x)
+                                | [ |- is_bounded_by_bool (Definitions.Z.ltz _ _) r[0 ~> 1] = true ]
+                                  => cbv [Definitions.Z.ltz]; break_innermost_match; cbv
                                 end
                               | progress Z.ltb_to_lt
-                              | progress rewrite ?Z.mul_split_div, ?Z.mul_split_mod, ?Z.add_get_carry_full_div, ?Z.add_get_carry_full_mod, ?Z.add_with_get_carry_full_div, ?Z.add_with_get_carry_full_mod, ?Z.sub_get_borrow_full_div, ?Z.sub_get_borrow_full_mod, ?Z.sub_with_get_borrow_full_div, ?Z.sub_with_get_borrow_full_mod, ?Z.zselect_correct, ?Z.add_modulo_correct, ?Z.rshi_correct_full, ?Z.truncating_shiftl_correct_land_ones ].
+                              | progress rewrite ?Z.mul_split_div, ?Z.mul_split_mod, ?Z.mul_high_div, ?Z.add_get_carry_full_div, ?Z.add_get_carry_full_mod, ?Z.add_with_get_carry_full_div, ?Z.add_with_get_carry_full_mod, ?Z.sub_get_borrow_full_div, ?Z.sub_get_borrow_full_mod, ?Z.sub_with_get_borrow_full_div, ?Z.sub_with_get_borrow_full_mod, ?Z.zselect_correct, ?Z.add_modulo_correct, ?Z.rshi_correct_full, ?Z.truncating_shiftl_correct_land_ones ].
             all: repeat lazymatch goal with
                         | [ |- is_bounded_by_bool (Z.land _ _) (ZRange.land_bounds _ _) = true ]
                           => apply ZRange.is_bounded_by_bool_land_bounds; auto

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -358,6 +358,9 @@ Module ForExtraction.
       ; use_mul_for_cmovznz :> use_mul_for_cmovznz_opt
       (** Should we split apart oversized operations? *)
       ; should_split_mul :> should_split_mul_opt
+      (** Should we split apart multi-return operations? *)
+      ; should_split_multiret :> should_split_multiret_opt
+        := false
       (** Should we widen the carry to the full bitwidth? *)
       ; widen_carry :> widen_carry_opt
       (** Should we widen the byte type to the full bitwidth? *)

--- a/src/Language/APINotations.v
+++ b/src/Language/APINotations.v
@@ -231,11 +231,13 @@ Module Compilers.
     Notation Z_lnot_modulo := Compilers.ident_Z_lnot_modulo (only parsing).
     Notation Z_truncating_shiftl := Compilers.ident_Z_truncating_shiftl (only parsing).
     Notation Z_mul_split := Compilers.ident_Z_mul_split (only parsing).
+    Notation Z_mul_high := Compilers.ident_Z_mul_high (only parsing).
     Notation Z_add_get_carry := Compilers.ident_Z_add_get_carry (only parsing).
     Notation Z_add_with_carry := Compilers.ident_Z_add_with_carry (only parsing).
     Notation Z_add_with_get_carry := Compilers.ident_Z_add_with_get_carry (only parsing).
     Notation Z_sub_get_borrow := Compilers.ident_Z_sub_get_borrow (only parsing).
     Notation Z_sub_with_get_borrow := Compilers.ident_Z_sub_with_get_borrow (only parsing).
+    Notation Z_ltz := Compilers.ident_Z_ltz (only parsing).
     Notation Z_zselect := Compilers.ident_Z_zselect (only parsing).
     Notation Z_add_modulo := Compilers.ident_Z_add_modulo (only parsing).
     Notation Z_rshi := Compilers.ident_Z_rshi (only parsing).

--- a/src/Language/IdentifierParameters.v
+++ b/src/Language/IdentifierParameters.v
@@ -110,11 +110,13 @@ Definition all_ident_named_interped : InductiveHList.hlist
       ; with_name ident_Z_min Z.min
       ; with_name ident_Z_max Z.max
       ; with_name ident_Z_mul_split Z.mul_split
+      ; with_name ident_Z_mul_high Z.mul_high
       ; with_name ident_Z_add_get_carry Z.add_get_carry_full
       ; with_name ident_Z_add_with_carry Z.add_with_carry
       ; with_name ident_Z_add_with_get_carry Z.add_with_get_carry_full
       ; with_name ident_Z_sub_get_borrow Z.sub_get_borrow_full
       ; with_name ident_Z_sub_with_get_borrow Z.sub_with_get_borrow_full
+      ; with_name ident_Z_ltz Z.ltz
       ; with_name ident_Z_zselect Z.zselect
       ; with_name ident_Z_add_modulo Z.add_modulo
       ; with_name ident_Z_truncating_shiftl Z.truncating_shiftl

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -60,6 +60,7 @@ Section rbarrett_red.
   Local Instance widen_carry : widen_carry_opt := false.
   Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance split_mul_to : split_mul_to_opt := None.
+  Local Instance split_multiret_to : split_multiret_to_opt := None.
   Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
 
   Let fancy_args

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -83,6 +83,7 @@ Section __.
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
+          {should_split_multiret : should_split_multiret_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           (s : Z) (c : list (Z * Z))
@@ -143,6 +144,7 @@ Section __.
     := List.map (fun u => Some r[0~>u]%zrange) out_upperbounds.
 
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values_of_machine_wordsize_with_bytes.
+  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values_of_machine_wordsize_with_bytes.
 
   (** Note: If you change the name or type signature of this
         function, you will need to update the code in CLI.v *)

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -67,6 +67,7 @@ Section rmontred.
   Local Instance widen_carry : widen_carry_opt := false.
   Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance split_mul_to : split_mul_to_opt := None.
+  Local Instance split_multiret_to : split_multiret_to_opt := None.
   Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
 
   Let fancy_args

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -643,6 +643,7 @@ Section __.
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
+          {should_split_multiret : should_split_multiret_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           (n : nat)
@@ -665,6 +666,7 @@ Section __.
   Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
 
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
+  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 
   Lemma length_saturated_bounds_list : List.length saturated_bounds_list = n.
   Proof using Type. cbv [saturated_bounds_list]; now autorewrite with distr_length. Qed.

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -65,6 +65,7 @@ Section __.
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
+          {should_split_multiret : should_split_multiret_opt}
           {widen_carry : widen_carry_opt}
           (widen_bytes : widen_bytes_opt := true) (* true, because we don't allow byte-sized things anyway, so we should not expect carries to be widened to byte-size when emitting C code *)
           (s : Z)
@@ -94,6 +95,7 @@ Section __.
     := repeat bound n.
 
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
+  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 
   (** Note: If you change the name or type signature of this
         function, you will need to update the code in CLI.v *)

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -21,6 +21,7 @@ Import Compilers.API.
 Import Associational Positional.
 
 Local Instance : split_mul_to_opt := None.
+Local Instance : split_multiret_to_opt := None.
 Local Existing Instance default_low_level_rewriter_method.
 
 Time Redirect "log" Compute

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -80,6 +80,7 @@ Section __.
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
+          {should_split_multiret : should_split_multiret_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           (n : nat)
@@ -130,6 +131,7 @@ Section __.
     := List.map (fun u => Some r[0~>u]%zrange) loose_upperbounds.
 
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
+  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 
   Lemma length_prime_upperbound_list : List.length prime_upperbound_list = n.
   Proof using Type. cbv [prime_upperbound_list]; now autorewrite with distr_length. Qed.

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -96,6 +96,7 @@ Section __.
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
+          {should_split_multiret : should_split_multiret_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           (m : Z)
@@ -142,6 +143,7 @@ Section __.
     := Option.invert_Some saturated_bounds (*List.map (fun u => Some r[0~>u]%zrange) upperbounds*).
 
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
+  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 
   (** Note: If you change the name or type signature of this
         function, you will need to update the code in CLI.v *)

--- a/src/Rewriter/All.v
+++ b/src/Rewriter/All.v
@@ -3,6 +3,7 @@ Require Import Crypto.Rewriter.Passes.Arith.
 Require Import Crypto.Rewriter.Passes.ArithWithCasts.
 Require Import Crypto.Rewriter.Passes.StripLiteralCasts.
 Require Import Crypto.Rewriter.Passes.MulSplit.
+Require Import Crypto.Rewriter.Passes.MultiRetSplit.
 Require Import Crypto.Rewriter.Passes.ToFancy.
 Require Import Crypto.Rewriter.Passes.ToFancyWithCasts.
 
@@ -12,6 +13,7 @@ Module Compilers.
   Export ArithWithCasts.Compilers.
   Export StripLiteralCasts.Compilers.
   Export MulSplit.Compilers.
+  Export MultiRetSplit.Compilers.
   Export ToFancy.Compilers.
   Export ToFancyWithCasts.Compilers.
 
@@ -21,6 +23,7 @@ Module Compilers.
     Export ArithWithCasts.Compilers.RewriteRules.
     Export StripLiteralCasts.Compilers.RewriteRules.
     Export MulSplit.Compilers.RewriteRules.
+    Export MultiRetSplit.Compilers.RewriteRules.
     Export ToFancy.Compilers.RewriteRules.
     Export ToFancyWithCasts.Compilers.RewriteRules.
   End RewriteRules.

--- a/src/Rewriter/Passes/MultiRetSplit.v
+++ b/src/Rewriter/Passes/MultiRetSplit.v
@@ -1,0 +1,44 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Rewriter.Language.Language.
+Require Import Crypto.Language.API.
+Require Import Rewriter.Language.Wf.
+Require Import Crypto.Language.WfExtra.
+Require Import Crypto.Rewriter.AllTacticsExtra.
+Require Import Crypto.Rewriter.RulesProofs.
+
+Module Compilers.
+  Import Language.Compilers.
+  Import Language.API.Compilers.
+  Import Language.Wf.Compilers.
+  Import Language.WfExtra.Compilers.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
+  Import Compilers.Classes.
+
+  Module Import RewriteRules.
+    Section __.
+      Context (bitwidth : Z)
+              (lgcarrymax : Z).
+
+      Definition VerifiedRewriterMultiRetSplit : VerifiedRewriter_with_args false false true (multiret_split_rewrite_rules_proofs bitwidth lgcarrymax).
+      Proof using All. make_rewriter. Defined.
+
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterMultiRetSplit.
+      Let optsT := Eval hnf in optsT VerifiedRewriterMultiRetSplit.
+
+      Definition RewriteMultiRetSplit (opts : optsT) {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterMultiRetSplit opts t.
+
+      Lemma Wf_RewriteMultiRetSplit opts {t} e (Hwf : Wf e) : Wf (@RewriteMultiRetSplit opts t e).
+      Proof. now apply VerifiedRewriterMultiRetSplit. Qed.
+
+      Lemma Interp_RewriteMultiRetSplit opts {t} e (Hwf : Wf e) : API.Interp (@RewriteMultiRetSplit opts t e) == API.Interp e.
+      Proof. now apply VerifiedRewriterMultiRetSplit. Qed.
+    End __.
+  End RewriteRules.
+
+  Module Export Hints.
+    Hint Resolve Wf_RewriteMultiRetSplit : wf wf_extra.
+    Hint Opaque RewriteMultiRetSplit : wf wf_extra interp interp_extra rewrite.
+    Hint Rewrite @Interp_RewriteMultiRetSplit : interp interp_extra.
+  End Hints.
+End Compilers.

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -49,6 +49,7 @@ Local Instance : internal_static_opt := true.
 Local Instance : use_mul_for_cmovznz_opt := false.
 Local Instance : emit_primitives_opt := true.
 Local Instance : should_split_mul_opt := false.
+Local Instance : should_split_multiret_opt := false.
 Local Instance : widen_bytes_opt := false.
 Local Instance : widen_carry_opt := false.
 

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -874,4 +874,50 @@ Section with_bitwidth.
                        = singlewidth xh)
              ]
           ]%Z%zrange.
+
+  Definition multiret_split_rewrite_rulesT : Datatypes.list (Datatypes.bool * Prop)
+    := Eval cbv [myapp mymap myflatten] in
+        myflatten
+          [mymap
+             dont_do_again
+             [(forall x y,
+                  0 <= lgcarrymax <= bitwidth
+                  -> singlewidth_carry (Z.add_get_carry_full ('(2^bitwidth)) (singlewidth x) (singlewidth y))
+                     = (dlet sum_xy := singlewidth (singlewidth x + singlewidth y) in
+                            dlet carry_xy := carrywidth (Z.ltz (singlewidth sum_xy) (singlewidth x)) in
+                            (singlewidth sum_xy, carrywidth carry_xy)))
+              ; (forall c x y,
+                    0 <= lgcarrymax <= bitwidth
+                    -> singlewidth_carry (Z.add_with_get_carry_full ('(2^bitwidth)) (carrywidth c) (singlewidth x) (singlewidth y))
+                       = (dlet sum_cx := singlewidth (carrywidth c + singlewidth x) in
+                              dlet carry_cx := carrywidth (Z.ltz (singlewidth sum_cx) (singlewidth x)) in
+                              dlet sum_cxy := singlewidth (singlewidth sum_cx + singlewidth y) in
+                              dlet carry_cx_y := carrywidth (Z.ltz (singlewidth sum_cxy) (singlewidth y)) in
+                              dlet carry_cxy := carrywidth (carrywidth carry_cx + carrywidth carry_cx_y) in
+                              (singlewidth sum_cxy, carrywidth carry_cxy)))
+
+              ; (forall x y,
+                    0 <= lgcarrymax <= bitwidth
+                    -> singlewidth_carry (Z.sub_get_borrow_full ('(2^bitwidth)) (singlewidth x) (singlewidth y))
+                       = (dlet diff_xy := singlewidth (singlewidth x - singlewidth y) in
+                              dlet borrow_xy := carrywidth (Z.ltz (singlewidth x) (singlewidth diff_xy)) in
+                              (singlewidth diff_xy, carrywidth borrow_xy)))
+              ; (forall c x y,
+                    0 <= lgcarrymax <= bitwidth
+                    -> singlewidth_carry (Z.sub_with_get_borrow_full ('(2^bitwidth)) (carrywidth c) (singlewidth x) (singlewidth y))
+                       = (dlet diff_xy := singlewidth (singlewidth x - singlewidth y) in
+                              dlet borrow_xy := carrywidth (Z.ltz (singlewidth x) (singlewidth diff_xy)) in
+                              dlet diff_xyc := singlewidth (singlewidth diff_xy - carrywidth c) in
+                              dlet borrow_xy_c := carrywidth (Z.ltz (singlewidth diff_xy) (singlewidth diff_xyc)) in
+                              dlet borrow_xyc := carrywidth (carrywidth borrow_xy + carrywidth borrow_xy_c) in
+                              (singlewidth diff_xyc, carrywidth borrow_xyc)))
+
+              ; (forall x y,
+                    0 <= lgcarrymax <= bitwidth
+                    -> pairsinglewidth (Z.mul_split ('(2^bitwidth)) (singlewidth x) (singlewidth y))
+                       = (dlet low := singlewidth (singlewidth x * singlewidth y) in
+                              dlet high := singlewidth (Z.mul_high ('(2^bitwidth)) (singlewidth x) (singlewidth y)) in
+                              (singlewidth low, singlewidth high)))
+             ]
+          ]%Z%zrange.
 End with_bitwidth.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -30,6 +30,8 @@ Local Coercion QArith_base.inject_Z : Z >-> Q.
 Local Coercion Z.pos : positive >-> Z.
 
 Local Existing Instance default_low_level_rewriter_method.
+Local Instance : should_split_multiret_opt := false.
+Local Instance : split_multiret_to_opt := None.
 
 Module debugging_go_build0.
   Import Stringification.Go.

--- a/src/Stringification/IR.v
+++ b/src/Stringification/IR.v
@@ -743,8 +743,10 @@ Module Compilers.
                  | ident.Z_log2_up
                  | ident.Z_of_nat
                  | ident.Z_to_nat
+                 | ident.Z_ltz
                  | ident.Z_zselect
                  | ident.Z_mul_split
+                 | ident.Z_mul_high
                  | ident.Z_add_get_carry
                  | ident.Z_add_with_carry
                  | ident.Z_add_with_get_carry

--- a/src/Stringification/Language.v
+++ b/src/Stringification/Language.v
@@ -333,6 +333,8 @@ Module Compilers.
              | ident.Z_lor => fun '((x, xr), ((y, yr), tt)) => (fun lvl => maybe_wrap_parens (Nat.ltb lvl 50) (x 50%nat ++ " | " ++ y 49%nat), ZRange.type.base.option.None)
              | ident.Z_mul_split
                => fun args => (show_application with_casts (fun _ => "Z.mul_split") args, ZRange.type.base.option.None)
+             | ident.Z_mul_high
+               => fun args => (show_application with_casts (fun _ => "Z.mul_high") args, ZRange.type.base.option.None)
              | ident.Z_add_get_carry
                => fun args => (show_application with_casts (fun _ => "Z.add_get_carry") args, ZRange.type.base.option.None)
              | ident.Z_add_with_carry
@@ -343,6 +345,8 @@ Module Compilers.
                => fun args => (show_application with_casts (fun _ => "Z.sub_get_borrow") args, ZRange.type.base.option.None)
              | ident.Z_sub_with_get_borrow
                => fun args => (show_application with_casts (fun _ => "Z.sub_with_get_borrow") args, ZRange.type.base.option.None)
+             | ident.Z_ltz
+               => fun args => (show_application with_casts (fun _ => "Z.ltz") args, ZRange.type.base.option.None)
              | ident.Z_zselect
                => fun args => (show_application with_casts (fun _ => "Z.zselect") args, ZRange.type.base.option.None)
              | ident.Z_add_modulo
@@ -460,11 +464,13 @@ Module Compilers.
                 | ident.Z_lnot_modulo => "~"
                 | ident.Z_bneg => "!"
                 | ident.Z_mul_split => "Z.mul_split"
+                | ident.Z_mul_high => "Z.mul_high"
                 | ident.Z_add_get_carry => "Z.add_get_carry"
                 | ident.Z_add_with_carry => "Z.add_with_carry"
                 | ident.Z_add_with_get_carry => "Z.add_with_get_carry"
                 | ident.Z_sub_get_borrow => "Z.sub_get_borrow"
                 | ident.Z_sub_with_get_borrow => "Z.sub_with_get_borrow"
+                | ident.Z_ltz => "Z.ltz"
                 | ident.Z_zselect => "Z.zselect"
                 | ident.Z_add_modulo => "Z.add_modulo"
                 | ident.Z_truncating_shiftl => "Z.truncating_shiftl"

--- a/src/Util/ZUtil/AddGetCarry.v
+++ b/src/Util/ZUtil/AddGetCarry.v
@@ -7,6 +7,8 @@ Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.LetIn.
 Require Import Crypto.Util.Tactics.BreakMatch.
+Require Import Crypto.Util.Tactics.DestructHead.
+Require Import Crypto.Util.Tactics.SpecializeBy.
 Require Import Crypto.Util.Tactics.RewriteHyp.
 Local Open Scope Z_scope.
 
@@ -110,4 +112,42 @@ Module Z.
   Proof. easypeasy. Qed.
   Hint Rewrite sub_with_get_borrow_full_div : to_div_mod.
 
+  Local Ltac fin_div_ltz :=
+    intros; cbv [Z.ltz]; Z.div_mod_to_quot_rem; break_innermost_match; Z.ltb_to_lt; try nia.
+
+  Lemma add_div_ltz_1 s x y :
+    0 <= x < s
+    -> 0 <= y < s
+    -> (x + y) / s = Z.ltz ((x + y) mod s) x.
+  Proof. fin_div_ltz. Qed.
+
+  Lemma add_div_ltz_2 s x y :
+    0 <= x < s
+    -> 0 <= y < s
+    -> (x + y) / s = Z.ltz ((x + y) mod s) y.
+  Proof. fin_div_ltz. Qed.
+
+  Lemma add_get_carry_full_ltz_1 s x y :
+    0 <= x < s
+    -> 0 <= y < s
+    -> snd (Z.add_get_carry_full s x y) = Z.ltz ((x + y) mod s) x.
+  Proof. rewrite add_get_carry_full_div; fin_div_ltz. Qed.
+
+  Lemma add_get_carry_full_ltz_2 s x y :
+    0 <= x < s
+    -> 0 <= y < s
+    -> snd (Z.add_get_carry_full s x y) = Z.ltz ((x + y) mod s) y.
+  Proof. rewrite add_get_carry_full_div; fin_div_ltz. Qed.
+
+  Lemma sub_div_ltz s x y :
+    0 <= x < s
+    -> 0 <= y < s
+    -> - ((x - y) / s) = Z.ltz x ((x - y) mod s).
+  Proof. fin_div_ltz. Qed.
+
+  Lemma sub_get_borrow_full_ltz s x y :
+    0 <= x < s
+    -> 0 <= y < s
+    -> snd (Z.sub_get_borrow_full s x y) = Z.ltz x ((x - y) mod s).
+  Proof. rewrite sub_get_borrow_full_div; fin_div_ltz. Qed.
 End Z.

--- a/src/Util/ZUtil/Definitions.v
+++ b/src/Util/ZUtil/Definitions.v
@@ -88,6 +88,13 @@ Module Z.
        then mul_split_at_bitwidth (Z.log2 s) x y
        else ((x * y) mod s, (x * y) / s).
 
+  Definition mul_high (s x y : Z) : Z
+    := snd (mul_split s x y).
+
+  (** returns [1] iff [x < y] *)
+  Definition ltz (x y : Z) : Z
+    := if x <? y then 1 else 0.
+
   Definition combine_at_bitwidth (bitwidth lo hi : Z) : Z
     := lo + (hi << bitwidth).
 

--- a/src/Util/ZUtil/MulSplit.v
+++ b/src/Util/ZUtil/MulSplit.v
@@ -28,4 +28,11 @@ Module Z.
       [ rewrite mul_split_at_bitwidth_div; congruence | reflexivity ].
   Qed.
   Hint Rewrite mul_split_div : to_div_mod.
+
+  Lemma mul_high_div s x y : Z.mul_high s x y = (x * y) / s.
+  Proof. cbv [Z.mul_high]; now apply mul_split_div. Qed.
+  Hint Rewrite mul_high_div : to_div_mod.
+
+  Lemma mul_split_high s x y : snd (Z.mul_split s x y) = Z.mul_high s x y.
+  Proof. reflexivity. Qed.
 End Z.


### PR DESCRIPTION
e.g., adc, sbb, mulx.  This should make porting to bedrock2 somewhat
easier.

<details><summary>Timing Diff</summary>
<p>

```
After     | File Name                                                       | Before    || Change    | % Change
---------------------------------------------------------------------------------------------------------------
90m31.83s | Total                                                           | 89m19.85s || +1m11.97s | +1.34%
---------------------------------------------------------------------------------------------------------------
3m48.59s  | fiat-rust/src/p384_32.rs                                        | 4m12.83s  || -0m24.24s | -9.58%
0m21.53s  | Rewriter/Passes/MultiRetSplit.vo                                |    N/A    || +0m21.53s | ∞
2m44.11s  | Rewriter/Passes/NBE.vo                                          | 2m32.66s  || +0m11.45s | +7.50%
0m15.34s  | BoundsPipeline.vo                                               | 0m08.72s  || +0m06.61s | +75.91%
3m49.36s  | PushButtonSynthesis/WordByWordMontgomeryReificationCache.vo     | 3m44.35s  || +0m05.01s | +2.23%
3m07.59s  | Curves/Montgomery/AffineProofs.vo                               | 3m02.57s  || +0m05.02s | +2.74%
2m21.03s  | Fancy/Barrett256.vo                                             | 2m15.86s  || +0m05.16s | +3.80%
1m18.33s  | Curves/Weierstrass/Jacobian.vo                                  | 1m14.64s  || +0m03.68s | +4.94%
3m25.33s  | Curves/Weierstrass/Projective.vo                                | 3m28.04s  || -0m02.71s | -1.30%
1m25.36s  | PushButtonSynthesis/UnsaturatedSolinas.vo                       | 1m23.06s  || +0m02.29s | +2.76%
0m49.99s  | Rewriter/RulesProofs.vo                                         | 0m47.35s  || +0m02.64s | +5.57%
0m27.84s  | ExtractionOCaml/unsaturated_solinas                             | 0m25.13s  || +0m02.71s | +10.78%
0m19.35s  | fiat-rust/src/p256_32.rs                                        | 0m17.26s  || +0m02.08s | +12.10%
0m17.29s  | p434_64.c                                                       | 0m14.99s  || +0m02.29s | +15.34%
8m17.56s  | Curves/Weierstrass/AffineProofs.vo                              | 8m19.51s  || -0m01.94s | -0.39%
4m15.66s  | p384_32.c                                                       | 4m14.20s  || +0m01.46s | +0.57%
3m52.81s  | Curves/Montgomery/XZProofs.vo                                   | 3m53.84s  || -0m01.03s | -0.44%
2m10.80s  | AbstractInterpretation/Wf.vo                                    | 2m12.42s  || -0m01.61s | -1.22%
1m02.25s  | Arithmetic/Core.vo                                              | 1m00.89s  || +0m01.35s | +2.23%
0m53.10s  | SlowPrimeSynthesisExamples.vo                                   | 0m51.50s  || +0m01.60s | +3.10%
0m43.16s  | p521_64.c                                                       | 0m42.16s  || +0m01.00s | +2.37%
0m42.64s  | PushButtonSynthesis/BarrettReductionReificationCache.vo         | 0m41.28s  || +0m01.35s | +3.29%
0m35.15s  | ExtractionOCaml/word_by_word_montgomery                         | 0m33.42s  || +0m01.72s | +5.17%
0m26.18s  | ExtractionOCaml/perf_word_by_word_montgomery                    | 0m24.79s  || +0m01.39s | +5.60%
0m24.40s  | ExtractionOCaml/base_conversion                                 | 0m22.80s  || +0m01.59s | +7.01%
0m21.91s  | ExtractionOCaml/word_by_word_montgomery.ml                      | 0m20.32s  || +0m01.58s | +7.82%
0m17.34s  | p256_32.c                                                       | 0m18.88s  || -0m01.53s | -8.15%
0m16.87s  | fiat-go/src/p434_64.go                                          | 0m15.00s  || +0m01.87s | +12.46%
0m16.75s  | fiat-rust/src/p434_64.rs                                        | 0m14.84s  || +0m01.91s | +12.87%
0m15.91s  | ExtractionOCaml/perf_word_by_word_montgomery.ml                 | 0m14.33s  || +0m01.58s | +11.02%
0m14.84s  | ExtractionOCaml/saturated_solinas.ml                            | 0m13.23s  || +0m01.60s | +12.16%
0m09.50s  | p224_32.c                                                       | 0m08.50s  || +0m01.00s | +11.76%
4m11.65s  | fiat-go/src/p384_32.go                                          | 4m11.93s  || -0m00.28s | -0.11%
3m35.23s  | Fancy/Compiler.vo                                               | 3m34.40s  || +0m00.82s | +0.38%
2m44.19s  | PushButtonSynthesis/FancyMontgomeryReductionReificationCache.vo | 2m44.36s  || -0m00.17s | -0.10%
2m27.87s  | Rewriter/Passes/ToFancyWithCasts.vo                             | 2m28.55s  || -0m00.68s | -0.45%
1m53.94s  | Rewriter/Passes/ArithWithCasts.vo                               | 1m53.46s  || +0m00.47s | +0.42%
1m27.94s  | Spec/Test/X25519.vo                                             | 1m28.11s  || -0m00.17s | -0.19%
1m15.07s  | AbstractInterpretation/ZRangeProofs.vo                          | 1m14.66s  || +0m00.40s | +0.54%
1m07.05s  | Fancy/Montgomery256.vo                                          | 1m06.60s  || +0m00.45s | +0.67%
1m01.52s  | PushButtonSynthesis/UnsaturatedSolinasReificationCache.vo       | 1m01.03s  || +0m00.49s | +0.80%
1m00.48s  | AbstractInterpretation/Proofs.vo                                | 1m00.85s  || -0m00.37s | -0.60%
0m58.83s  | PushButtonSynthesis/WordByWordMontgomery.vo                     | 0m58.55s  || +0m00.28s | +0.47%
0m54.16s  | Demo.vo                                                         | 0m53.40s  || +0m00.75s | +1.42%
0m47.74s  | Rewriter/Passes/Arith.vo                                        | 0m47.59s  || +0m00.14s | +0.31%
0m41.03s  | Arithmetic/BarrettReduction.vo                                  | 0m41.16s  || -0m00.12s | -0.31%
0m39.38s  | fiat-rust/src/p521_64.rs                                        | 0m39.35s  || +0m00.03s | +0.07%
0m33.05s  | Arithmetic/Saturated.vo                                         | 0m33.13s  || -0m00.08s | -0.24%
0m32.91s  | Rewriter/Passes/MulSplit.vo                                     | 0m32.48s  || +0m00.42s | +1.32%
0m30.73s  | Arithmetic/WordByWordMontgomery.vo                              | 0m30.76s  || -0m00.03s | -0.09%
0m23.17s  | PushButtonSynthesis/BarrettReduction.vo                         | 0m22.48s  || +0m00.69s | +3.06%
0m23.13s  | ExtractionOCaml/saturated_solinas                               | 0m22.77s  || +0m00.35s | +1.58%
0m22.96s  | ExtractionOCaml/perf_unsaturated_solinas                        | 0m22.20s  || +0m00.76s | +3.42%
0m20.84s  | fiat-go/src/p521_64.go                                          | 0m20.79s  || +0m00.05s | +0.24%
0m20.37s  | fiat-go/src/secp256k1_32.go                                     | 0m19.80s  || +0m00.57s | +2.87%
0m19.89s  | fiat-rust/src/secp256k1_32.rs                                   | 0m19.34s  || +0m00.55s | +2.84%
0m19.59s  | fiat-go/src/p256_32.go                                          | 0m19.42s  || +0m00.16s | +0.87%
0m19.42s  | secp256k1_32.c                                                  | 0m19.47s  || -0m00.04s | -0.25%
0m19.10s  | fiat-rust/src/p448_solinas_64.rs                                | 0m19.07s  || +0m00.03s | +0.15%
0m19.00s  | p448_solinas_64.c                                               | 0m19.01s  || -0m00.01s | -0.05%
0m18.96s  | Curves/Edwards/XYZT/Basic.vo                                    | 0m18.56s  || +0m00.40s | +2.15%
0m17.41s  | Curves/Edwards/AffineProofs.vo                                  | 0m17.61s  || -0m00.19s | -1.13%
0m17.41s  | ExtractionOCaml/unsaturated_solinas.ml                          | 0m17.08s  || +0m00.33s | +1.93%
0m16.73s  | Algebra/Field.vo                                                | 0m16.72s  || +0m00.01s | +0.05%
0m16.09s  | Language/IdentifiersGENERATED.vo                                | 0m15.60s  || +0m00.49s | +3.14%
0m14.52s  | ExtractionOCaml/perf_unsaturated_solinas.ml                     | 0m13.74s  || +0m00.77s | +5.67%
0m14.46s  | ExtractionOCaml/base_conversion.ml                              | 0m13.93s  || +0m00.53s | +3.80%
0m14.38s  | Arithmetic/FancyMontgomeryReduction.vo                          | 0m14.38s  || +0m00.00s | +0.00%
0m13.65s  | Language/IdentifiersGENERATEDProofs.vo                          | 0m13.30s  || +0m00.34s | +2.63%
0m13.48s  | Bedrock/Translation/Cmd.vo                                      | 0m13.04s  || +0m00.44s | +3.37%
0m13.26s  | Util/ZRange/LandLorBounds.vo                                    | 0m13.15s  || +0m00.10s | +0.83%
0m13.17s  | Primitives/MxDHRepChange.vo                                     | 0m12.95s  || +0m00.22s | +1.69%
0m11.44s  | Stringification/IR.vo                                           | 0m11.87s  || -0m00.42s | -3.62%
0m11.04s  | Algebra/Ring.vo                                                 | 0m11.02s  || +0m00.01s | +0.18%
0m10.22s  | Util/ZRange/CornersMonotoneBounds.vo                            | 0m10.51s  || -0m00.28s | -2.75%
0m09.63s  | fiat-go/src/p224_32.go                                          | 0m09.44s  || +0m00.19s | +2.01%
0m09.53s  | fiat-rust/src/p224_32.rs                                        | 0m08.59s  || +0m00.93s | +10.94%
0m09.44s  | PushButtonSynthesis/BaseConversion.vo                           | 0m09.14s  || +0m00.29s | +3.28%
0m09.42s  | PushButtonSynthesis/Primitives.vo                               | 0m09.49s  || -0m00.07s | -0.73%
0m08.99s  | PushButtonSynthesis/SmallExamples.vo                            | 0m09.34s  || -0m00.34s | -3.74%
0m08.86s  | Arithmetic/BarrettReduction/RidiculousFish.vo                   | 0m08.99s  || -0m00.13s | -1.44%
0m08.85s  | fiat-go/src/p448_solinas_64.go                                  | 0m08.83s  || +0m00.01s | +0.22%
0m08.53s  | Language/IdentifiersBasicGENERATED.vo                           | 0m08.30s  || +0m00.22s | +2.77%
0m08.18s  | p384_64.c                                                       | 0m07.69s  || +0m00.48s | +6.37%
0m08.11s  | fiat-go/src/p384_64.go                                          | 0m07.84s  || +0m00.26s | +3.44%
0m07.92s  | Arithmetic/MontgomeryReduction/Proofs.vo                        | 0m07.99s  || -0m00.07s | -0.87%
0m07.57s  | fiat-rust/src/p384_64.rs                                        | 0m07.69s  || -0m00.12s | -1.56%
0m07.43s  | COperationSpecifications.vo                                     | 0m07.46s  || -0m00.03s | -0.40%
0m07.29s  | PushButtonSynthesis/SaturatedSolinas.vo                         | 0m07.13s  || +0m00.16s | +2.24%
0m07.26s  | Util/ListUtil.vo                                                | 0m07.24s  || +0m00.01s | +0.27%
0m06.94s  | PushButtonSynthesis/SaturatedSolinasReificationCache.vo         | 0m07.02s  || -0m00.07s | -1.13%
0m06.90s  | Fancy/Prod.vo                                                   | 0m06.76s  || +0m00.14s | +2.07%
0m06.57s  | Util/ZUtil/LandLorBounds.vo                                     | 0m06.62s  || -0m00.04s | -0.75%
0m06.34s  | Util/ZUtil/Modulo.vo                                            | 0m06.14s  || +0m00.20s | +3.25%
0m06.34s  | Util/ZUtil/ZSimplify/Autogenerated.vo                           | 0m06.61s  || -0m00.27s | -4.08%
0m05.97s  | Util/ZUtil/Morphisms.vo                                         | 0m06.06s  || -0m00.08s | -1.48%
0m05.79s  | Arithmetic/BarrettReduction/Generalized.vo                      | 0m05.61s  || +0m00.17s | +3.20%
0m05.68s  | Curves/Edwards/Pre.vo                                           | 0m05.70s  || -0m00.02s | -0.35%
0m05.63s  | Util/FsatzAutoLemmas.vo                                         | 0m05.32s  || +0m00.30s | +5.82%
0m05.58s  | CastLemmas.vo                                                   | 0m05.55s  || +0m00.03s | +0.54%
0m05.23s  | Arithmetic/UniformWeight.vo                                     | 0m05.21s  || +0m00.02s | +0.38%
0m05.01s  | Language/InversionExtra.vo                                      | 0m04.69s  || +0m00.31s | +6.82%
0m04.94s  | Arithmetic/BarrettReduction/HAC.vo                              | 0m04.92s  || +0m00.02s | +0.40%
0m04.85s  | Algebra/Field_test.vo                                           | 0m05.04s  || -0m00.19s | -3.76%
0m04.49s  | Curves/Montgomery/Affine.vo                                     | 0m04.43s  || +0m00.06s | +1.35%
0m03.71s  | Util/ZUtil/LandLorShiftBounds.vo                                | 0m03.72s  || -0m00.01s | -0.26%
0m03.70s  | PushButtonSynthesis/FancyMontgomeryReduction.vo                 | 0m03.44s  || +0m00.26s | +7.55%
0m03.67s  | Util/ZUtil/Shift.vo                                             | 0m03.68s  || -0m00.01s | -0.27%
0m03.66s  | Algebra/Group.vo                                                | 0m03.72s  || -0m00.06s | -1.61%
0m03.58s  | PushButtonSynthesis/BaseConversionReificationCache.vo           | 0m03.56s  || +0m00.02s | +0.56%
0m03.57s  | Arithmetic/Freeze.vo                                            | 0m03.42s  || +0m00.14s | +4.38%
0m03.29s  | Util/ZUtil/Div.vo                                               | 0m03.28s  || +0m00.01s | +0.30%
0m03.23s  | Arithmetic/Primitives.vo                                        | 0m03.33s  || -0m00.10s | -3.00%
0m02.98s  | Arithmetic/ModOps.vo                                            | 0m02.93s  || +0m00.04s | +1.70%
0m02.97s  | MiscCompilerPassesProofs.vo                                     | 0m02.89s  || +0m00.08s | +2.76%
0m02.87s  | Bedrock/Translation/ExprWithSet.vo                              | 0m02.70s  || +0m00.16s | +6.29%
0m02.86s  | curve25519_32.c                                                 | 0m02.84s  || +0m00.02s | +0.70%
0m02.80s  | Bedrock/Varnames.vo                                             | 0m02.71s  || +0m00.08s | +3.32%
0m02.75s  | fiat-rust/src/curve25519_32.rs                                  | 0m02.84s  || -0m00.08s | -3.16%
0m02.74s  | Arithmetic/ModularArithmeticTheorems.vo                         | 0m02.77s  || -0m00.02s | -1.08%
0m02.71s  | Bedrock/Translation/Expr.vo                                     | 0m02.69s  || +0m00.02s | +0.74%
0m02.64s  | Spec/MontgomeryCurve.vo                                         | 0m02.62s  || +0m00.02s | +0.76%
0m02.47s  | Rewriter/Passes/StripLiteralCasts.vo                            | 0m02.32s  || +0m00.15s | +6.46%
0m02.45s  | CLI.vo                                                          | 0m02.50s  || -0m00.04s | -1.99%
0m02.28s  | Arithmetic/BaseConversion.vo                                    | 0m02.29s  || -0m00.01s | -0.43%
0m02.26s  | AbstractInterpretation/AbstractInterpretation.vo                | 0m02.35s  || -0m00.09s | -3.82%
0m02.25s  | Stringification/Go.vo                                           | 0m02.20s  || +0m00.04s | +2.27%
0m02.24s  | Util/ZUtil/Quot.vo                                              | 0m02.22s  || +0m00.02s | +0.90%
0m02.21s  | Rewriter/Passes/ToFancy.vo                                      | 0m02.24s  || -0m00.03s | -1.33%
0m02.18s  | Util/ZRange/BasicLemmas.vo                                      | 0m02.18s  || +0m00.00s | +0.00%
0m02.17s  | CompilersTestCases.vo                                           | 0m02.14s  || +0m00.02s | +1.40%
0m02.16s  | Rewriter/PerfTesting/Core.vo                                    | 0m02.23s  || -0m00.06s | -3.13%
0m02.14s  | Stringification/Rust.vo                                         | 0m01.97s  || +0m00.17s | +8.62%
0m02.04s  | Util/ZRange/SplitBounds.vo                                      | 0m02.06s  || -0m00.02s | -0.97%
0m02.01s  | Arithmetic/Partition.vo                                         | 0m02.02s  || -0m00.01s | -0.49%
0m01.99s  | Rewriter/PerfTesting/StandaloneOCamlMain.vo                     | 0m01.99s  || +0m00.00s | +0.00%
0m01.96s  | curve25519_64.c                                                 | 0m01.96s  || +0m00.00s | +0.00%
0m01.95s  | Stringification/Language.vo                                     | 0m01.94s  || +0m00.01s | +0.51%
0m01.92s  | Util/ZUtil/AddGetCarry.vo                                       | 0m01.89s  || +0m00.03s | +1.58%
0m01.90s  | StandaloneOCamlMain.vo                                          | 0m01.82s  || +0m00.07s | +4.39%
0m01.88s  | fiat-rust/src/curve25519_64.rs                                  | 0m01.93s  || -0m00.05s | -2.59%
0m01.87s  | Bedrock/Translation/Func.vo                                     | 0m01.80s  || +0m00.07s | +3.88%
0m01.87s  | StandaloneHaskellMain.vo                                        | 0m01.87s  || +0m00.00s | +0.00%
0m01.84s  | Util/Tuple.vo                                                   | 0m01.83s  || +0m00.01s | +0.54%
0m01.84s  | Util/ZUtil/Rshi.vo                                              | 0m01.79s  || +0m00.05s | +2.79%
0m01.82s  | Spec/WeierstrassCurve.vo                                        | 0m01.82s  || +0m00.00s | +0.00%
0m01.81s  | fiat-go/src/curve25519_32.go                                    | 0m01.74s  || +0m00.07s | +4.02%
0m01.80s  | Util/ZUtil/Ones.vo                                              | 0m01.69s  || +0m00.11s | +6.50%
0m01.77s  | Util/ZUtil/Pow2Mod.vo                                           | 0m01.77s  || +0m00.00s | +0.00%
0m01.76s  | fiat-rust/src/secp256k1_64.rs                                   | 0m01.67s  || +0m00.09s | +5.38%
0m01.74s  | fiat-go/src/secp256k1_64.go                                     | 0m01.72s  || +0m00.02s | +1.16%
0m01.71s  | fiat-go/src/p224_64.go                                          | 0m01.65s  || +0m00.06s | +3.63%
0m01.71s  | fiat-rust/src/p224_64.rs                                        | 0m01.67s  || +0m00.04s | +2.39%
0m01.70s  | p224_64.c                                                       | 0m01.61s  || +0m00.08s | +5.59%
0m01.68s  | Util/NatUtil.vo                                                 | 0m01.69s  || -0m00.01s | -0.59%
0m01.66s  | fiat-go/src/p256_64.go                                          | 0m01.59s  || +0m00.06s | +4.40%
0m01.62s  | p256_64.c                                                       | 0m01.57s  || +0m00.05s | +3.18%
0m01.62s  | secp256k1_64.c                                                  | 0m01.61s  || +0m00.01s | +0.62%
0m01.61s  | fiat-rust/src/p256_64.rs                                        | 0m01.53s  || +0m00.08s | +5.22%
0m01.58s  | Arithmetic/BarrettReduction/Wikipedia.vo                        | 0m01.61s  || -0m00.03s | -1.86%
0m01.58s  | Util/ListUtil/Forall.vo                                         | 0m01.60s  || -0m00.02s | -1.25%
0m01.57s  | Algebra/ScalarMult.vo                                           | 0m01.64s  || -0m00.06s | -4.26%
0m01.56s  | Stringification/C.vo                                            | 0m01.41s  || +0m00.15s | +10.63%
0m01.55s  | Curves/Edwards/XYZT/Precomputed.vo                              | 0m01.46s  || +0m00.09s | +6.16%
0m01.51s  | Arithmetic/PrimeFieldTheorems.vo                                | 0m01.45s  || +0m00.06s | +4.13%
0m01.44s  | Util/ZUtil/Testbit.vo                                           | 0m01.38s  || +0m00.06s | +4.34%
0m01.40s  | Fancy/Spec.vo                                                   | 0m01.36s  || +0m00.03s | +2.94%
0m01.37s  | Rewriter/All.vo                                                 | 0m01.28s  || +0m00.09s | +7.03%
0m01.35s  | Bedrock/Types.vo                                                | 0m01.21s  || +0m00.14s | +11.57%
0m01.34s  | Language/APINotations.vo                                        | 0m01.27s  || +0m00.07s | +5.51%
0m01.33s  | Curves/Montgomery/AffineInstances.vo                            | 0m01.34s  || -0m00.01s | -0.74%
0m01.33s  | Util/QUtil.vo                                                   | 0m01.27s  || +0m00.06s | +4.72%
0m01.31s  | Util/ZUtil/CC.vo                                                | 0m01.29s  || +0m00.02s | +1.55%
0m01.25s  | Language/WfExtra.vo                                             | 0m01.18s  || +0m00.07s | +5.93%
0m01.24s  | MiscCompilerPassesProofsExtra.vo                                | 0m01.25s  || -0m00.01s | -0.80%
0m01.23s  | AbstractInterpretation/WfExtra.vo                               | 0m01.24s  || -0m00.01s | -0.80%
0m01.17s  | Language/API.vo                                                 | 0m01.07s  || +0m00.09s | +9.34%
0m01.14s  | ArithmeticCPS/WordByWordMontgomery.vo                           | 0m01.12s  || +0m00.01s | +1.78%
0m01.14s  | PushButtonSynthesis/ReificationCache.vo                         | 0m01.18s  || -0m00.04s | -3.38%
0m01.12s  | Util/ZUtil/Stabilization.vo                                     | 0m01.11s  || +0m00.01s | +0.90%
0m01.09s  | Util/ZUtil/Modulo/PullPush.vo                                   | 0m01.05s  || +0m00.04s | +3.80%
0m01.08s  | Language/UnderLetsProofsExtra.vo                                | 0m01.10s  || -0m00.02s | -1.81%
0m01.08s  | Rewriter/AllTacticsExtra.vo                                     | 0m01.09s  || -0m00.01s | -0.91%
0m01.07s  | Algebra/IntegralDomain.vo                                       | 0m01.04s  || +0m00.03s | +2.88%
0m01.06s  | Util/ZUtil/Combine.vo                                           | 0m01.05s  || +0m00.01s | +0.95%
0m01.00s  | Util/NumTheoryUtil.vo                                           | 0m00.90s  || +0m00.09s | +11.11%
0m00.98s  | ArithmeticCPS/Core.vo                                           | 0m00.86s  || +0m00.12s | +13.95%
0m00.98s  | ArithmeticCPS/Freeze.vo                                         | 0m00.97s  || +0m00.01s | +1.03%
0m00.97s  | UnsaturatedSolinasHeuristics.vo                                 | 0m00.92s  || +0m00.04s | +5.43%
0m00.95s  | fiat-go/src/curve25519_64.go                                    | 0m00.94s  || +0m00.01s | +1.06%
0m00.93s  | ArithmeticCPS/Saturated.vo                                      | 0m01.09s  || -0m00.16s | -14.67%
0m00.92s  | MiscCompilerPasses.vo                                           | 0m01.02s  || -0m00.09s | -9.80%
0m00.91s  | ArithmeticCPS/BaseConversion.vo                                 | 0m00.87s  || +0m00.04s | +4.59%
0m00.88s  | Util/CPSUtil.vo                                                 | 0m00.80s  || +0m00.07s | +9.99%
0m00.87s  | ArithmeticCPS/ModOps.vo                                         | 0m00.93s  || -0m00.06s | -6.45%
0m00.87s  | Util/ZUtil/Log2.vo                                              | 0m00.83s  || +0m00.04s | +4.81%
0m00.86s  | Rewriter/Rules.vo                                               | 0m01.00s  || -0m00.14s | -14.00%
0m00.85s  | Util/Bool/Reflect.vo                                            | 0m00.85s  || +0m00.00s | +0.00%
0m00.85s  | Util/ZRange/OperationsBounds.vo                                 | 0m00.89s  || -0m00.04s | -4.49%
0m00.85s  | Util/ZUtil/Land.vo                                              | 0m00.80s  || +0m00.04s | +6.24%
0m00.85s  | Util/ZUtil/TruncatingShiftl.vo                                  | 0m00.78s  || +0m00.06s | +8.97%
0m00.82s  | Util/Factorize.vo                                               | 0m00.84s  || -0m00.02s | -2.38%
0m00.82s  | Util/ZUtil/EquivModulo.vo                                       | 0m00.87s  || -0m00.05s | -5.74%
0m00.80s  | Util/ZUtil/Le.vo                                                | 0m00.85s  || -0m00.04s | -5.88%
0m00.80s  | Util/ZUtil/ZSimplify/Simple.vo                                  | 0m00.82s  || -0m00.01s | -2.43%
0m00.79s  | Util/ZUtil/Peano.vo                                             | 0m00.78s  || +0m00.01s | +1.28%
0m00.78s  | Util/PartiallyReifiedProp.vo                                    | 0m00.80s  || -0m00.02s | -2.50%
0m00.78s  | Util/ZUtil/Pow.vo                                               | 0m00.76s  || +0m00.02s | +2.63%
0m00.76s  | Util/ZUtil/Z2Nat.vo                                             | 0m00.80s  || -0m00.04s | -5.00%
0m00.72s  | Curves/Montgomery/XZ.vo                                         | 0m00.70s  || +0m00.02s | +2.85%
0m00.69s  | Spec/CompleteEdwardsCurve.vo                                    | 0m00.66s  || +0m00.02s | +4.54%
0m00.68s  | Curves/Weierstrass/Affine.vo                                    | 0m00.65s  || +0m00.03s | +4.61%
0m00.67s  | Algebra/SubsetoidRing.vo                                        | 0m00.75s  || -0m00.07s | -10.66%
0m00.67s  | Util/ZUtil/Lnot.vo                                              | 0m00.71s  || -0m00.03s | -5.63%
0m00.65s  | Util/Decidable.vo                                               | 0m00.63s  || +0m00.02s | +3.17%
0m00.64s  | Util/Decidable/Decidable2Bool.vo                                | 0m00.66s  || -0m00.02s | -3.03%
0m00.63s  | Util/ZBounded.vo                                                | 0m00.62s  || +0m00.01s | +1.61%
0m00.61s  | Util/ZUtil/Divide.vo                                            | 0m00.62s  || -0m00.01s | -1.61%
0m00.61s  | Util/ZUtil/Mul.vo                                               | 0m00.71s  || -0m00.09s | -14.08%
0m00.59s  | Arithmetic/ModularArithmeticPre.vo                              | 0m00.60s  || -0m00.01s | -1.66%
0m00.59s  | Util/HList.vo                                                   | 0m00.63s  || -0m00.04s | -6.34%
0m00.58s  | Util/Strings/ParseArithmeticToTaps.vo                           | 0m00.51s  || +0m00.06s | +13.72%
0m00.58s  | Util/ZRange.vo                                                  | 0m00.55s  || +0m00.02s | +5.45%
0m00.57s  | Util/Arg.vo                                                     | 0m00.53s  || +0m00.03s | +7.54%
0m00.56s  | Util/MSetPositive/Facts.vo                                      | 0m00.54s  || +0m00.02s | +3.70%
0m00.55s  | Language/IdentifierParameters.vo                                | 0m00.58s  || -0m00.02s | -5.17%
0m00.53s  | Util/IdfunWithAlt.vo                                            | 0m00.42s  || +0m00.11s | +26.19%
0m00.53s  | Util/Loops.vo                                                   | 0m00.53s  || +0m00.00s | +0.00%
0m00.52s  | Bedrock/Tactics.vo                                              | 0m00.52s  || +0m00.00s | +0.00%
0m00.52s  | Util/ZUtil/Tactics/RewriteModSmall.vo                           | 0m00.54s  || -0m00.02s | -3.70%
0m00.51s  | Language/PreExtra.vo                                            | 0m00.54s  || -0m00.03s | -5.55%
0m00.51s  | Util/AdditionChainExponentiation.vo                             | 0m00.48s  || +0m00.03s | +6.25%
0m00.51s  | Util/ZRange/Operations.vo                                       | 0m00.50s  || +0m00.01s | +2.00%
0m00.50s  | Util/Strings/String_as_OT.vo                                    | 0m00.49s  || +0m00.01s | +2.04%
0m00.49s  | Util/MSetPositive/Equality.vo                                   | 0m00.44s  || +0m00.04s | +11.36%
0m00.48s  | Util/ZUtil/MulSplit.vo                                          | 0m00.47s  || +0m00.01s | +2.12%
0m00.47s  | Util/ZUtil.vo                                                   | 0m00.46s  || +0m00.00s | +2.17%
0m00.46s  | Algebra/Nsatz.vo                                                | 0m00.46s  || +0m00.00s | +0.00%
0m00.46s  | Util/NUtil/WithoutReferenceToZ.vo                               | 0m00.49s  || -0m00.02s | -6.12%
0m00.43s  | Spec/ModularArithmetic.vo                                       | 0m00.42s  || +0m00.01s | +2.38%
0m00.43s  | Util/ZUtil/Tactics.vo                                           | 0m00.39s  || +0m00.03s | +10.25%
0m00.43s  | Util/ZUtil/Tactics/Ztestbit.vo                                  | 0m00.49s  || -0m00.06s | -12.24%
0m00.42s  | Util/ZUtil/Hints/Core.vo                                        | 0m00.41s  || +0m00.01s | +2.43%
0m00.41s  | Util/ZRange/Show.vo                                             | 0m00.36s  || +0m00.04s | +13.88%
0m00.41s  | Util/ZUtil/N2Z.vo                                               | 0m00.42s  || -0m00.01s | -2.38%
0m00.41s  | Util/ZUtil/Tactics/PeelLe.vo                                    | 0m00.37s  || +0m00.03s | +10.81%
0m00.41s  | Util/ZUtil/Tactics/SimplifyFractionsLe.vo                       | 0m00.36s  || +0m00.04s | +13.88%
0m00.41s  | Util/ZUtil/Tactics/ZeroBounds.vo                                | 0m00.36s  || +0m00.04s | +13.88%
0m00.40s  | Arithmetic/MontgomeryReduction/Definition.vo                    | 0m00.42s  || -0m00.01s | -4.76%
0m00.40s  | Util/ZUtil/CPS.vo                                               | 0m00.39s  || +0m00.01s | +2.56%
0m00.39s  | Util/Strings/ParseArithmetic.vo                                 | 0m00.38s  || +0m00.01s | +2.63%
0m00.39s  | Util/ZUtil/Modulo/Bootstrap.vo                                  | 0m00.37s  || +0m00.02s | +5.40%
0m00.38s  | Util/Strings/HexString.vo                                       | 0m00.33s  || +0m00.04s | +15.15%
0m00.38s  | Util/ZUtil/Hints.vo                                             | 0m00.39s  || -0m00.01s | -2.56%
0m00.37s  | Algebra/Monoid.vo                                               | 0m00.37s  || +0m00.00s | +0.00%
0m00.37s  | Util/Strings/String.vo                                          | 0m00.41s  || -0m00.03s | -9.75%
0m00.37s  | Util/ZUtil/DistrIf.vo                                           | 0m00.35s  || +0m00.02s | +5.71%
0m00.37s  | Util/ZUtil/Hints/PullPush.vo                                    | 0m00.34s  || +0m00.02s | +8.82%
0m00.37s  | Util/ZUtil/Hints/Ztestbit.vo                                    | 0m00.37s  || +0m00.00s | +0.00%
0m00.37s  | Util/ZUtil/Sorting.vo                                           | 0m00.33s  || +0m00.03s | +12.12%
0m00.37s  | Util/ZUtil/ZSimplify/Core.vo                                    | 0m00.37s  || +0m00.00s | +0.00%
0m00.36s  | Util/Strings/Show.vo                                            | 0m00.33s  || +0m00.02s | +9.09%
0m00.36s  | Util/ZUtil/Tactics/DivModToQuotRem.vo                           | 0m00.36s  || +0m00.00s | +0.00%
0m00.35s  | Util/Strings/StringMap.vo                                       | 0m00.35s  || +0m00.00s | +0.00%
0m00.35s  | Util/ZUtil/Hints/ZArith.vo                                      | 0m00.37s  || -0m00.02s | -5.40%
0m00.35s  | Util/ZUtil/Opp.vo                                               | 0m00.38s  || -0m00.03s | -7.89%
0m00.35s  | Util/ZUtil/Sgn.vo                                               | 0m00.39s  || -0m00.04s | -10.25%
0m00.34s  | Util/ZUtil/Div/Bootstrap.vo                                     | 0m00.40s  || -0m00.06s | -15.00%
0m00.34s  | Util/ZUtil/Pow2.vo                                              | 0m00.33s  || +0m00.01s | +3.03%
0m00.34s  | Util/ZUtil/Tactics/PullPush.vo                                  | 0m00.30s  || +0m00.04s | +13.33%
0m00.34s  | Util/ZUtil/ZSimplify.vo                                         | 0m00.36s  || -0m00.01s | -5.55%
0m00.33s  | Util/ZUtil/Odd.vo                                               | 0m00.40s  || -0m00.07s | -17.50%
0m00.33s  | Util/ZUtil/Tactics/PullPush/Modulo.vo                           | 0m00.38s  || -0m00.04s | -13.15%
0m00.32s  | Util/Sum.vo                                                     | 0m00.30s  || +0m00.02s | +6.66%
0m00.32s  | Util/ZUtil/Tactics/LtbToLt.vo                                   | 0m00.26s  || +0m00.06s | +23.07%
0m00.31s  | Util/ZUtil/AddModulo.vo                                         | 0m00.25s  || +0m00.06s | +24.00%
0m00.30s  | Util/FMapPositive/Equality.vo                                   | 0m00.32s  || -0m00.02s | -6.25%
0m00.30s  | Util/ZUtil/Zselect.vo                                           | 0m00.27s  || +0m00.02s | +11.11%
0m00.29s  | Algebra/Hierarchy.vo                                            | 0m00.27s  || +0m00.01s | +7.40%
0m00.29s  | Util/SideConditions/ModInvPackage.vo                            | 0m00.25s  || +0m00.03s | +15.99%
0m00.28s  | Util/ZUtil/Definitions.vo                                       | 0m00.30s  || -0m00.01s | -6.66%
0m00.28s  | Util/ZUtil/ModInv.vo                                            | 0m00.25s  || +0m00.03s | +12.00%
0m00.27s  | Util/Strings/Parse/Common.vo                                    | 0m00.31s  || -0m00.03s | -12.90%
0m00.27s  | Util/ZUtil/Tactics/ReplaceNegWithPos.vo                         | 0m00.26s  || +0m00.01s | +3.84%
0m00.26s  | TAPSort.vo                                                      | 0m00.25s  || +0m00.01s | +4.00%
0m00.26s  | Util/Option.vo                                                  | 0m00.28s  || -0m00.02s | -7.14%
0m00.26s  | Util/SideConditions/RingPackage.vo                              | 0m00.21s  || +0m00.05s | +23.80%
0m00.26s  | Util/Strings/Ascii.vo                                           | 0m00.22s  || +0m00.04s | +18.18%
0m00.26s  | Util/Strings/Equality.vo                                        | 0m00.24s  || +0m00.02s | +8.33%
0m00.26s  | Util/Strings/OctalString.vo                                     | 0m00.24s  || +0m00.02s | +8.33%
0m00.26s  | Util/ZUtil/Ge.vo                                                | 0m00.26s  || +0m00.00s | +0.00%
0m00.26s  | Util/ZUtil/Tactics/SplitMinMax.vo                               | 0m00.24s  || +0m00.02s | +8.33%
0m00.25s  | PushButtonSynthesis/InvertHighLow.vo                            | 0m00.24s  || +0m00.01s | +4.16%
0m00.24s  | Util/Strings/Decimal.vo                                         | 0m00.21s  || +0m00.03s | +14.28%
0m00.24s  | Util/ZUtil/Tactics/LinearSubstitute.vo                          | 0m00.28s  || -0m00.04s | -14.28%
0m00.23s  | Spec/MxDH.vo                                                    | 0m00.22s  || +0m00.01s | +4.54%
0m00.23s  | Util/SideConditions/Autosolve.vo                                | 0m00.20s  || +0m00.03s | +15.00%
0m00.23s  | Util/ZUtil/Tactics/CompareToSgn.vo                              | 0m00.26s  || -0m00.03s | -11.53%
0m00.23s  | Util/ZUtil/Tactics/PrimeBound.vo                                | 0m00.24s  || -0m00.00s | -4.16%
0m00.22s  | Util/LetInMonad.vo                                              | 0m00.22s  || +0m00.00s | +0.00%
0m00.22s  | Util/ZUtil/Tactics/DivideExistsMul.vo                           | 0m00.26s  || -0m00.04s | -15.38%
0m00.21s  | Util/Decidable/Bool2Prop.vo                                     | 0m00.19s  || +0m00.01s | +10.52%
0m00.21s  | Util/PointedProp.vo                                             | 0m00.19s  || +0m00.01s | +10.52%
0m00.21s  | Util/Strings/BinaryString.vo                                    | 0m00.26s  || -0m00.05s | -19.23%
0m00.20s  | Util/ListUtil/FoldBool.vo                                       | 0m00.20s  || +0m00.00s | +0.00%
0m00.20s  | Util/OptionList.vo                                              | 0m00.25s  || -0m00.04s | -19.99%
0m00.20s  | Util/ParseTaps.vo                                               | 0m00.18s  || +0m00.02s | +11.11%
0m00.20s  | Util/SideConditions/ReductionPackages.vo                        | 0m00.20s  || +0m00.00s | +0.00%
0m00.18s  | Util/Sigma.vo                                                   | 0m00.16s  || +0m00.01s | +12.49%
0m00.18s  | Util/ZUtil/Notations.vo                                         | 0m00.16s  || +0m00.01s | +12.49%
0m00.15s  | Util/ListUtil/ForallIn.vo                                       | 0m00.13s  || +0m00.01s | +15.38%
0m00.15s  | Util/ListUtil/SetoidList.vo                                     | 0m00.13s  || +0m00.01s | +15.38%
0m00.13s  | Util/PrimitiveProd.vo                                           | 0m00.12s  || +0m00.01s | +8.33%
0m00.12s  | Util/Relations.vo                                               | 0m00.11s  || +0m00.00s | +9.09%
0m00.11s  | Util/PrimitiveHList.vo                                          | 0m00.10s  || +0m00.00s | +9.99%
0m00.11s  | Util/TagList.vo                                                 | 0m00.11s  || +0m00.00s | +0.00%
0m00.10s  | Util/Equality.vo                                                | 0m00.12s  || -0m00.01s | -16.66%
0m00.10s  | Util/PrimitiveSigma.vo                                          | 0m00.14s  || -0m00.04s | -28.57%
0m00.10s  | Util/Prod.vo                                                    | 0m00.09s  || +0m00.01s | +11.11%
0m00.09s  | Util/Bool.vo                                                    | 0m00.09s  || +0m00.00s | +0.00%
0m00.08s  | Util/Logic/ExistsEqAnd.vo                                       | 0m00.08s  || +0m00.00s | +0.00%
0m00.08s  | Util/Sigma/Related.vo                                           | 0m00.08s  || +0m00.00s | +0.00%
0m00.08s  | Util/Tactics/RewriteHyp.vo                                      | 0m00.05s  || +0m00.03s | +60.00%
0m00.07s  | Util/Notations.vo                                               | 0m00.06s  || +0m00.01s | +16.66%
0m00.07s  | Util/Tactics.vo                                                 | 0m00.05s  || +0m00.02s | +40.00%
0m00.06s  | Util/LetIn.vo                                                   | 0m00.08s  || -0m00.02s | -25.00%
0m00.06s  | Util/PER.vo                                                     | 0m00.05s  || +0m00.00s | +19.99%
0m00.06s  | Util/Pointed.vo                                                 | 0m00.07s  || -0m00.01s | -14.28%
0m00.06s  | Util/SideConditions/CorePackages.vo                             | 0m00.06s  || +0m00.00s | +0.00%
0m00.06s  | Util/Sumbool.vo                                                 | 0m00.07s  || -0m00.01s | -14.28%
0m00.06s  | Util/Tactics/PoseTermWithName.vo                                | 0m00.04s  || +0m00.01s | +49.99%
0m00.06s  | Util/Tower.vo                                                   | 0m00.06s  || +0m00.00s | +0.00%
0m00.05s  | Util/AutoRewrite.vo                                             | 0m00.06s  || -0m00.00s | -16.66%
0m00.05s  | Util/Bool/Equality.vo                                           | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/HProp.vo                                                   | 0m00.07s  || -0m00.02s | -28.57%
0m00.05s  | Util/Isomorphism.vo                                             | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Sigma/MapProjections.vo                                    | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/ClearbodyAll.vo                                    | 0m00.03s  || +0m00.02s | +66.66%
0m00.05s  | Util/Tactics/DebugPrint.vo                                      | 0m00.06s  || -0m00.00s | -16.66%
0m00.05s  | Util/Tactics/DestructHead.vo                                    | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/GetGoal.vo                                         | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/NormalizeCommutativeIdentifier.vo                  | 0m00.03s  || +0m00.02s | +66.66%
0m00.05s  | Util/Tactics/RunTacticAsConstr.vo                               | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Tactics/SpecializeBy.vo                                    | 0m00.04s  || +0m00.01s | +25.00%
0m00.05s  | Util/Tactics/UniquePose.vo                                      | 0m00.05s  || +0m00.00s | +0.00%
0m00.05s  | Util/Unit.vo                                                    | 0m00.04s  || +0m00.01s | +25.00%
0m00.04s  | Util/Bool/IsTrue.vo                                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/CPSNotations.vo                                            | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Comparison.vo                                              | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Curry.vo                                                   | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/DefaultedTypes.vo                                          | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/ErrorT.vo                                                  | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/FixCoqMistakes.vo                                          | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/GlobalSettings.vo                                          | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/IffT.vo                                                    | 0m00.06s  || -0m00.01s | -33.33%
0m00.04s  | Util/Logic.vo                                                   | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Logic/ImplAnd.vo                                           | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Logic/ProdForall.vo                                        | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Sigma/Associativity.vo                                     | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Sigma/Lift.vo                                              | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/BreakMatch.vo                                      | 0m00.06s  || -0m00.01s | -33.33%
0m00.04s  | Util/Tactics/CPSId.vo                                           | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/CacheTerm.vo                                       | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/ClearDuplicates.vo                                 | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/ConstrFail.vo                                      | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/ConvoyDestruct.vo                                  | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/DestructTrivial.vo                                 | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/DoWithHyp.vo                                       | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/ESpecialize.vo                                     | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/ETransitivity.vo                                   | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/Forward.vo                                         | 0m00.06s  || -0m00.01s | -33.33%
0m00.04s  | Util/Tactics/HasBody.vo                                         | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/Head.vo                                            | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/HeadUnderBinders.vo                                | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/PrintContext.vo                                    | 0m00.05s  || -0m00.01s | -20.00%
0m00.04s  | Util/Tactics/PrintGoal.vo                                       | 0m00.02s  || +0m00.02s | +100.00%
0m00.04s  | Util/Tactics/SetEvars.vo                                        | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/SimplifyProjections.vo                             | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/SimplifyRepeatedIfs.vo                             | 0m00.02s  || +0m00.02s | +100.00%
0m00.04s  | Util/Tactics/SpecializeAllWays.vo                               | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/SplitInContext.vo                                  | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/SubstEvars.vo                                      | 0m00.01s  || +0m00.03s | +300.00%
0m00.04s  | Util/Tactics/SubstLet.vo                                        | 0m00.06s  || -0m00.01s | -33.33%
0m00.04s  | Util/Tactics/TransparentAssert.vo                               | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/UnfoldArg.vo                                       | 0m00.04s  || +0m00.00s | +0.00%
0m00.04s  | Util/Tactics/UnifyAbstractReflexivity.vo                        | 0m00.03s  || +0m00.01s | +33.33%
0m00.04s  | Util/Tactics/VM.vo                                              | 0m00.05s  || -0m00.01s | -20.00%
0m00.03s  | Util/ChangeInAll.vo                                             | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Pos.vo                                                     | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/SideConditions/AdmitPackage.vo                             | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/Contains.vo                                        | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/DestructHyps.vo                                    | 0m00.06s  || -0m00.03s | -50.00%
0m00.03s  | Util/Tactics/EvarExists.vo                                      | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/MoveLetIn.vo                                       | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Tactics/Not.vo                                             | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/OnSubterms.vo                                      | 0m00.04s  || -0m00.01s | -25.00%
0m00.03s  | Util/Tactics/Revert.vo                                          | 0m00.03s  || +0m00.00s | +0.00%
0m00.03s  | Util/Tactics/SetoidSubst.vo                                     | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Tactics/SideConditionsBeforeToAfter.vo                     | 0m00.05s  || -0m00.02s | -40.00%
0m00.03s  | Util/Tactics/Test.vo                                            | 0m00.03s  || +0m00.00s | +0.00%
0m00.02s  | Util/Tactics/ChangeInAll.vo                                     | 0m00.05s  || -0m00.03s | -60.00%
0m00.02s  | Util/Tactics/ClearAll.vo                                        | 0m00.03s  || -0m00.00s | -33.33%
0m00.02s  | Util/Tactics/EvarNormalize.vo                                   | 0m00.05s  || -0m00.03s | -60.00%
```
</p>
