### PR TITLE
Add support for Z.lxor

### DIFF
--- a/src/AbstractInterpretation/AbstractInterpretation.v
+++ b/src/AbstractInterpretation/AbstractInterpretation.v
@@ -504,6 +504,7 @@ Module Compilers.
              | ident.Z_max as idc
              | ident.Z_min as idc
              | ident.Z_pow as idc
+             | ident.Z_lxor as idc
              | ident.Z_modulo as idc
              | ident.Build_zrange as idc
                => fun x y => match to_literal x, to_literal y with

--- a/src/Language/APINotations.v
+++ b/src/Language/APINotations.v
@@ -229,6 +229,7 @@ Module Compilers.
     Notation Z_max := Compilers.ident_Z_max (only parsing).
     Notation Z_bneg := Compilers.ident_Z_bneg (only parsing).
     Notation Z_lnot_modulo := Compilers.ident_Z_lnot_modulo (only parsing).
+    Notation Z_lxor := Compilers.ident_Z_lxor (only parsing).
     Notation Z_truncating_shiftl := Compilers.ident_Z_truncating_shiftl (only parsing).
     Notation Z_mul_split := Compilers.ident_Z_mul_split (only parsing).
     Notation Z_mul_high := Compilers.ident_Z_mul_high (only parsing).

--- a/src/Language/IdentifierParameters.v
+++ b/src/Language/IdentifierParameters.v
@@ -122,6 +122,7 @@ Definition all_ident_named_interped : InductiveHList.hlist
       ; with_name ident_Z_truncating_shiftl Z.truncating_shiftl
       ; with_name ident_Z_bneg Z.bneg
       ; with_name ident_Z_lnot_modulo Z.lnot_modulo
+      ; with_name ident_Z_lxor Z.lxor
       ; with_name ident_Z_rshi Z.rshi
       ; with_name ident_Z_cc_m Z.cc_m
       ; with_name ident_Z_combine_at_bitwidth Z.combine_at_bitwidth

--- a/src/Stringification/IR.v
+++ b/src/Stringification/IR.v
@@ -751,6 +751,7 @@ Module Compilers.
                  | ident.Z_sub_get_borrow
                  | ident.Z_sub_with_get_borrow
                  | ident.Z_add_modulo
+                 | ident.Z_lxor
                  | ident.Z_rshi
                  | ident.Z_cc_m
                  | ident.Z_combine_at_bitwidth

--- a/src/Stringification/Language.v
+++ b/src/Stringification/Language.v
@@ -320,6 +320,7 @@ Module Compilers.
              | ident.Z_opp => fun '((x, xr), tt) => (fun lvl => maybe_wrap_parens (Nat.ltb lvl 35) ("-" ++ x 35%nat), ZRange.type.base.option.None)
              | ident.Z_bneg => fun '((x, xr), tt) => (fun lvl => maybe_wrap_parens (Nat.ltb lvl 75) ("!" ++ x 75%nat), ZRange.type.base.option.None)
              | ident.Z_lnot_modulo => fun '((x, xr), ((m, mr), tt)) => (fun lvl => maybe_wrap_parens (Nat.ltb lvl 75) ("~" ++ x 75%nat ++ (if with_casts then " (mod " ++ m 200%nat ++ ")" else "")), ZRange.type.base.option.None)
+             | ident.Z_lxor => fun '((x, xr), ((y, yr), tt)) => (fun lvl => maybe_wrap_parens (Nat.ltb lvl 50) (x 50%nat ++ " ⊕ " ++ y 49%nat), ZRange.type.base.option.None)
              | ident.Z_div => fun '((x, xr), ((y, yr), tt)) => (fun lvl => maybe_wrap_parens (Nat.ltb lvl 40) (x 40%nat ++ " / " ++ y 39%nat), ZRange.type.base.option.None)
              | ident.Z_modulo => fun '((x, xr), ((y, yr), tt)) => (fun lvl => maybe_wrap_parens (Nat.ltb lvl 40) (x 40%nat ++ " mod " ++ y 39%nat), ZRange.type.base.option.None)
              | ident.Z_eqb => fun '((x, xr), ((y, yr), tt)) => (fun lvl => maybe_wrap_parens (Nat.ltb lvl 70) (x 69%nat ++ " = " ++ y 69%nat), ZRange.type.base.option.None)
@@ -474,6 +475,7 @@ Module Compilers.
                 | ident.Z_land => "(&)"
                 | ident.Z_lor => "(|)"
                 | ident.Z_lnot_modulo => "~"
+                | ident.Z_lxor => "⊕"
                 | ident.Z_bneg => "!"
                 | ident.Z_mul_split => "Z.mul_split"
                 | ident.Z_mul_high => "Z.mul_high"


### PR DESCRIPTION
Currently bounds analysis only knows how to analyze Z.lxor applied to
constants, but it still can be used in post-bounds-analysis rewrite
rules.