### PR TITLE
Use an MSet for int.type directly

### DIFF
--- a/src/COperationSpecifications.v
+++ b/src/COperationSpecifications.v
@@ -112,14 +112,20 @@ Module Primitives.
       -> subborrowx b x y = ((-b + x + -y) mod 2^s, -((-b + x + -y) / 2^s))
          /\ is_bounded_by2 (r[0~>2^s-1], r[0~>1]) (subborrowx b x y) = true.
 
-  Definition cmovznz_correct s
+  Definition cmovznz_correct (is_signed : bool) s
              (cmovznz : Z -> Z -> Z -> Z)
-    := forall cond z nz,
-      is_bounded_by0 r[0~>1] cond = true
-      -> is_bounded_by0 r[0~>2^s-1] z = true
-      -> is_bounded_by0 r[0~>2^s-1] nz = true
-      -> cmovznz cond z nz = (if Decidable.dec (cond = 0) then z else nz)
-         /\ is_bounded_by0 r[0~>2^s-1] (cmovznz cond z nz) = true.
+    := match (if is_signed
+              then r[-2^(s-1) ~> 2^(s-1) - 1]
+              else r[0 ~> 2^s - 1])%zrange with
+       | rs
+         =>
+         forall cond z nz,
+           is_bounded_by0 r[0~>1] cond = true
+           -> is_bounded_by0 rs z = true
+           -> is_bounded_by0 rs nz = true
+           -> cmovznz cond z nz = (if Decidable.dec (cond = 0) then z else nz)
+              /\ is_bounded_by0 rs (cmovznz cond z nz) = true
+       end.
 End Primitives.
 
 Module selectznz.

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -49,11 +49,11 @@ Module Compilers.
         : list string
           := let bitwidths_used := bitwidths_used infos in
              (["#include <stdint.h>"]
-                ++ (if PositiveSet.mem 1 bitwidths_used
+                ++ (if IntSet.mem _Bool bitwidths_used || IntSet.mem (int.signed_counterpart_of _Bool) bitwidths_used
                     then ["typedef unsigned char " ++ prefix ++ "uint1;";
                             "typedef signed char " ++ prefix ++ "int1;"]%string
                     else [])
-                ++ (if PositiveSet.mem 128 bitwidths_used
+                ++ (if IntSet.mem uint128 bitwidths_used || IntSet.mem int128 bitwidths_used
                     then ["typedef signed __int128 " ++ prefix ++ "int128;";
                             "typedef unsigned __int128 " ++ prefix ++ "uint128;"]%string
                     else [])

--- a/src/Stringification/Go.v
+++ b/src/Stringification/Go.v
@@ -16,6 +16,8 @@ Local Open Scope Z_scope.
 Import IR.Compilers.ToString.
 Import Stringification.Language.Compilers.
 Import Stringification.Language.Compilers.Options.
+Import Stringification.Language.Compilers.ToString.
+Import Stringification.Language.Compilers.ToString.int.Notations.
 
 Module Go.
 
@@ -41,15 +43,15 @@ Module Go.
        ((["package " ++ pkg_name;
             ""]%string)
           ++ (if needs_bits_import then ["import ""math/bits"""]%string else [])
-          ++ (if PositiveSet.mem 1 bitwidths_used
+          ++ (if IntSet.mem _Bool bitwidths_used || IntSet.mem (ToString.int.signed_counterpart_of _Bool) bitwidths_used
               then [type_prefix ++ "uint1 int"; (* C: typedef unsigned char prefix_uint1 *)
                       type_prefix ++ "int1 int" ]%string (* C: typedef signed char prefix_int1 *)
               else [])
-          ++ (if PositiveSet.mem 2 bitwidths_used
+          ++ (if IntSet.mem (int.of_bitwidth false 2) bitwidths_used || IntSet.mem (int.of_bitwidth true 2) bitwidths_used
               then [type_prefix ++ "uint2 uint8";
                       type_prefix ++ "int2 int8" ]%string
               else [])
-          ++ (if PositiveSet.mem 128 bitwidths_used
+          ++ (if IntSet.mem uint128 bitwidths_used || IntSet.mem int128 bitwidths_used
               then ["var _ = error_Go_output_does_not_support_128_bit_integers___instead_use_rewriting_rules_for_removing_128_bit_integers"]%string
               else []))%list.
 

--- a/src/Stringification/IR.v
+++ b/src/Stringification/IR.v
@@ -127,18 +127,16 @@ Module Compilers.
            end.
 
       Module ident_infos.
-        Definition collect_bitwidths_of_int_type (t : int.type) : PositiveSet.t
-          := PositiveSet.add (Z.to_pos (int.bitwidth_of t)) PositiveSet.empty.
         Definition collect_infos_of_ident {s d} (idc : ident s d) : ident_infos
           := match idc with
-             | Z_static_cast ty => ident_info_of_bitwidths_used (collect_bitwidths_of_int_type ty)
+             | Z_static_cast ty => ident_info_of_bitwidths_used (IntSet.singleton ty)
              | Z_mul_split lg2s
                => ident_info_of_mulx (PositiveSet.add (Z.to_pos lg2s) PositiveSet.empty)
              | Z_add_with_get_carry lg2s
              | Z_sub_with_get_borrow lg2s
                => ident_info_of_addcarryx (PositiveSet.add (Z.to_pos lg2s) PositiveSet.empty)
              | Z_zselect ty
-               => ident_info_of_cmovznz (collect_bitwidths_of_int_type ty)
+               => ident_info_of_cmovznz (IntSet.singleton ty)
              | literal _
              | List_nth _
              | Addr
@@ -160,14 +158,14 @@ Module Compilers.
           := match e with
              | Assign _ _ (Some sz) _ val
              | AssignZPtr _ (Some sz) val
-               => ident_info_union (ident_info_of_bitwidths_used (collect_bitwidths_of_int_type sz)) (collect_infos_of_arith_expr val)
+               => ident_info_union (ident_info_of_bitwidths_used (IntSet.singleton sz)) (collect_infos_of_arith_expr val)
              | Call val
              | Assign _ _ None _ val
              | AssignZPtr _ None val
              | AssignNth _ _ val
                => collect_infos_of_arith_expr val
              | DeclareVar _ (Some sz) _
-               => ident_info_of_bitwidths_used (collect_bitwidths_of_int_type sz)
+               => ident_info_of_bitwidths_used (IntSet.singleton sz)
              | DeclareVar _ None _
                => ident_info_empty
              end.

--- a/src/Stringification/Java.v
+++ b/src/Stringification/Java.v
@@ -18,6 +18,8 @@ Local Open Scope Z_scope.
 Import IR.Compilers.ToString.
 Import Stringification.Language.Compilers.
 Import Stringification.Language.Compilers.Options.
+Import Stringification.Language.Compilers.ToString.
+Import Stringification.Language.Compilers.ToString.int.Notations.
 
 Module Java.
 

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -16,6 +16,8 @@ Local Open Scope Z_scope.
 Import IR.Compilers.ToString.
 Import Stringification.Language.Compilers.
 Import Stringification.Language.Compilers.Options.
+Import Stringification.Language.Compilers.ToString.
+Import Stringification.Language.Compilers.ToString.int.Notations.
 
 Module Rust.
 
@@ -27,11 +29,11 @@ Module Rust.
        (["#![allow(unused_parens)]";
         "#[allow(non_camel_case_types)]";
         ""]%string
-          ++ (if PositiveSet.mem 1 bitwidths_used
+          ++ (if IntSet.mem _Bool bitwidths_used || IntSet.mem (ToString.int.signed_counterpart_of _Bool) bitwidths_used
               then [type_prefix ++ "u1 = u8;"; (* C: typedef unsigned char prefix_uint1 *)
                       type_prefix ++ "i1 = i8;" ]%string (* C: typedef signed char prefix_int1 *)
               else [])
-          ++ (if PositiveSet.mem 2 bitwidths_used
+          ++ (if IntSet.mem (int.of_bitwidth false 2) bitwidths_used || IntSet.mem (int.of_bitwidth true 2) bitwidths_used
               then [type_prefix ++ "u2 = u8;";
                       type_prefix ++ "i2 = i8;" ]%string
               else []))%list.


### PR DESCRIPTION
This will let us be more accurate about what bitwidths we need
primitives for, and will also pave the way for possibly allowing cmovznz
to operate on negative integer types