### PR TITLE
Instantiate correctness proofs for bedrock2 tests

### DIFF
--- a/src/Bedrock/Tests/Proofs/X25519_64.v
+++ b/src/Bedrock/Tests/Proofs/X25519_64.v
@@ -28,6 +28,7 @@ Require Import Crypto.PushButtonSynthesis.UnsaturatedSolinas.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Tactics.RewriteModSmall.
+Require Import Rewriter.Language.Wf.
 Require bedrock2.Map.SeparationLogic. (* if imported, list firstn/skipn get overwritten and it's annoying *)
 Local Open Scope Z_scope.
 
@@ -112,10 +113,9 @@ Section Proofs.
     vm_compute; reflexivity.
   Qed.
 
-  (* TODO: ask Jason for help *)
   Lemma mulmod_Wf :
     Wf.Compilers.expr.Wf3 mulmod.
-  Admitted.
+  Proof. Compilers.prove_Wf3 (). Qed.
 
   Lemma mulmod_length (x y : API.interp_type type_listZ) :
     length

--- a/src/Bedrock/Tests/Proofs/X25519_64.v
+++ b/src/Bedrock/Tests/Proofs/X25519_64.v
@@ -1,4 +1,5 @@
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.QArith.QArith.
 Require Import Coq.Strings.String. (* should go before lists *)
 Require Import Coq.Lists.List.
 Require Import coqutil.Word.Interface.
@@ -33,16 +34,21 @@ Require bedrock2.Map.SeparationLogic. (* if imported, list firstn/skipn get over
 Local Open Scope Z_scope.
 
 Import Language.Compilers.
+Import Language.Wf.Compilers.
 Import Associational Positional.
 
 Require Import Crypto.Util.Notations.
 Import Types.Notations ListNotations.
+Import QArith_base.
 Local Open Scope Z_scope.
 Local Open Scope string_scope.
 
 Require Import Crypto.Bedrock.Tests.X25519_64.
 Import X25519_64.
 Local Coercion name_of_func (f : bedrock_func) := fst f.
+Local Coercion Z.of_nat : nat >-> Z.
+Local Coercion inject_Z : Z >-> Q.
+Local Coercion Z.pos : positive >-> Z.
 
 Existing Instance Defaults64.default_parameters.
 
@@ -62,15 +68,8 @@ Section Proofs.
 
   Local Notation M := (s - Associational.eval c)%Z.
   Local Notation eval :=
-    (eval (weight
-         (QArith_base.Qnum
-            (QArith_base.Qdiv (QArith_base.inject_Z (Z.log2_up M))
-                              (QArith_base.inject_Z (Z.of_nat n))))
-         (Z.pos
-            (QArith_base.Qden
-               (QArith_base.Qdiv (QArith_base.inject_Z (Z.log2_up M))
-                                 (QArith_base.inject_Z (Z.of_nat n))))))
-          n).
+    (eval (weight (Qnum (inject_Z (Z.log2_up M) / inject_Z (Z.of_nat n)))
+                  (QDen (inject_Z (Z.log2_up M) / inject_Z (Z.of_nat n)))) n).
   Local Notation loose_bounds := (UnsaturatedSolinas.loose_bounds n s c).
   Local Notation tight_bounds := (UnsaturatedSolinas.tight_bounds n s c).
 
@@ -113,18 +112,12 @@ Section Proofs.
     vm_compute; reflexivity.
   Qed.
 
-  Lemma mulmod_Wf :
-    Wf.Compilers.expr.Wf3 mulmod.
-  Proof. Compilers.prove_Wf3 (). Qed.
+  Lemma mulmod_Wf : expr.Wf3 mulmod.
+  Proof. prove_Wf3 (). Qed.
 
   Lemma mulmod_length (x y : API.interp_type type_listZ) :
-    length
-      (expr.interp (@Compilers.ident_interp)
-                   (mulmod API.interp_type)
-                   x y) = n.
-  Proof.
-    vm_compute. reflexivity.
-  Qed.
+    length (API.interp (mulmod _) x y) = n.
+  Proof. vm_compute. reflexivity. Qed.
 
   Lemma map_word_wrap_bounded x :
     length x = n ->
@@ -153,21 +146,13 @@ Section Proofs.
     reflexivity.
   Qed.
 
-
   Lemma mulmod_carry_mul_correct :
     Solinas.carry_mul_correct
-      (weight
-         (QArith_base.Qnum
-            (QArith_base.Qdiv (QArith_base.inject_Z (Z.log2_up M))
-                              (QArith_base.inject_Z (Z.of_nat n))))
-         (Z.pos
-            (QArith_base.Qden
-               (QArith_base.Qdiv (QArith_base.inject_Z (Z.log2_up M))
-                                 (QArith_base.inject_Z (Z.of_nat n))))))
+      (weight (Qnum (Z.log2_up M / n)) (Qden (Z.log2_up M / n)))
       n M
       (UnsaturatedSolinas.tight_bounds n s c)
       (UnsaturatedSolinas.loose_bounds n s c)
-      (expr.Interp (@Compilers.ident_interp) mulmod).
+      (API.Interp mulmod).
   Proof.
     apply carry_mul_correct with (machine_wordsize0:=machine_wordsize).
     { subst n s c machine_wordsize. vm_compute. reflexivity. }
@@ -182,8 +167,7 @@ Section Proofs.
     let xy :=
         map word.wrap
             (type.app_curried
-               (expr.interp (@Compilers.ident_interp)
-                            (mulmod API.interp_type))
+               (API.Interp mulmod)
                (x, (y, tt))) in
     list_Z_bounded_by tight_bounds xy /\
     eval xy mod M = (eval x * eval y) mod M.

--- a/src/Bedrock/Tests/X25519_32.v
+++ b/src/Bedrock/Tests/X25519_32.v
@@ -1,27 +1,19 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.derive.Derive.
-Require Import Coq.QArith.QArith.
-Require Import Coq.QArith.Qround.
 Require Import Coq.Strings.String.
 Require Import Coq.Lists.List.
 Require Import Crypto.BoundsPipeline.
-Require Import Crypto.Arithmetic.Core.
-Require Import Crypto.Arithmetic.ModOps.
 Require Import Crypto.Bedrock.Defaults.
 Require Import Crypto.Bedrock.Defaults32.
 Require Import Crypto.Bedrock.Types.
 Require Import Crypto.Bedrock.Translation.Func.
 Require Import Crypto.PushButtonSynthesis.UnsaturatedSolinas.
 Require Import Crypto.Language.API.
-Require Import Crypto.Util.ZRange.
-Require Import Crypto.Util.ZUtil.ModInv.
 Require Import bedrock2.Syntax.
 Require Import bedrock2.Semantics.
-Require Import bedrock2.BasicC32Semantics.
 Require bedrock2.NotationsCustomEntry.
 
 Import Language.Compilers.
-Import Associational Positional.
 Import Types.Notations Defaults32.Notations.
 
 Require Import Crypto.Util.Notations.
@@ -29,10 +21,6 @@ Import ListNotations. Local Open Scope Z_scope.
 Local Open Scope string_scope.
 Local Open Scope expr_scope.
 Local Open Scope core_scope.
-
-Local Coercion Z.of_nat : nat >-> Z.
-Local Coercion QArith_base.inject_Z : Z >-> Q.
-Local Coercion Z.pos : positive >-> Z.
 
 Existing Instances split_mul_to split_multiret_to.
 Existing Instance Defaults32.default_parameters.

--- a/src/Bedrock/Tests/X25519_64.v
+++ b/src/Bedrock/Tests/X25519_64.v
@@ -1,27 +1,19 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.derive.Derive.
-Require Import Coq.QArith.QArith.
-Require Import Coq.QArith.Qround.
 Require Import Coq.Strings.String.
 Require Import Coq.Lists.List.
 Require Import Crypto.BoundsPipeline.
-Require Import Crypto.Arithmetic.Core.
-Require Import Crypto.Arithmetic.ModOps.
 Require Import Crypto.Bedrock.Defaults.
 Require Import Crypto.Bedrock.Defaults64.
 Require Import Crypto.Bedrock.Types.
 Require Import Crypto.Bedrock.Translation.Func.
 Require Import Crypto.Language.API.
 Require Import Crypto.PushButtonSynthesis.UnsaturatedSolinas.
-Require Import Crypto.Util.ZRange.
-Require Import Crypto.Util.ZUtil.ModInv.
 Require Import bedrock2.Syntax.
 Require Import bedrock2.Semantics.
-Require Import bedrock2.BasicC64Semantics.
 Require bedrock2.NotationsCustomEntry.
 
 Import Language.Compilers.
-Import Associational Positional.
 Import Types.Notations Defaults64.Notations.
 
 Require Import Crypto.Util.Notations.
@@ -29,10 +21,6 @@ Import ListNotations. Local Open Scope Z_scope.
 Local Open Scope string_scope.
 Local Open Scope expr_scope.
 Local Open Scope core_scope.
-
-Local Coercion Z.of_nat : nat >-> Z.
-Local Coercion QArith_base.inject_Z : Z >-> Q.
-Local Coercion Z.pos : positive >-> Z.
 
 Existing Instances split_mul_to split_multiret_to.
 Existing Instance Defaults64.default_parameters.

--- a/src/Bedrock/Tests/X25519_64.v
+++ b/src/Bedrock/Tests/X25519_64.v
@@ -12,6 +12,7 @@ Require Import Crypto.Bedrock.Defaults64.
 Require Import Crypto.Bedrock.Types.
 Require Import Crypto.Bedrock.Translation.Func.
 Require Import Crypto.Language.API.
+Require Import Crypto.PushButtonSynthesis.UnsaturatedSolinas.
 Require Import Crypto.Util.ZRange.
 Require Import Crypto.Util.ZUtil.ModInv.
 Require Import bedrock2.Syntax.
@@ -43,34 +44,9 @@ Module X25519_64.
             (s : Z := 2^255)
             (c : list (Z * Z) := [(1,19)]%list).
 
-    Let limbwidth := (Z.log2_up (s - Associational.eval c) / Z.of_nat n)%Q.
-    Let idxs := (List.seq 0 n ++ [0; 1])%list%nat.
-
-    Let prime_upperbound_list : list Z
-      := encode_no_reduce (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
-    Let tight_upperbounds : list Z
-      := List.map
-           (fun v : Z => Qceiling (11/10 * v))
-           prime_upperbound_list.
-    Definition tight_bounds : list (ZRange.type.option.interp (type.base (base.type.type_base base.type.Z)))
-      := List.map (fun u => Some r[0~>u]%zrange) tight_upperbounds.
-    Definition loose_bounds : list (ZRange.type.option.interp (type.base (base.type.type_base base.type.Z)))
-      := List.map (fun u => Some r[0 ~> 3*u]%zrange) tight_upperbounds.
-
-    Definition limbwidth_num := Eval vm_compute in Qnum limbwidth.
-    Definition limbwidth_den := Eval vm_compute in QDen limbwidth.
-
-    Definition mulmod_ : Pipeline.ErrorT (Expr _) :=
-      Pipeline.BoundsPipeline
-        true (* subst01 *)
-        None (* fancy *)
-        possible_values
-        ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n idxs)) in
-              exact r)
-               (Some loose_bounds, (Some loose_bounds, tt))
-               (Some tight_bounds).
     Derive mulmod
-           SuchThat (mulmod_ = ErrorT.Success mulmod)
+           SuchThat
+           (carry_mul n s c machine_wordsize = ErrorT.Success mulmod)
            As mulmod_eq.
     Proof. vm_compute; reflexivity. Qed.
 
@@ -84,17 +60,10 @@ Module X25519_64.
     Goal (error_free_cmd (snd (snd mulmod_bedrock)) = true).
     Proof. vm_compute. reflexivity. Qed.
 
-    Definition addmod_ : Pipeline.ErrorT (Expr _) :=
-      Pipeline.BoundsPipeline
-        true (* subst01 *)
-        None (* fancy *)
-        possible_values
-        ltac:(let r := Reify (addmod limbwidth_num limbwidth_den n) in
-              exact r)
-               (Some tight_bounds, (Some tight_bounds, tt))
-               (Some loose_bounds).
     Derive addmod
-           SuchThat (addmod_ = ErrorT.Success addmod)
+           SuchThat
+           (UnsaturatedSolinas.add
+              n s c machine_wordsize = ErrorT.Success addmod)
            As addmod_eq.
     Proof. vm_compute; reflexivity. Qed.
 


### PR DESCRIPTION
As discussed in #757, this change removes the remaining admits in the bedrock2 translation tests with the help of Jason's shiny new `prove_Wf3` tactic (which I can now confirm works beautifully and quickly!) and the existing `PushButtonSynthesis` infrastructure.

Now, when I `Print Assumptions mulmod_bedrock_correct` in the 64-bit test, the only dependencies are:
```
FunctionalExtensionality.functional_extensionality_dep : 
forall (A : Type) (B : A -> Type) (f g : forall x : A, B x),
(forall x : A, f x = g x) -> f = g
SortedListString.TODO_andres : False
 used in string_strict_order to prove: SortedList.parameters.strict_order
                                         String.ltb
SortedList.TODO_andres : False
 used in map_ok to prove: forall (m : map.rep)
                            (k k' : SortedList.parameters.key),
                          k <> k' ->
                          map.get (map.remove m k') k = map.get m k
 used in map_ok to prove: forall (m : map.rep)
                            (k : SortedList.parameters.key),
                          map.get (map.remove m k) k = None
 used in map_ok to prove: forall (m : map.rep)
                            (k : SortedList.parameters.key)
                            (v : SortedList.parameters.value)
                            (k' : SortedList.parameters.key),
                          k <> k' ->
                          map.get (map.put m k' v) k = map.get m k
 used in map_ok to prove: forall (m : map.rep)
                            (k : SortedList.parameters.key)
                            (v : SortedList.parameters.value),
                          map.get (map.put m k v) k = Some v
```

I believe the first comes from the rewriter, and the second two from coqutil. @andres-erbsen just out of curiosity, how close are you to completing those todos? Is it worth it for me to try to prove them?

The 32-bit `Print Assumptions` is the same, except it has an extra axiom for the `Semantics.parameters_ok` instance that is missing from `BasicC32Semantics` (see mit-plv/bedrock2#151).

Relevant prior discussion:
https://github.com/mit-plv/fiat-crypto/pull/757#discussion_r410706758
https://github.com/mit-plv/fiat-crypto/pull/757#discussion_r410717055