### PR TITLE
Comment out uploading-timing-info stage from GH actions

### DIFF
--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -109,12 +109,12 @@ jobs:
       run: cat time-of-build-pretty.log
     - name: display per-line timing info
       run: etc/ci/github-actions-display-per-line-timing.sh
-    - name: upload timing and .vo info
-      uses: actions/upload-artifact@v1
-      with:
-        name: build-outputs
-        path: .
-      if: always ()
+#    - name: upload timing and .vo info
+#      uses: actions/upload-artifact@v1
+#      with:
+#        name: build-outputs
+#        path: .
+#      if: always ()
     - name: validate
       run: make TIMED=1 validate COQCHKFLAGS="-o"
       if: github.event_name != 'pull_request'

--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -136,12 +136,12 @@ jobs:
     - name: display per-line timing info
       run: C:\cygwin64\bin\bash -l -c 'cd "%cd%"; etc/ci/github-actions-display-per-line-timing.sh'
       shell: cmd
-    - name: upload timing and .vo info
-      uses: actions/upload-artifact@v1
-      with:
-        name: build-outputs
-        path: .
-      if: always ()
+#    - name: upload timing and .vo info
+#      uses: actions/upload-artifact@v1
+#      with:
+#        name: build-outputs
+#        path: .
+#      if: always ()
     - name: validate
       run: C:\cygwin64\bin\bash -l -c 'cd "%cd%"; make TIMED=1 validate COQCHKFLAGS="-o"'
       shell: cmd

--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -91,12 +91,12 @@ jobs:
       run: cat time-of-build-pretty.log
     - name: display per-line timing info
       run: etc/ci/github-actions-display-per-line-timing.sh
-    - name: upload timing and .vo info
-      uses: actions/upload-artifact@v1
-      with:
-        name: build-outputs-${{ matrix.env.COQ_VERSION }}
-        path: .
-      if: always ()
+#    - name: upload timing and .vo info
+#      uses: actions/upload-artifact@v1
+#      with:
+#        name: build-outputs-${{ matrix.env.COQ_VERSION }}
+#        path: .
+#      if: always ()
     - name: validate
       run: make TIMED=1 validate COQCHKFLAGS="-o"
       if: matrix.env.SKIP_VALIDATE == '' && github.event_name != 'pull_request'


### PR DESCRIPTION
Discussed with Jason offline. Summary of the conversation: It's been happening frequently that builds fail at the last minute due to failures in the stage when timing info is uploaded, possibly due to the timing info being simply too much data. So we're commenting out those lines to remove some development pain. (This is the cause of the current failure on master.)

See actions/virtual-environments/issues/736