### PR TITLE
Parameterize the main functions on supported langs

### DIFF
--- a/src/CLI.v
+++ b/src/CLI.v
@@ -178,7 +178,9 @@ Module ForExtraction.
          => inr [res]
        end.
 
-  Definition supported_languages : list (string * ToString.OutputLanguageAPI)
+  Class supported_languagesT := supported_languages : list (string * ToString.OutputLanguageAPI).
+
+  Definition default_supported_languages : supported_languagesT
     := [("C", ToString.OutputCAPI)
        ; ("Rust", Rust.OutputRustAPI)
        ; ("Go", Go.OutputGoAPI)
@@ -186,7 +188,7 @@ Module ForExtraction.
 
   Definition curve_description_help
     := "  curve_description       A string which will be prefixed to every function name generated".
-  Definition lang_help
+  Definition lang_help {supported_languages : supported_languagesT}
     := "  LANGUAGE                The output language code should be emitted in.  Defaults to C if no language is given.  Case-sensitive."
          ++ String.NewLine ++
        "                            Valid options are: " ++ String.concat ", " (List.map (@fst _ _) supported_languages).
@@ -410,6 +412,10 @@ Module ForExtraction.
           list (string * Pipeline.ErrorT (list string))
     }.
 
+  Module Export Notations.
+    Bind Scope list_scope with supported_languagesT.
+  End Notations.
+
   Module Parameterized.
     Section __.
       Context {api : PipelineAPI}.
@@ -462,7 +468,9 @@ Module ForExtraction.
            | inr s => error s
            end.
 
-      Definition argv_to_language_and_argv (argv : list string)
+      Definition argv_to_language_and_argv
+                 {supported_languages : supported_languagesT}
+                 (argv : list string)
         : list string * (ToString.OutputLanguageAPI + list string)
         := let '(argv, opts) := argv_to_startswith_opt_and_argv "--lang=" argv in
            (argv,
@@ -480,6 +488,7 @@ Module ForExtraction.
             end).
 
       Definition PipelineMain
+                 {supported_languages : supported_languagesT}
                  {A}
                  (argv : list string)
                  (success : list string -> A)
@@ -581,6 +590,7 @@ Module ForExtraction.
         }.
 
     Definition PipelineMain
+               {supported_languages : supported_languagesT}
                {A}
                (argv : list string)
                (success : list string -> A)
@@ -635,6 +645,7 @@ Module ForExtraction.
         }.
 
     Definition PipelineMain
+               {supported_languages : supported_languagesT}
                {A}
                (argv : list string)
                (success : list string -> A)
@@ -682,6 +693,7 @@ Module ForExtraction.
         }.
 
     Definition PipelineMain
+               {supported_languages : supported_languagesT}
                {A}
                (argv : list string)
                (success : list string -> A)
@@ -769,6 +781,7 @@ Module ForExtraction.
         }.
 
     Definition PipelineMain
+               {supported_languages : supported_languagesT}
                {A}
                (argv : list string)
                (success : list string -> A)

--- a/src/StandaloneHaskellMain.v
+++ b/src/StandaloneHaskellMain.v
@@ -36,50 +36,41 @@ Extract Inlined Constant cast_io => "".
 
 Local Notation "x <- y ; f" := (_IO_bind _ _ y (fun x => f)).
 
+Definition main_gen
+           {supported_languages : ForExtraction.supported_languagesT}
+           (PipelineMain : forall (A := _)
+                                  (argv : list String.string)
+                                  (success : list String.string -> A)
+                                  (error : list String.string -> A),
+               A)
+  : IO_unit
+  := cast_io
+       (argv <- getArgs;
+       prog <- getProgName;
+       PipelineMain
+         (prog::argv)
+         (fun res => printf_string
+                       (String.concat "" res))
+         (fun err => raise_failure _ (String.concat String.NewLine err))).
+
+Local Existing Instance ForExtraction.default_supported_languages.
+
 Module UnsaturatedSolinas.
   Definition main : IO_unit
-    := cast_io
-         (argv <- getArgs;
-            prog <- getProgName;
-            ForExtraction.UnsaturatedSolinas.PipelineMain
-              (prog::argv)
-              (fun res => printf_string
-                         (String.concat "" res))
-              (fun err => raise_failure _ (String.concat String.NewLine err))).
+    := main_gen ForExtraction.UnsaturatedSolinas.PipelineMain.
 End UnsaturatedSolinas.
 
 Module WordByWordMontgomery.
   Definition main : IO_unit
-    := cast_io
-         (argv <- getArgs;
-            prog <- getProgName;
-            ForExtraction.WordByWordMontgomery.PipelineMain
-              (prog::argv)
-              (fun res => printf_string
-                         (String.concat "" res))
-              (fun err => raise_failure _ (String.concat String.NewLine err))).
+    := main_gen ForExtraction.WordByWordMontgomery.PipelineMain.
 End WordByWordMontgomery.
 
 Module SaturatedSolinas.
   Definition main : IO_unit
-    := cast_io
-         (argv <- getArgs;
-            prog <- getProgName;
-            ForExtraction.SaturatedSolinas.PipelineMain
-              (prog::argv)
-              (fun res => printf_string
-                         (String.concat "" res))
-              (fun err => raise_failure _ (String.concat String.NewLine err))).
+    := main_gen ForExtraction.SaturatedSolinas.PipelineMain.
 End SaturatedSolinas.
 
 Module BaseConversion.
   Definition main : IO_unit
-    := cast_io
-         (argv <- getArgs;
-            prog <- getProgName;
-            ForExtraction.BaseConversion.PipelineMain
-              (prog::argv)
-              (fun res => printf_string
-                         (String.concat "" res))
-              (fun err => raise_failure _ (String.concat String.NewLine err))).
+    := main_gen ForExtraction.BaseConversion.PipelineMain.
 End BaseConversion.

--- a/src/StandaloneOCamlMain.v
+++ b/src/StandaloneOCamlMain.v
@@ -92,38 +92,38 @@ Definition raise_failure {A} (msg : list String.string) : A
   := seq (fun _ => printf_list_string_with_newlines msg)
          (fun _ => raise_Failure _ (string_of_Coq_string "Synthesis failed")).
 
+Definition main_gen
+           {supported_languages : ForExtraction.supported_languagesT}
+           (PipelineMain : forall (A := _)
+                                  (argv : list String.string)
+                                  (success : list String.string -> A)
+                                  (error : list String.string -> A),
+               A)
+  : unit
+  := let argv := List.map string_to_Coq_string sys_argv in
+     PipelineMain
+       argv
+       printf_list_string
+       raise_failure.
+
+Local Existing Instance ForExtraction.default_supported_languages.
+
 Module UnsaturatedSolinas.
   Definition main : unit
-    := let argv := List.map string_to_Coq_string sys_argv in
-       ForExtraction.UnsaturatedSolinas.PipelineMain
-         argv
-         printf_list_string
-         raise_failure.
+    := main_gen ForExtraction.UnsaturatedSolinas.PipelineMain.
 End UnsaturatedSolinas.
 
 Module WordByWordMontgomery.
   Definition main : unit
-    := let argv := List.map string_to_Coq_string sys_argv in
-       ForExtraction.WordByWordMontgomery.PipelineMain
-         argv
-         printf_list_string
-         raise_failure.
+    := main_gen ForExtraction.WordByWordMontgomery.PipelineMain.
 End WordByWordMontgomery.
 
 Module SaturatedSolinas.
   Definition main : unit
-    := let argv := List.map string_to_Coq_string sys_argv in
-       ForExtraction.SaturatedSolinas.PipelineMain
-         argv
-         printf_list_string
-         raise_failure.
+    := main_gen ForExtraction.SaturatedSolinas.PipelineMain.
 End SaturatedSolinas.
 
 Module BaseConversion.
   Definition main : unit
-    := let argv := List.map string_to_Coq_string sys_argv in
-       ForExtraction.BaseConversion.PipelineMain
-         argv
-         printf_list_string
-         raise_failure.
+    := main_gen ForExtraction.BaseConversion.PipelineMain.
 End BaseConversion.


### PR DESCRIPTION
This should allow extremely easy adaptation of the binaries to support
bedrock2.  Namely, we just need to inhabit `supported_languagesT := list
(string * ToString.OutputLanguageAPI)` with a list containing
`"bedrock2"` paired with a way of converting PHOAS ASTs to strings, and
then we can do something like
```coq
Require Import Coq.Lists.List.
Require Import Coq.Strings.String.
Require Import Crypto.CLI.
Require Import Crypto.StandaloneOCamlMain.
Require Import Crypto.Bedrock2.Stringification.
Local Open Scope string_scope.
Local Open Scope list_scope.

Local Instance bedrock2_supported_languages : ForExtraction.supported_languagesT
  := ForExtraction.default_supported_languages
       ++ [("bedrock2", OutputBedrock2API)].

Module UnsaturatedSolinas.
  Definition main : unit
    := main_gen ForExtraction.UnsaturatedSolinas.PipelineMain.
End UnsaturatedSolinas.

Module WordByWordMontgomery.
  Definition main : unit
    := main_gen ForExtraction.WordByWordMontgomery.PipelineMain.
End WordByWordMontgomery.

Module SaturatedSolinas.
  Definition main : unit
    := main_gen ForExtraction.SaturatedSolinas.PipelineMain.
End SaturatedSolinas.

Module BaseConversion.
  Definition main : unit
    := main_gen ForExtraction.BaseConversion.PipelineMain.
End BaseConversion.
```
and make copies of the various two-line `.v` files in
`src/ExtractionOCaml/` and add the relevant targets to the `Makefile`.

cc @jadephilipoom 