### PR TITLE
Better computation of loose bounds

### DIFF
--- a/src/Bedrock/Tests/Proofs/X1305_32.v
+++ b/src/Bedrock/Tests/Proofs/X1305_32.v
@@ -78,8 +78,8 @@ Section Proofs.
   Local Notation eval :=
     (eval (weight (Qnum (inject_Z (Z.log2_up M) / inject_Z (Z.of_nat n)))
                   (QDen (inject_Z (Z.log2_up M) / inject_Z (Z.of_nat n)))) n).
-  Local Notation loose_bounds := (UnsaturatedSolinas.loose_bounds n s c).
-  Local Notation tight_bounds := (UnsaturatedSolinas.tight_bounds n s c).
+  Local Notation loose_bounds := (UnsaturatedSolinasHeuristics.loose_bounds n s c).
+  Local Notation tight_bounds := (UnsaturatedSolinasHeuristics.tight_bounds n s c).
 
   Definition Bignum
              bounds
@@ -190,8 +190,8 @@ Section Proofs.
     Solinas.carry_mul_correct
       (weight (Qnum (Z.log2_up M / n)) (Qden (Z.log2_up M / n)))
       n M
-      (UnsaturatedSolinas.tight_bounds n s c)
-      (UnsaturatedSolinas.loose_bounds n s c)
+      tight_bounds
+      loose_bounds
       (API.Interp mulmod).
   Proof.
     apply carry_mul_correct with (machine_wordsize0:=machine_wordsize).

--- a/src/Bedrock/Tests/Proofs/X25519_32.v
+++ b/src/Bedrock/Tests/Proofs/X25519_32.v
@@ -79,8 +79,8 @@ Section Proofs.
   Local Notation eval :=
     (eval (weight (Qnum (inject_Z (Z.log2_up M) / inject_Z (Z.of_nat n)))
                   (QDen (inject_Z (Z.log2_up M) / inject_Z (Z.of_nat n)))) n).
-  Local Notation loose_bounds := (UnsaturatedSolinas.loose_bounds n s c).
-  Local Notation tight_bounds := (UnsaturatedSolinas.tight_bounds n s c).
+  Local Notation loose_bounds := (UnsaturatedSolinasHeuristics.loose_bounds n s c).
+  Local Notation tight_bounds := (UnsaturatedSolinasHeuristics.tight_bounds n s c).
 
   Definition Bignum
              bounds
@@ -191,8 +191,8 @@ Section Proofs.
     Solinas.carry_mul_correct
       (weight (Qnum (Z.log2_up M / n)) (Qden (Z.log2_up M / n)))
       n M
-      (UnsaturatedSolinas.tight_bounds n s c)
-      (UnsaturatedSolinas.loose_bounds n s c)
+      tight_bounds
+      loose_bounds
       (API.Interp mulmod).
   Proof.
     apply carry_mul_correct with (machine_wordsize0:=machine_wordsize).

--- a/src/UnsaturatedSolinasHeuristics.v
+++ b/src/UnsaturatedSolinasHeuristics.v
@@ -1,10 +1,16 @@
 Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.QArith.QArith_base Coq.QArith.Qround.
+Require Import Coq.QArith.Qabs.
 Require Import Crypto.Arithmetic.Core.
 Require Import Crypto.Arithmetic.ModOps.
 Require Import Crypto.Util.ListUtil.
 Require Import Crypto.Util.ZRange.
+Require Import Crypto.Util.Option.
+Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
+Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
+Require Import Crypto.Util.ListUtil.FoldBool.
 Require Crypto.TAPSort.
 Import ListNotations.
 Local Open Scope Z_scope. Local Open Scope list_scope. Local Open Scope bool_scope.
@@ -20,6 +26,13 @@ Local Coercion Z.pos : positive >-> Z.
 (** The fraction by which to multiply upper bounds *)
 Class tight_upperbound_fraction_opt := tight_upperbound_fraction : Q.
 Typeclasses Opaque tight_upperbound_fraction_opt.
+
+Local Notation is_tighter_than0 x y
+  := ((lower y <=? lower x) && (upper x <=? upper y)).
+Local Notation is_tighter_than0oo r1 r2
+  := (match r1, r2 with _, None => true | None, Some _ => false | Some r1', Some r2' => is_tighter_than0 r1' r2' end).
+Local Notation is_tighter_than ls1 ls2
+  := (fold_andb_map (fun x y => is_tighter_than0oo x y) ls1 ls2).
 
 Section __.
   Context {tight_upperbound_fraction : tight_upperbound_fraction_opt}
@@ -60,23 +73,53 @@ else:
        else (List.seq 0 n ++ [0; 1])%list%nat.
 
   Definition default_tight_upperbound_fraction : Q := (11/10)%Q.
-  Definition loose_upperbound_extra_multiplicand : Z := 3.
+  Definition coef := 2. (* for balance in sub *)
   Definition prime_upperbound_list : list Z
     := encode_no_reduce (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
+  (** We take the absolute value mostly to make proofs easy *)
   Definition tight_upperbounds : list Z
     := List.map
-         (fun v : Z => Qceiling (tight_upperbound_fraction * v))
+         (fun v : Z => Qceiling (Qabs (tight_upperbound_fraction * v)))
          prime_upperbound_list.
+
+  (** We compute loose bounds based on how much headspace we have in
+      each limb, and treat separately the maximum number of additions
+      and subtractions that we guarantee *)
+  (** Allow enough space to do two additions in a row w/o carrying *)
+  Definition headspace_add_count : nat := 2.
+  (** Allow enough space to do one subtraction w/o carrying *)
+  Definition headspace_sub_count : nat := 1.
 
   Definition loose_upperbounds : list Z
     := List.map
-         (fun v : Z => loose_upperbound_extra_multiplicand * v)
-         tight_upperbounds.
+         (fun '(v, bal) => v + Z.max (headspace_add_count * v)
+                                     (headspace_sub_count * bal))
+         (List.combine tight_upperbounds (balance (weight (Qnum limbwidth) (Qden limbwidth)) n s c coef)).
 
   Definition tight_bounds : list (option zrange)
     := List.map (fun u => Some r[0~>u]%zrange) tight_upperbounds.
   Definition loose_bounds : list (option zrange)
     := List.map (fun u => Some r[0~>u]%zrange) loose_upperbounds.
+
+  Lemma tight_bounds_tighter : is_tighter_than tight_bounds loose_bounds = true.
+  Proof using Type.
+    cbv [tight_bounds loose_bounds tight_upperbounds loose_upperbounds balance scmul].
+    rewrite !combine_map_l, !fold_andb_map_map, !fold_andb_map_map1, fold_andb_map_iff.
+    cbn [lower upper].
+    autorewrite with distr_length.
+    split.
+    { cbv [prime_upperbound_list].
+      now autorewrite with distr_length natsimplify. }
+    { intro; rewrite In_nth_error_iff; intros [n' H].
+      rewrite !nth_error_combine in H.
+      break_innermost_match_hyps; inversion_option; subst; cbn [fst snd].
+      rewrite !Bool.andb_true_iff; split; [ reflexivity | Z.ltb_to_lt ].
+      let x := lazymatch goal with |- ?x <= _ => x end in
+      rewrite <- (Z.add_0_r x) at 1; apply Zplus_le_compat_l.
+      etransitivity; [ | apply Z.le_max_l ].
+      cbv [Qceiling Qmult Qfloor Qnum Qden Qopp inject_Z Qabs]; case tight_upperbound_fraction; intros; clear.
+      Z.div_mod_to_quot_rem; nia. }
+  Qed.
 
   (** check if the suggested number of limbs will overflow
       double-width registers when adding partial products after a


### PR DESCRIPTION
We now compute the loose bounds by recording the number of additions
and/or balanced subtractions we want to be able to do in a row before we
need to multiply and carry.  Note that balanced subtraction always takes
a bit more overhead than addition.

This is a more conservative variant of #799 that doesn't actually change
the bounds, and makes the genuine change of #799 easier to see, namely,
reducing `headspace_add_count` from `2` to `1`.