### PR TITLE
Add support for comments and stripping annotations

### DIFF
--- a/src/AbstractInterpretation/WfExtra.v
+++ b/src/AbstractInterpretation/WfExtra.v
@@ -18,8 +18,8 @@ Module Compilers.
   Import AbstractInterpretation.AbstractInterpretation.Compilers.partial.
   Import AbstractInterpretation.Wf.Compilers.partial.
 
-  Hint Resolve Wf_Eval Wf_EvalWithBound Wf_EtaExpandWithBound Wf_EtaExpandWithListInfoFromBound : wf_extra.
-  Hint Opaque partial.Eval EvalWithBound EtaExpandWithBound EtaExpandWithListInfoFromBound : wf_extra interp_extra.
+  Hint Resolve Wf_Eval Wf_EvalWithBound Wf_EtaExpandWithBound Wf_EtaExpandWithListInfoFromBound Wf_StripAnnotations Wf_StripAllAnnotations : wf_extra.
+  Hint Opaque partial.Eval EvalWithBound EtaExpandWithBound EtaExpandWithListInfoFromBound StripAnnotations StripAllAnnotations : wf_extra interp_extra.
 
   Hint Resolve Wf_PartialEvaluateWithListInfoFromBounds : wf_extra.
   Hint Opaque PartialEvaluateWithListInfoFromBounds : wf_extra interp_extra.

--- a/src/AbstractInterpretation/ZRange.v
+++ b/src/AbstractInterpretation/ZRange.v
@@ -440,6 +440,9 @@ Module Compilers.
           := let interp_Z_cast := if assume_cast_truncates then interp_Z_cast_truncate else interp_Z_cast in
              match idc in ident.ident t return type.option.interp t with
              | ident.Literal t v => @of_literal (base.type.type_base t) v
+             | ident.comment _
+             | ident.comment_no_keep _
+               => fun _ => tt
              | ident.tt as idc
                => ident.interp idc
              | ident.Nat_succ as idc

--- a/src/AbstractInterpretation/ZRangeProofs.v
+++ b/src/AbstractInterpretation/ZRangeProofs.v
@@ -262,6 +262,10 @@ Module Compilers.
                                 apply nth_error_error_length in H';
                                 omega
                            | [ |- (0 <= 1)%Z ] => clear; omega
+                           | [ H : ?beq ?x ?y = true |- ?x = ?y ]
+                             => progress reflect_beq_to_eq beq
+                           | [ |- ?beq ?x ?x = true ]
+                             => progress reflect_beq_to_eq beq
                            end
                          | handle_lt_le_t_step_fast
                          | simplify_ranges_t_step_fast

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -256,6 +256,7 @@ Module Pipeline.
          | base.type.type_base base.type.nat
          | base.type.type_base base.type.bool
          | base.type.type_base base.type.zrange
+         | base.type.type_base base.type.string
            => fun _ _ => (false, nil, nil)
          | base.type.type_base base.type.Z
            => fun a b
@@ -401,14 +402,14 @@ Module Pipeline.
           first *)
        dlet_nd e := ToFlat E in
        let E := FromFlat e in
-       let E := if with_subst01 then Subst01.Subst01 E
-                else if with_dead_code_elimination then DeadCodeElimination.EliminateDead E
+       let E := if with_subst01 then Subst01.Subst01 ident.is_comment E
+                else if with_dead_code_elimination then DeadCodeElimination.EliminateDead ident.is_comment E
                      else E in
        let E := UnderLets.LetBindReturn (@ident.is_var_like) E in
        let E := DoRewrite E in (* after inlining, see if any new rewrite redexes are available *)
        dlet_nd e := ToFlat E in
        let E := FromFlat e in
-       let E := if with_dead_code_elimination then DeadCodeElimination.EliminateDead E else E in
+       let E := if with_dead_code_elimination then DeadCodeElimination.EliminateDead ident.is_comment E else E in
        E.
 
   Definition opts_of_method
@@ -459,14 +460,14 @@ Module Pipeline.
       (** We first do bounds analysis with no relaxation so that we
           can do rewriting with casts, and then once that's out of the
           way, we do bounds analysis again to relax the bounds. *)
-      let E' := CheckedPartialEvaluateWithBounds (fun _ => None) false E arg_bounds out_bounds in
+      let E' := CheckedPartialEvaluateWithBounds (fun _ => None) (@ident.is_comment) false E arg_bounds out_bounds in
       let E'
           := match E' with
              | inl E
                => let E := RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArithWithCasts adc_no_carry_to_add opts) with_dead_code_elimination with_subst01 E in
                   dlet_nd e := ToFlat E in
                   let E := FromFlat e in
-                  let E' := CheckedPartialEvaluateWithBounds relax_zrange true (* strip pre-existing casts *) E arg_bounds out_bounds in
+                  let E' := CheckedPartialEvaluateWithBounds relax_zrange (@ident.is_comment) true (* strip pre-existing casts *) E arg_bounds out_bounds in
                   E'
              | inr v => inr v
              end in

--- a/src/Language/APINotations.v
+++ b/src/Language/APINotations.v
@@ -62,6 +62,8 @@ Module Compilers.
   Bind Scope etype_scope with base.
 
   Global Arguments ident_Literal {_} _ : assert.
+  Global Arguments ident_comment {_} : assert.
+  Global Arguments ident_comment_no_keep {_} : assert.
   Global Arguments ident_nil {_} : assert.
   Global Arguments ident_cons {_} : assert.
   Global Arguments ident_pair {_ _} : assert.
@@ -129,6 +131,7 @@ Module Compilers.
       Notation zrange := zrange (only parsing).
       Notation bool := bool (only parsing).
       Notation base_beq := Compilers.base_beq (only parsing).
+      Notation string := string (only parsing).
 
       Export Language.Compilers.base.type.
       Notation type := (@type base) (only parsing).
@@ -166,6 +169,8 @@ Module Compilers.
     Notation ident := Compilers.ident (only parsing).
 
     Notation Literal := Compilers.ident_Literal (only parsing).
+    Notation comment := Compilers.ident_comment (only parsing).
+    Notation comment_no_keep := Compilers.ident_comment_no_keep (only parsing).
     Notation Nat_succ := Compilers.ident_Nat_succ (only parsing).
     Notation Nat_pred := Compilers.ident_Nat_pred (only parsing).
     Notation Nat_max := Compilers.ident_Nat_max (only parsing).
@@ -282,6 +287,13 @@ Module Compilers.
     Notation buildInterpIdentCorrect := Compilers.buildInterpIdentCorrect (only parsing).
     Notation eqv_Reflexive_Proper := Compilers.eqv_Reflexive_Proper (only parsing).
     Notation interp_Proper := Compilers.ident_interp_Proper (only parsing).
+
+    Definition is_comment t (idc : ident t) : Datatypes.bool
+      := match idc with
+         | comment _ => true
+         | comment_no_keep _ => true
+         | _ => false
+         end.
 
     Module Export Notations.
       Export Language.Compilers.ident.Notations.

--- a/src/Language/IdentifierParameters.v
+++ b/src/Language/IdentifierParameters.v
@@ -1,3 +1,4 @@
+Require Import Coq.Strings.String.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.ListUtil Coq.Lists.List.
 Require Import Crypto.Util.ZRange.
@@ -35,6 +36,7 @@ Definition var_like_idents : InductiveHList.hlist
       ; @Datatypes.pair
       ; @Datatypes.fst
       ; @Datatypes.snd
+      ; Datatypes.tt
       ; Z.opp
       ; ident.cast
       ; ident.cast2
@@ -44,10 +46,13 @@ Definition base_type_list_named : InductiveHList.hlist
   := [with_name Z BinInt.Z
       ; with_name bool Datatypes.bool
       ; with_name nat Datatypes.nat
-      ; with_name zrange ZRange.zrange]%hlist.
+      ; with_name zrange ZRange.zrange
+      ; with_name string String.string]%hlist.
 
 Definition all_ident_named_interped : InductiveHList.hlist
   := [with_name ident_Literal (@ident.literal)
+      ; with_name ident_comment (@ident.comment)
+      ; with_name ident_comment_no_keep (@ident.comment_no_keep)
       ; with_name ident_Nat_succ Nat.succ
       ; with_name ident_Nat_pred Nat.pred
       ; with_name ident_Nat_max Nat.max

--- a/src/Language/PreExtra.v
+++ b/src/Language/PreExtra.v
@@ -43,6 +43,12 @@ Module ident.
           cast (Datatypes.snd r) (Datatypes.snd x)).
   End cast.
 
+  Section comment.
+    Definition comment {A} (x : A) := tt.
+    (** Version of [comment] which does not keep its arguments alive in the final output *)
+    Definition comment_no_keep {A} (x : A) := tt.
+  End comment.
+
   Module fancy.
     Module with_wordmax.
       Section with_wordmax.
@@ -114,6 +120,8 @@ Module ident.
 End ident.
 
 Global Opaque ident.cast. (* This should never be unfolded except in [Language.Wf] *)
+Global Opaque ident.comment.
+Global Opaque ident.comment_no_keep.
 
 Notation prod_rect_nodep := Rewriter.Util.Prod.prod_rect_nodep (only parsing).
 Notation nat_rect_arrow_nodep := Rewriter.Util.NatUtil.nat_rect_arrow_nodep (only parsing).

--- a/src/MiscCompilerPassesProofsExtra.v
+++ b/src/MiscCompilerPassesProofsExtra.v
@@ -26,8 +26,8 @@ Module Compilers.
   Module Subst01.
     Import MiscCompilerPassesProofs.Compilers.Subst01.
 
-    Definition Interp_Subst01 {t} e Hwf
-      := @Interp_Subst01 _ ident _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
+    Definition Interp_Subst01 is_ident_always_live {t} e Hwf
+      := @Interp_Subst01 _ ident is_ident_always_live _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
   End Subst01.
 
   Hint Resolve Subst01.Wf_Subst01 : wf_extra.
@@ -37,8 +37,8 @@ Module Compilers.
   Module DeadCodeElimination.
     Import MiscCompilerPassesProofs.Compilers.DeadCodeElimination.
 
-    Definition Interp_EliminateDead {t} e Hwf
-      := @Interp_EliminateDead _ ident _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
+    Definition Interp_EliminateDead is_ident_always_live {t} e Hwf
+      := @Interp_EliminateDead _ ident is_ident_always_live _ (@ident.interp) (@ident.interp_Proper) t e Hwf.
   End DeadCodeElimination.
 
   Hint Resolve DeadCodeElimination.Wf_EliminateDead : wf_extra.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -17,6 +17,8 @@ Require Import Crypto.BoundsPipeline.
 Require Import Crypto.Util.ZUtil.ModInv.
 
 Require Import Crypto.Util.Notations.
+Local Open Scope string_scope.
+Local Open Scope list_scope.
 Import ListNotations. Local Open Scope Z_scope.
 
 Import
@@ -99,6 +101,7 @@ Module debugging_sat_solinas_25519.
 End debugging_sat_solinas_25519.
 
 Module debugging_sat_solinas_25519_expanded.
+  Import PreExtra.
   Import Util.LetIn.
   Import ZUtil.Definitions.
   Module Saturated.
@@ -106,6 +109,7 @@ Module debugging_sat_solinas_25519_expanded.
       Definition sat_multerm :=
         fun (s : Z) (t t' : Z * Z) =>
           dlet xy : Z * Z := Z.mul_split s (snd t) (snd t') in
+          dlet _ := ident.comment ("sat_multerm", ("xy", xy)) in
           [(fst t * fst t', fst xy); (fst t * fst t' * s, snd xy)].
       Definition sat_mul :=
         fun (s : Z) (p q : list (Z * Z)) =>
@@ -284,7 +288,8 @@ Module debugging_sat_solinas_25519_expanded.
     Let boundsn : list (ZRange.type.option.interp base.type.Z)
       := repeat bound n.
 
-    Time Redirect "log" Compute
+    Time Redirect "log"
+         Compute
          Show.show (* [show] for pretty-printing of the AST without needing lots of imports *)
          false
          (Pipeline.BoundsPipelineToString
@@ -338,7 +343,7 @@ Module debugging_p256_mul_bedrock2.
       cbv [mul] in k.
       cbv -[Pipeline.BoundsPipeline WordByWordMontgomeryReificationCache.WordByWordMontgomery.reified_mul_gen] in k.
       cbv [Pipeline.BoundsPipeline Rewriter.Util.LetIn.Let_In] in k.
-      set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _) in (value of k).
+      set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'; cbv beta iota zeta in k.
       cbv [Pipeline.RewriteAndEliminateDeadAndInline] in k.
@@ -355,7 +360,7 @@ Module debugging_p256_mul_bedrock2.
       set (k' := ArithWithCasts.Compilers.RewriteRules.RewriteArithWithCasts _ _ _) in (value of k).
       vm_compute in k'.
       subst k'; cbv beta iota zeta in k.
-      set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _) in (value of k).
+      set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'; cbv beta iota zeta in k.
       set (k' := MulSplit.Compilers.RewriteRules.RewriteMulSplit _ _ _ _) in (value of k) at 1.
@@ -408,7 +413,7 @@ Module debugging_25519_to_bytes_bedrock2.
       set (k' := Arith.Compilers.RewriteRules.RewriteArith _ _ _) in (value of k).
       vm_compute in k'.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
-      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _) in (value of k).
+      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
       vm_compute in k''.
       set (uint64 := r[0 ~> 18446744073709551615]%zrange) in (value of k'').
       subst k''.
@@ -417,7 +422,7 @@ Module debugging_25519_to_bytes_bedrock2.
       vm_compute in k''.
       Compute Z.log2 9223372036854775808.
       clear -k''.
-      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _) in (value of k).
+      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
       vm_compute in k''.
       subst k''.
       cbv beta iota zeta in k.
@@ -814,7 +819,7 @@ Module debugging_25519_to_bytes_bedrock2.
       set (k' := GeneralizeVar.FromFlat (GeneralizeVar.ToFlat _)) in (value of k) at 1.
       vm_compute in k'.
       subst k'.
-      set (k' := PartialEvaluateWithBounds _ _ _ _) in (value of k).
+      set (k' := PartialEvaluateWithBounds _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'.*)
 *)
@@ -966,7 +971,7 @@ Module debugging_25519_to_bytes_java.
       set (k' := GeneralizeVar.FromFlat (GeneralizeVar.ToFlat _)) in (value of k) at 1.
       vm_compute in k'.
       subst k'.
-      set (k' := PartialEvaluateWithBounds _ _ _ _) in (value of k).
+      set (k' := PartialEvaluateWithBounds _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'.*)
     Abort.
@@ -1028,7 +1033,7 @@ Module debugging_p256_uint1.
       cbv [should_split_mul] in k.
       cbv [should_split_mul_opt_instance_0] in k.
       cbv [split_multiret_to should_split_multiret should_split_multiret_opt_instance_0] in k.
-      set (k' := PartialEvaluateWithBounds _ _ _ _) in (value of k).
+      set (k' := PartialEvaluateWithBounds _ _ _ _ _) in (value of k).
       vm_compute in k'.
     Abort.
   End __.
@@ -1189,7 +1194,7 @@ Module debugging_go_build.
       cbv [split_mul_to] in k.
       cbv [should_split_mul] in k.
       cbv [should_split_mul_opt_instance_0] in k.
-      set (k' := PartialEvaluateWithBounds _ _ _) in (value of k).
+      set (k' := PartialEvaluateWithBounds _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'.
       vm_compute in k.
@@ -2097,6 +2102,8 @@ Local Instance : use_mul_for_cmovznz_opt := false.
 Local Instance : emit_primitives_opt := true.
 
 Module debugging_remove_mul_split_to_C_uint1_carry.
+  Import PreExtra.
+  Import LetIn.
   Section __.
     Context (n : nat := 5%nat)
             (s : Z := 2^255)
@@ -2135,7 +2142,9 @@ Module debugging_remove_mul_split_to_C_uint1_carry.
 
     Set Printing Depth 100000.
     Local Open Scope string_scope.
-    Redirect "log" Compute
+
+    Redirect "log"
+      Compute
       Pipeline.BoundsPipelineToString
       "" (* prefix *)
       "mul"
@@ -2143,7 +2152,7 @@ Module debugging_remove_mul_split_to_C_uint1_carry.
       None (* fancy *)
       possible_values
       machine_wordsize
-      ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n idxs)) in
+      ltac:(let r := Reify ((fun f g => dlet _ := ident.comment ("foo", f, g) in carry_mulmod limbwidth_num limbwidth_den s c n idxs f g)) in
             exact r)
              (fun _ _ => []) (* comment *)
              (Some loose_bounds, (Some loose_bounds, tt))
@@ -2156,6 +2165,7 @@ Module debugging_remove_mul_split_to_C_uint1_carry.
  *   out1: [[0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc], [0x0 ~> 0x8cccccccccccc]]
  */
 static void mul(uint64_t out1[5], const uint64_t arg1[5], const uint64_t arg2[5]) {
+  /* (""foo"", arg1[0] :: arg1[1] :: arg1[2] :: arg1[3] :: arg1[4] :: [], arg2[0] :: arg2[1] :: arg2[2] :: arg2[3] :: arg2[4] :: []) */
   uint64_t x1;
   uint64_t x2;
   mulx_u64(&x1, &x2, (arg1[4]), ((arg2[4]) * (uint64_t)UINT8_C(0x13)));
@@ -2882,7 +2892,7 @@ Module debugging_remove_mul_split2.
       Import WordByWordMontgomeryReificationCache.
       cbv -[Pipeline.BoundsPipeline reified_mul_gen] in k.
       cbv [Pipeline.BoundsPipeline LetIn.Let_In] in k.
-      set (v := CheckedPartialEvaluateWithBounds _ _ _ _ _) in (value of k).
+      set (v := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
       Notation INL := (inl _).
       vm_compute in v.
       Notation IDD := (id _).

--- a/src/StandaloneHaskellMain.v
+++ b/src/StandaloneHaskellMain.v
@@ -31,6 +31,8 @@ Extract Inlined Constant _IO_bind => "(Prelude.>>=)".
 Extract Inlined Constant _IO_return => "return".
 Extract Inlined Constant IO_unit => "GHC.Base.IO ()".
 Extract Inlined Constant cast_io => "".
+(* COQBUG(https://github.com/coq/coq/issues/12258) *)
+Extract Inlined Constant String.eqb => "((Prelude.==) :: Prelude.String -> Prelude.String -> Prelude.Bool)".
 
 Local Notation "x <- y ; f" := (_IO_bind _ _ y (fun x => f)).
 

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -44,6 +44,8 @@ Module Compilers.
     Local Notation tZ := (base.type.type_base base.type.Z).
 
     Module C.
+      Definition comment_block := List.map (fun line => "/* " ++ line ++ " */")%string.
+
       Module String.
         Definition header (machine_wordsize : Z) (static : bool) (prefix : string) (infos : ident_infos)
         : list string
@@ -181,6 +183,8 @@ Module Compilers.
              => "*" ++ name ++ " = " ++ arith_to_string prefix val ++ ";"
            | DeclareVar t sz name
              => String.type.primitive.to_string prefix t sz ++ " " ++ name ++ ";"
+           | Comment lines _
+             => String.concat String.NewLine (comment_block lines)
            | AssignNth name n val
              => name ++ "[" ++ Decimal.Z.to_string (Z.of_nat n) ++ "] = " ++ arith_to_string prefix val ++ ";"
            end.
@@ -525,8 +529,7 @@ Module Compilers.
 
       Definition OutputCAPI : OutputLanguageAPI :=
         {|
-          comment_block s
-          := List.map (fun line => "/* " ++ line ++ " */")%string s;
+          ToString.comment_block := comment_block;
 
           ToString.ToFunctionLines := @ToFunctionLines;
 

--- a/src/Stringification/Go.v
+++ b/src/Stringification/Go.v
@@ -23,6 +23,8 @@ Import Stringification.Language.Compilers.ToString.int.Notations.
 
 Module Go.
 
+  Definition comment_block := List.map (fun line => "/* " ++ line ++ " */")%string.
+
   (* Supported integer bitwidths *)
   Definition stdint_bitwidths : list Z := [8; 16; 32; 64].
   (* supported bitwidth for things like bits.Mul64 *)
@@ -231,6 +233,8 @@ Module Go.
          call that will store its result in this variable. 2.) this will
          have a non-pointer an integer type *)
       "var " ++ name ++ " " ++ primitive_type_to_string prefix t sz
+    | IR.Comment lines _ =>
+      String.concat String.NewLine (comment_block lines)
     | IR.AssignNth name n val =>
       name ++ "[" ++ Decimal.Z.to_string (Z.of_nat n) ++ "] = " ++ arith_to_string prefix val
     end.
@@ -435,7 +439,7 @@ Module Go.
     end.
 
   Definition OutputGoAPI : ToString.OutputLanguageAPI :=
-    {| ToString.comment_block := List.map (fun line => "/* " ++ line ++ " */")%string;
+    {| ToString.comment_block := comment_block;
        ToString.ToFunctionLines := @ToFunctionLines;
        ToString.header := header;
        ToString.footer := fun _ _ _ _ => [];

--- a/src/Stringification/Java.v
+++ b/src/Stringification/Java.v
@@ -24,6 +24,7 @@ Import Stringification.Language.Compilers.ToString.
 Import Stringification.Language.Compilers.ToString.int.Notations.
 
 Module Java.
+  Definition comment_block := List.map (fun line => "/* " ++ line ++ " */")%string.
 
   (* Header imports and type defs *)
   Definition header (machine_wordsize : Z) (static : bool) (prefix : string) (infos : ToString.ident_infos)
@@ -177,6 +178,8 @@ Module Java.
          call that will store its result in this variable. 2.) this will
          have a non-pointer an integer type *)
       primitive_type_to_string true prefix IR.type.Zptr sz ++ " " ++ name ++ " = new " ++ primitive_type_to_string true prefix IR.type.Zptr sz ++ "((" ++ primitive_type_to_string false prefix IR.type.Z sz ++ ")0);"
+    | IR.Comment lines _ =>
+      String.concat String.NewLine (comment_block lines)
     | IR.AssignNth name n val =>
       name ++ "[" ++ Decimal.Z.to_string (Z.of_nat n) ++ "] = " ++ arith_to_string prefix val ++ ";"
     end.
@@ -375,7 +378,7 @@ Module Java.
     end.
 
   Definition OutputJavaAPI : ToString.OutputLanguageAPI :=
-    {| ToString.comment_block := List.map (fun line => "/* " ++ line ++ " */")%string;
+    {| ToString.comment_block := comment_block;
        ToString.ToFunctionLines := @ToFunctionLines;
        ToString.header := header;
        ToString.footer := footer;

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -22,6 +22,7 @@ Import Stringification.Language.Compilers.ToString.
 Import Stringification.Language.Compilers.ToString.int.Notations.
 
 Module Rust.
+  Definition comment_block := List.map (fun line => "/* " ++ line ++ " */")%string.
 
   (* Header imports and type defs *)
   Definition header (machine_wordsize : Z) (static : bool) (prefix : string) (infos : ToString.ident_infos)
@@ -173,6 +174,8 @@ Module Rust.
          call that will store its result in this variable. 2.) this will
          have a non-pointer an integer type *)
       "let mut " ++ name ++ ": " ++ primitive_type_to_string prefix t sz ++ " = 0;"
+    | IR.Comment lines _ =>
+      String.concat String.NewLine (comment_block lines)
     | IR.AssignNth name n val =>
       name ++ "[" ++ Decimal.Z.to_string (Z.of_nat n) ++ "] = " ++ arith_to_string prefix val ++ ";"
     end.
@@ -353,7 +356,7 @@ Module Rust.
     end.
 
   Definition OutputRustAPI : ToString.OutputLanguageAPI :=
-    {| ToString.comment_block := List.map (fun line => "/* " ++ line ++ " */")%string;
+    {| ToString.comment_block := comment_block;
        ToString.ToFunctionLines := @ToFunctionLines;
        ToString.header := header;
        ToString.footer := fun _ _ _ _ => [];


### PR DESCRIPTION
After `Import Crypto.Language.PreExtra`, it's now possible to do `dlet _
:= ident.comment stuff in ...` and have `stuff` appear in the
synthesized code as a comment.  There's room for improvement with
regards to quoting and handling multi-line comments, but it works for
debugging purposes.

Note that bounds analysis does not add casts underneath comments, though
I believe let-lifting still happens, and the comments are still
definitely subject to rewriting.

If you want comments whose variable dependencies are eliminated during
the very last dead-code-elimination phase of the stringification
pipeline, use `ident.comment_no_keep`.  Both `ident.comment` and
`ident.comment_no_keep` have type `forall {A}, A -> unit`.

There are now also passes `StripAnnotations` and `StripAllAnnotations`;
the former takes an expression and input bounds, and strips cast
annotations which are guaranteed to be no-ops given the bounds; it's
proven to preserve `Wf` and `Interp`-relatedness.  The
`StripAllAnnotations` pass strips *all* cast annotations, even the ones
that might be doing necessary truncation or modulo computations, and
does not require input bounds.  It's proven to preserve `Wf` but has no
`Interp` proofs.

Closes #779

cc @andres-erbsen, what do you think?