### PR TITLE
Deal with splitting 32x64 mul, not just 64x32 mul

### DIFF
--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -851,6 +851,13 @@ Section with_bitwidth.
                               dlet h2 := singlewidth (singlewidth xh * singlewidth y) in
                               dlet h := singlewidth (singlewidth (snd lh1) + singlewidth h2) in
                               cstZsingle_to_double (fst lh1) h))
+              ; (forall x yl yh,
+                    0 <= bitwidth
+                    -> doublewidth (singlewidth x * cstZsingle_to_double yl yh)
+                       = (dlet lh1 := pairsinglewidth (Z.mul_split cstZ_pow2_bitwidth (singlewidth x) (singlewidth yl)) in
+                              dlet h2 := singlewidth (singlewidth x * singlewidth yh) in
+                              dlet h := singlewidth (singlewidth (snd lh1) + singlewidth h2) in
+                              cstZsingle_to_double (fst lh1) h))
               ; (forall xl xh yl yh,
                     0 <= bitwidth
                     -> 1 <= lgcarrymax

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -671,6 +671,9 @@ Proof using Type.
            | |- ((_ + _) * ?y) mod _ = _ =>
              (* double * single multiplication case *)
              rewrite Z.mul_add_distr_r, <- Z.mul_assoc, (Z.mul_comm (2^_) y), Z.mul_assoc
+           | |- (?x * (_ + _)) mod _ = _ =>
+             (* single * double multiplication case *)
+             rewrite Z.mul_add_distr_l, Z.mul_assoc
            | |- (_ + _) mod (_ * _) = _ =>
              (* addition cases *)
              rewrite !Z.rem_mul_r by lia;


### PR DESCRIPTION
We previously only had a rule for the double-width multiplicand on the
left; this commit adds a rewrite rule for having the double-width
multiplicand on the right.  This should allow synthesis of 32-bit
carry_square for bedrock2.