### PR TITLE
Moving names of primitive atomic tactics from Coq.Init.Notations to Coq.Init.Ltac

### DIFF
--- a/src/Util/Tactics/ETransitivity.v
+++ b/src/Util/Tactics/ETransitivity.v
@@ -1,5 +1,9 @@
 Require Import Coq.Classes.RelationClasses.
 
+(** We call Coq's [etransitivity] for compatibility
+    because it's more powerful than [etransitivity _] in some cases,
+    e.g., when things need to be unfolded. *)
+Tactic Notation "etransitivity" := etransitivity.
 Tactic Notation "etransitivity" open_constr(y) :=
   intros;
   let R := match goal with |- ?R ?x ?z => constr:(R) end in
@@ -8,10 +12,6 @@ Tactic Notation "etransitivity" open_constr(y) :=
   let pre_proof_term_head := constr:(@transitivity _ R _) in
   let proof_term_head := (eval cbn in pre_proof_term_head) in
   refine (proof_term_head x y z _ _); [ change (R x y) | change (R y z) ].
-(** We call [Coq.Init.Notations.etransitivity] for compatibility
-    because it's more powerful than [etransitivity _] in some cases,
-    e.g., when things need to be unfolded. *)
-Tactic Notation "etransitivity" := Coq.Init.Notations.etransitivity.
 Tactic Notation "etransitivity_rev" uconstr(y) := [ > etransitivity y; cycle 1.. ].
 Tactic Notation "etransitivity_rev" := [ > etransitivity; cycle 1.. ].
 


### PR DESCRIPTION
Coq PR coq/coq#12023 introduces a specific file `Ltac.v` to activate the ltac plugin. This implies a change of qualification of the primitive atomic tactics from `Coq.Init.Notations` to `Coq.Init.Ltac`.

This PR adapts fiat-crypto to the change. I slightly modified the flow of the impacted file so as to be backwards-compatible, but there is a little lost in clarity. So, maybe would you prefer a word-by-word backward-incompatible change.
