### PR TITLE
Remove allowed-failure status from bedrock2 BoringSSL tests

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -35,4 +35,4 @@ jobs:
     - name: BoringSSL C test
       run: EXTRA_CFLAGS="" etc/ci/test-fiat-c-boringssl.sh fiat-c/src
     - name: BoringSSL bedrock2 test
-      run: EXTRA_CFLAGS="$(make bedrock2-extra-cflags SKIP_INCLUDE=1 2>/dev/null)" etc/ci/test-fiat-c-boringssl.sh fiat-bedrock2/src
+      run: EXTRA_CFLAGS="$(make bedrock2-extra-boringssl-cflags SKIP_INCLUDE=1 2>/dev/null)" etc/ci/test-fiat-c-boringssl.sh fiat-bedrock2/src

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -36,4 +36,3 @@ jobs:
       run: EXTRA_CFLAGS="" etc/ci/test-fiat-c-boringssl.sh fiat-c/src
     - name: BoringSSL bedrock2 test
       run: EXTRA_CFLAGS="$(make bedrock2-extra-cflags SKIP_INCLUDE=1 2>/dev/null)" etc/ci/test-fiat-c-boringssl.sh fiat-bedrock2/src
-      continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ BEDROCK2_WORD_BY_WORD_MONTGOMERY := src/ExtractionOCaml/bedrock2_word_by_word_mo
 
 BEDROCK2_ARGS := --no-wide-int --widen-carry --widen-bytes --split-multiret --no-select
 BEDROCK2_EXTRA_CFLAGS := -Wno-error=unused-but-set-variable -Wno-error=tautological-compare
+BEDROCK2_EXTRA_BORINGSSL_CFLAGS := -Wno-error=int-conversion -Wno-error=missing-prototypes $(BEDROCK2_EXTRA_CFLAGS)
 
 GO_EXTRA_ARGS_ALL := --cmovznz-by-mul --widen-carry --widen-bytes
 GO_EXTRA_ARGS_64  := --no-wide-int $(GO_EXTRA_ARGS_ALL)
@@ -215,6 +216,10 @@ JAVA_EXTRA_ARGS_32  := $(JAVA_EXTRA_ARGS_ALL)
 .PHONY: bedrock2-extra-cflags
 bedrock2-extra-cflags:
 	@echo "$(BEDROCK2_EXTRA_CFLAGS)"
+
+.PHONY: bedrock2-extra-boringssl-cflags
+bedrock2-extra-boringssl-cflags:
+	@echo "$(BEDROCK2_EXTRA_BORINGSSL_CFLAGS)"
 
 OUTPUT_VOS := \
 	src/Fancy/Montgomery256.vo \


### PR DESCRIPTION
This reverts commit e63c69686fb03b36b18746fb71573799adedef64.

Blocked on #821 