### PR TITLE
Add another rewrite arith pass after mul split

### DIFF
--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -457,6 +457,14 @@ Module Pipeline.
                       => RewriteAndEliminateDeadAndInline (RewriteRules.RewriteMultiRetSplit max_bitwidth lgcarrymax opts) with_dead_code_elimination with_subst01 E
                     | None => E
                     end in
+           let rewrote_E_so_should_rewrite_arith_again
+               := match split_mul_to, split_multiret_to with
+                  | Some _, _ | _, Some _ => true
+                  | None, None => false
+                  end in
+           let E := if rewrote_E_so_should_rewrite_arith_again
+                    then RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArithWithCasts opts) with_dead_code_elimination with_subst01 E
+                    else E in
 
            let E := match translate_to_fancy with
                     | Some {| invert_low := invert_low ; invert_high := invert_high ; value_range := value_range ; flag_range := flag_range |}

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -289,6 +289,7 @@ Definition arith_with_casts_rewrite_rulesT : list (bool * Prop)
             ; (forall r v, lower r = upper r -> cstZ r v = cstZ r ('(lower r)))
             ; (forall r0 v, 0 ∈ r0 -> cstZ r0 0 + v = v)
             ; (forall r0 v, 0 ∈ r0 -> v + cstZ r0 0 = v)
+            ; (forall r0 v, 0 ∈ r0 -> v - cstZ r0 0 = v)
             ; (forall r0 v, 0 ∈ r0 -> cstZ r0 0 - v = -v)
             ; (forall r0 v, 0 ∈ r0 -> cstZ r0 0 << v = 0)
             ; (forall r0 rnv rv v,


### PR DESCRIPTION
This lets us rewrite things like 'x - 0' into 'x'.

This probably makes the BoundsPipeline file a tad bit slower, but I'm not going to bother timing it at this point.

On top of #726.

Edit: It makes BoundsPipeline 2x slower.  Probably we have a quadratic or exponential factor somewhere in proving interp correctness or wf correctness.  Since it's still only 30s to build the file, I'm not going to bother debugging it right now.
<details><summary>Timing Diff</summary>
<p>

```
    After |   Peak Mem | File Name                                       |    Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
----------------------------------------------------------------------------------------------------------------------------------------------------------
38m39.11s | 1817532 ko | Total Time / Peak Mem                           | 38m17.26s | 1817172 ko || +0m21.84s ||       360 ko |   +0.95% |         +0.01%
----------------------------------------------------------------------------------------------------------------------------------------------------------
 0m27.89s |  781916 ko | BoundsPipeline.vo                               |  0m12.97s |  701120 ko || +0m14.92s ||     80796 ko | +115.03% |        +11.52%
 4m11.15s | 1060840 ko | fiat-go/src/p384_32.go                          |  4m09.20s | 1060768 ko || +0m01.95s ||        72 ko |   +0.78% |         +0.00%
 4m09.08s |  960996 ko | fiat-java/src/FiatP384.java                     |  4m10.08s |  960840 ko || -0m01.00s ||       156 ko |   -0.39% |         +0.01%
 0m44.23s |   61976 ko | fiat-go/src/p521_64.go                          |  0m43.06s |   61996 ko || +0m01.16s ||       -20 ko |   +2.71% |         -0.03%
 0m17.06s |  181548 ko | fiat-rust/src/p256_32.rs                        |  0m15.48s |  181540 ko || +0m01.57s ||         8 ko |  +10.20% |         +0.00%
 0m13.73s |  115184 ko | fiat-rust/src/p434_64.rs                        |  0m15.29s |  114964 ko || -0m01.55s ||       220 ko |  -10.20% |         +0.19%
 4m16.48s | 1097036 ko | fiat-c/src/p384_32.c                            |  4m16.55s | 1096980 ko || -0m00.06s ||        56 ko |   -0.02% |         +0.00%
 4m15.83s |  980092 ko | fiat-rust/src/p384_32.rs                        |  4m15.18s |  980236 ko || +0m00.65s ||      -144 ko |   +0.25% |         -0.01%
 2m23.92s | 1811404 ko | Fancy/Barrett256.vo                             |  2m23.59s | 1811220 ko || +0m00.33s ||       184 ko |   +0.22% |         +0.01%
 1m24.47s | 1817532 ko | Fancy/Montgomery256.vo                          |  1m24.35s | 1817172 ko || +0m00.12s ||       360 ko |   +0.14% |         +0.01%
 1m14.53s | 1314488 ko | SlowPrimeSynthesisExamples.vo                   |  1m15.32s | 1456892 ko || -0m00.78s ||   -142404 ko |   -1.04% |         -9.77%
 0m53.13s |  933260 ko | PushButtonSynthesis/UnsaturatedSolinas.vo       |  0m53.00s |  933712 ko || +0m00.13s ||      -452 ko |   +0.24% |         -0.04%
 0m43.90s |   61896 ko | fiat-rust/src/p521_64.rs                        |  0m42.96s |   62088 ko || +0m00.93s ||      -192 ko |   +2.18% |         -0.30%
 0m43.64s |   61764 ko | fiat-c/src/p521_64.c                            |  0m42.68s |   61788 ko || +0m00.96s ||       -24 ko |   +2.24% |         -0.03%
 0m37.74s |  979008 ko | Bedrock/Proofs/ValidComputable/Expr.vo          |  0m37.73s |  979268 ko || +0m00.01s ||      -260 ko |   +0.02% |         -0.02%
 0m35.83s | 1389968 ko | ExtractionOCaml/word_by_word_montgomery         |  0m35.71s | 1389996 ko || +0m00.11s ||       -28 ko |   +0.33% |         -0.00%
 0m28.64s | 1054100 ko | ExtractionOCaml/unsaturated_solinas             |  0m28.70s | 1054108 ko || -0m00.05s ||        -8 ko |   -0.20% |         -0.00%
 0m25.82s |  919132 ko | ExtractionOCaml/perf_word_by_word_montgomery    |  0m25.66s |  919164 ko || +0m00.16s ||       -32 ko |   +0.62% |         -0.00%
 0m24.45s |  943280 ko | ExtractionOCaml/saturated_solinas               |  0m24.59s |  943668 ko || -0m00.14s ||      -388 ko |   -0.56% |         -0.04%
 0m23.98s |  944364 ko | ExtractionOCaml/base_conversion                 |  0m23.88s |  999044 ko || +0m00.10s ||    -54680 ko |   +0.41% |         -5.47%
 0m23.12s |  941124 ko | ExtractionOCaml/perf_unsaturated_solinas        |  0m23.03s |  941764 ko || +0m00.08s ||      -640 ko |   +0.39% |         -0.06%
 0m22.50s | 1602956 ko | ExtractionOCaml/word_by_word_montgomery.ml      |  0m22.46s | 1602916 ko || +0m00.03s ||        40 ko |   +0.17% |         +0.00%
 0m21.60s | 1021912 ko | PushButtonSynthesis/WordByWordMontgomery.vo     |  0m22.39s | 1022292 ko || -0m00.78s ||      -380 ko |   -3.52% |         -0.03%
 0m19.78s |   45684 ko | fiat-go/src/p448_solinas_64.go                  |  0m19.08s |   45780 ko || +0m00.70s ||       -96 ko |   +3.66% |         -0.20%
 0m19.38s |   46848 ko | fiat-rust/src/p448_solinas_64.rs                |  0m18.85s |   46932 ko || +0m00.52s ||       -84 ko |   +2.81% |         -0.17%
 0m19.30s |   46856 ko | fiat-c/src/p448_solinas_64.c                    |  0m18.70s |   46772 ko || +0m00.60s ||        84 ko |   +3.20% |         +0.17%
 0m18.66s |  940656 ko | Bedrock/Proofs/Expr.vo                          |  0m18.63s |  940592 ko || +0m00.03s ||        64 ko |   +0.16% |         +0.00%
 0m18.41s |  182840 ko | fiat-java/src/FiatSecp256K1.java                |  0m18.33s |  183136 ko || +0m00.08s ||      -296 ko |   +0.43% |         -0.16%
 0m17.88s |  208044 ko | fiat-java/src/FiatP256.java                     |  0m17.93s |  208020 ko || -0m00.05s ||        24 ko |   -0.27% |         +0.01%
 0m17.86s | 1479248 ko | ExtractionOCaml/unsaturated_solinas.ml          |  0m17.97s | 1479168 ko || -0m00.10s ||        80 ko |   -0.61% |         +0.00%
 0m17.85s |  172176 ko | fiat-go/src/secp256k1_32.go                     |  0m17.92s |  171972 ko || -0m00.07s ||       204 ko |   -0.39% |         +0.11%
 0m17.76s |  212360 ko | fiat-rust/src/secp256k1_32.rs                   |  0m17.72s |  212540 ko || +0m00.04s ||      -180 ko |   +0.22% |         -0.08%
 0m17.47s |  167888 ko | fiat-c/src/secp256k1_32.c                       |  0m17.41s |  168004 ko || +0m00.05s ||      -116 ko |   +0.34% |         -0.06%
 0m17.18s |  167292 ko | fiat-go/src/p256_32.go                          |  0m17.24s |  166956 ko || -0m00.05s ||       336 ko |   -0.34% |         +0.20%
 0m16.80s |  188420 ko | fiat-c/src/p256_32.c                            |  0m16.75s |  188664 ko || +0m00.05s ||      -244 ko |   +0.29% |         -0.12%
 0m16.50s | 1673488 ko | ExtractionOCaml/perf_word_by_word_montgomery.ml |  0m16.52s | 1673300 ko || -0m00.01s ||       188 ko |   -0.12% |         +0.01%
 0m15.92s |  128512 ko | fiat-go/src/p434_64.go                          |  0m15.75s |  122012 ko || +0m00.16s ||      6500 ko |   +1.07% |         +5.32%
 0m15.22s |  132016 ko | fiat-c/src/p434_64.c                            |  0m15.31s |  132120 ko || -0m00.08s ||      -104 ko |   -0.58% |         -0.07%
 0m14.93s | 1421528 ko | ExtractionOCaml/base_conversion.ml              |  0m14.16s | 1422476 ko || +0m00.76s ||      -948 ko |   +5.43% |         -0.06%
 0m14.81s | 1423880 ko | ExtractionOCaml/saturated_solinas.ml            |  0m14.78s | 1423940 ko || +0m00.03s ||       -60 ko |   +0.20% |         -0.00%
 0m14.42s | 1654132 ko | ExtractionOCaml/perf_unsaturated_solinas.ml     |  0m14.39s | 1654204 ko || +0m00.02s ||       -72 ko |   +0.20% |         -0.00%
 0m13.41s |  888968 ko | Bedrock/Proofs/LoadStoreList.vo                 |  0m13.88s |  888712 ko || -0m00.47s ||       256 ko |   -3.38% |         +0.02%
 0m13.22s |  871476 ko | Bedrock/Proofs/Cmd.vo                           |  0m13.29s |  871052 ko || -0m00.06s ||       424 ko |   -0.52% |         +0.04%
 0m10.64s | 1434564 ko | Bedrock/Proofs/Varnames.vo                      |  0m10.50s | 1434424 ko || +0m00.14s ||       140 ko |   +1.33% |         +0.00%
 0m09.50s |  760060 ko | Bedrock/Tests/Proofs/X25519_64.vo               |  0m10.21s |  760868 ko || -0m00.71s ||      -808 ko |   -6.95% |         -0.10%
 0m09.14s |  772964 ko | PushButtonSynthesis/SmallExamples.vo            |  0m09.05s |  773052 ko || +0m00.08s ||       -88 ko |   +0.99% |         -0.01%
 0m08.42s |  104356 ko | fiat-java/src/FiatP224.java                     |  0m08.43s |  104652 ko || -0m00.00s ||      -296 ko |   -0.11% |         -0.28%
 0m08.31s |  126592 ko | fiat-c/src/p224_32.c                            |  0m08.36s |  126604 ko || -0m00.04s ||       -12 ko |   -0.59% |         -0.00%
 0m08.24s |  115296 ko | fiat-rust/src/p224_32.rs                        |  0m08.30s |  115188 ko || -0m00.06s ||       108 ko |   -0.72% |         +0.09%
 0m08.22s |  103584 ko | fiat-go/src/p224_32.go                          |  0m07.52s |  103508 ko || +0m00.70s ||        76 ko |   +9.30% |         +0.07%
 0m07.26s |   72224 ko | fiat-go/src/p384_64.go                          |  0m07.35s |   80568 ko || -0m00.08s ||     -8344 ko |   -1.22% |        -10.35%
 0m07.25s |  849316 ko | Bedrock/Proofs/Func.vo                          |  0m07.30s |  849292 ko || -0m00.04s ||        24 ko |   -0.68% |         +0.00%
 0m07.16s |   80116 ko | fiat-rust/src/p384_64.rs                        |  0m07.20s |   80328 ko || -0m00.04s ||      -212 ko |   -0.55% |         -0.26%
 0m07.06s |   80148 ko | fiat-c/src/p384_64.c                            |  0m07.11s |   79860 ko || -0m00.05s ||       288 ko |   -0.70% |         +0.36%
 0m06.90s |  789936 ko | Bedrock/Tests/X25519_64.vo                      |  0m07.02s |  796340 ko || -0m00.11s ||     -6404 ko |   -1.70% |         -0.80%
 0m06.53s |  856300 ko | PushButtonSynthesis/BarrettReduction.vo         |  0m06.42s |  856316 ko || +0m00.11s ||       -16 ko |   +1.71% |         -0.00%
 0m05.70s |  850016 ko | PushButtonSynthesis/BaseConversion.vo           |  0m05.43s |  849988 ko || +0m00.27s ||        28 ko |   +4.97% |         +0.00%
 0m05.42s |  845796 ko | PushButtonSynthesis/Primitives.vo               |  0m05.39s |  846496 ko || +0m00.03s ||      -700 ko |   +0.55% |         -0.08%
 0m05.16s |  821136 ko | Bedrock/Proofs/Flatten.vo                       |  0m05.42s |  820852 ko || -0m00.25s ||       284 ko |   -4.79% |         +0.03%
 0m04.86s |  688524 ko | Bedrock/Proofs/ValidComputable/Cmd.vo           |  0m04.83s |  688508 ko || +0m00.03s ||        16 ko |   +0.62% |         +0.00%
 0m03.86s |  842456 ko | PushButtonSynthesis/FancyMontgomeryReduction.vo |  0m03.79s |  842748 ko || +0m00.06s ||      -292 ko |   +1.84% |         -0.03%
 0m03.35s |  834148 ko | PushButtonSynthesis/SaturatedSolinas.vo         |  0m03.45s |  834556 ko || -0m00.10s ||      -408 ko |   -2.89% |         -0.04%
 0m02.95s |   24892 ko | fiat-java/src/FiatCurve25519.java               |  0m02.89s |   25040 ko || +0m00.06s ||      -148 ko |   +2.07% |         -0.59%
 0m02.89s |   23360 ko | fiat-rust/src/curve25519_32.rs                  |  0m02.86s |   23240 ko || +0m00.03s ||       120 ko |   +1.04% |         +0.51%
 0m02.87s |   23292 ko | fiat-c/src/curve25519_32.c                      |  0m02.75s |   23316 ko || +0m00.12s ||       -24 ko |   +4.36% |         -0.10%
 0m02.87s |   22572 ko | fiat-go/src/curve25519_32.go                    |  0m02.79s |   22660 ko || +0m00.08s ||       -88 ko |   +2.86% |         -0.38%
 0m02.49s |  727216 ko | CLI.vo                                          |  0m02.36s |  726816 ko || +0m00.13s ||       400 ko |   +5.50% |         +0.05%
 0m02.31s |  730296 ko | Rewriter/PerfTesting/Core.vo                    |  0m02.18s |  730184 ko || +0m00.12s ||       112 ko |   +5.96% |         +0.01%
 0m02.03s |  748988 ko | Rewriter/PerfTesting/StandaloneOCamlMain.vo     |  0m02.00s |  749160 ko || +0m00.02s ||      -172 ko |   +1.49% |         -0.02%
 0m02.03s |   23620 ko | fiat-go/src/curve25519_64.go                    |  0m01.97s |   23744 ko || +0m00.05s ||      -124 ko |   +3.04% |         -0.52%
 0m01.98s |   22236 ko | fiat-c/src/curve25519_64.c                      |  0m01.90s |   22040 ko || +0m00.08s ||       196 ko |   +4.21% |         +0.88%
 0m01.96s |   23296 ko | fiat-rust/src/curve25519_64.rs                  |  0m01.92s |   23236 ko || +0m00.04s ||        60 ko |   +2.08% |         +0.25%
 0m01.95s |  733044 ko | StandaloneHaskellMain.vo                        |  0m01.99s |  733220 ko || -0m00.04s ||      -176 ko |   -2.01% |         -0.02%
 0m01.87s |  733600 ko | StandaloneOCamlMain.vo                          |  0m01.97s |  733636 ko || -0m00.09s ||       -36 ko |   -5.07% |         -0.00%
 0m01.76s |  678400 ko | Bedrock/Proofs/ValidComputable/Func.vo          |  0m01.76s |  678236 ko || +0m00.00s ||       164 ko |   +0.00% |         +0.02%
 0m01.66s |  672444 ko | Bedrock/Translation/Cmd.vo                      |  0m01.64s |  672468 ko || +0m00.02s ||       -24 ko |   +1.21% |         -0.00%
 0m01.62s |   31576 ko | fiat-go/src/secp256k1_64.go                     |  0m01.51s |   32552 ko || +0m00.11s ||      -976 ko |   +7.28% |         -2.99%
 0m01.59s |   32548 ko | fiat-go/src/p224_64.go                          |  0m01.41s |   30624 ko || +0m00.18s ||      1924 ko |  +12.76% |         +6.28%
 0m01.52s |  666124 ko | Bedrock/Translation/Func.vo                     |  0m01.58s |  666200 ko || -0m00.06s ||       -76 ko |   -3.79% |         -0.01%
 0m01.52s |   32912 ko | fiat-rust/src/secp256k1_64.rs                   |  0m01.54s |   32980 ko || -0m00.02s ||       -68 ko |   -1.29% |         -0.20%
 0m01.51s |   32688 ko | fiat-c/src/p224_64.c                            |  0m01.49s |   32420 ko || +0m00.02s ||       268 ko |   +1.34% |         +0.82%
 0m01.51s |   32744 ko | fiat-c/src/secp256k1_64.c                       |  0m01.51s |   32672 ko || +0m00.00s ||        72 ko |   +0.00% |         +0.22%
 0m01.51s |   32516 ko | fiat-rust/src/p224_64.rs                        |  0m01.52s |   32572 ko || -0m00.01s ||       -56 ko |   -0.65% |         -0.17%
 0m01.50s |   32760 ko | fiat-go/src/p256_64.go                          |  0m01.34s |   32796 ko || +0m00.15s ||       -36 ko |  +11.94% |         -0.10%
 0m01.41s |   30636 ko | fiat-rust/src/p256_64.rs                        |  0m01.42s |   30788 ko || -0m00.01s ||      -152 ko |   -0.70% |         -0.49%
 0m01.34s |   32676 ko | fiat-c/src/p256_64.c                            |  0m01.42s |   32612 ko || -0m00.07s ||        64 ko |   -5.63% |         +0.19%
```
</p>