### PR TITLE
Give stringification access to machine_wordsize

### DIFF
--- a/src/Bedrock/Stringification.v
+++ b/src/Bedrock/Stringification.v
@@ -156,6 +156,7 @@ Definition make_header {t}
 (* TODO: for now, name_list is just ignored -- could probably make it not ignored *)
 Definition Bedrock2_ToFunctionLines
            {relax_zrange : relax_zrange_opt}
+           (machine_wordsize : Z)
            (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
            {t}
            (e : @API.Expr t)
@@ -213,11 +214,11 @@ Definition OutputBedrock2API : ToString.OutputLanguageAPI :=
 
     ToString.ToFunctionLines := @Bedrock2_ToFunctionLines;
 
-    ToString.header := fun _ _ _ => ["#include <stdint.h>"];
+    ToString.header := fun _ _ _ _ => ["#include <stdint.h>"];
 
-    ToString.footer := fun _ _ _ => [];
+    ToString.footer := fun _ _ _ _ => [];
 
     (** No special handling for any functions *)
-    ToString.strip_special_infos infos := infos;
+    ToString.strip_special_infos machine_wordsize infos := infos;
 
   |}.

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -178,7 +178,7 @@ Section rbarrett_red.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "barrett_red" barrett_red
+          machine_wordsize prefix "barrett_red" barrett_red
           (fun _ _ _ => @nil string).
 
   Local Ltac solve_barrett_red_preconditions :=

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -273,7 +273,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "convert_bases" convert_bases
+          machine_wordsize prefix "convert_bases" convert_bases
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " converts a field element from base " ++ Decimal.show_Q false src_limbwidth ++ " to base " ++ Decimal.show_Q false dst_limbwidth ++ " in little-endian order."]%string)
              (convert_bases_correct src_weight dst_weight src_n dst_n in_bounds)).

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -170,7 +170,7 @@ Section rmontred.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "montred" montred
+          machine_wordsize prefix "montred" montred
           (fun _ _ _ => @nil string).
 
   Local Ltac solve_montred_preconditions :=

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -152,10 +152,10 @@ Local Notation out_bounds_of_pipeline result
   := ((fun a b c d e arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ result eq_refl)
        (only parsing).
 
-Notation FromPipelineToString prefix name result
-  := (Pipeline.FromPipelineToString prefix name result).
-Notation FromPipelineToInternalString prefix name result
-  := (Pipeline.FromPipelineToInternalString prefix name result).
+Notation FromPipelineToString machine_wordsize prefix name result
+  := (Pipeline.FromPipelineToString machine_wordsize prefix name result).
+Notation FromPipelineToInternalString machine_wordsize prefix name result
+  := (Pipeline.FromPipelineToInternalString machine_wordsize prefix name result).
 
 Ltac prove_correctness' should_not_clear use_curve_good :=
   let Hres := match goal with H : _ = Success _ |- _ => H end in
@@ -700,7 +700,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "selectznz" selectznz
+          machine_wordsize prefix "selectznz" selectznz
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " is a multi-limb conditional select."]%string)
              (selectznz_correct dummy_weight n saturated_bounds_list)).
@@ -719,7 +719,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToInternalString
-          prefix ("mulx_u" ++ decimal_string_of_Z s) (mulx s)
+          machine_wordsize prefix ("mulx_u" ++ decimal_string_of_Z s) (mulx s)
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " is a multiplication, returning the full double-width result."]%string)
              (mulx_correct s)).
@@ -739,7 +739,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToInternalString
-          prefix ("addcarryx_u" ++ decimal_string_of_Z s) (addcarryx s)
+          machine_wordsize prefix ("addcarryx_u" ++ decimal_string_of_Z s) (addcarryx s)
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " is an addition with carry."]%string)
              (addcarryx_correct s)).
@@ -758,7 +758,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToInternalString
-          prefix ("subborrowx_u" ++ decimal_string_of_Z s) (subborrowx s)
+          machine_wordsize prefix ("subborrowx_u" ++ decimal_string_of_Z s) (subborrowx s)
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " is a subtraction with borrow."]%string)
              (subborrowx_correct s)).
@@ -778,7 +778,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToInternalString
-          prefix ("cmovznz_u" ++ decimal_string_of_Z s) (cmovznz s)
+          machine_wordsize prefix ("cmovznz_u" ++ decimal_string_of_Z s) (cmovznz s)
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " is a single-word conditional move."]%string)
              (cmovznz_correct false s)).
@@ -797,7 +797,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToInternalString
-          prefix ("cmovznz_u" ++ decimal_string_of_Z s) (cmovznz_by_mul s)
+          machine_wordsize prefix ("cmovznz_u" ++ decimal_string_of_Z s) (cmovznz_by_mul s)
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " is a single-word conditional move."]%string)
              (cmovznz_correct false s)).
@@ -919,17 +919,17 @@ Section __.
                    | requests => List.map (synthesize_of_name function_name_prefix) requests
                    end in
          let infos := aggregate_infos ls in
-         let '(extra_ls, extra_bit_widths) := extra_synthesis function_name_prefix (ToString.strip_special_infos infos) in
+         let '(extra_ls, extra_bit_widths) := extra_synthesis function_name_prefix (ToString.strip_special_infos machine_wordsize infos) in
          let res := (if emit_primitives then extra_ls else nil) ++ List.map (fun '(name, res) => (name, (res <- res; Success (fst res))%error)) ls in
          let infos := ToString.ident_info_union
                         infos
                         (ToString.ident_info_of_bitwidths_used extra_bit_widths) in
          let header :=
              (comment_header
-                ++ ToString.header static function_name_prefix infos
+                ++ ToString.header machine_wordsize static function_name_prefix infos
                 ++ [""]) in
          let footer :=
-             ToString.footer static function_name_prefix infos in
+             ToString.footer machine_wordsize static function_name_prefix infos in
          [("check_args" ++ String.NewLine ++ String.concat String.NewLine header,
            check_args (ErrorT.Success header))%string]
            ++ res

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -183,7 +183,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "mul" mul
+          machine_wordsize prefix "mul" mul
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " multiplies two field elements."]%string)
              (mul_correct weightf n m boundsn)).

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -73,7 +73,7 @@ Local Instance : emit_primitives_opt := true.
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_mulx_u64"
-        true None [64; 128]
+        true None [64; 128] 64
         ltac:(let r := Reify (mulx 64) in
               exact r)
                (fun _ _ => [])
@@ -83,7 +83,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_addcarryx_u64"
-        true None [1; 64; 128]
+        true None [1; 64; 128] 64
         ltac:(let r := Reify (addcarryx 64) in
               exact r)
                (fun _ _ => [])
@@ -93,7 +93,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_addcarryx_u51"
-        true None [1; 64; 128]
+        true None [1; 64; 128] 64
         ltac:(let r := Reify (addcarryx 51) in
               exact r)
                (fun _ _ => [])
@@ -103,7 +103,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_subborrowx_u64"
-        true None [1; 64; 128]
+        true None [1; 64; 128] 64
         ltac:(let r := Reify (subborrowx 64) in
               exact r)
                (fun _ _ => [])
@@ -112,7 +112,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_subborrowx_u51"
-        true None [1; 64; 128]
+        true None [1; 64; 128] 64
         ltac:(let r := Reify (subborrowx 51) in
               exact r)
                (fun _ _ => [])
@@ -122,7 +122,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_cmovznz64"
-        true None [1; 64; 128]
+        true None [1; 64; 128] 64
         ltac:(let r := Reify (cmovznz 64) in
               exact r)
                (fun _ _ => [])

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -294,7 +294,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "carry_mul" carry_mul
+          machine_wordsize prefix "carry_mul" carry_mul
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " multiplies two field elements and reduces the result."]%string)
              (carry_mul_correct weightf n m tight_bounds loose_bounds)).
@@ -313,7 +313,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "carry_square" carry_square
+          machine_wordsize prefix "carry_square" carry_square
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " squares a field element and reduces the result."]%string)
              (carry_square_correct weightf n m tight_bounds loose_bounds)).
@@ -332,7 +332,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix ("carry_scmul_" ++ decimal_string_of_Z x) (carry_scmul_const x)
+          machine_wordsize prefix ("carry_scmul_" ++ decimal_string_of_Z x) (carry_scmul_const x)
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " multiplies a field element by " ++ decimal_string_of_Z x ++ " and reduces the result."]%string)
              (carry_scmul_const_correct weightf n m tight_bounds loose_bounds x)).
@@ -351,7 +351,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "carry" carry
+          machine_wordsize prefix "carry" carry
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " reduces a field element."]%string)
              (carry_correct weightf n m tight_bounds loose_bounds)).
@@ -370,7 +370,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "add" add
+          machine_wordsize prefix "add" add
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " adds two field elements."]%string)
              (add_correct weightf n m tight_bounds loose_bounds)).
@@ -389,7 +389,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "sub" sub
+          machine_wordsize prefix "sub" sub
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " subtracts two field elements."]%string)
              (sub_correct weightf n m tight_bounds loose_bounds)).
@@ -408,7 +408,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "opp" opp
+          machine_wordsize prefix "opp" opp
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " negates a field element."]%string)
              (opp_correct weightf n m tight_bounds loose_bounds)).
@@ -427,7 +427,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "to_bytes" to_bytes
+          machine_wordsize prefix "to_bytes" to_bytes
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " serializes a field element to bytes in little-endian order."]%string)
              (to_bytes_correct weightf n n_bytes m tight_bounds)).
@@ -446,7 +446,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "from_bytes" from_bytes
+          machine_wordsize prefix "from_bytes" from_bytes
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " deserializes a field element from bytes in little-endian order."]%string)
              (from_bytes_correct weightf n n_bytes m s tight_bounds)).
@@ -465,7 +465,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "encode" encode
+          machine_wordsize prefix "encode" encode
           (docstring_with_summary_from_lemma!
              (fun fname : string => ["The function " ++ fname ++ " encodes an integer as a field element."]%string)
              (encode_correct weightf n m tight_bounds)).
@@ -484,7 +484,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "zero" zero
+          machine_wordsize prefix "zero" zero
           (docstring_with_summary_from_lemma!
              (fun fname => ["The function " ++ fname ++ " returns the field element zero."]%string)
              (zero_correct weightf n m tight_bounds)).
@@ -503,7 +503,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "one" one
+          machine_wordsize prefix "one" one
           (docstring_with_summary_from_lemma!
              (fun fname => ["The function " ++ fname ++ " returns the field element one."]%string)
              (one_correct weightf n m tight_bounds)).

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -283,7 +283,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "mul" mul
+          machine_wordsize prefix "mul" mul
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " multiplies two field elements in the Montgomery domain."]%string)
@@ -303,7 +303,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "square" square
+          machine_wordsize prefix "square" square
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " squares a field element in the Montgomery domain."]%string)
@@ -323,7 +323,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "add" add
+          machine_wordsize prefix "add" add
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " adds two field elements in the Montgomery domain."]%string)
@@ -343,7 +343,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "sub" sub
+          machine_wordsize prefix "sub" sub
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " subtracts two field elements in the Montgomery domain."]%string)
@@ -363,7 +363,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "opp" opp
+          machine_wordsize prefix "opp" opp
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " negates a field element in the Montgomery domain."]%string)
@@ -383,7 +383,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "from_montgomery" from_montgomery
+          machine_wordsize prefix "from_montgomery" from_montgomery
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " translates a field element out of the Montgomery domain."]%string)
@@ -402,7 +402,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "nonzero" nonzero
+          machine_wordsize prefix "nonzero" nonzero
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " outputs a single non-zero word if the input is non-zero and zero otherwise."]%string)
@@ -422,7 +422,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "to_bytes" to_bytes
+          machine_wordsize prefix "to_bytes" to_bytes
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " serializes a field element in the Montgomery domain to bytes in little-endian order."]%string)
@@ -442,7 +442,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "from_bytes" from_bytes
+          machine_wordsize prefix "from_bytes" from_bytes
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " deserializes a field element in the Montgomery domain from bytes in little-endian order."]%string)
@@ -462,7 +462,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "encode" encode
+          machine_wordsize prefix "encode" encode
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname : string => ["The function " ++ fname ++ " encodes an integer as a field element in the Montgomery domain."]%string)
@@ -482,7 +482,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "zero" zero
+          machine_wordsize prefix "zero" zero
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname => ["The function " ++ fname ++ " returns the field element zero in the Montgomery domain."]%string)
@@ -502,7 +502,7 @@ Section __.
     : string * (Pipeline.ErrorT (list string * ToString.ident_infos))
     := Eval cbv beta in
         FromPipelineToString
-          prefix "one" one
+          machine_wordsize prefix "one" one
           (docstring_with_summary_from_lemma!
              prefix
              (fun fname => ["The function " ++ fname ++ " returns the field element one in the Montgomery domain."]%string)

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -1864,6 +1864,7 @@ Module debugging_remove_mul_split_to_C_uint1_carry.
       false (* subst01 *)
       None (* fancy *)
       possible_values
+      machine_wordsize
       ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n idxs)) in
             exact r)
              (fun _ _ => []) (* comment *)
@@ -2789,7 +2790,7 @@ Section debugging_p448.
        "mul"
        false (* subst01 *)
        None (* fancy *)
-       possible_values
+       possible_values machine_wordsize
        ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n [3; 7; 4; 0; 5; 1; 6; 2; 7; 3; 4; 0]%nat)) in
              exact r)
               (fun _ _ => []) (* comment *)

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -45,7 +45,7 @@ Module Compilers.
 
     Module C.
       Module String.
-        Definition header (static : bool) (prefix : string) (infos : ident_infos)
+        Definition header (machine_wordsize : Z) (static : bool) (prefix : string) (infos : ident_infos)
         : list string
           := let bitwidths_used := bitwidths_used infos in
              (["#include <stdint.h>"]
@@ -479,6 +479,7 @@ Module Compilers.
 
       Definition ToFunctionLines
                  {relax_zrange : relax_zrange_opt}
+                 (machine_wordsize : Z)
                  (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
                  {t}
                  (e : @Compilers.expr.Expr base.type ident.ident t)
@@ -508,6 +509,7 @@ Module Compilers.
 
       Definition ToFunctionString
                  {relax_zrange : relax_zrange_opt}
+                 (machine_wordsize : Z)
                  (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
                  {t}
                  (e : @Compilers.expr.Expr base.type ident.ident t)
@@ -516,7 +518,7 @@ Module Compilers.
                  (inbounds : type.for_each_lhs_of_arrow ZRange.type.option.interp t)
                  (outbounds : ZRange.type.option.interp (type.base (type.final_codomain t)))
         : (string * ident_infos) + string
-        := match ToFunctionLines do_bounds_check static prefix name e comment name_list inbounds outbounds with
+        := match ToFunctionLines machine_wordsize do_bounds_check static prefix name e comment name_list inbounds outbounds with
            | inl (ls, used_types) => inl (LinesToString ls, used_types)
            | inr err => inr err
            end.
@@ -530,10 +532,10 @@ Module Compilers.
 
           ToString.header := String.header;
 
-          ToString.footer := fun _ _ _ => [];
+          ToString.footer := fun _ _ _ _ => [];
 
           (** No special handling for any functions *)
-          ToString.strip_special_infos infos := infos;
+          ToString.strip_special_infos machine_wordsize infos := infos;
 
         |}.
     End C.

--- a/src/Stringification/Go.v
+++ b/src/Stringification/Go.v
@@ -29,7 +29,7 @@ Module Go.
   Definition is_special_bitwidth (bw : Z) := negb (is_standard_bitwidth bw).
 
   (* Header imports and type defs *)
-  Definition header (static : bool) (prefix : string) (infos : ToString.ident_infos)
+  Definition header (machine_wordsize : Z) (static : bool) (prefix : string) (infos : ToString.ident_infos)
   : list string
     (* N.B. We don't do anything with static; we never export anything *)
     := let bitwidths_used := ToString.bitwidths_used infos in
@@ -404,6 +404,7 @@ Module Go.
 
   Definition ToFunctionLines
              {relax_zrange : relax_zrange_opt}
+             (machine_wordsize : Z)
              (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
              {t}
              (e : API.Expr t)
@@ -435,7 +436,7 @@ Module Go.
     {| ToString.comment_block := List.map (fun line => "/* " ++ line ++ " */")%string;
        ToString.ToFunctionLines := @ToFunctionLines;
        ToString.header := header;
-       ToString.footer := fun _ _ _ => [];
-       ToString.strip_special_infos := strip_special_infos |}.
+       ToString.footer := fun _ _ _ _ => [];
+       ToString.strip_special_infos machine_wordsize := strip_special_infos |}.
 
 End Go.

--- a/src/Stringification/Java.v
+++ b/src/Stringification/Java.v
@@ -24,7 +24,7 @@ Import Stringification.Language.Compilers.ToString.int.Notations.
 Module Java.
 
   (* Header imports and type defs *)
-  Definition header (static : bool) (prefix : string) (infos : ToString.ident_infos)
+  Definition header (machine_wordsize : Z) (static : bool) (prefix : string) (infos : ToString.ident_infos)
   : list string
     (* N.B. We don't do anything with static; we always export everything *)
     := let bitwidths_used := ToString.bitwidths_used infos in
@@ -42,7 +42,7 @@ Module Java.
          "  public T get() { return this.value; }";
          "}";
          ""]%string)).
-  Definition footer (static : bool) (prefix : string) (infos : ToString.ident_infos)
+  Definition footer (machine_wordsize : Z) (static : bool) (prefix : string) (infos : ToString.ident_infos)
     : list string
     := ["}"]%string.
 
@@ -345,6 +345,7 @@ Module Java.
 
   Definition ToFunctionLines
              {relax_zrange : relax_zrange_opt}
+             (machine_wordsize : Z)
              (do_bounds_check : bool) (internal : bool) (prefix : string) (name : string)
              {t}
              (e : API.Expr t)
@@ -376,6 +377,6 @@ Module Java.
        ToString.ToFunctionLines := @ToFunctionLines;
        ToString.header := header;
        ToString.footer := footer;
-       ToString.strip_special_infos infos := infos |}.
+       ToString.strip_special_infos machine_wordsize infos := infos |}.
 
 End Java.

--- a/src/Stringification/Language.v
+++ b/src/Stringification/Language.v
@@ -1010,6 +1010,7 @@ Module Compilers.
             primitive functions are called, or else an error string *)
         ToFunctionLines
         : forall {relax_zrange : relax_zrange_opt}
+                 (machine_wordsize : Z)
                  (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
                  {t}
                  (e : @Compilers.expr.Expr base.type ident.ident t)
@@ -1021,18 +1022,20 @@ Module Compilers.
 
         (** Generates a header of any needed typedefs, etc based on the idents used and the curve-specific prefix *)
         header
-        : forall (static : bool) (prefix : string) (ident_info : ident_infos),
+        : forall (machine_wordsize : Z) (static : bool) (prefix : string) (ident_info : ident_infos),
             list string;
 
         (** The footer on the file, if any *)
         footer
-        : forall (static : bool) (prefix : string) (ident_info : ident_infos),
+        : forall (machine_wordsize : Z) (static : bool) (prefix : string) (ident_info : ident_infos),
             list string;
 
         (** Filters [ident_infos] to strip out primitive functions
             that we don't want to request (because they have special
             language handling *)
-        strip_special_infos : ident_infos -> ident_infos;
+        strip_special_infos
+        : forall (machine_wordsize : Z),
+            ident_infos -> ident_infos;
 
       }.
   End ToString.

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -22,7 +22,7 @@ Import Stringification.Language.Compilers.ToString.int.Notations.
 Module Rust.
 
   (* Header imports and type defs *)
-  Definition header (static : bool) (prefix : string) (infos : ToString.ident_infos)
+  Definition header (machine_wordsize : Z) (static : bool) (prefix : string) (infos : ToString.ident_infos)
     : list string
     := let bitwidths_used := ToString.bitwidths_used infos in
        let type_prefix := ((if static then "type " else "pub type ") ++ prefix)%string in
@@ -322,6 +322,7 @@ Module Rust.
 
   Definition ToFunctionLines
              {relax_zrange : relax_zrange_opt}
+             (machine_wordsize : Z)
              (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
              {t}
              (e : API.Expr t)
@@ -353,8 +354,8 @@ Module Rust.
     {| ToString.comment_block := List.map (fun line => "/* " ++ line ++ " */")%string;
        ToString.ToFunctionLines := @ToFunctionLines;
        ToString.header := header;
-       ToString.footer := fun _ _ _ => [];
+       ToString.footer := fun _ _ _ _ => [];
        (** No special handling for any functions *)
-       ToString.strip_special_infos infos := infos |}.
+       ToString.strip_special_infos machine_wordsize infos := infos |}.
 
 End Rust.


### PR DESCRIPTION
This will make bedrock2 32-bit support significantly easier.

Currently the CLI support is a bit messy, because I couldn't decide
whether bitwidth was "owned" by the overall pipeline (in which case it
probably shouldn't show up in the header, or should show up uniformly
with all the other options in the header, like static and some rewriter
options), or whether it's "owned" by individual synthesis pipelines
(like m, s, and c) (which allows it to continue showing up as its own
line in the header, as it currently does).

Probably we should eventually choose the former, but because I haven't
really thought out this design decision at this point, I currently
preserve the way the output files are currently being generated and do
this sort-of mixed support mode.