### PR TITLE
Add support for 32-bit bedrock2 translations

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -74,7 +74,9 @@ src/Bedrock/Proofs/ValidComputable/Cmd.v
 src/Bedrock/Proofs/ValidComputable/Expr.v
 src/Bedrock/Proofs/ValidComputable/Func.v
 src/Bedrock/Tests/X25519_64.v
+src/Bedrock/Tests/X25519_32.v
 src/Bedrock/Tests/Proofs/X25519_64.v
+src/Bedrock/Tests/Proofs/X25519_32.v
 src/Bedrock/Translation/Cmd.v
 src/Bedrock/Translation/Expr.v
 src/Bedrock/Translation/Flatten.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -56,6 +56,8 @@ src/ArithmeticCPS/ModOps.v
 src/ArithmeticCPS/Saturated.v
 src/ArithmeticCPS/WordByWordMontgomery.v
 src/Bedrock/Defaults.v
+src/Bedrock/Defaults32.v
+src/Bedrock/Defaults64.v
 src/Bedrock/StandaloneHaskellMain.v
 src/Bedrock/StandaloneOCamlMain.v
 src/Bedrock/Stringification.v

--- a/src/Bedrock/Defaults.v
+++ b/src/Bedrock/Defaults.v
@@ -1,6 +1,7 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Strings.String.
 Require Import Coq.Lists.List.
+Require Import coqutil.Word.Interface.
 Require Import bedrock2.Syntax.
 Require Import Crypto.Bedrock.Types.
 Require Import Crypto.BoundsPipeline.

--- a/src/Bedrock/Defaults.v
+++ b/src/Bedrock/Defaults.v
@@ -39,7 +39,7 @@ Section Defs.
     string * (list string * list string * cmd.cmd).
 
   Definition varname_gen (i : nat) : string :=
-    String.append "x" (Decimal.decimal_string_of_Z (Z.of_nat i)).
+    String.append "x" (Decimal.Z.to_string (Z.of_nat i)).
 
   (* quick check to make sure the expression produced no errors *)
   Fixpoint error_free_expr (x : Syntax.expr) : bool :=
@@ -66,10 +66,16 @@ Section Defs.
 End Defs.
 
 Section Proofs.
-  (* requires some kind of proof about decimal stringification *)
-  Lemma decimal_varname_gen_unique :
-    forall i j : nat, varname_gen i = varname_gen j <-> i = j.
-  Admitted.
+  Lemma decimal_varname_gen_unique i j :
+    varname_gen i = varname_gen j <-> i = j.
+  Proof.
+    cbv [varname_gen].
+    pose proof (Decimal.Z.of_to (Z.of_nat i)).
+    pose proof (Decimal.Z.of_to (Z.of_nat j)).
+    split; [ | intros; subst; reflexivity ].
+    cbn [String.append]; inversion 1.
+    apply Nat2Z.inj. congruence.
+  Qed.
 
   Lemma varname_gen_startswith v i :
     v = varname_gen i ->

--- a/src/Bedrock/Defaults.v
+++ b/src/Bedrock/Defaults.v
@@ -1,9 +1,11 @@
+Require Import Coq.ZArith.ZArith.
 Require Import Coq.Strings.String.
 Require Import Coq.Lists.List.
 Require Import bedrock2.Syntax.
 Require Import Crypto.Bedrock.Types.
 Require Import Crypto.BoundsPipeline.
 Require Crypto.Util.Strings.Decimal.
+Require Import Crypto.Util.Strings.String.
 
 (* Declares default parameters for the bedrock2 backend that apply to all
    machine word sizes. Do NOT import this file unless you're prepared to have a
@@ -35,6 +37,9 @@ Section Defs.
   Definition bedrock_func : Type :=
     string * (list string * list string * cmd.cmd).
 
+  Definition varname_gen (i : nat) : string :=
+    String.append "x" (Decimal.decimal_string_of_Z (Z.of_nat i)).
+
   (* quick check to make sure the expression produced no errors *)
   Fixpoint error_free_expr (x : Syntax.expr) : bool :=
     match x with
@@ -58,3 +63,19 @@ Section Defs.
     | cmd.interact _ _ args => forallb error_free_expr args
     end.
 End Defs.
+
+Section Proofs.
+  (* requires some kind of proof about decimal stringification *)
+  Lemma decimal_varname_gen_unique :
+    forall i j : nat, varname_gen i = varname_gen j <-> i = j.
+  Admitted.
+
+  Lemma varname_gen_startswith v i :
+    v = varname_gen i ->
+    String.startswith "x" v = true.
+  Proof.
+    cbn [varname_gen]. intro.
+    subst. cbn. rewrite substring_0_0.
+    reflexivity.
+  Qed.
+End Proofs.

--- a/src/Bedrock/Defaults.v
+++ b/src/Bedrock/Defaults.v
@@ -9,6 +9,9 @@ Require Crypto.Util.Strings.Decimal.
    machine word sizes. Do NOT import this file unless you're prepared to have a
    bunch of global typeclass instances declared for you. *)
 
+(* use in-memory lists; local ones are only used internally *)
+Global Existing Instances Types.rep.Z Types.rep.listZ_mem.
+
 (* Reification/bounds pipeline options *)
 Global Existing Instance default_low_level_rewriter_method.
 (* Split multiplications into two outputs, not just one huge word *)

--- a/src/Bedrock/Defaults32.v
+++ b/src/Bedrock/Defaults32.v
@@ -16,10 +16,8 @@ Import Types.Notations ListNotations.
 Local Open Scope Z_scope.
 Local Open Scope string_scope.
 
-(* Declares default parameters for the bedrock2 backend and includes useful
-   definitions/proofs that apply specifically to the defaults. Do NOT import
-   this file unless you're prepared to have a bunch of global typeclass
-   instances and notations declared for you. *)
+(* Declares default parameters for the bedrock2 backend specific to systems with
+a 32-bit word size. *)
 
 Section Defaults_32.
   Definition machine_wordsize := 32.
@@ -27,12 +25,12 @@ Section Defaults_32.
   (* Define how to split mul/multi-return functions *)
   Definition possible_values
     := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
-  Global Instance split_mul_to : split_mul_to_opt :=
+  Instance split_mul_to : split_mul_to_opt :=
     split_mul_to_of_should_split_mul machine_wordsize possible_values.
-  Global Instance split_multiret_to : split_multiret_to_opt :=
+  Instance split_multiret_to : split_multiret_to_opt :=
     split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
   Let wordsize_bytes := Eval vm_compute in (machine_wordsize / 8)%Z.
-  Global Instance default_parameters : Types.parameters :=
+  Instance default_parameters : Types.parameters :=
     {| semantics := BasicC32Semantics.parameters;
        varname_gen := fun i => String.append "x" (Decimal.decimal_string_of_Z (Z.of_nat i));
        error := expr.var Defaults.ERROR;

--- a/src/Bedrock/Defaults32.v
+++ b/src/Bedrock/Defaults32.v
@@ -32,7 +32,7 @@ Section Defaults_32.
   Let wordsize_bytes := Eval vm_compute in (machine_wordsize / 8)%Z.
   Instance default_parameters : Types.parameters :=
     {| semantics := BasicC32Semantics.parameters;
-       varname_gen := fun i => String.append "x" (Decimal.decimal_string_of_Z (Z.of_nat i));
+       varname_gen := Defaults.varname_gen;
        error := expr.var Defaults.ERROR;
        word_size_in_bytes := wordsize_bytes;
     |}.

--- a/src/Bedrock/Defaults64.v
+++ b/src/Bedrock/Defaults64.v
@@ -32,7 +32,7 @@ Section Defaults_64.
   Let wordsize_bytes := Eval vm_compute in (machine_wordsize / 8)%Z.
   Instance default_parameters : Types.parameters :=
     {| semantics := BasicC64Semantics.parameters;
-       varname_gen := fun i => String.append "x" (Decimal.decimal_string_of_Z (Z.of_nat i));
+       varname_gen := Defaults.varname_gen;
        error := expr.var Defaults.ERROR;
        word_size_in_bytes := wordsize_bytes;
     |}.

--- a/src/Bedrock/Defaults64.v
+++ b/src/Bedrock/Defaults64.v
@@ -16,10 +16,8 @@ Import Types.Notations ListNotations.
 Local Open Scope Z_scope.
 Local Open Scope string_scope.
 
-(* Declares default parameters for the bedrock2 backend and includes useful
-   definitions/proofs that apply specifically to the defaults. Do NOT import
-   this file unless you're prepared to have a bunch of global typeclass
-   instances and notations declared for you. *)
+(* Declares default parameters for the bedrock2 backend specific to systems with
+a 64-bit word size. *)
 
 Section Defaults_64.
   Definition machine_wordsize := 64.
@@ -27,12 +25,12 @@ Section Defaults_64.
   (* Define how to split mul/multi-return functions *)
   Definition possible_values
     := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
-  Global Instance split_mul_to : split_mul_to_opt :=
+  Instance split_mul_to : split_mul_to_opt :=
     split_mul_to_of_should_split_mul machine_wordsize possible_values.
-  Global Instance split_multiret_to : split_multiret_to_opt :=
+  Instance split_multiret_to : split_multiret_to_opt :=
     split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
   Let wordsize_bytes := Eval vm_compute in (machine_wordsize / 8)%Z.
-  Global Instance default_parameters : Types.parameters :=
+  Instance default_parameters : Types.parameters :=
     {| semantics := BasicC64Semantics.parameters;
        varname_gen := fun i => String.append "x" (Decimal.decimal_string_of_Z (Z.of_nat i));
        error := expr.var Defaults.ERROR;

--- a/src/Bedrock/Stringification.v
+++ b/src/Bedrock/Stringification.v
@@ -37,9 +37,8 @@ Fixpoint infer_machine_wordsize {t : base.type}
     fun x =>
       match x with
       | Some r =>
-        let max := (ZRange.upper r + 1)%Z in
-        if ((ZRange.lower r =? 0)%Z && (2 ^ (Z.log2 max) =? max)%Z)%bool
-        then Some (Z.log2 max)
+        if (ZRange.lower r =? 0)%Z
+        then Some (32 * (Z.log2 (ZRange.upper r) / 32 + 1))%Z
         else None
       | None => None
       end

--- a/src/Bedrock/Stringification.v
+++ b/src/Bedrock/Stringification.v
@@ -76,138 +76,138 @@ Definition select_parameters wordsize : parameters + string :=
 
 Section with_parameters.
   Context {p : parameters}.
-Fixpoint make_names (prefix : string)
-         (nextn : nat) (t : base.type)
-  : option (nat * base_ltype t) :=
-  match t as t0 return
-        option (nat * base_ltype t0)
-  with
-  | base.type.prod a b =>
-    (olet '(nextn, anames) <- make_names prefix nextn a;
-    olet '(nextn, bnames) <- make_names prefix nextn b;
-    Some (nextn, (anames, bnames)))%option
-  | base_listZ =>
-    let num := Decimal.Z.to_string (Z.of_nat nextn) in
-    Some (S nextn, String.append prefix num)
-  | base_Z =>
-    let num := Decimal.Z.to_string (Z.of_nat nextn) in
-    Some (S nextn, String.append prefix num)
-  | _ => None
-  end.
-Fixpoint make_innames' (nextn : nat) (t : API.type)
-  : option (nat * type.for_each_lhs_of_arrow ltype t) :=
-  match t with
-  | type.base _ => Some (nextn, tt)
-  | type.arrow (type.base s) d =>
-    (olet '(nextn, snames) <- make_names "in" nextn s;
-    olet '(nextn, dnames) <- make_innames' nextn d;
-    Some (nextn, (snames, dnames)))%option
-  | type.arrow _ _ => None
-  end.
-Definition make_innames t : option (type.for_each_lhs_of_arrow ltype t) :=
-  option_map snd (make_innames' 0 t).
-Definition make_outnames t : option (base_ltype t) :=
-  option_map snd (make_names "out" 0 t).
+  Fixpoint make_names (prefix : string)
+           (nextn : nat) (t : base.type)
+    : option (nat * base_ltype t) :=
+    match t as t0 return
+          option (nat * base_ltype t0)
+    with
+    | base.type.prod a b =>
+      (olet '(nextn, anames) <- make_names prefix nextn a;
+      olet '(nextn, bnames) <- make_names prefix nextn b;
+      Some (nextn, (anames, bnames)))%option
+    | base_listZ =>
+      let num := Decimal.Z.to_string (Z.of_nat nextn) in
+      Some (S nextn, String.append prefix num)
+    | base_Z =>
+      let num := Decimal.Z.to_string (Z.of_nat nextn) in
+      Some (S nextn, String.append prefix num)
+    | _ => None
+    end.
+  Fixpoint make_innames' (nextn : nat) (t : API.type)
+    : option (nat * type.for_each_lhs_of_arrow ltype t) :=
+    match t with
+    | type.base _ => Some (nextn, tt)
+    | type.arrow (type.base s) d =>
+      (olet '(nextn, snames) <- make_names "in" nextn s;
+      olet '(nextn, dnames) <- make_innames' nextn d;
+      Some (nextn, (snames, dnames)))%option
+    | type.arrow _ _ => None
+    end.
+  Definition make_innames t : option (type.for_each_lhs_of_arrow ltype t) :=
+    option_map snd (make_innames' 0 t).
+  Definition make_outnames t : option (base_ltype t) :=
+    option_map snd (make_names "out" 0 t).
 
-(* mostly a duplicate of list_lengths_from_value, just with ZRange interp *)
-Fixpoint list_lengths_from_bounds {t}
-  : ZRange.type.base.option.interp t -> option (base_listonly nat t) :=
-  match t as t0 return
-        ZRange.type.base.option.interp t0 -> option (base_listonly nat t0) with
-  | base.type.prod a b =>
-    fun x =>
-      (x1 <- list_lengths_from_bounds (fst x);
-      x2 <- list_lengths_from_bounds (snd x);
-      Some (x1, x2))%option
-  | base_listZ =>
-    fun x : option (list _) => option_map (@List.length _) x
-  | _ => fun _ => Some tt
-  end.
-Fixpoint list_lengths_from_argbounds {t}
-  : type.for_each_lhs_of_arrow ZRange.type.option.interp t ->
-    option (type.for_each_lhs_of_arrow list_lengths t) :=
-  match t as t0 return
-        type.for_each_lhs_of_arrow _ t0 ->
-        option (type.for_each_lhs_of_arrow _ t0) with
-  | type.base b => fun _ => Some tt
-  | type.arrow (type.base a) b =>
-    fun x =>
-      (x1 <- list_lengths_from_bounds (fst x);
-      x2 <- list_lengths_from_argbounds (snd x);
-       Some (x1, x2))%option
-  | type.arrow a b => fun _ => None
-  end.
+  (* mostly a duplicate of list_lengths_from_value, just with ZRange interp *)
+  Fixpoint list_lengths_from_bounds {t}
+    : ZRange.type.base.option.interp t -> option (base_listonly nat t) :=
+    match t as t0 return
+          ZRange.type.base.option.interp t0 -> option (base_listonly nat t0) with
+    | base.type.prod a b =>
+      fun x =>
+        (x1 <- list_lengths_from_bounds (fst x);
+           x2 <- list_lengths_from_bounds (snd x);
+           Some (x1, x2))%option
+    | base_listZ =>
+      fun x : option (list _) => option_map (@List.length _) x
+    | _ => fun _ => Some tt
+    end.
+  Fixpoint list_lengths_from_argbounds {t}
+    : type.for_each_lhs_of_arrow ZRange.type.option.interp t ->
+      option (type.for_each_lhs_of_arrow list_lengths t) :=
+    match t as t0 return
+          type.for_each_lhs_of_arrow _ t0 ->
+          option (type.for_each_lhs_of_arrow _ t0) with
+    | type.base b => fun _ => Some tt
+    | type.arrow (type.base a) b =>
+      fun x =>
+        (x1 <- list_lengths_from_bounds (fst x);
+           x2 <- list_lengths_from_argbounds (snd x);
+           Some (x1, x2))%option
+    | type.arrow a b => fun _ => None
+    end.
 
-Fixpoint make_base_var_data {t}
-  : base_ltype t -> list_lengths (type.base t) ->
-    option (base_var_data t) :=
-  let int_type :=
-      ToString.int.unsigned (Z.to_nat Semantics.width) in
-  match t as t0 return
-        base_ltype t0 ->
-        list_lengths (type.base t0) ->
-        option (base_var_data t0) with
-  | base.type.prod A B =>
-    fun x ll =>
-      (x1 <- make_base_var_data (fst x) (fst ll);
-      x2 <- make_base_var_data (snd x) (snd ll);
-      Some (x1, x2))%option
-  | base_Z =>
-    fun name _ =>
-      let is_pointer := false in (* never a pointer *)
-      Some (name, is_pointer, Some int_type)
-  | base_listZ =>
-    fun name len => Some (name, Some int_type, len)
-  | _ => fun _ _ => None
-  end.
+  Fixpoint make_base_var_data {t}
+    : base_ltype t -> list_lengths (type.base t) ->
+      option (base_var_data t) :=
+    let int_type :=
+        ToString.int.unsigned (Z.to_nat Semantics.width) in
+    match t as t0 return
+          base_ltype t0 ->
+          list_lengths (type.base t0) ->
+          option (base_var_data t0) with
+    | base.type.prod A B =>
+      fun x ll =>
+        (x1 <- make_base_var_data (fst x) (fst ll);
+           x2 <- make_base_var_data (snd x) (snd ll);
+           Some (x1, x2))%option
+    | base_Z =>
+      fun name _ =>
+        let is_pointer := false in (* never a pointer *)
+        Some (name, is_pointer, Some int_type)
+    | base_listZ =>
+      fun name len => Some (name, Some int_type, len)
+    | _ => fun _ _ => None
+    end.
 
-Definition make_var_data {t}
-  : ltype t -> list_lengths t -> option (var_data t) :=
-  match t with
-  | type.base b => make_base_var_data
-  | type.arrow _ _ => fun _ _ => None
-  end.
+  Definition make_var_data {t}
+    : ltype t -> list_lengths t -> option (var_data t) :=
+    match t with
+    | type.base b => make_base_var_data
+    | type.arrow _ _ => fun _ _ => None
+    end.
 
-Fixpoint make_var_data_of_args {t}
-  : type.for_each_lhs_of_arrow ltype t ->
-    type.for_each_lhs_of_arrow list_lengths t ->
-    option (type.for_each_lhs_of_arrow var_data t) :=
-  match t as t0 return
-        type.for_each_lhs_of_arrow ltype t0 ->
-        type.for_each_lhs_of_arrow list_lengths t0 ->
-        option (type.for_each_lhs_of_arrow var_data t0)
-  with
-  | type.arrow s d =>
-    fun names lengths =>
-      (x <- make_var_data (fst names) (fst lengths);
-      y <- make_var_data_of_args (snd names) (snd lengths);
-      Some (x, y))%option
-  | type.base b => fun _ _ => Some tt
-  end.
+  Fixpoint make_var_data_of_args {t}
+    : type.for_each_lhs_of_arrow ltype t ->
+      type.for_each_lhs_of_arrow list_lengths t ->
+      option (type.for_each_lhs_of_arrow var_data t) :=
+    match t as t0 return
+          type.for_each_lhs_of_arrow ltype t0 ->
+          type.for_each_lhs_of_arrow list_lengths t0 ->
+          option (type.for_each_lhs_of_arrow var_data t0)
+    with
+    | type.arrow s d =>
+      fun names lengths =>
+        (x <- make_var_data (fst names) (fst lengths);
+           y <- make_var_data_of_args (snd names) (snd lengths);
+           Some (x, y))%option
+    | type.base b => fun _ _ => Some tt
+    end.
 
-Definition make_header {t}
-           (innames : type.for_each_lhs_of_arrow ltype t)
-           (inlengths : type.for_each_lhs_of_arrow list_lengths t)
-           (inbounds : type.for_each_lhs_of_arrow
-                         ZRange.type.option.interp t)
-           (outnames : ltype (type.base (type.final_codomain t)))
-           (outlengths : list_lengths (type.base (type.final_codomain t)))
-           (outbounds : ZRange.type.option.interp
-                          (type.base (type.final_codomain t)))
-  : option (list string) :=
-  match make_var_data_of_args innames inlengths,
-        make_base_var_data outnames outlengths with
-  | Some indata, Some outdata =>
-    Some (["/*"]
-            ++ [" * Input Bounds:"]
-            ++ (List.map (fun v => " *   " ++ v)%string
-                         (input_bounds_to_string indata inbounds))
-            ++ [" * Output Bounds:"]
-            ++ (List.map (fun v => " *   " ++ v)%string
-                         (bound_to_string outdata outbounds))
-            ++ [" */"])
-  | _, _ => None
-  end.
+  Definition make_header {t}
+             (innames : type.for_each_lhs_of_arrow ltype t)
+             (inlengths : type.for_each_lhs_of_arrow list_lengths t)
+             (inbounds : type.for_each_lhs_of_arrow
+                           ZRange.type.option.interp t)
+             (outnames : ltype (type.base (type.final_codomain t)))
+             (outlengths : list_lengths (type.base (type.final_codomain t)))
+             (outbounds : ZRange.type.option.interp
+                            (type.base (type.final_codomain t)))
+    : option (list string) :=
+    match make_var_data_of_args innames inlengths,
+          make_base_var_data outnames outlengths with
+    | Some indata, Some outdata =>
+      Some (["/*"]
+              ++ [" * Input Bounds:"]
+              ++ (List.map (fun v => " *   " ++ v)%string
+                           (input_bounds_to_string indata inbounds))
+              ++ [" * Output Bounds:"]
+              ++ (List.map (fun v => " *   " ++ v)%string
+                           (bound_to_string outdata outbounds))
+              ++ [" */"])
+    | _, _ => None
+    end.
 End with_parameters.
 
 Definition bedrock_func_to_lines (f : bedrock_func)
@@ -231,49 +231,49 @@ Definition Bedrock2_ToFunctionLines
     match infer_machine_wordsize outbounds with
     | None => inr ("Unable to infer machine word size.")
     | Some wordsize =>
-    match select_parameters wordsize with
-    | inr err => inr err
-    | inl p =>
-    match make_innames t, make_outnames (type.final_codomain t),
-          list_lengths_from_argbounds inbounds with
-    | Some innames, Some outnames, Some inlengths =>
-      let out := translate_func e innames inlengths outnames in
-      let f : bedrock_func := (name, fst out) in
-      let outlengths := snd out in
-      if error_free_cmd (snd (snd f))
-      then
-        match make_header innames inlengths inbounds
-                          outnames outlengths outbounds with
-        | Some header =>
-          inl (header ++ bedrock_func_to_lines f,
-               ToString.ident_info_empty)
-        | None =>
-          inr
-            (String.concat
-               String.NewLine
-               ("Failed to generate header for function:"
-                  :: bedrock_func_to_lines f))
-        end
-      else
-        let header :=
+      match select_parameters wordsize with
+      | inr err => inr err
+      | inl p =>
+        match make_innames t, make_outnames (type.final_codomain t),
+              list_lengths_from_argbounds inbounds with
+        | Some innames, Some outnames, Some inlengths =>
+          let out := translate_func e innames inlengths outnames in
+          let f : bedrock_func := (name, fst out) in
+          let outlengths := snd out in
+          if error_free_cmd (snd (snd f))
+          then
             match make_header innames inlengths inbounds
                               outnames outlengths outbounds with
-            | Some x => x | None => [] end in
-        inr
-             (String.concat
-                String.NewLine
-                (["ERROR-CONTAINING OUTPUT:"]
-                   ++ header
-                   ++ bedrock_func_to_lines f
-                   ++ ["Error occured during translation to bedrock2. This is likely because a part of the input expression either had unsupported integer types (bedrock2 requires that all integers have the same size) or contained an unsupported operation."]))
-    | None, _, _ =>
-      inr ("Error determining argument names")
-    | _, None, _ =>
-      inr ("Error determining return value names")
-    | _, _, None =>
-      inr ("Error determining argument lengths")
-    end
-    end
+            | Some header =>
+              inl (header ++ bedrock_func_to_lines f,
+                   ToString.ident_info_empty)
+            | None =>
+              inr
+                (String.concat
+                   String.NewLine
+                   ("Failed to generate header for function:"
+                      :: bedrock_func_to_lines f))
+            end
+          else
+            let header :=
+                match make_header innames inlengths inbounds
+                                  outnames outlengths outbounds with
+                | Some x => x | None => [] end in
+            inr
+              (String.concat
+                 String.NewLine
+                 (["ERROR-CONTAINING OUTPUT:"]
+                    ++ header
+                    ++ bedrock_func_to_lines f
+                    ++ ["Error occured during translation to bedrock2. This is likely because a part of the input expression either had unsupported integer types (bedrock2 requires that all integers have the same size) or contained an unsupported operation."]))
+        | None, _, _ =>
+          inr ("Error determining argument names")
+        | _, None, _ =>
+          inr ("Error determining return value names")
+        | _, _, None =>
+          inr ("Error determining argument lengths")
+        end
+      end
     end.
 
 Definition OutputBedrock2API : ToString.OutputLanguageAPI :=

--- a/src/Bedrock/Stringification.v
+++ b/src/Bedrock/Stringification.v
@@ -32,9 +32,9 @@ Definition select_parameters wordsize : parameters + string :=
   | None =>
     let wordsize_choices := List.map fst parameter_choices in
     let wordsize_choices_str :=
-        List.map Decimal.decimal_string_of_Z wordsize_choices in
+        List.map Decimal.Z.to_string wordsize_choices in
     inr ("Invalid machine word size ("
-           ++  Decimal.decimal_string_of_Z wordsize
+           ++  Decimal.Z.to_string wordsize
            ++ "); valid choices are "
            ++ concat "," wordsize_choices_str)%string
   end.

--- a/src/Bedrock/Tests/Proofs/X25519_32.v
+++ b/src/Bedrock/Tests/Proofs/X25519_32.v
@@ -1,0 +1,322 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Strings.String. (* should go before lists *)
+Require Import Coq.Lists.List.
+Require Import coqutil.Word.Interface.
+Require Import coqutil.Word.Properties.
+Require Import coqutil.Map.Interface.
+Require Import coqutil.Map.Properties.
+Require Import bedrock2.Array.
+Require Import bedrock2.BasicC32Semantics.
+Require Import bedrock2.Scalars.
+Require Import bedrock2.ProgramLogic.
+Require Import bedrock2.WeakestPrecondition.
+Require Import bedrock2.WeakestPreconditionProperties.
+Require Import bedrock2.Map.Separation.
+Require Import Crypto.BoundsPipeline.
+Require Import Crypto.Arithmetic.Core.
+Require Import Crypto.Arithmetic.ModOps.
+Require Import Crypto.Bedrock.Defaults.
+Require Import Crypto.Bedrock.Defaults32.
+Require Import Crypto.Bedrock.Types.
+Require Import Crypto.Bedrock.Tactics.
+Require Import Crypto.Bedrock.Proofs.Func.
+Require Import Crypto.Bedrock.Proofs.ValidComputable.Func.
+Require Import Crypto.Bedrock.Util.
+Require Import Crypto.Language.API.
+Require Import Crypto.Util.Tactics.BreakMatch.
+Require bedrock2.Map.SeparationLogic. (* if imported, list firstn/skipn get overwritten and it's annoying *)
+Local Open Scope Z_scope.
+
+Import Language.Compilers.
+Import Associational Positional.
+
+Require Import Crypto.Util.Notations.
+Import Types.Notations ListNotations.
+Local Open Scope Z_scope.
+Local Open Scope string_scope.
+
+Require Import Crypto.Bedrock.Tests.X25519_32.
+Import X25519_32.
+Local Coercion name_of_func (f : bedrock_func) := fst f.
+
+Axiom BasicC32Semantics_parameters_ok : Semantics.parameters_ok BasicC32Semantics.parameters.
+(* TODO: why does BasicC32Semantics not have a Semantics.parameters_ok instance? *) }
+Existing Instance BasicC32Semantics_parameters_ok.
+
+Section Proofs.
+  Context (n : nat := 10%nat)
+          (s : Z := 2^255)
+          (c : list (Z * Z) := [(1,19)])
+          (machine_wordsize : Z := 32).
+
+  (* requires some kind of proof about decimal stringification *)
+  Lemma decimal_varname_gen_unique :
+    forall i j : nat, varname_gen i = varname_gen j <-> i = j.
+  Admitted.
+
+  Instance p_ok : Types.ok.
+  Proof.
+    constructor.
+    { exact BasicC32Semantics_parameters_ok. }
+    { reflexivity. }
+    { exact decimal_varname_gen_unique. }
+  Admitted.
+
+  Local Notation M := (s - Associational.eval c)%Z.
+  Local Notation eval :=
+    (eval (weight limbwidth_num limbwidth_den) n).
+
+  Definition Bignum (addr : Semantics.word) (x : Z) :
+    Semantics.mem -> Prop :=
+    Lift1Prop.ex1
+      (fun xs =>
+         sep (emp (eval (map word.unsigned xs) = x))
+             (sep (emp (length xs = n))
+                  (array scalar (word.of_Z word_size_in_bytes)
+                         addr xs))).
+
+  Instance spec_of_mulmod_bedrock : spec_of mulmod_bedrock :=
+    fun functions =>
+      forall x y px py pout old_out t m
+             (Ra Rr : Semantics.mem -> Prop),
+        sep (sep (Bignum px x) (Bignum py y)) Ra m ->
+        sep (Bignum pout old_out) Rr m ->
+        WeakestPrecondition.call
+          (p:=@semantics default_parameters)
+          functions mulmod_bedrock t m
+          (px :: py :: pout :: nil)
+          (fun t' m' rets =>
+             t = t' /\
+             rets = []%list /\
+             sep (Bignum pout ((x * y) mod M)%Z) Rr m').
+
+  Lemma mulmod_valid_func :
+    valid_func (mulmod (fun H3 : API.type => unit)).
+  Proof.
+    apply valid_func_bool_iff.
+    vm_compute; reflexivity.
+  Qed.
+
+  (* TODO: ask Jason for help *)
+  Lemma mulmod_Wf :
+    Wf.Compilers.expr.Wf3 mulmod.
+  Admitted.
+
+  Lemma mulmod_length (x y : API.interp_type type_listZ) :
+    length
+      (expr.interp (@Compilers.ident_interp)
+                   (mulmod API.interp_type)
+                   x y) = n.
+  Proof.
+    vm_compute. reflexivity.
+  Qed.
+
+  (* TODO: here's where we need to use the FC pipeline to say things about
+         correctness *)
+  (* this can be changed to use type.app_curried if that's easier *)
+  Lemma mulmod_correct x y :
+    eval
+      (map word.wrap
+           (expr.interp
+              (@Compilers.ident_interp) (mulmod API.interp_type)
+              (map word.unsigned x) (map word.unsigned y))) =
+    ((eval (map word.unsigned x) * eval (map word.unsigned y)) mod M)%Z.
+  Admitted.
+
+  (* TODO : move *)
+  Lemma substring_0_0 :
+    forall s, substring 0 0 s = "".
+  Proof.
+    clear. destruct s; reflexivity.
+  Qed.
+
+  Lemma varname_gen_startswith v i :
+    v = varname_gen i ->
+    String.startswith "x" v = true.
+  Proof.
+    cbn [varname_gen default_parameters]. intro.
+    subst. cbn. rewrite substring_0_0.
+    reflexivity.
+  Qed.
+
+  (* TODO : move *)
+  Lemma map_of_Z_unsigned x :
+    map word.of_Z (map word.unsigned x) = x.
+  Proof.
+    rewrite map_map.
+    rewrite map_ext with (g:=id);
+      [ solve [apply map_id] | ].
+    intros. rewrite word.of_Z_unsigned.
+    reflexivity.
+  Qed.
+
+  (* TODO : move *)
+  Lemma map_unsigned_of_Z x :
+    map word.unsigned (map word.of_Z x) = map word.wrap x.
+  Proof.
+    rewrite map_map. apply map_ext.
+    exact word.unsigned_of_Z.
+  Qed.
+
+  (* TODO: move *)
+  Lemma Forall_map_unsigned x :
+    Forall (fun z : Z => 0 <= z < 2 ^ Semantics.width)
+           (map word.unsigned x).
+  Proof.
+    induction x; intros; cbn [map]; constructor;
+      auto using word.unsigned_range.
+  Qed.
+
+  Lemma mulmod_bedrock_correct :
+    program_logic_goal_for_function! mulmod_bedrock.
+  Proof.
+    cbv [program_logic_goal_for spec_of_mulmod_bedrock].
+    cbn [name_of_func mulmod_bedrock fst]. intros.
+    cbv [mulmod_bedrock].
+    intros. cbv [Bignum] in * |-. sepsimpl.
+    eapply Proper_call.
+    2:{
+      let xs := match goal with
+                  Hx : eval ?xs = x |- _ =>
+                  xs end in
+      let ys := match goal with
+                  Hy : eval ?ys = y |- _ =>
+                  ys end in
+      apply translate_func_correct
+        with (args:=(xs, (ys, tt)))
+             (flat_args:=[px;py]%list)
+             (out_ptrs:=[pout]%list)
+             (Ra0:=Ra) (Rr0:=Rr).
+      { apply mulmod_valid_func; eauto. }
+      { apply mulmod_Wf; eauto. }
+      { cbn [LoadStoreList.list_lengths_from_args
+               LoadStoreList.list_lengths_from_value
+               fst snd].
+        rewrite !map_length.
+        repeat match goal with H : length _ = n |- _ =>
+                               rewrite H end.
+        reflexivity. }
+      { reflexivity. }
+      { reflexivity. }
+      { intros.
+        cbn [fst snd Types.varname_set_args Types.varname_set_base
+                 Types.rep.varname_set Types.rep.listZ_mem
+                 Types.rep.Z].
+        cbv [PropSet.union PropSet.singleton_set PropSet.elem_of
+                           PropSet.empty_set].
+        destruct 1 as [? | [? | ?] ]; try tauto;
+          match goal with H : _ = varname_gen _ |- _ =>
+                          apply varname_gen_startswith in H;
+                            vm_compute in H; congruence
+          end. }
+      { cbn [fst snd Types.equivalent_flat_args Types.rep.listZ_mem
+                 Types.equivalent_flat_base Types.rep.equiv
+                 Types.rep.Z]. sepsimpl.
+        exists 1%nat. cbn [firstn skipn length hd].
+        apply SeparationLogic.sep_comm.
+        apply SeparationLogic.sep_assoc.
+        apply SeparationLogic.sep_comm.
+        apply SeparationLogic.sep_ex1_l.
+        exists 1%nat. cbn [firstn skipn length hd].
+        apply SeparationLogic.sep_assoc.
+        sepsimpl; try reflexivity; [ ].
+        eexists.
+        sepsimpl;
+          try match goal with
+              | |- dexpr _ _ (Syntax.expr.literal _) _ => reflexivity
+              | _ => apply word.unsigned_range
+              end;
+          eauto using Forall_map_unsigned; [ ].
+        apply SeparationLogic.sep_comm.
+        apply SeparationLogic.sep_assoc.
+        apply SeparationLogic.sep_comm.
+        sepsimpl; try reflexivity; [ ].
+        eexists.
+        sepsimpl;
+          try match goal with
+              | |- dexpr _ _ (Syntax.expr.literal _) _ => reflexivity
+              | _ => apply word.unsigned_range
+              end;
+          eauto using Forall_map_unsigned; [ ].
+        rewrite !map_of_Z_unsigned.
+        rewrite !word.of_Z_unsigned in *.
+        change BasicC32Semantics.parameters with semantics in *.
+        SeparationLogic.ecancel_assumption. }
+      { cbn. repeat constructor; cbn [In]; try tauto.
+        destruct 1; congruence. }
+      { intros.
+        cbn [fst snd Types.varname_set_base type.final_codomain
+                 Types.rep.varname_set Types.rep.listZ_mem
+                 Types.rep.Z].
+        cbv [PropSet.singleton_set PropSet.elem_of PropSet.empty_set].
+        intro;
+          match goal with H : _ = varname_gen _ |- _ =>
+                          apply varname_gen_startswith in H;
+                            vm_compute in H; congruence
+          end. }
+      { cbn. repeat constructor; cbn [In]; tauto. }
+      { cbn. rewrite union_empty_r.
+        apply disjoint_singleton_r_iff.
+        cbv [PropSet.singleton_set PropSet.elem_of PropSet.union].
+        destruct 1; congruence. }
+      { cbn [LoadStoreList.lists_reserved_with_initial_context
+               LoadStoreList.list_lengths_from_value
+               LoadStoreList.extract_listnames
+               LoadStoreList.lists_reserved
+               Flatten.flatten_listonly_base_ltype
+               Flatten.flatten_base_ltype
+               Flatten.flatten_argnames List.app
+               map.of_list_zip map.putmany_of_list_zip
+               type.app_curried type.final_codomain fst snd].
+        sepsimpl.
+        (let xs := (match goal with
+                      Hx : eval ?xs = old_out |- _ =>
+                      xs end) in
+         exists xs).
+        sepsimpl;
+          [ rewrite map_length, mulmod_length by assumption;
+            congruence | ].
+        cbn [Types.rep.equiv Types.base_rtype_of_ltype
+                             Types.rep.Z Types.rep.listZ_mem].
+        rewrite map_of_Z_unsigned.
+        sepsimpl.
+        eexists.
+        sepsimpl;
+          try match goal with
+                | |- dexpr _ _ _ _ =>
+                  apply get_put_same, word.of_Z_unsigned
+                | _ => apply word.unsigned_range
+              end; eauto using Forall_map_unsigned; [ ].
+        rewrite word.of_Z_unsigned.
+        assumption. } }
+
+    repeat intro; cbv beta in *.
+    cbn [Types.equivalent_flat_base
+           Types.equivalent_listexcl_flat_base
+           Types.equivalent_listonly_flat_base
+           Types.rep.equiv Types.rep.listZ_mem Types.rep.Z
+           type.final_codomain] in *.
+    repeat match goal with
+           | _ => progress subst
+           | _ => progress sepsimpl_hyps
+           | H : _ /\ _ |- _ => destruct H
+           | |- _ /\ _ => split; [ reflexivity | ]
+           end.
+    sepsimpl.
+    match goal with
+    | H : dexpr _ _ (Syntax.expr.literal _) _ |- _ =>
+      cbn [dexpr WeakestPrecondition.expr expr_body hd] in H;
+        cbv [literal] in H; rewrite word.of_Z_unsigned in H;
+          inversion H; clear H; subst
+    end.
+    cbv [Bignum].
+    sepsimpl.
+    eexists; sepsimpl; [ | | eassumption];
+      [ | cbn [type.app_curried];
+          rewrite map_length, mulmod_length; solve [eauto] ].
+    cbn [type.app_curried fst snd].
+    rewrite map_unsigned_of_Z.
+    apply mulmod_correct; eauto.
+  Qed.
+  (* Print Assumptions mulmod_bedrock_correct. *)
+End Proofs.

--- a/src/Bedrock/Tests/Proofs/X25519_32.v
+++ b/src/Bedrock/Tests/Proofs/X25519_32.v
@@ -39,6 +39,7 @@ Require Import Crypto.Bedrock.Tests.X25519_32.
 Import X25519_32.
 Local Coercion name_of_func (f : bedrock_func) := fst f.
 
+Existing Instance Defaults32.default_parameters.
 Axiom BasicC32Semantics_parameters_ok : Semantics.parameters_ok BasicC32Semantics.parameters.
 (* TODO: why does BasicC32Semantics not have a Semantics.parameters_ok instance? *) }
 Existing Instance BasicC32Semantics_parameters_ok.

--- a/src/Bedrock/Tests/Proofs/X25519_32.v
+++ b/src/Bedrock/Tests/Proofs/X25519_32.v
@@ -50,18 +50,13 @@ Section Proofs.
           (c : list (Z * Z) := [(1,19)])
           (machine_wordsize : Z := 32).
 
-  (* requires some kind of proof about decimal stringification *)
-  Lemma decimal_varname_gen_unique :
-    forall i j : nat, varname_gen i = varname_gen j <-> i = j.
-  Admitted.
-
   Instance p_ok : Types.ok.
   Proof.
     constructor.
     { exact BasicC32Semantics_parameters_ok. }
     { reflexivity. }
     { exact decimal_varname_gen_unique. }
-  Admitted.
+  Qed.
 
   Local Notation M := (s - Associational.eval c)%Z.
   Local Notation eval :=
@@ -123,50 +118,6 @@ Section Proofs.
               (map word.unsigned x) (map word.unsigned y))) =
     ((eval (map word.unsigned x) * eval (map word.unsigned y)) mod M)%Z.
   Admitted.
-
-  (* TODO : move *)
-  Lemma substring_0_0 :
-    forall s, substring 0 0 s = "".
-  Proof.
-    clear. destruct s; reflexivity.
-  Qed.
-
-  Lemma varname_gen_startswith v i :
-    v = varname_gen i ->
-    String.startswith "x" v = true.
-  Proof.
-    cbn [varname_gen default_parameters]. intro.
-    subst. cbn. rewrite substring_0_0.
-    reflexivity.
-  Qed.
-
-  (* TODO : move *)
-  Lemma map_of_Z_unsigned x :
-    map word.of_Z (map word.unsigned x) = x.
-  Proof.
-    rewrite map_map.
-    rewrite map_ext with (g:=id);
-      [ solve [apply map_id] | ].
-    intros. rewrite word.of_Z_unsigned.
-    reflexivity.
-  Qed.
-
-  (* TODO : move *)
-  Lemma map_unsigned_of_Z x :
-    map word.unsigned (map word.of_Z x) = map word.wrap x.
-  Proof.
-    rewrite map_map. apply map_ext.
-    exact word.unsigned_of_Z.
-  Qed.
-
-  (* TODO: move *)
-  Lemma Forall_map_unsigned x :
-    Forall (fun z : Z => 0 <= z < 2 ^ Semantics.width)
-           (map word.unsigned x).
-  Proof.
-    induction x; intros; cbn [map]; constructor;
-      auto using word.unsigned_range.
-  Qed.
 
   Lemma mulmod_bedrock_correct :
     program_logic_goal_for_function! mulmod_bedrock.

--- a/src/Bedrock/Tests/Proofs/X25519_64.v
+++ b/src/Bedrock/Tests/Proofs/X25519_64.v
@@ -39,6 +39,8 @@ Require Import Crypto.Bedrock.Tests.X25519_64.
 Import X25519_64.
 Local Coercion name_of_func (f : bedrock_func) := fst f.
 
+Existing Instance Defaults64.default_parameters.
+
 Section Proofs.
   Context (n : nat := 5%nat)
           (s : Z := 2^255)

--- a/src/Bedrock/Tests/Proofs/X25519_64.v
+++ b/src/Bedrock/Tests/Proofs/X25519_64.v
@@ -16,6 +16,7 @@ Require Import Crypto.BoundsPipeline.
 Require Import Crypto.Arithmetic.Core.
 Require Import Crypto.Arithmetic.ModOps.
 Require Import Crypto.Bedrock.Defaults.
+Require Import Crypto.Bedrock.Defaults64.
 Require Import Crypto.Bedrock.Types.
 Require Import Crypto.Bedrock.Tactics.
 Require Import Crypto.Bedrock.Proofs.Func.

--- a/src/Bedrock/Tests/Proofs/X25519_64.v
+++ b/src/Bedrock/Tests/Proofs/X25519_64.v
@@ -47,11 +47,6 @@ Section Proofs.
           (c : list (Z * Z) := [(1,19)])
           (machine_wordsize : Z := 64).
 
-  (* requires some kind of proof about decimal stringification *)
-  Lemma decimal_varname_gen_unique :
-    forall i j : nat, varname_gen i = varname_gen j <-> i = j.
-  Admitted.
-
   Instance p_ok : Types.ok.
   Proof.
     constructor.
@@ -120,50 +115,6 @@ Section Proofs.
               (map word.unsigned x) (map word.unsigned y))) =
     ((eval (map word.unsigned x) * eval (map word.unsigned y)) mod M)%Z.
   Admitted.
-
-  (* TODO : move *)
-  Lemma substring_0_0 :
-    forall s, substring 0 0 s = "".
-  Proof.
-    clear. destruct s; reflexivity.
-  Qed.
-
-  Lemma varname_gen_startswith v i :
-    v = varname_gen i ->
-    String.startswith "x" v = true.
-  Proof.
-    cbn [varname_gen default_parameters]. intro.
-    subst. cbn. rewrite substring_0_0.
-    reflexivity.
-  Qed.
-
-  (* TODO : move *)
-  Lemma map_of_Z_unsigned x :
-    map word.of_Z (map word.unsigned x) = x.
-  Proof.
-    rewrite map_map.
-    rewrite map_ext with (g:=id);
-      [ solve [apply map_id] | ].
-    intros. rewrite word.of_Z_unsigned.
-    reflexivity.
-  Qed.
-
-  (* TODO : move *)
-  Lemma map_unsigned_of_Z x :
-    map word.unsigned (map word.of_Z x) = map word.wrap x.
-  Proof.
-    rewrite map_map. apply map_ext.
-    exact word.unsigned_of_Z.
-  Qed.
-
-  (* TODO: move *)
-  Lemma Forall_map_unsigned x :
-    Forall (fun z : Z => 0 <= z < 2 ^ Semantics.width)
-           (map word.unsigned x).
-  Proof.
-    induction x; intros; cbn [map]; constructor;
-      auto using word.unsigned_range.
-  Qed.
 
   Lemma mulmod_bedrock_correct :
     program_logic_goal_for_function! mulmod_bedrock.

--- a/src/Bedrock/Tests/X25519_32.v
+++ b/src/Bedrock/Tests/X25519_32.v
@@ -1,0 +1,113 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.derive.Derive.
+Require Import Coq.QArith.QArith.
+Require Import Coq.QArith.Qround.
+Require Import Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Crypto.BoundsPipeline.
+Require Import Crypto.Arithmetic.Core.
+Require Import Crypto.Arithmetic.ModOps.
+Require Import Crypto.Bedrock.Defaults.
+Require Import Crypto.Bedrock.Defaults32.
+Require Import Crypto.Bedrock.Types.
+Require Import Crypto.Bedrock.Translation.Func.
+Require Import Crypto.Language.API.
+Require Import Crypto.Util.ZRange.
+Require Import Crypto.Util.ZUtil.ModInv.
+Require Import bedrock2.Syntax.
+Require Import bedrock2.Semantics.
+Require Import bedrock2.BasicC32Semantics.
+Require bedrock2.NotationsCustomEntry.
+
+Import Language.Compilers.
+Import Associational Positional.
+Import Types.Notations Defaults32.Notations.
+
+Require Import Crypto.Util.Notations.
+Import ListNotations. Local Open Scope Z_scope.
+Local Open Scope string_scope.
+Local Open Scope expr_scope.
+Local Open Scope core_scope.
+
+Local Coercion Z.of_nat : nat >-> Z.
+Local Coercion QArith_base.inject_Z : Z >-> Q.
+Local Coercion Z.pos : positive >-> Z.
+
+(* Curve25519 32-bit *)
+Module X25519_32.
+  Section __.
+    Context (n : nat := 10%nat)
+            (s : Z := 2^255)
+            (c : list (Z * Z) := [(1,19)]%list).
+
+    Let limbwidth := (Z.log2_up (s - Associational.eval c) / Z.of_nat n)%Q.
+    Let idxs := (List.seq 0 n ++ [0; 1])%list%nat.
+
+    Let prime_upperbound_list : list Z
+      := encode_no_reduce (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
+    Let tight_upperbounds : list Z
+      := List.map
+           (fun v : Z => Qceiling (11/10 * v))
+           prime_upperbound_list.
+    Definition tight_bounds : list (ZRange.type.option.interp (type.base (base.type.type_base base.type.Z)))
+      := List.map (fun u => Some r[0~>u]%zrange) tight_upperbounds.
+    Definition loose_bounds : list (ZRange.type.option.interp (type.base (base.type.type_base base.type.Z)))
+      := List.map (fun u => Some r[0 ~> 3*u]%zrange) tight_upperbounds.
+
+    Definition limbwidth_num := Eval vm_compute in Qnum limbwidth.
+    Definition limbwidth_den := Eval vm_compute in QDen limbwidth.
+
+    Definition mulmod_ : Pipeline.ErrorT (Expr _) :=
+      Pipeline.BoundsPipeline
+        true (* subst01 *)
+        None (* fancy *)
+        possible_values
+        ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n idxs)) in
+              exact r)
+               (Some loose_bounds, (Some loose_bounds, tt))
+               (Some tight_bounds).
+    Derive mulmod
+           SuchThat (mulmod_ = ErrorT.Success mulmod)
+           As mulmod_eq.
+    Proof. vm_compute; reflexivity. Qed.
+
+    Definition mulmod_bedrock : bedrock_func :=
+      ("mulmod_bedrock",
+       fst (translate_func mulmod
+                           ("in0", ("in1", tt)) (* argument names *)
+                           (n, (n, tt)) (* lengths for list arguments *)
+                           "out0" (* return value name *))).
+
+    Goal (error_free_cmd (snd (snd mulmod_bedrock)) = true).
+    Proof. vm_compute. reflexivity. Qed.
+
+    Definition addmod_ : Pipeline.ErrorT (Expr _) :=
+      Pipeline.BoundsPipeline
+        true (* subst01 *)
+        None (* fancy *)
+        possible_values
+        ltac:(let r := Reify (addmod limbwidth_num limbwidth_den n) in
+              exact r)
+               (Some tight_bounds, (Some tight_bounds, tt))
+               (Some loose_bounds).
+    Derive addmod
+           SuchThat (addmod_ = ErrorT.Success addmod)
+           As addmod_eq.
+    Proof. vm_compute; reflexivity. Qed.
+
+    Definition addmod_bedrock : bedrock_func :=
+      ("addmod_bedrock",
+       fst (translate_func addmod
+                           ("in0", ("in1", tt)) (* argument names *)
+                           (n, (n, tt)) (* lengths for list arguments *)
+                           "out0" (* return value name *))).
+
+    Goal (error_free_cmd (snd (snd addmod_bedrock)) = true).
+    Proof. vm_compute. reflexivity. Qed.
+
+    Import NotationsCustomEntry.
+    Local Set Printing Width 150.
+    (* Compute mulmod_bedrock. *)
+    Redirect "Crypto.Bedrock.Tests.X25519_32.mulmod_bedrock" Compute mulmod_bedrock.
+  End __.
+End X25519_32.

--- a/src/Bedrock/Tests/X25519_32.v
+++ b/src/Bedrock/Tests/X25519_32.v
@@ -33,6 +33,9 @@ Local Coercion Z.of_nat : nat >-> Z.
 Local Coercion QArith_base.inject_Z : Z >-> Q.
 Local Coercion Z.pos : positive >-> Z.
 
+Existing Instances split_mul_to split_multiret_to.
+Existing Instance Defaults32.default_parameters.
+
 (* Curve25519 32-bit *)
 Module X25519_32.
   Section __.

--- a/src/Bedrock/Tests/X25519_64.v
+++ b/src/Bedrock/Tests/X25519_64.v
@@ -33,6 +33,9 @@ Local Coercion Z.of_nat : nat >-> Z.
 Local Coercion QArith_base.inject_Z : Z >-> Q.
 Local Coercion Z.pos : positive >-> Z.
 
+Existing Instances split_mul_to split_multiret_to.
+Existing Instance Defaults64.default_parameters.
+
 (* Curve25519 64-bit *)
 Module X25519_64.
   Section __.

--- a/src/Bedrock/Tests/X25519_64.v
+++ b/src/Bedrock/Tests/X25519_64.v
@@ -8,6 +8,7 @@ Require Import Crypto.BoundsPipeline.
 Require Import Crypto.Arithmetic.Core.
 Require Import Crypto.Arithmetic.ModOps.
 Require Import Crypto.Bedrock.Defaults.
+Require Import Crypto.Bedrock.Defaults64.
 Require Import Crypto.Bedrock.Types.
 Require Import Crypto.Bedrock.Translation.Func.
 Require Import Crypto.Language.API.
@@ -20,7 +21,7 @@ Require bedrock2.NotationsCustomEntry.
 
 Import Language.Compilers.
 Import Associational Positional.
-Import Types.Notations Defaults.Notations.
+Import Types.Notations Defaults64.Notations.
 
 Require Import Crypto.Util.Notations.
 Import ListNotations. Local Open Scope Z_scope.

--- a/src/Bedrock/Util.v
+++ b/src/Bedrock/Util.v
@@ -10,7 +10,7 @@ Require Import bedrock2.WeakestPrecondition.
 Require Import bedrock2.WeakestPreconditionProperties.
 Require Import coqutil.Tactics.destr.
 Require Import coqutil.Map.Interface coqutil.Map.Properties.
-Require Import coqutil.Word.Interface.
+Require Import coqutil.Word.Interface coqutil.Word.Properties.
 Require Import coqutil.Datatypes.PropSet.
 Require Import Crypto.Util.Option.
 Require Import Crypto.Util.ListUtil.
@@ -661,6 +661,35 @@ Section Maps.
     { auto. } 
   Qed.
 End Maps.
+
+Section Words.
+  Context {width} {word : word.word width} {ok : word.ok word}.
+
+  Lemma map_of_Z_unsigned x :
+    map word.of_Z (map word.unsigned x) = x.
+  Proof.
+    rewrite map_map.
+    rewrite map_ext with (g:=id);
+      [ solve [apply map_id] | ].
+    intros. rewrite word.of_Z_unsigned.
+    reflexivity.
+  Qed.
+
+  Lemma map_unsigned_of_Z x :
+    map word.unsigned (map word.of_Z x) = map word.wrap x.
+  Proof.
+    rewrite map_map. apply map_ext.
+    exact word.unsigned_of_Z.
+  Qed.
+
+  Lemma Forall_map_unsigned x :
+    Forall (fun z : Z => (0 <= z < 2 ^ width)%Z)
+           (map word.unsigned x).
+  Proof.
+    induction x; intros; cbn [map]; constructor;
+      auto using word.unsigned_range.
+  Qed.
+End Words.
 
 (* These lemmas should be moved to bedrock2, not coqutil *)
 Section Separation.

--- a/src/Util/Strings/String.v
+++ b/src/Util/Strings/String.v
@@ -322,3 +322,7 @@ Definition capitalize_first_letter (s : string) : string
      end.
 Definition to_title_case (s : string) : string
   := concat " " (List.map capitalize_first_letter (split " " s)).
+
+Lemma substring_0_0 :
+  forall s, substring 0 0 s = "".
+Proof. destruct s; reflexivity. Qed.


### PR DESCRIPTION
This PR:
- separates out the `Bedrock/Defaults.v` file into three files: one for global defaults, one for 32-bit-specific defaults, and one for 64-bit-specific defaults
- creates a 32-bit test in `Bedrock/Tests`
- modifies `Bedrock/Stringification.v` to select the translation parameters based on the word size

Put together, this gives us working 32-bit code from the CLI. I've tested it on all currently supported operations for curve25519 and p256. The changes should make #752 work!