### PR TITLE
encode_no_reduce -> partition

### DIFF
--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -1278,23 +1278,9 @@ Module Positional.
     Lemma length_encode n s c x
       : length (encode n s c x) = n.
     Proof using Type. cbv [encode]; repeat distr_length.                 Qed.
-
-    (* Reverse of [eval]; translate from Z to basesystem by putting
-    everything in first digit and then carrying, but without reduction. *)
-    Definition encode_no_reduce n (x : Z) : list Z :=
-      chained_carries_no_reduce n (from_associational n [(1,x)]) (seq 0 n).
-    Lemma eval_encode_no_reduce n x :
-      (n <> 0%nat) ->
-      (forall i, In i (seq 0 n) -> weight (S i) / weight i <> 0) ->
-      eval n (encode_no_reduce n x) = x.
-    Proof using Type*. cbv [encode_no_reduce]; intros; push; auto; f_equal; omega. Qed.
-    Lemma length_encode_no_reduce n x
-      : length (encode_no_reduce n x) = n.
-    Proof using Type. cbv [encode_no_reduce]; repeat distr_length.                 Qed.
-
   End Carries.
-  Hint Rewrite @eval_encode @eval_encode_no_reduce @eval_carry @eval_carry_reduce @eval_chained_carries @eval_chained_carries_no_reduce : push_eval.
-  Hint Rewrite @length_encode @length_encode_no_reduce @length_carry @length_carry_reduce @length_chained_carries @length_chained_carries_no_reduce : distr_length.
+  Hint Rewrite @eval_encode @eval_carry @eval_carry_reduce @eval_chained_carries @eval_chained_carries_no_reduce : push_eval.
+  Hint Rewrite @length_encode @length_carry @length_carry_reduce @length_chained_carries @length_chained_carries_no_reduce : distr_length.
 
   Section sub.
     Context (n:nat)
@@ -1417,7 +1403,7 @@ Module Positional.
   End select.
 End Positional.
 (* Hint Rewrite disappears after the end of a section *)
-Hint Rewrite length_zeros length_add_to_nth length_from_associational @length_add @length_carry_reduce @length_carry @length_chained_carries @length_chained_carries_no_reduce @length_encode @length_encode_no_reduce @length_sub @length_opp @length_select @length_zselect @length_select_min @length_extend_to_length @length_drop_high_to_length : distr_length.
+Hint Rewrite length_zeros length_add_to_nth length_from_associational @length_add @length_carry_reduce @length_carry @length_chained_carries @length_chained_carries_no_reduce @length_encode @length_sub @length_opp @length_select @length_zselect @length_select_min @length_extend_to_length @length_drop_high_to_length : distr_length.
 Hint Rewrite @eval_zeros @eval_nil @eval_snoc_S @eval_select @eval_zselect @eval_extend_to_length using solve [auto; distr_length]: push_eval.
 Section Positional_nonuniform.
   Context (weight weight' : nat -> Z).

--- a/src/Bedrock/Util.v
+++ b/src/Bedrock/Util.v
@@ -842,6 +842,29 @@ Section ListZBoundedBy.
              end.
   Qed.
 
+  Lemma list_Z_bounded_by_snoc b0 bs x0 xs:
+    list_Z_bounded_by (bs ++ [b0]) (xs ++ [x0]) <->
+    (match b0 with
+     | Some r =>
+       ZRange.is_bounded_by_bool x0 r = true
+     | None => True
+     end /\ list_Z_bounded_by bs xs).
+  Proof.
+    cbv [list_Z_bounded_by].
+    rewrite FoldBool.fold_andb_map_snoc.
+    cbv [ZRange.is_bounded_by_bool].
+    split; destruct b0; intros;
+      repeat match goal with
+             | H : (_ && _)%bool = true |- _ =>
+               apply Bool.andb_true_iff in H
+             | |- (_ && _)%bool = true => apply Bool.andb_true_iff
+             | H : _ /\ _ |- _ => destruct H
+             | |- _ /\ _ => split
+             | _ => assumption
+             | _ => tauto
+             end.
+  Qed.
+
   Lemma relax_to_bounded_upperbounds bs upperbounds x :
     list_Z_bounded_by
       (map (fun v : Z => Some {| ZRange.lower := 0; ZRange.upper := v |})

--- a/src/COperationSpecifications.v
+++ b/src/COperationSpecifications.v
@@ -220,7 +220,7 @@ Module Solinas.
     Local Notation bytes_eval := (Positional.eval (weight 8 1) n_bytes).
 
     Let prime_bytes_upperbound_list : list Z
-      := Positional.encode_no_reduce (weight 8 1) n_bytes (s-1).
+      := Partition.partition (weight 8 1) n_bytes (s-1).
     Let prime_bytes_bounds : list (option zrange)
       := List.map (fun v => Some r[0 ~> v]%zrange) prime_bytes_upperbound_list.
     Let prime_bound : zrange

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -30,6 +30,7 @@ Require Import Crypto.Stringification.Language.
 Require Import Crypto.Arithmetic.Core.
 Require Import Crypto.Arithmetic.ModOps.
 Require Import Crypto.Arithmetic.BaseConversion.
+Require Import Crypto.Arithmetic.Partition.
 Require Import Crypto.BoundsPipeline.
 Require Import Crypto.COperationSpecifications.
 Require Import Crypto.UnsaturatedSolinasHeuristics.
@@ -106,7 +107,7 @@ Section __.
   Let in_upperbounds : list Z
     := List.map
          (fun v : Z => Qceiling (Option.value inbounds_multiplier 1 * v))
-         (let encode := encode_no_reduce src_weight src_n in
+         (let encode := Partition.partition src_weight src_n in
           match inbounds with
           | exactly l => l
           | use_prime => encode (s - 1)
@@ -126,7 +127,7 @@ Section __.
   Let out_upperbounds : list Z
     := List.map
          (fun v : Z => Qceiling (Option.value outbounds_multiplier 1 * v))
-         (let encode := encode_no_reduce dst_weight dst_n in
+         (let encode := Partition.partition dst_weight dst_n in
           match outbounds with
           | exactly l => l
           | use_prime => encode (s - 1)

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -101,7 +101,7 @@ Section __.
   Definition n_bytes := bytes_n (Qnum limbwidth) (Qden limbwidth) n.
   Local Notation prime_upperbound_list := (prime_upperbound_list n s c) (only parsing).
   Definition prime_bytes_upperbound_list : list Z
-    := encode_no_reduce (weight 8 1) n_bytes (s-1).
+    := Partition.partition (weight 8 1) n_bytes (s-1).
   Local Notation tight_upperbounds := (tight_upperbounds n s c) (only parsing).
   Local Notation loose_upperbounds := (loose_upperbounds n s c) (only parsing).
   Local Notation tight_bounds := (tight_bounds n s c) (only parsing).

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -2140,7 +2140,7 @@ Module debugging_remove_mul_split_to_C_uint1_carry.
     Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
 
     Let prime_upperbound_list : list Z
-      := encode_no_reduce (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
+      := Paritition.partition (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
     Let tight_upperbounds : list Z
       := List.map
            (fun v : Z => Qceiling (11/10 * v))
@@ -2442,7 +2442,7 @@ Module debugging_remove_mul_split.
     Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
 
     Let prime_upperbound_list : list Z
-      := encode_no_reduce (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
+      := Partition.partition (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
     Let tight_upperbounds : list Z
       := List.map
            (fun v : Z => Qceiling (11/10 * v))
@@ -2952,7 +2952,7 @@ Module debugging_rewriting.
 
 
     Let prime_upperbound_list : list Z
-      := encode_no_reduce (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
+      := Partition.partition (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
     Let tight_upperbounds : list Z
       := List.map
            (fun v : Z => Qceiling (11/10 * v))
@@ -3059,7 +3059,7 @@ Section debugging_p448.
 
 
   Let prime_upperbound_list : list Z
-    := encode_no_reduce (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
+    := Partition.partition (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
   Let tight_upperbounds : list Z
     := List.map
          (fun v : Z => Qceiling (11/10 * v))

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -7,6 +7,7 @@ Require Import Coq.Lists.List.
 Require Import Crypto.Util.ZRange.
 Require Import Crypto.Arithmetic.Core.
 Require Import Crypto.Arithmetic.ModOps.
+Require Import Crypto.Arithmetic.Partition.
 Require Import Crypto.PushButtonSynthesis.UnsaturatedSolinas.
 Require Import Crypto.UnsaturatedSolinasHeuristics.
 Require Crypto.PushButtonSynthesis.SaturatedSolinas.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -2141,7 +2141,7 @@ Module debugging_remove_mul_split_to_C_uint1_carry.
     Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
 
     Let prime_upperbound_list : list Z
-      := Paritition.partition (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
+      := Partition.partition (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
     Let tight_upperbounds : list Z
       := List.map
            (fun v : Z => Qceiling (11/10 * v))

--- a/src/UnsaturatedSolinasHeuristics.v
+++ b/src/UnsaturatedSolinasHeuristics.v
@@ -5,6 +5,7 @@ Require Import Coq.QArith.QArith_base Coq.QArith.Qround.
 Require Import Coq.QArith.Qabs.
 Require Import Crypto.Arithmetic.Core.
 Require Import Crypto.Arithmetic.ModOps.
+Require Import Crypto.Arithmetic.Partition.
 Require Import Crypto.Util.ListUtil.
 Require Import Crypto.Util.ZRange.
 Require Import Crypto.Util.Option.
@@ -75,7 +76,7 @@ else:
   Definition default_tight_upperbound_fraction : Q := (11/10)%Q.
   Definition coef := 2. (* for balance in sub *)
   Definition prime_upperbound_list : list Z
-    := encode_no_reduce (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
+    := Partition.partition (weight (Qnum limbwidth) (Qden limbwidth)) n (s-1).
   (** We take the absolute value mostly to make proofs easy *)
   Definition tight_upperbounds : list Z
     := List.map


### PR DESCRIPTION
Very belatedly fixes #468 

When we did the unsaturated version of the core arithmetic library, we created `encode` (which converts a number to limbs by putting the number all in the first digit and then carrying) and also `encode_no_reduce`, which does the same thing except omitting the reduction step in carrying so the number doesn't get reduced mod M. `encode_no_reduce` was only used in a few places, e.g. for bounds, and is easily superseded by the more robust and easy to reason about `partition` definition that we wrote for saturated arithmetic. This PR replaces it with `partition` and uses that replacement to prove a couple of admits I had been waiting on the change for.

Note: this change means `chained_carries_no_reduce` is no longer used in `Core.v` and should probably be moved to `BaseConversion.v`. I'm hoping I can also remove all the enormous proofs about `nth_default` and carries from `Core.v`, which are major culprits to adding time and complexity to that file, but that will be a different PR.