### PR TITLE
Adapt to Coq PR #12146: tactic subst now inactive on section variables with indirect dependency in goal

### DIFF
--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -1327,7 +1327,7 @@ Module Positional.
         eval n (sub a b) mod (s - Associational.eval c)
         = (eval n a - eval n b) mod (s - Associational.eval c).
     Proof using s_nz m_nz weight_0 weight_nz.
-      destruct (zerop n); subst; try reflexivity.
+      destruct (zerop n) as [->|]; try reflexivity.
       intros; cbv [sub balance scmul negate_snd]; push; repeat distr_length;
         eauto with omega.
       push_Zmod; push; pull_Zmod; push_Zmod; pull_Zmod; distr_length; eauto.


### PR DESCRIPTION
The fix is a priori backward-compatible and can be merged now.

See [coq/coq#12139](https://github.com/coq/coq/issues/12139#issuecomment-622743684) for the motivation as suggested by @JasonGross and supported by @samuelgruetter.