### PR TITLE
New rewrite rules for add/sub with carries/borrows (for bedrock2)

### DIFF
--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -937,6 +937,20 @@ Section with_bitwidth.
                        = (dlet low := singlewidth (singlewidth x * singlewidth y) in
                               dlet high := singlewidth (Z.mul_high (cstZ rpow2_bitwidth ('(2^bitwidth))) (singlewidth x) (singlewidth y)) in
                               (singlewidth low, singlewidth high)))
+              ; (forall x y n,
+                    0 <= lgcarrymax <= bitwidth
+                    -> 0 < n < bitwidth
+                    -> 0 < bitwidth < n + lgcarrymax
+                    -> singlewidth_carry (Z.add_get_carry_full ('(2^n)) (singlewidth x) (singlewidth y))
+                       = (dlet sum_xy := singlewidth (singlewidth x + singlewidth y) in
+                              dlet carry_xy := carrywidth (Z.ltz (singlewidth sum_xy) (singlewidth x)) in
+                              dlet low := singlewidth (Z.land (singlewidth sum_xy) ('(2^n - 1))) in
+                              dlet high :=
+                            singlewidth
+                              (Z.add (singlewidth (Z.shiftr (singlewidth sum_xy) ('n)))
+                                     (singlewidth (Z.shiftl (carrywidth carry_xy) ('(bitwidth - n)))))
+                                in
+                              (singlewidth low, singlewidth high)))
              ]
            ; mymap
                do_again

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -957,6 +957,27 @@ Section with_bitwidth.
                                                             (singlewidth ('(bitwidth - Z.log2 two_pow_n))))))
                             in
                               (singlewidth low, singlewidth high)))
+              ; (forall c x y two_pow_n r,
+                    0 <= lgcarrymax <= bitwidth
+                    -> two_pow_n = 2 ^ Z.log2 two_pow_n
+                    -> 0 < Z.log2 two_pow_n < bitwidth
+                    -> bitwidth + 1 < Z.log2 two_pow_n + lgcarrymax
+                    -> two_pow_n ∈ r
+                    -> singlewidth_carry
+                         (Z.add_with_get_carry_full (cstZ r ('(two_pow_n))) (carrywidth c) (singlewidth x) (singlewidth y))
+                       = (dlet sum_cx := singlewidth (carrywidth c + singlewidth x) in
+                              dlet carry_cx := carrywidth (Z.ltz (singlewidth sum_cx) (singlewidth x)) in
+                              dlet sum_cxy := singlewidth (singlewidth sum_cx + singlewidth y) in
+                              dlet carry_cxy := carrywidth (Z.ltz (singlewidth sum_cxy) (singlewidth y)) in
+                              dlet carry := singlewidth (Z.add (carrywidth carry_cx) (carrywidth carry_cxy)) in
+                              dlet low := singlewidth
+                                            (Z.land (singlewidth sum_cxy) (singlewidth ('(two_pow_n - 1)))) in
+                              dlet high := singlewidth
+                                             (Z.add (singlewidth (Z.shiftr (singlewidth sum_cxy)
+                                                                           (singlewidth ('(Z.log2 two_pow_n)))))
+                                                    (singlewidth (Z.shiftl (carrywidth carry)
+                                                                           (singlewidth ('(bitwidth - Z.log2 two_pow_n)))))) in
+                              (singlewidth low, singlewidth high)))
              ]
            ; mymap
                do_again

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -937,22 +937,24 @@ Section with_bitwidth.
                        = (dlet low := singlewidth (singlewidth x * singlewidth y) in
                               dlet high := singlewidth (Z.mul_high (cstZ rpow2_bitwidth ('(2^bitwidth))) (singlewidth x) (singlewidth y)) in
                               (singlewidth low, singlewidth high)))
-              ; (forall x y n rpow2_n,
+              ; (forall x y two_pow_n r,
                     0 <= lgcarrymax <= bitwidth
-                    -> 0 < n < bitwidth
-                    -> bitwidth < n + lgcarrymax
-                    -> 2^n ∈ rpow2_n
+                    -> two_pow_n = 2 ^ Z.log2 two_pow_n
+                    -> 0 < Z.log2 two_pow_n < bitwidth
+                    -> bitwidth < Z.log2 two_pow_n + lgcarrymax
+                    -> two_pow_n ∈ r
                     -> singlewidth_carry
-                         (Z.add_get_carry_full (cstZ rpow2_n ('(2^n))) (singlewidth x) (singlewidth y))
+                         (Z.add_get_carry_full (cstZ r ('(two_pow_n))) (singlewidth x) (singlewidth y))
                        = (dlet sum_xy := singlewidth (singlewidth x + singlewidth y) in
                               dlet carry_xy := carrywidth (Z.ltz (singlewidth sum_xy) (singlewidth x)) in
                               dlet low := singlewidth
-                                            (Z.land (singlewidth sum_xy) (singlewidth ('(2^n - 1)))) in
+                                            (Z.land (singlewidth sum_xy) (singlewidth ('(two_pow_n - 1)))) in
                               dlet high :=
                             singlewidth
-                              (Z.add (singlewidth (Z.shiftr (singlewidth sum_xy) (singlewidth ('n))))
+                              (Z.add (singlewidth (Z.shiftr (singlewidth sum_xy)
+                                                            (singlewidth ('(Z.log2 two_pow_n)))))
                                      (singlewidth (Z.shiftl (carrywidth carry_xy)
-                                                            (singlewidth ('(bitwidth - n))))))
+                                                            (singlewidth ('(bitwidth - Z.log2 two_pow_n))))))
                             in
                               (singlewidth low, singlewidth high)))
              ]

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -978,6 +978,49 @@ Section with_bitwidth.
                                                     (singlewidth (Z.shiftl (carrywidth carry)
                                                                            (singlewidth ('(bitwidth - Z.log2 two_pow_n)))))) in
                               (singlewidth low, singlewidth high)))
+              ; (forall x y two_pow_n r,
+                    0 <= lgcarrymax <= bitwidth
+                    -> two_pow_n = 2 ^ Z.log2 two_pow_n
+                    -> 0 < Z.log2 two_pow_n < bitwidth
+                    -> bitwidth < Z.log2 two_pow_n + lgcarrymax
+                    -> two_pow_n ∈ r
+                    -> singlewidth_carry
+                         (Z.sub_get_borrow_full (cstZ r ('(two_pow_n))) (singlewidth x) (singlewidth y))
+                       = (dlet diff_xy := singlewidth (singlewidth x - singlewidth y) in
+                              dlet borrow_xy := carrywidth (Z.ltz (singlewidth x) (singlewidth diff_xy)) in
+                              dlet low := singlewidth
+                                            (Z.land (singlewidth diff_xy) (singlewidth ('(two_pow_n - 1)))) in
+                              dlet high :=
+                            singlewidth
+                              (Z.sub (singlewidth (Z.shiftl (carrywidth borrow_xy)
+                                                            (singlewidth ('(bitwidth - Z.log2 two_pow_n)))))
+                                     (singlewidth (Z.shiftr (singlewidth diff_xy)
+                                                            (singlewidth ('(Z.log2 two_pow_n))))))
+                            in
+                              (singlewidth low, carrywidth high)))
+              ; (forall c x y two_pow_n r,
+                    0 <= lgcarrymax <= bitwidth
+                    -> two_pow_n = 2 ^ Z.log2 two_pow_n
+                    -> 0 < Z.log2 two_pow_n < bitwidth
+                    -> bitwidth < Z.log2 two_pow_n + lgcarrymax
+                    -> two_pow_n ∈ r
+                    -> singlewidth_carry
+                         (Z.sub_with_get_borrow_full (cstZ r ('(two_pow_n))) (carrywidth c) (singlewidth x) (singlewidth y))
+                       = (dlet diff_xy := singlewidth (singlewidth x - singlewidth y) in
+                              dlet borrow_xy := carrywidth (Z.ltz (singlewidth x) (singlewidth diff_xy)) in
+                              dlet diff_xyc := singlewidth (singlewidth diff_xy - carrywidth c) in
+                              dlet borrow_xyc := carrywidth (Z.ltz (singlewidth diff_xy) (singlewidth diff_xyc)) in
+                              dlet borrow :=  singlewidth (carrywidth borrow_xy + carrywidth borrow_xyc) in
+                              dlet low := singlewidth
+                                            (Z.land (singlewidth diff_xyc) (singlewidth ('(two_pow_n - 1)))) in
+                              dlet high :=
+                            singlewidth
+                              (Z.sub (singlewidth (Z.shiftl (carrywidth borrow)
+                                                            (singlewidth ('(bitwidth - Z.log2 two_pow_n)))))
+                                     (singlewidth (Z.shiftr (singlewidth diff_xyc)
+                                                            (singlewidth ('(Z.log2 two_pow_n))))))
+                            in
+                              (singlewidth low, carrywidth high)))
              ]
            ; mymap
                do_again

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -941,7 +941,7 @@ Section with_bitwidth.
                     0 <= lgcarrymax <= bitwidth
                     -> 0 < n < bitwidth
                     -> 0 < bitwidth < n + lgcarrymax
-                    -> singlewidth_carry (Z.add_get_carry_full ('(2^n)) (singlewidth x) (singlewidth y))
+                    -> pairsinglewidth (Z.add_get_carry_full ('(2^n)) (singlewidth x) (singlewidth y))
                        = (dlet sum_xy := singlewidth (singlewidth x + singlewidth y) in
                               dlet carry_xy := carrywidth (Z.ltz (singlewidth sum_xy) (singlewidth x)) in
                               dlet low := singlewidth (Z.land (singlewidth sum_xy) ('(2^n - 1))) in
@@ -949,7 +949,7 @@ Section with_bitwidth.
                             singlewidth
                               (Z.add (singlewidth (Z.shiftr (singlewidth sum_xy) ('n)))
                                      (singlewidth (Z.shiftl (carrywidth carry_xy) ('(bitwidth - n)))))
-                                in
+                            in
                               (singlewidth low, singlewidth high)))
              ]
            ; mymap

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -944,7 +944,7 @@ Section with_bitwidth.
                     -> bitwidth < Z.log2 two_pow_n + lgcarrymax
                     -> two_pow_n ∈ r
                     -> singlewidth_carry
-                         (Z.add_get_carry_full (cstZ r ('(two_pow_n))) (singlewidth x) (singlewidth y))
+                         (Z.add_get_carry_full (cstZ r ('two_pow_n)) (singlewidth x) (singlewidth y))
                        = (dlet sum_xy := singlewidth (singlewidth x + singlewidth y) in
                               dlet carry_xy := carrywidth (Z.ltz (singlewidth sum_xy) (singlewidth x)) in
                               dlet low := singlewidth
@@ -964,7 +964,7 @@ Section with_bitwidth.
                     -> bitwidth + 1 < Z.log2 two_pow_n + lgcarrymax
                     -> two_pow_n ∈ r
                     -> singlewidth_carry
-                         (Z.add_with_get_carry_full (cstZ r ('(two_pow_n))) (carrywidth c) (singlewidth x) (singlewidth y))
+                         (Z.add_with_get_carry_full (cstZ r ('two_pow_n)) (carrywidth c) (singlewidth x) (singlewidth y))
                        = (dlet sum_cx := singlewidth (carrywidth c + singlewidth x) in
                               dlet carry_cx := carrywidth (Z.ltz (singlewidth sum_cx) (singlewidth x)) in
                               dlet sum_cxy := singlewidth (singlewidth sum_cx + singlewidth y) in
@@ -985,7 +985,7 @@ Section with_bitwidth.
                     -> bitwidth < Z.log2 two_pow_n + lgcarrymax
                     -> two_pow_n ∈ r
                     -> singlewidth_carry
-                         (Z.sub_get_borrow_full (cstZ r ('(two_pow_n))) (singlewidth x) (singlewidth y))
+                         (Z.sub_get_borrow_full (cstZ r ('two_pow_n)) (singlewidth x) (singlewidth y))
                        = (dlet diff_xy := singlewidth (singlewidth x - singlewidth y) in
                               dlet borrow_xy := carrywidth (Z.ltz (singlewidth x) (singlewidth diff_xy)) in
                               dlet low := singlewidth
@@ -1005,7 +1005,7 @@ Section with_bitwidth.
                     -> bitwidth < Z.log2 two_pow_n + lgcarrymax
                     -> two_pow_n ∈ r
                     -> singlewidth_carry
-                         (Z.sub_with_get_borrow_full (cstZ r ('(two_pow_n))) (carrywidth c) (singlewidth x) (singlewidth y))
+                         (Z.sub_with_get_borrow_full (cstZ r ('two_pow_n)) (carrywidth c) (singlewidth x) (singlewidth y))
                        = (dlet diff_xy := singlewidth (singlewidth x - singlewidth y) in
                               dlet borrow_xy := carrywidth (Z.ltz (singlewidth x) (singlewidth diff_xy)) in
                               dlet diff_xyc := singlewidth (singlewidth diff_xy - carrywidth c) in

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -940,15 +940,18 @@ Section with_bitwidth.
               ; (forall x y n,
                     0 <= lgcarrymax <= bitwidth
                     -> 0 < n < bitwidth
-                    -> 0 < bitwidth < n + lgcarrymax
-                    -> pairsinglewidth (Z.add_get_carry_full ('(2^n)) (singlewidth x) (singlewidth y))
+                    -> bitwidth < n + lgcarrymax
+                    -> singlewidth_carry
+                         (Z.add_get_carry_full (singlewidth ('(2^n))) (singlewidth x) (singlewidth y))
                        = (dlet sum_xy := singlewidth (singlewidth x + singlewidth y) in
                               dlet carry_xy := carrywidth (Z.ltz (singlewidth sum_xy) (singlewidth x)) in
-                              dlet low := singlewidth (Z.land (singlewidth sum_xy) ('(2^n - 1))) in
+                              dlet low := singlewidth
+                                            (Z.land (singlewidth sum_xy) (singlewidth ('(2^n - 1)))) in
                               dlet high :=
                             singlewidth
-                              (Z.add (singlewidth (Z.shiftr (singlewidth sum_xy) ('n)))
-                                     (singlewidth (Z.shiftl (carrywidth carry_xy) ('(bitwidth - n)))))
+                              (Z.add (singlewidth (Z.shiftr (singlewidth sum_xy) (singlewidth ('n))))
+                                     (singlewidth (Z.shiftl (carrywidth carry_xy)
+                                                            (singlewidth ('(bitwidth - n))))))
                             in
                               (singlewidth low, singlewidth high)))
              ]

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -937,12 +937,13 @@ Section with_bitwidth.
                        = (dlet low := singlewidth (singlewidth x * singlewidth y) in
                               dlet high := singlewidth (Z.mul_high (cstZ rpow2_bitwidth ('(2^bitwidth))) (singlewidth x) (singlewidth y)) in
                               (singlewidth low, singlewidth high)))
-              ; (forall x y n,
+              ; (forall x y n rpow2_n,
                     0 <= lgcarrymax <= bitwidth
                     -> 0 < n < bitwidth
                     -> bitwidth < n + lgcarrymax
+                    -> 2^n ∈ rpow2_n
                     -> singlewidth_carry
-                         (Z.add_get_carry_full (singlewidth ('(2^n))) (singlewidth x) (singlewidth y))
+                         (Z.add_get_carry_full (cstZ rpow2_n ('(2^n))) (singlewidth x) (singlewidth y))
                        = (dlet sum_xy := singlewidth (singlewidth x + singlewidth y) in
                               dlet carry_xy := carrywidth (Z.ltz (singlewidth sum_xy) (singlewidth x)) in
                               dlet low := singlewidth

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -709,6 +709,10 @@ Proof using Type.
   all: systematically_handle_casts; try reflexivity.
   all: rewrite !ident.platform_specific_cast_0_is_mod, ?Z.sub_add, ?Z.mod_mod by lia; try reflexivity.
   all: progress specialize_by lia.
+  all: try match goal with
+           | H : ?x = 2 ^ Z.log2 ?x |- _ =>
+             rewrite H
+           end.
   all:
     try match goal with
         | |- context [(2^?n - 1) mod 2^?bw] =>
@@ -723,6 +727,9 @@ Proof using Type.
             rewrite !Z.land_ones by lia
           end).
   all: push_Zmod; pull_Zmod; try reflexivity.
+  all: Z.rewrite_mod_small.
+  all: rewrite ?Z.shiftr_div_pow2, ?Z.shiftl_mul_pow2 by lia.
+  all: rewrite ?Z.log2_pow2 by lia.
   all: Z.rewrite_mod_small.
   all: rewrite ?Z.shiftr_div_pow2, ?Z.shiftl_mul_pow2 by lia.
   all: rewrite ?Z_mod_pow_same_base_larger,
@@ -757,6 +764,7 @@ Proof using Type.
   { (* TODO : long and manual; fix *)
     push_Zmod; pull_Zmod.
     Z.rewrite_mod_small.
+    subst.
     rewrite <-Z.add_mul_mod by
         (rewrite <-?Z.add_div_ltz_1 by lia;
          try split; auto with zarith; rewrite Z.pow_sub_r by lia;
@@ -780,7 +788,7 @@ Proof using Type.
       assert (0 <= x + z < 2^y + 2^y) as P by auto with zarith;
         rewrite Z.add_diag, Z.pow_mul_base in P by lia
     end.
-    assert (2 ^ (bitwidth+1) <= 2 ^ (n+lgcarrymax))
+    assert (2 ^ (bitwidth+1) <= 2 ^ (Z.log2 two_pow_n+lgcarrymax))
         by auto with zarith.
     match goal with
     | |- context[(?x / ?y) mod ?z] =>

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -775,7 +775,7 @@ Proof using Type.
         by auto with zarith.
     match goal with
     | |- context[(?x / ?y) mod ?z] =>
-      assert (0 <= x / y < z)
+      assert (0 <= x / y < 2^lgcarrymax)
         by (split; auto with zarith;
             apply Z.div_lt_upper_bound; auto with zarith;
             rewrite <-Z.pow_add_r by lia; auto with zarith)

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -701,25 +701,34 @@ Lemma multiret_split_rewrite_rules_proofs (bitwidth : Z) (lgcarrymax : Z)
   : PrimitiveHList.hlist (@snd bool Prop) (multiret_split_rewrite_rulesT bitwidth lgcarrymax).
 Proof using Type.
   assert (0 <= lgcarrymax <= bitwidth -> 0 < 2^lgcarrymax <= 2^bitwidth) by auto with zarith.
+  assert (0 <= bitwidth -> bitwidth < 2^bitwidth)
+    by (intros; apply Z.pow_gt_lin_r; auto with zarith).
 
   start_proof; auto; intros; try lia.
   all: repeat interp_good_t_step_related.
   all: systematically_handle_casts; try reflexivity.
   all: rewrite !ident.platform_specific_cast_0_is_mod, ?Z.sub_add, ?Z.mod_mod by lia; try reflexivity.
+  all: progress specialize_by lia.
   all:
-    try
-      (match goal with
-      | |- context [Z.land ?x (2^?n - 1)] =>
-        replace (2^n-1) with (Z.ones n) by
-            (rewrite Z.sub_1_r, <-Z.ones_equiv; reflexivity);
-          rewrite !Z.land_ones by lia
-       end).
+    try match goal with
+        | |- context [(2^?n - 1) mod 2^?bw] =>
+          assert (0 < 2^n < 2^bw) by auto with zarith;
+            Z.rewrite_mod_small
+        end.
+  all: try
+         (match goal with
+          | |- context [Z.land ?x (2^?n - 1)] =>
+            replace (2^n-1) with (Z.ones n) by
+                (rewrite Z.sub_1_r, <-Z.ones_equiv; reflexivity);
+            rewrite !Z.land_ones by lia
+          end).
+  all: push_Zmod; pull_Zmod; try reflexivity.
+  all: Z.rewrite_mod_small.
   all: rewrite ?Z.shiftr_div_pow2, ?Z.shiftl_mul_pow2 by lia.
   all: rewrite ?Z_mod_pow_same_base_larger,
        ?Z_mod_pow_same_base_smaller by lia.
   all: try reflexivity.
   all: push_Zmod; pull_Zmod; try reflexivity.
-  all: progress specialize_by auto.
   all: try solve[
   lazymatch goal with
        | [ |- ?x mod ?y = _ mod ?y ]

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -674,58 +674,6 @@ Proof using Type.
   all:autorewrite with zsimplify; lia.
 Qed.
 
-(* TODO: move *)
-Lemma Z_mod_pow_same_base_larger a b n m :
-  0 <= n < m -> 0 < b ->
-  (a mod (b^n)) mod (b^m) = a mod b^n.
-Proof.
-  intros.
-  pose proof Z.mod_pos_bound a (b^n) ltac:(auto with zarith).
-  assert (b^n <= b^m) by auto with zarith.
-  apply Z.mod_small. auto with zarith.
-Qed.
-
-(* TODO: move *)
-Lemma Z_mod_pow_same_base_smaller a b n m :
-  0 <= m <= n -> 0 < b ->
-  (a mod (b^n)) mod (b^m) = a mod b^m.
-Proof.
-  intros.
-  replace n with (m+(n-m)) by lia.
-  rewrite Z.pow_add_r by lia.
-  rewrite Z.rem_mul_r by auto with zarith.
-  push_Zmod; pull_Zmod.
-  autorewrite with zsimplify_fast; reflexivity.
-Qed.
-
-(* TODO: move *)
-(* This sequence actually performs a bitwise or. In terms of
-   bit ranges,
-       b...a + a...c << a-b = b...c *)
-Lemma Z_add_div_pow2 x a b :
-  0 <= b <= a ->
-  (x mod (2 ^ a)) / 2 ^ b + x / 2 ^ a * 2 ^ (a - b)
-  = x / 2 ^ b.
-Proof.
-  intros.
-  rewrite <-Z.div_add by auto with zarith.
-  match goal with
-    |- context [?x * 2^(?a-?b) * 2^?b] =>
-    replace (x * 2^(a-b) * 2^b) with (x * 2^a)
-      by (rewrite <-Z.mul_assoc, <-Z.pow_add_r by auto with zarith;
-          repeat (f_equal; try lia))
-  end.
-  rewrite <-Z.div_mod'''; auto with zarith.
-Qed.
-
-Lemma Z_ltz_mod_pow2_small x y z :
-  0 < z ->
-  (Z.ltz x y) mod (2 ^ z) = Z.ltz x y.
-Proof.
-  cbv [Z.ltz]; break_match; intros; Z.ltb_to_lt;
-    apply Z.mod_small; auto with zarith.
-Qed.
-
 Lemma multiret_split_rewrite_rules_proofs (bitwidth : Z) (lgcarrymax : Z)
   : PrimitiveHList.hlist (@snd bool Prop) (multiret_split_rewrite_rulesT bitwidth lgcarrymax).
 Proof using Type.
@@ -761,9 +709,9 @@ Proof using Type.
   all: rewrite ?Z.log2_pow2 by lia.
   all: Z.rewrite_mod_small.
   all: rewrite ?Z.shiftr_div_pow2, ?Z.shiftl_mul_pow2 by lia.
-  all: rewrite ?Z_mod_pow_same_base_larger,
-       ?Z_mod_pow_same_base_smaller by lia.
-  all: rewrite ?Z_ltz_mod_pow2_small by lia.
+  all: rewrite ?Z.mod_pow_same_base_larger,
+       ?Z.mod_pow_same_base_smaller by lia.
+  all: rewrite ?Z.ltz_mod_pow2_small by lia.
   all: rewrite <-?Z.add_div_ltz_1 by lia.
   all: try reflexivity.
   all: push_Zmod; pull_Zmod; try reflexivity.
@@ -787,8 +735,8 @@ Proof using Type.
            | H : 0 <= ?x < 2 ^ ?z |- context [?x mod 2 ^ ?y] =>
              unique assert (2 ^ z <= 2 ^ y) by auto with zarith;
                unique assert (0 <= x <= 2 ^ y) by auto with zarith
-           | _ => rewrite Z_ltz_mod_pow2_small by lia
-           | _ => rewrite Z_add_div_pow2 by auto with zarith
+           | _ => rewrite Z.ltz_mod_pow2_small by lia
+           | _ => rewrite Z.add_div_pow2 by auto with zarith
            | _ => rewrite <-Z.add_add_div_ltz_2 by lia
            | _ => rewrite Z.mod_pull_div, <-?Z.pow_add_r
                by auto with zarith

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -24,6 +24,7 @@ Require Import Crypto.Util.ZUtil.Zselect.
 Require Import Crypto.Util.ZUtil.Div.
 Require Import Crypto.Util.ZUtil.Divide.
 Require Import Crypto.Util.ZUtil.Modulo.
+Require Import Crypto.Util.ZUtil.Opp.
 Require Import Crypto.Util.ZUtil.Pow.
 Require Import Crypto.Util.ZUtil.Land.
 Require Import Crypto.Util.ZUtil.LandLorShiftBounds.
@@ -762,10 +763,14 @@ Proof using Type.
   all: rewrite ?Z.shiftr_div_pow2, ?Z.shiftl_mul_pow2 by lia.
   all: rewrite ?Z_mod_pow_same_base_larger,
        ?Z_mod_pow_same_base_smaller by lia.
+  all: rewrite ?Z_ltz_mod_pow2_small by lia.
   all: rewrite <-?Z.add_div_ltz_1 by lia.
   all: try reflexivity.
   all: push_Zmod; pull_Zmod; try reflexivity.
   all: rewrite ?Z.mod_pull_div, <-?Z.pow_add_r by auto with zarith.
+  all: rewrite <-?Z.sub_sub_div_ltz by lia.
+  all: rewrite <-?Z.sub_div_ltz by lia.
+  all: try rewrite Z.mul_opp_l, Z.sub_opp_l, Opp.Z.opp_sub.
   all:
     repeat match goal with
            | Hx : 0 <= ?x <= 2^?n - 1,
@@ -789,7 +794,6 @@ Proof using Type.
                by auto with zarith
            | _ => progress Z.rewrite_mod_small
            end.
-
   all: try solve[
   try lazymatch goal with
        | [ |- ?x mod ?y = _ mod ?y ]

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -686,7 +686,7 @@ Qed.
 
 (* TODO: move *)
 Lemma Z_mod_pow_same_base_smaller a b n m :
-  0 <= m < n -> 0 < b ->
+  0 <= m <= n -> 0 < b ->
   (a mod (b^n)) mod (b^m) = a mod b^m.
 Proof.
   intros.
@@ -695,6 +695,34 @@ Proof.
   rewrite Z.rem_mul_r by auto with zarith.
   push_Zmod; pull_Zmod.
   autorewrite with zsimplify_fast; reflexivity.
+Qed.
+
+(* TODO: move *)
+(* This sequence actually performs a bitwise or. In terms of
+   bit ranges,
+       b...a + a...c << a-b = b...c *)
+Lemma Z_add_div_pow2 x a b :
+  0 <= b <= a ->
+  (x mod (2 ^ a)) / 2 ^ b + x / 2 ^ a * 2 ^ (a - b)
+  = x / 2 ^ b.
+Proof.
+  intros.
+  rewrite <-Z.div_add by auto with zarith.
+  match goal with
+    |- context [?x * 2^(?a-?b) * 2^?b] =>
+    replace (x * 2^(a-b) * 2^b) with (x * 2^a)
+      by (rewrite <-Z.mul_assoc, <-Z.pow_add_r by auto with zarith;
+          repeat (f_equal; try lia))
+  end.
+  rewrite <-Z.div_mod'''; auto with zarith.
+Qed.
+
+Lemma Z_ltz_mod_pow2_small x y z :
+  0 < z ->
+  (Z.ltz x y) mod (2 ^ z) = Z.ltz x y.
+Proof.
+  cbv [Z.ltz]; break_match; intros; Z.ltb_to_lt;
+    apply Z.mod_small; auto with zarith.
 Qed.
 
 Lemma multiret_split_rewrite_rules_proofs (bitwidth : Z) (lgcarrymax : Z)
@@ -734,14 +762,40 @@ Proof using Type.
   all: rewrite ?Z.shiftr_div_pow2, ?Z.shiftl_mul_pow2 by lia.
   all: rewrite ?Z_mod_pow_same_base_larger,
        ?Z_mod_pow_same_base_smaller by lia.
+  all: rewrite <-?Z.add_div_ltz_1 by lia.
   all: try reflexivity.
   all: push_Zmod; pull_Zmod; try reflexivity.
+  all: rewrite ?Z.mod_pull_div, <-?Z.pow_add_r by auto with zarith.
+  all:
+    repeat match goal with
+           | Hx : 0 <= ?x <= 2^?n - 1,
+                  Hy : 0 <= ?y <= 2^?n - 1 |- context [?x + ?y] =>
+             unique assert (0 <= x + y < 2^(n+1))
+               by (rewrite Z.pow_add_r, Z.pow_1_r; auto with zarith)
+           | Hx : 0 <= ?x <= 2^?n - 1,
+                  Hy : 0 <= ?y <= 2^?n - 1 |- context [?c + ?x + ?y] =>
+             unique assert (0 <= c + x + y < 2^(n+2))
+               by (rewrite Z.pow_add_r, Z.pow_2_r; auto with zarith)
+           | H : 0 < ?n |- _ =>
+             unique assert (2^(bitwidth+1) <= 2^(bitwidth+n))
+               by auto with zarith
+           | H : 0 <= ?x < 2 ^ ?z |- context [?x mod 2 ^ ?y] =>
+             unique assert (2 ^ z <= 2 ^ y) by auto with zarith;
+               unique assert (0 <= x <= 2 ^ y) by auto with zarith
+           | _ => rewrite Z_ltz_mod_pow2_small by lia
+           | _ => rewrite Z_add_div_pow2 by auto with zarith
+           | _ => rewrite <-Z.add_add_div_ltz_2 by lia
+           | _ => rewrite Z.mod_pull_div, <-?Z.pow_add_r
+               by auto with zarith
+           | _ => progress Z.rewrite_mod_small
+           end.
+
   all: try solve[
-  lazymatch goal with
+  try lazymatch goal with
        | [ |- ?x mod ?y = _ mod ?y ]
          => apply f_equal2; [ | reflexivity ];
-              cbv [Z.ltz]; break_innermost_match; Z.ltb_to_lt; Z.div_mod_to_quot_rem
-       end;
+              cbv [Z.ltz]; break_innermost_match; Z.ltb_to_lt
+       end; Z.div_mod_to_quot_rem;
    repeat match goal with
               | [ H : ?x + ?y = ?d * ?q + ?r, H' : ?r < ?y |- _ ]
                 => is_var q; unique assert (q = 1) by do_clear_nia x y r H H'; subst
@@ -761,46 +815,4 @@ Proof using Type.
                       remember (q - q0) as q' eqn:?; (tryif is_var q then Z.linear_substitute q else idtac)
               | _ => nia
           end].
-  { (* TODO : long and manual; fix *)
-    push_Zmod; pull_Zmod.
-    Z.rewrite_mod_small.
-    subst.
-    rewrite <-Z.add_mul_mod by
-        (rewrite <-?Z.add_div_ltz_1 by lia;
-         try split; auto with zarith; rewrite Z.pow_sub_r by lia;
-         apply Z.div_lt_upper_bound; auto with zarith;
-         rewrite Z.mul_div_eq, Z.mod_same_pow by auto with zarith;
-         autorewrite with zsimplify_fast; auto with zarith).
-    rewrite <-Z.div_add by auto with zarith.
-    match goal with
-      |- context [?x * 2 ^ (?y - ?z) * 2^?z] =>
-      replace (x * 2^(y-z) * 2^z) with (x * 2^y);
-        [ | transitivity (x * (2^(y-z) * 2^z)); [ | lia];
-            rewrite <-Z.pow_add_r by lia; repeat (f_equal; try lia) ]
-    end.
-    rewrite <-Z.add_div_ltz_1, <-Z.div_mod''', <-!Z.pow_add_r
-      by auto with zarith.
-
-    match goal with
-    | H : 0 <= ?x <= 2^?y-1, H' : 0 <= ?z <= 2^?y-1 |-
-      context [?x + ?z] =>
-      let P := fresh "H" in
-      assert (0 <= x + z < 2^y + 2^y) as P by auto with zarith;
-        rewrite Z.add_diag, Z.pow_mul_base in P by lia
-    end.
-    assert (2 ^ (bitwidth+1) <= 2 ^ (Z.log2 two_pow_n+lgcarrymax))
-        by auto with zarith.
-    match goal with
-    | |- context[(?x / ?y) mod ?z] =>
-      assert (0 <= x / y < 2^lgcarrymax)
-        by (split; auto with zarith;
-            apply Z.div_lt_upper_bound; auto with zarith;
-            rewrite <-Z.pow_add_r by lia; auto with zarith)
-    end.
-    match goal with
-    | |- context[_ mod (2 ^ (?x + ?y))] =>
-      assert (2^x < 2^(x+y)) by auto with zarith
-    end.
-    Z.rewrite_mod_small.
-    reflexivity. }
 Qed.

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -22,6 +22,7 @@ Require Import Crypto.Util.ZUtil.MulSplit.
 Require Import Crypto.Util.ZUtil.TruncatingShiftl.
 Require Import Crypto.Util.ZUtil.Zselect.
 Require Import Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Divide.
 Require Import Crypto.Util.ZUtil.Modulo.
 Require Import Crypto.Util.ZUtil.Pow.
 Require Import Crypto.Util.ZUtil.Land.
@@ -672,6 +673,30 @@ Proof using Type.
   all:autorewrite with zsimplify; lia.
 Qed.
 
+(* TODO: move *)
+Lemma Z_mod_pow_same_base_larger a b n m :
+  0 <= n < m -> 0 < b ->
+  (a mod (b^n)) mod (b^m) = a mod b^n.
+Proof.
+  intros.
+  pose proof Z.mod_pos_bound a (b^n) ltac:(auto with zarith).
+  assert (b^n <= b^m) by auto with zarith.
+  apply Z.mod_small. auto with zarith.
+Qed.
+
+(* TODO: move *)
+Lemma Z_mod_pow_same_base_smaller a b n m :
+  0 <= m < n -> 0 < b ->
+  (a mod (b^n)) mod (b^m) = a mod b^m.
+Proof.
+  intros.
+  replace n with (m+(n-m)) by lia.
+  rewrite Z.pow_add_r by lia.
+  rewrite Z.rem_mul_r by auto with zarith.
+  push_Zmod; pull_Zmod.
+  autorewrite with zsimplify_fast; reflexivity.
+Qed.
+
 Lemma multiret_split_rewrite_rules_proofs (bitwidth : Z) (lgcarrymax : Z)
   : PrimitiveHList.hlist (@snd bool Prop) (multiret_split_rewrite_rulesT bitwidth lgcarrymax).
 Proof using Type.
@@ -681,14 +706,27 @@ Proof using Type.
   all: repeat interp_good_t_step_related.
   all: systematically_handle_casts; try reflexivity.
   all: rewrite !ident.platform_specific_cast_0_is_mod, ?Z.sub_add, ?Z.mod_mod by lia; try reflexivity.
+  all:
+    try
+      (match goal with
+      | |- context [Z.land ?x (2^?n - 1)] =>
+        replace (2^n-1) with (Z.ones n) by
+            (rewrite Z.sub_1_r, <-Z.ones_equiv; reflexivity);
+          rewrite !Z.land_ones by lia
+       end).
+  all: rewrite ?Z.shiftr_div_pow2, ?Z.shiftl_mul_pow2 by lia.
+  all: rewrite ?Z_mod_pow_same_base_larger,
+       ?Z_mod_pow_same_base_smaller by lia.
+  all: try reflexivity.
   all: push_Zmod; pull_Zmod; try reflexivity.
   all: progress specialize_by auto.
-  all: lazymatch goal with
+  all: try solve[
+  lazymatch goal with
        | [ |- ?x mod ?y = _ mod ?y ]
          => apply f_equal2; [ | reflexivity ];
-              progress cbv [Z.ltz]; break_innermost_match; Z.ltb_to_lt; Z.div_mod_to_quot_rem
-       end.
-  all: repeat match goal with
+              cbv [Z.ltz]; break_innermost_match; Z.ltb_to_lt; Z.div_mod_to_quot_rem
+       end;
+   repeat match goal with
               | [ H : ?x + ?y = ?d * ?q + ?r, H' : ?r < ?y |- _ ]
                 => is_var q; unique assert (q = 1) by do_clear_nia x y r H H'; subst
               | [ H : ?x + ?y = ?d * ?q + ?r, H' : ?r >= ?y |- _ ]
@@ -706,5 +744,46 @@ Proof using Type.
                       let q' := fresh "q" in
                       remember (q - q0) as q' eqn:?; (tryif is_var q then Z.linear_substitute q else idtac)
               | _ => nia
-              end.
+          end].
+  { (* TODO : long and manual; fix *)
+    push_Zmod; pull_Zmod.
+    Z.rewrite_mod_small.
+    rewrite <-Z.add_mul_mod by
+        (rewrite <-?Z.add_div_ltz_1 by lia;
+         try split; auto with zarith; rewrite Z.pow_sub_r by lia;
+         apply Z.div_lt_upper_bound; auto with zarith;
+         rewrite Z.mul_div_eq, Z.mod_same_pow by auto with zarith;
+         autorewrite with zsimplify_fast; auto with zarith).
+    rewrite <-Z.div_add by auto with zarith.
+    match goal with
+      |- context [?x * 2 ^ (?y - ?z) * 2^?z] =>
+      replace (x * 2^(y-z) * 2^z) with (x * 2^y);
+        [ | transitivity (x * (2^(y-z) * 2^z)); [ | lia];
+            rewrite <-Z.pow_add_r by lia; repeat (f_equal; try lia) ]
+    end.
+    rewrite <-Z.add_div_ltz_1, <-Z.div_mod''', <-!Z.pow_add_r
+      by auto with zarith.
+
+    match goal with
+    | H : 0 <= ?x <= 2^?y-1, H' : 0 <= ?z <= 2^?y-1 |-
+      context [?x + ?z] =>
+      let P := fresh "H" in
+      assert (0 <= x + z < 2^y + 2^y) as P by auto with zarith;
+        rewrite Z.add_diag, Z.pow_mul_base in P by lia
+    end.
+    assert (2 ^ (bitwidth+1) <= 2 ^ (n+lgcarrymax))
+        by auto with zarith.
+    match goal with
+    | |- context[(?x / ?y) mod ?z] =>
+      assert (0 <= x / y < z)
+        by (split; auto with zarith;
+            apply Z.div_lt_upper_bound; auto with zarith;
+            rewrite <-Z.pow_add_r by lia; auto with zarith)
+    end.
+    match goal with
+    | |- context[_ mod (2 ^ (?x + ?y))] =>
+      assert (2^x < 2^(x+y)) by auto with zarith
+    end.
+    Z.rewrite_mod_small.
+    reflexivity. }
 Qed.

--- a/src/Util/ZUtil/AddGetCarry.v
+++ b/src/Util/ZUtil/AddGetCarry.v
@@ -174,4 +174,33 @@ Module Z.
     -> 0 <= y < s
     -> snd (Z.sub_get_borrow_full s x y) = Z.ltz x ((x - y) mod s).
   Proof. rewrite sub_get_borrow_full_div; fin_div_ltz. Qed.
+
+  (* TODO: should this lemma go elsewhere? Where? *)
+  Lemma ltz_mod_pow2_small x y z :
+    0 < z ->
+    (Z.ltz x y) mod (2 ^ z) = Z.ltz x y.
+  Proof.
+    cbv [Z.ltz]; break_match; intros; Z.ltb_to_lt;
+      apply Z.mod_small; auto with zarith.
+  Qed.
+
+  (* TODO: should this lemma go elsewhere? Where? *)
+  (* Useful lemma for add-get-carry patterns.
+     This expression performs a bitwise or. In terms of bit ranges,
+       b...a + a...c << a-b = b...c *)
+  Lemma add_div_pow2 x a b :
+    0 <= b <= a ->
+    (x mod (2 ^ a)) / 2 ^ b + x / 2 ^ a * 2 ^ (a - b)
+    = x / 2 ^ b.
+  Proof.
+    intros.
+    rewrite <-Z.div_add by auto with zarith.
+    match goal with
+      |- context [?x * 2^(?a-?b) * 2^?b] =>
+      replace (x * 2^(a-b) * 2^b) with (x * 2^a)
+        by (rewrite <-Z.mul_assoc, <-Z.pow_add_r by auto with zarith;
+            repeat (f_equal; try lia))
+    end.
+    fin_div_ltz.
+  Qed.
 End Z.

--- a/src/Util/ZUtil/AddGetCarry.v
+++ b/src/Util/ZUtil/AddGetCarry.v
@@ -127,6 +127,18 @@ Module Z.
     -> (x + y) / s = Z.ltz ((x + y) mod s) y.
   Proof. fin_div_ltz. Qed.
 
+  Lemma add_add_div_ltz_2 s c x y :
+    0 <= c < s
+    -> 0 <= x < s
+    -> 0 <= y < s
+    -> (c + x + y) / s =
+       Z.ltz ((c + x) mod s) x + Z.ltz ((c + x + y) mod s) y.
+  Proof.
+    intros. rewrite <-(Z.add_mod_idemp_l (c + x)) by lia.
+    rewrite <-!add_div_ltz_2 by auto with zarith.
+    fin_div_ltz.
+  Qed.
+
   Lemma add_get_carry_full_ltz_1 s x y :
     0 <= x < s
     -> 0 <= y < s

--- a/src/Util/ZUtil/AddGetCarry.v
+++ b/src/Util/ZUtil/AddGetCarry.v
@@ -157,6 +157,18 @@ Module Z.
     -> - ((x - y) / s) = Z.ltz x ((x - y) mod s).
   Proof. fin_div_ltz. Qed.
 
+  Lemma sub_sub_div_ltz s x y c :
+    0 <= c < s
+    -> 0 <= x < s
+    -> 0 <= y < s
+    -> - ((x - y - c) / s) =
+       Z.ltz x ((x - y) mod s) + Z.ltz ((x - y) mod s) ((x - y - c) mod s).
+  Proof.
+    intros. rewrite (PullPush.Z.sub_mod_l (x-y)).
+    rewrite <-!sub_div_ltz by auto with zarith.
+    fin_div_ltz.
+  Qed.
+
   Lemma sub_get_borrow_full_ltz s x y :
     0 <= x < s
     -> 0 <= y < s

--- a/src/Util/ZUtil/AddGetCarry.v
+++ b/src/Util/ZUtil/AddGetCarry.v
@@ -1,6 +1,7 @@
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
+Require Import Crypto.Util.ZUtil.Modulo.PullPush.
 Require Import Crypto.Util.Prod.
 Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
@@ -164,7 +165,7 @@ Module Z.
     -> - ((x - y - c) / s) =
        Z.ltz x ((x - y) mod s) + Z.ltz ((x - y) mod s) ((x - y - c) mod s).
   Proof.
-    intros. rewrite (PullPush.Z.sub_mod_l (x-y)).
+    intros. rewrite (Z.sub_mod_l (x-y)).
     rewrite <-!sub_div_ltz by auto with zarith.
     fin_div_ltz.
   Qed.
@@ -182,25 +183,5 @@ Module Z.
   Proof.
     cbv [Z.ltz]; break_match; intros; Z.ltb_to_lt;
       apply Z.mod_small; auto with zarith.
-  Qed.
-
-  (* TODO: should this lemma go elsewhere? Where? *)
-  (* Useful lemma for add-get-carry patterns.
-     This expression performs a bitwise or. In terms of bit ranges,
-       b...a + a...c << a-b = b...c *)
-  Lemma add_div_pow2 x a b :
-    0 <= b <= a ->
-    (x mod (2 ^ a)) / 2 ^ b + x / 2 ^ a * 2 ^ (a - b)
-    = x / 2 ^ b.
-  Proof.
-    intros.
-    rewrite <-Z.div_add by auto with zarith.
-    match goal with
-      |- context [?x * 2^(?a-?b) * 2^?b] =>
-      replace (x * 2^(a-b) * 2^b) with (x * 2^a)
-        by (rewrite <-Z.mul_assoc, <-Z.pow_add_r by auto with zarith;
-            repeat (f_equal; try lia))
-    end.
-    fin_div_ltz.
   Qed.
 End Z.

--- a/src/Util/ZUtil/Modulo.v
+++ b/src/Util/ZUtil/Modulo.v
@@ -380,4 +380,24 @@ Module Z.
     rewrite Z.rem_mul_r by auto with zarith.
     reflexivity.
   Qed.
+
+  Lemma mod_pow_same_base_larger a b n m :
+    0 <= n < m -> 0 < b ->
+    (a mod (b^n)) mod (b^m) = a mod b^n.
+  Proof.
+    intros.
+    pose proof Z.mod_pos_bound a (b^n) ltac:(auto with zarith).
+    assert (b^n <= b^m) by auto with zarith.
+    apply Z.mod_small. auto with zarith.
+  Qed.
+
+  Lemma mod_pow_same_base_smaller a b n m :
+    0 <= m <= n -> 0 < b ->
+    (a mod (b^n)) mod (b^m) = a mod b^m.
+  Proof.
+    intros. replace n with (m+(n-m)) by lia.
+    rewrite Z.pow_add_r, Z.rem_mul_r by auto with zarith.
+    push_Zmod; pull_Zmod.
+    autorewrite with zsimplify_fast; reflexivity.
+  Qed.
 End Z.

--- a/src/Util/ZUtil/Modulo.v
+++ b/src/Util/ZUtil/Modulo.v
@@ -6,6 +6,7 @@ Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Tactics.ReplaceNegWithPos.
 Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
 Require Import Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Divide.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.DestructHead.
 Local Open Scope Z_scope.
@@ -399,5 +400,22 @@ Module Z.
     rewrite Z.pow_add_r, Z.rem_mul_r by auto with zarith.
     push_Zmod; pull_Zmod.
     autorewrite with zsimplify_fast; reflexivity.
+  Qed.
+
+  (* Useful lemma for add-get-carry patterns.
+     This expression performs a bitwise or. In terms of bit ranges,
+       b...a + a...c << a-b = b...c *)
+  Lemma add_div_pow2 x a b :
+    0 <= b <= a ->
+    (x mod (2 ^ a)) / 2 ^ b + x / 2 ^ a * 2 ^ (a - b)
+    = x / 2 ^ b.
+  Proof.
+    intros. rewrite Z.pow_sub_r by auto with zarith.
+    rewrite <-Z.divide_div_mul_exact
+      by auto using Z.divide_pow_le with zarith.
+    rewrite <-Z.div_add by auto with zarith.
+    rewrite Z.mul_div_eq', Z.mul_mod, Z.mod_same_pow by auto with zarith.
+    autorewrite with zsimplify.
+    Z.div_mod_to_quot_rem; nia.
   Qed.
 End Z.

--- a/src/Util/ZUtil/Opp.v
+++ b/src/Util/ZUtil/Opp.v
@@ -8,4 +8,7 @@ Module Z.
   Lemma opp_eq_0_iff a : -a = 0 <-> a = 0.
   Proof. omega. Qed.
   Hint Rewrite opp_eq_0_iff : zsimplify.
+
+  Lemma opp_sub n m : - n - m = - (n + m).
+  Proof. lia. Qed.
 End Z.


### PR DESCRIPTION
As discussed in #686 and #722, the bedrock2 translation was failing on `to_bytes` due to two problems, one of which was adds-with-carry and subs-with-borrow that split on a bit index other than the word size (e.g. `Z.add_with_get_carry (2^51) c x y`). These expressions weren't matching the `split_multiret` rewrite rules and were showing up as assignments to two variables, which bedrock2 doesn't support. This PR fixes that issue by adding new rules that match on non-word-size splits and split the return values.

Since we still lack a bedrock2-expressible transformation for `Z.zselect` (the second problem, which I'll start working on now), generating `to_bytes` still fails. But with many fewer errors than before!