### PR TITLE
Enable bedrock2 translation for Z.zselect

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -136,6 +136,7 @@ src/Rewriter/Passes/ArithWithCasts.v
 src/Rewriter/Passes/MulSplit.v
 src/Rewriter/Passes/MultiRetSplit.v
 src/Rewriter/Passes/NBE.v
+src/Rewriter/Passes/NoSelect.v
 src/Rewriter/Passes/StripLiteralCasts.v
 src/Rewriter/Passes/ToFancy.v
 src/Rewriter/Passes/ToFancyWithCasts.v

--- a/src/Bedrock/Defaults.v
+++ b/src/Bedrock/Defaults.v
@@ -28,6 +28,8 @@ Global Instance widen_carry : widen_carry_opt := true.
 Global Instance widen_bytes : widen_bytes_opt := true.
 (* Unsigned integers *)
 Global Instance only_signed : only_signed_opt := false.
+(* Rewrite selects into expressions that don't require cmov *)
+Global Instance no_select : no_select_opt := true.
 
 (* bedrock2 backend parameters *)
 Global Existing Instances Types.rep.Z Types.rep.listZ_mem.

--- a/src/Bedrock/Defaults32.v
+++ b/src/Bedrock/Defaults32.v
@@ -25,6 +25,8 @@ Section Defaults_32.
   (* Define how to split mul/multi-return functions *)
   Definition possible_values
     := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
+  Instance no_select_size : no_select_size_opt :=
+    no_select_size_of_no_select machine_wordsize.
   Instance split_mul_to : split_mul_to_opt :=
     split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Instance split_multiret_to : split_multiret_to_opt :=

--- a/src/Bedrock/Defaults64.v
+++ b/src/Bedrock/Defaults64.v
@@ -25,6 +25,8 @@ Section Defaults_64.
   (* Define how to split mul/multi-return functions *)
   Definition possible_values
     := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
+  Instance no_select_size : no_select_size_opt :=
+    no_select_size_of_no_select machine_wordsize.
   Instance split_mul_to : split_mul_to_opt :=
     split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Instance split_multiret_to : split_multiret_to_opt :=

--- a/src/Bedrock/Translation/Expr.v
+++ b/src/Bedrock/Translation/Expr.v
@@ -88,6 +88,16 @@ Section Expr.
            else make_error type_Z
       else base_make_error _.
 
+  Definition rselect
+    : rtype (type_Z -> type_Z -> type_Z -> type_Z) :=
+    fun c x y =>
+      if literal_eqb x 0
+      then if literal_eqb y (2^Semantics.width - 1)
+           then expr.op bopname.add (expr.literal (-1))
+                        (expr.op bopname.eq c (expr.literal 0))
+           else base_make_error _
+      else base_make_error _.
+
   Definition rnth_default
     : rtype (type_Z -> type_listZ -> type_nat -> type_Z) :=
     fun d l i =>
@@ -200,6 +210,7 @@ Section Expr.
     | ident.Z_ltz => Some (expr.op bopname.ltu)
     | ident.Z_lor => Some (expr.op bopname.or)
     | ident.Z_land => Some (expr.op bopname.and)
+    | ident.Z_lxor => Some (expr.op bopname.xor)
     | _ => None 
     end.
 
@@ -212,6 +223,7 @@ Section Expr.
     | ident.Z_shiftr => rshiftr
     | ident.Z_shiftl => rshiftl
     | ident.Z_truncating_shiftl => rtruncating_shiftl
+    | ident.Z_zselect => rselect
     | ident.Z_mul_high => rmul_high
     | ident.Z_cast => fun _ x => x
     | ident.Z_cast2 => fun _ x => x

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -204,6 +204,8 @@ Module ForExtraction.
     := ("--internal-static", "Declare internal functions as static, i.e., local to the file.").
   Definition only_signed_and_help
     := ("--only-signed", "Only allow signed integer types.").
+  Definition no_select_and_help
+    := ("--no-select", "Use expressions that don't require cmov.").
   Definition no_wide_int_and_help
     := ("--no-wide-int", "Don't use integers wider than the bitwidth.").
   Definition widen_carry_and_help
@@ -254,6 +256,7 @@ Module ForExtraction.
         ; no_wide_int_and_help
         ; widen_carry_and_help
         ; widen_bytes_and_help
+        ; no_select_and_help
         ; split_multiret_and_help
         ; no_primitives_and_help
         ; cmovznz_by_mul_and_help
@@ -367,6 +370,8 @@ Module ForExtraction.
       ; internal_static :> internal_static_opt
       (** Should we only use signed integers *)
       ; only_signed :> only_signed_opt
+      (** Should we emit expressions requiring cmov *)
+      ; no_select :> no_select_opt
       (** Should we emit primitive operations *)
       ; emit_primitives :> emit_primitives_opt
       (** Should we use the alternate implementation of cmovznz *)
@@ -527,6 +532,7 @@ Module ForExtraction.
            let '(argv, staticv) := argv_to_contains_opt_and_argv "--static" argv in
            let '(argv, internal_staticv) := argv_to_contains_opt_and_argv "--internal-static" argv in
            let '(argv, only_signedv) := argv_to_contains_opt_and_argv "--only-signed" argv in
+           let '(argv, no_selectv) := argv_to_contains_opt_and_argv "--no-select" argv in
            let '(argv, no_wide_intsv) := argv_to_contains_opt_and_argv "--no-wide-int" argv in
            let '(argv, use_mul_for_cmovznzv) := argv_to_contains_opt_and_argv "--cmovznz-by-mul" argv in
            let '(argv, widen_carryv) := argv_to_contains_opt_and_argv "--widen-carry" argv in
@@ -546,6 +552,7 @@ Module ForExtraction.
                          := {| static := staticv
                                ; internal_static := internal_staticv
                                ; only_signed := only_signedv
+                               ; no_select := no_selectv
                                ; use_mul_for_cmovznz := use_mul_for_cmovznzv
                                ; widen_carry := widen_carryv
                                ; widen_bytes := widen_bytesv

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -60,6 +60,7 @@ Section rbarrett_red.
   Local Instance widen_carry : widen_carry_opt := false.
   Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance only_signed : only_signed_opt := false.
+  Local Instance no_select_size : no_select_size_opt := None.
   Local Instance split_mul_to : split_mul_to_opt := None.
   Local Instance split_multiret_to : split_multiret_to_opt := None.
   Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -80,6 +80,7 @@ Section __.
           {internal_static : internal_static_opt}
           {low_level_rewriter_method : low_level_rewriter_method_opt}
           {only_signed : only_signed_opt}
+          {no_select : no_select_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
@@ -143,6 +144,7 @@ Section __.
   Definition out_bounds : list (ZRange.type.option.interp base.type.Z)
     := List.map (fun u => Some r[0~>u]%zrange) out_upperbounds.
 
+  Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values_of_machine_wordsize_with_bytes.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values_of_machine_wordsize_with_bytes.
 

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -67,6 +67,7 @@ Section rmontred.
   Local Instance widen_carry : widen_carry_opt := false.
   Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance only_signed : only_signed_opt := false.
+  Local Instance no_select_size : no_select_size_opt := None.
   Local Instance split_mul_to : split_mul_to_opt := None.
   Local Instance split_multiret_to : split_multiret_to_opt := None.
   Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -641,6 +641,7 @@ Section __.
           {internal_static : internal_static_opt}
           {low_level_rewriter_method : low_level_rewriter_method_opt}
           {only_signed : only_signed_opt}
+          {no_select : no_select_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
@@ -666,6 +667,7 @@ Section __.
   Let possible_values := possible_values_of_machine_wordsize.
   Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
 
+  Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -62,6 +62,7 @@ Section __.
           {internal_static : internal_static_opt}
           {low_level_rewriter_method : low_level_rewriter_method_opt}
           {only_signed : only_signed_opt}
+          {no_select : no_select_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
@@ -94,6 +95,7 @@ Section __.
   Let boundsn : list (ZRange.type.option.interp base.type.Z)
     := repeat bound n.
 
+  Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -23,6 +23,7 @@ Import Associational Positional.
 Local Instance : split_mul_to_opt := None.
 Local Instance : split_multiret_to_opt := None.
 Local Instance : only_signed_opt := false.
+Local Instance : no_select_size_opt := None.
 Local Existing Instance default_low_level_rewriter_method.
 
 Time Redirect "log" Compute

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -79,6 +79,7 @@ Section __.
           {internal_static : internal_static_opt}
           {low_level_rewriter_method : low_level_rewriter_method_opt}
           {only_signed : only_signed_opt}
+          {no_select : no_select_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
@@ -132,6 +133,7 @@ Section __.
   Definition loose_bounds : list (ZRange.type.option.interp base.type.Z)
     := List.map (fun u => Some r[0~>u]%zrange) loose_upperbounds.
 
+  Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -93,6 +93,7 @@ Section __.
           {internal_static : internal_static_opt}
           {low_level_rewriter_method : low_level_rewriter_method_opt}
           {only_signed : only_signed_opt}
+          {no_select : no_select_opt}
           {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
           {emit_primitives : emit_primitives_opt}
           {should_split_mul : should_split_mul_opt}
@@ -142,6 +143,7 @@ Section __.
   Definition bounds : list (ZRange.type.option.interp base.type.Z)
     := Option.invert_Some saturated_bounds (*List.map (fun u => Some r[0~>u]%zrange) upperbounds*).
 
+  Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 

--- a/src/Rewriter/All.v
+++ b/src/Rewriter/All.v
@@ -4,6 +4,7 @@ Require Import Crypto.Rewriter.Passes.ArithWithCasts.
 Require Import Crypto.Rewriter.Passes.StripLiteralCasts.
 Require Import Crypto.Rewriter.Passes.MulSplit.
 Require Import Crypto.Rewriter.Passes.MultiRetSplit.
+Require Import Crypto.Rewriter.Passes.NoSelect.
 Require Import Crypto.Rewriter.Passes.ToFancy.
 Require Import Crypto.Rewriter.Passes.ToFancyWithCasts.
 
@@ -14,6 +15,7 @@ Module Compilers.
   Export StripLiteralCasts.Compilers.
   Export MulSplit.Compilers.
   Export MultiRetSplit.Compilers.
+  Export NoSelect.Compilers.
   Export ToFancy.Compilers.
   Export ToFancyWithCasts.Compilers.
 
@@ -24,6 +26,7 @@ Module Compilers.
     Export StripLiteralCasts.Compilers.RewriteRules.
     Export MulSplit.Compilers.RewriteRules.
     Export MultiRetSplit.Compilers.RewriteRules.
+    Export NoSelect.Compilers.RewriteRules.
     Export ToFancy.Compilers.RewriteRules.
     Export ToFancyWithCasts.Compilers.RewriteRules.
   End RewriteRules.

--- a/src/Rewriter/Passes/NoSelect.v
+++ b/src/Rewriter/Passes/NoSelect.v
@@ -1,0 +1,43 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Rewriter.Language.Language.
+Require Import Crypto.Language.API.
+Require Import Rewriter.Language.Wf.
+Require Import Crypto.Language.WfExtra.
+Require Import Crypto.Rewriter.AllTacticsExtra.
+Require Import Crypto.Rewriter.RulesProofs.
+
+Module Compilers.
+  Import Language.Compilers.
+  Import Language.API.Compilers.
+  Import Language.Wf.Compilers.
+  Import Language.WfExtra.Compilers.
+  Import Rewriter.AllTacticsExtra.Compilers.RewriteRules.GoalType.
+  Import Rewriter.AllTactics.Compilers.RewriteRules.Tactic.
+  Import Compilers.Classes.
+
+  Module Import RewriteRules.
+    Section __.
+      Context (bitwidth : Z).
+
+      Definition VerifiedRewriterNoSelect : VerifiedRewriter_with_args false false true (noselect_rewrite_rules_proofs bitwidth).
+      Proof using All. make_rewriter. Defined.
+
+      Definition default_opts := Eval hnf in @default_opts VerifiedRewriterNoSelect.
+      Let optsT := Eval hnf in optsT VerifiedRewriterNoSelect.
+
+      Definition RewriteNoSelect (opts : optsT) {t : API.type} := Eval hnf in @Rewrite VerifiedRewriterNoSelect opts t.
+
+      Lemma Wf_RewriteNoSelect opts {t} e (Hwf : Wf e) : Wf (@RewriteNoSelect opts t e).
+      Proof. now apply VerifiedRewriterNoSelect. Qed.
+
+      Lemma Interp_RewriteNoSelect opts {t} e (Hwf : Wf e) : API.Interp (@RewriteNoSelect opts t e) == API.Interp e.
+      Proof. now apply VerifiedRewriterNoSelect. Qed.
+    End __.
+  End RewriteRules.
+
+  Module Export Hints.
+    Hint Resolve Wf_RewriteNoSelect : wf wf_extra.
+    Hint Opaque RewriteNoSelect : wf wf_extra interp interp_extra rewrite.
+    Hint Rewrite @Interp_RewriteNoSelect : interp interp_extra.
+  End Hints.
+End Compilers.

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -49,6 +49,7 @@ Local Instance : internal_static_opt := true.
 Local Instance : use_mul_for_cmovznz_opt := false.
 Local Instance : emit_primitives_opt := true.
 Local Instance : only_signed_opt := false.
+Local Instance : no_select_opt := false.
 Local Instance : should_split_mul_opt := false.
 Local Instance : should_split_multiret_opt := false.
 Local Instance : widen_bytes_opt := false.

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -1065,11 +1065,11 @@ Section with_bitwidth.
                these can be succinctly expressed as 0-c *)
             (forall rc c,
                 singlewidth (Z.zselect (cstZ rc c)
-                                  (singlewidth ('0))
-                                  (singlewidth ('(2^bitwidth - 1))))
+                                       (singlewidth ('0))
+                                       (singlewidth ('(2^bitwidth - 1))))
                 = singlewidth (Z.zselect (cstZ rc c)
-                                    (singlewidth ('0))
-                                    (singlewidth ('(2^bitwidth - 1)))))
+                                         (singlewidth ('0))
+                                         (singlewidth ('(2^bitwidth - 1)))))
             ; (forall rc c x y,
                   (0 <= bitwidth) ->
                   singlewidth (Z.zselect (cstZ rc c) (singlewidth x) (singlewidth y))

--- a/src/Rewriter/Rules.v
+++ b/src/Rewriter/Rules.v
@@ -1071,7 +1071,7 @@ Section with_bitwidth.
                                          (singlewidth ('0))
                                          (singlewidth ('(2^bitwidth - 1)))))
             ; (forall rc c x y,
-                  (0 <= bitwidth) ->
+                  0 <= bitwidth ->
                   singlewidth (Z.zselect (cstZ rc c) (singlewidth x) (singlewidth y))
                   = (dlet a :=
                        singlewidth

--- a/src/Rewriter/RulesProofs.v
+++ b/src/Rewriter/RulesProofs.v
@@ -737,13 +737,7 @@ Proof using Type.
           assert (0 < 2^n < 2^bw) by auto with zarith;
             Z.rewrite_mod_small
         end.
-  all: try
-         (match goal with
-          | |- context [Z.land ?x (2^?n - 1)] =>
-            replace (2^n-1) with (Z.ones n) by
-                (rewrite Z.sub_1_r, <-Z.ones_equiv; reflexivity);
-            rewrite !Z.land_ones by lia
-          end).
+  all: rewrite ?Z.land_pow2 by auto with zarith.
   all: push_Zmod; pull_Zmod; try reflexivity.
   all: Z.rewrite_mod_small.
   all: rewrite ?Z.shiftr_div_pow2, ?Z.shiftl_mul_pow2 by lia.
@@ -808,4 +802,28 @@ Proof using Type.
                       remember (q - q0) as q' eqn:?; (tryif is_var q then Z.linear_substitute q else idtac)
               | _ => nia
           end].
+Qed.
+
+Lemma noselect_rewrite_rules_proofs (bitwidth : Z)
+  : PrimitiveHList.hlist (@snd bool Prop) (noselect_rewrite_rulesT bitwidth).
+Proof.
+  assert (0 <= bitwidth -> 0 < 2^bitwidth) by auto with zarith.
+  start_proof; auto; intros; try lia.
+  all: repeat interp_good_t_step_related.
+  all: systematically_handle_casts; try reflexivity.
+  all: specialize_by auto.
+  all: rewrite !ident.platform_specific_cast_0_is_mod by lia.
+  all: rewrite ?Z.sub_simpl_r by auto.
+  all: autorewrite with zsimplify_fast.
+  Time
+  all: repeat match goal with
+              | _ => progress rewrite ?Z.lxor_0_l, ?Z.lxor_0_r
+              | _ => progress rewrite ?Z.lor_0_l, ?Z.lor_0_r
+              | _ => progress rewrite ?Z.land_0_l, ?Z.land_0_r
+              | _ => rewrite Z.lxor_nilpotent
+              | _ => rewrite Z.land_pow2 by auto with zarith
+              | _ => progress Z.rewrite_mod_small
+              | _ => progress (push_Zmod; pull_Zmod)
+              | _ => reflexivity
+              end.
 Qed.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -46,6 +46,7 @@ Module debugging_p256_mul_bedrock2.
     Local Instance : widen_carry_opt := true.
     Local Instance : widen_bytes_opt := true.
     Local Instance : only_signed_opt := false.
+    Local Instance : no_select_opt := false.
     Local Instance : should_split_mul_opt := true.
     Local Instance : should_split_multiret_opt := true.
 
@@ -112,6 +113,7 @@ Module debugging_25519_to_bytes_bedrock2.
     Local Instance : widen_carry_opt := true.
     Local Instance : widen_bytes_opt := true.
     Local Instance : only_signed_opt := false.
+    Local Instance : no_select_opt := false.
     Local Instance : should_split_mul_opt := true.
     Local Instance : should_split_multiret_opt := true.
 
@@ -562,6 +564,7 @@ Module debugging_25519_to_bytes_java.
     Local Instance : widen_carry_opt := true.
     Local Instance : widen_bytes_opt := true.
     Local Instance : only_signed_opt := true.
+    Local Instance : no_select_opt := false.
     Local Instance : should_split_mul_opt := false. (* only for x64 *)
 
     Definition n := 2%nat (*10%nat*).
@@ -698,6 +701,7 @@ Module debugging_25519_to_bytes_java.
 End debugging_25519_to_bytes_java.
 
 Local Instance : only_signed_opt := false.
+Local Instance : no_select_opt := false.
 
 Module debugging_p256_uint1.
   Import Crypto.PushButtonSynthesis.WordByWordMontgomery.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -702,6 +702,7 @@ End debugging_25519_to_bytes_java.
 
 Local Instance : only_signed_opt := false.
 Local Instance : no_select_opt := false.
+Local Instance : no_select_size_opt := None.
 
 Module debugging_p256_uint1.
   Import Crypto.PushButtonSynthesis.WordByWordMontgomery.

--- a/src/Util/ZUtil/Land.v
+++ b/src/Util/ZUtil/Land.v
@@ -54,4 +54,12 @@ Module Z.
       by auto with zarith.
     rewrite Z.land_ones_low; auto with zarith.
   Qed.
+
+  Lemma land_pow2 x n :
+    0 <= n ->
+    Z.land x (2^n-1) = x mod 2^n.
+  Proof.
+    intros. rewrite Z.sub_1_r, <- Z.ones_equiv.
+    apply Z.land_ones; auto with zarith.
+  Qed.
 End Z.


### PR DESCRIPTION
Closes #750
On top of #760 

Enables translation of zselects by, as discussed in #750, adding a new rewriter pass that translates selects into a bedrock2-expressible form, adding a new CLI flag indicating whether the rewriter pass should be run, and then introducing support for a few new patterns in the bedrock2 backend.

After this is merged and `--no-select` flags are added to the bedrock2 build targets, #733 should work.