### PR TITLE
Generalize abstract interpretation over cast assumption

### DIFF
--- a/src/AbstractInterpretation/Proofs.v
+++ b/src/AbstractInterpretation/Proofs.v
@@ -1189,6 +1189,12 @@ Module Compilers.
           = partial.Extract assume_cast_truncates e b_in.
       Proof using Type. apply Extract_FromFlat_ToFlat'; assumption. Qed.
 
+      Lemma Extract_GeneralizeVar {assume_cast_truncates : bool} {t} (e : Expr t) (Hwf : Wf e) b_in
+            (Hb : Proper (type.and_for_each_lhs_of_arrow (fun t => type.eqv)) b_in)
+        : partial.Extract assume_cast_truncates (GeneralizeVar.GeneralizeVar (e _)) b_in
+          = partial.Extract assume_cast_truncates e b_in.
+      Proof using Type. apply Extract_FromFlat_ToFlat; assumption. Qed.
+
       Section with_relax.
         Context {relax_zrange : zrange -> option zrange}
                 (Hrelax : forall r r' z, is_tighter_than_bool z r = true
@@ -1234,6 +1240,7 @@ Module Compilers.
         Local Hint Resolve interp_annotate_expr abstract_interp_ident_related : core.
 
         Lemma interp_eval_with_bound
+              {assume_cast_truncates : bool}
               {skip_annotations_under : forall t, ident t -> bool}
               {strip_preexisting_annotations : bool}
               {t} (e_st e1 e2 : expr t)
@@ -1244,14 +1251,14 @@ Module Compilers.
           : (forall arg1 arg2
                     (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
                     (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) st arg1 = true),
-                type.app_curried (expr.interp (@ident.interp) (eval_with_bound relax_zrange skip_annotations_under strip_preexisting_annotations e1 st)) arg1
+                type.app_curried (expr.interp (@ident.interp) (eval_with_bound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e1 st)) arg1
                 = type.app_curried (expr.interp (@ident.interp) e2) arg2)
             /\ (forall arg1
                        (Harg11 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg1)
                        (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) st arg1 = true),
                    abstraction_relation'
-                     (extract false e_st st)
-                     (type.app_curried (expr.interp (@ident.interp) (eval_with_bound relax_zrange skip_annotations_under strip_preexisting_annotations e1 st)) arg1)).
+                     (extract assume_cast_truncates e_st st)
+                     (type.app_curried (expr.interp (@ident.interp) (eval_with_bound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e1 st)) arg1)).
         Proof using Hrelax.
           cbv [eval_with_bound]; split;
             [ intros arg1 arg2 Harg12 Harg1
@@ -1279,6 +1286,7 @@ Module Compilers.
         Qed.
 
         Lemma Interp_EvalWithBound
+              {assume_cast_truncates : bool}
               {skip_annotations_under : forall t, ident t -> bool}
               {strip_preexisting_annotations : bool}
               {t} (e : Expr t)
@@ -1290,14 +1298,14 @@ Module Compilers.
           : (forall arg1 arg2
                     (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
                     (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) st arg1 = true),
-                type.app_curried (expr.Interp (@ident.interp) (EvalWithBound relax_zrange skip_annotations_under strip_preexisting_annotations e st)) arg1
+                type.app_curried (expr.Interp (@ident.interp) (EvalWithBound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e st)) arg1
                 = type.app_curried (expr.Interp (@ident.interp) e) arg2)
             /\ (forall arg1
                        (Harg11 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg1)
                        (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) st arg1 = true),
                    abstraction_relation'
-                     (Extract false e st)
-                     (type.app_curried (expr.Interp (@ident.interp) (EvalWithBound relax_zrange skip_annotations_under strip_preexisting_annotations e st)) arg1)).
+                     (Extract assume_cast_truncates e st)
+                     (type.app_curried (expr.Interp (@ident.interp) (EvalWithBound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e st)) arg1)).
         Proof using Hrelax. cbv [Extract EvalWithBound]; apply interp_eval_with_bound; auto. Qed.
 
         Lemma Interp_EtaExpandWithBound
@@ -1356,6 +1364,7 @@ Module Compilers.
       Qed.
 
       Lemma interp_strip_annotations
+            {assume_cast_truncates : bool}
             {t} (e_st e1 e2 : expr t)
             (Hwf : expr.wf3 nil e_st e1 e2)
             (Hwf' : expr.wf nil e2 e2)
@@ -1364,14 +1373,14 @@ Module Compilers.
         : (forall arg1 arg2
                   (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
                   (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) st arg1 = true),
-              type.app_curried (expr.interp (@ident.interp) (strip_annotations e1 st)) arg1
+              type.app_curried (expr.interp (@ident.interp) (strip_annotations assume_cast_truncates e1 st)) arg1
               = type.app_curried (expr.interp (@ident.interp) e2) arg2)
           /\ (forall arg1
                      (Harg11 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg1)
                      (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) st arg1 = true),
                  abstraction_relation'
-                   (extract false e_st st)
-                   (type.app_curried (expr.interp (@ident.interp) (strip_annotations e1 st)) arg1)).
+                   (extract assume_cast_truncates e_st st)
+                   (type.app_curried (expr.interp (@ident.interp) (strip_annotations assume_cast_truncates e1 st)) arg1)).
       Proof using Type.
         cbv [strip_annotations]; split;
           [ intros arg1 arg2 Harg12 Harg1
@@ -1382,6 +1391,7 @@ Module Compilers.
       Qed.
 
       Lemma Interp_StripAnnotations
+            {assume_cast_truncates : bool}
             {t} (E : Expr t)
             (Hwf : Wf E)
             (Ht : type.is_not_higher_order t = true)
@@ -1389,13 +1399,13 @@ Module Compilers.
         : forall arg1 arg2
                  (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
                  (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) b_in arg1 = true),
-          type.app_curried (expr.Interp (@ident.interp) (StripAnnotations E b_in)) arg1
+          type.app_curried (expr.Interp (@ident.interp) (StripAnnotations assume_cast_truncates E b_in)) arg1
           = type.app_curried (expr.Interp (@ident.interp) E) arg2.
       Proof using Type.
         cbv [StripAnnotations].
         intros *; rewrite <- (GeneralizeVar.Interp_gen1_GeneralizeVar E) by assumption.
         apply (let E := GeneralizeVar.GeneralizeVar (E _) in
-               @interp_strip_annotations t (E _) (E _) (E _));
+               @interp_strip_annotations assume_cast_truncates t (E _) (E _) (E _));
           try assumption;
           try apply GeneralizeVar.Wf_GeneralizeVar;
           try apply GeneralizeVar.Wf3_GeneralizeVar;
@@ -1403,6 +1413,7 @@ Module Compilers.
       Qed.
 
       Lemma Interp_StripAnnotations_bounded
+            {assume_cast_truncates : bool}
             {t} (E : Expr t)
             (Hwf : expr.Wf E)
             (Ht : type.is_not_higher_order t = true)
@@ -1411,14 +1422,14 @@ Module Compilers.
                  (Harg11 : Proper (type.and_for_each_lhs_of_arrow (@type.eqv)) arg1)
                  (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) b_in arg1 = true),
           ZRange.type.base.option.is_bounded_by
-            (partial.Extract false E b_in)
-            (type.app_curried (expr.Interp (@ident.interp) (StripAnnotations E b_in)) arg1)
+            (partial.Extract assume_cast_truncates E b_in)
+            (type.app_curried (expr.Interp (@ident.interp) (StripAnnotations assume_cast_truncates E b_in)) arg1)
           = true.
       Proof using Type.
         cbv [StripAnnotations].
         intros; rewrite <- Extract_FromFlat_ToFlat by auto with wf typeclass_instances.
         apply (let E := GeneralizeVar.GeneralizeVar (E _) in
-               @interp_strip_annotations t (E _) (E _) (E _));
+               @interp_strip_annotations assume_cast_truncates t (E _) (E _) (E _));
           try assumption;
           try apply GeneralizeVar.Wf_GeneralizeVar;
           try apply GeneralizeVar.Wf3_GeneralizeVar;
@@ -1445,7 +1456,7 @@ Module Compilers.
   Import API.
 
   Lemma Interp_PartialEvaluateWithBounds
-        relax_zrange skip_annotations_under strip_preexisting_annotations
+        relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations
         (Hrelax : forall r r' z, is_tighter_than_bool z r = true
                                  -> relax_zrange r = Some r'
                                  -> is_tighter_than_bool z r' = true)
@@ -1456,7 +1467,7 @@ Module Compilers.
     : forall arg1 arg2
         (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
         (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) b_in arg1 = true),
-      type.app_curried (expr.Interp (@ident.interp) (PartialEvaluateWithBounds relax_zrange skip_annotations_under strip_preexisting_annotations E b_in)) arg1
+      type.app_curried (expr.Interp (@ident.interp) (PartialEvaluateWithBounds relax_zrange skip_annotations_under strip_preexisting_annotations assume_cast_truncates E b_in)) arg1
       = type.app_curried (expr.Interp (@ident.interp) E) arg2.
   Proof.
     cbv [PartialEvaluateWithBounds].
@@ -1470,7 +1481,7 @@ Module Compilers.
   Qed.
 
   Lemma Interp_PartialEvaluateWithBounds_bounded
-        relax_zrange skip_annotations_under strip_preexisting_annotations
+        relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations
         (Hrelax : forall r r' z, is_tighter_than_bool z r = true
                                  -> relax_zrange r = Some r'
                                  -> is_tighter_than_bool z r' = true)
@@ -1482,14 +1493,14 @@ Module Compilers.
              (Harg11 : Proper (type.and_for_each_lhs_of_arrow (@type.eqv)) arg1)
              (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) b_in arg1 = true),
       ZRange.type.base.option.is_bounded_by
-        (partial.Extract false E b_in)
-        (type.app_curried (expr.Interp (@ident.interp) (PartialEvaluateWithBounds relax_zrange skip_annotations_under strip_preexisting_annotations E b_in)) arg1)
+        (partial.Extract assume_cast_truncates E b_in)
+        (type.app_curried (expr.Interp (@ident.interp) (PartialEvaluateWithBounds relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations E b_in)) arg1)
       = true.
   Proof.
     cbv [PartialEvaluateWithBounds].
     intros arg1 Harg11 Harg1.
-    rewrite <- Extract_FromFlat_ToFlat by auto with wf typeclass_instances.
-    eapply Interp_EvalWithBound; eauto with wf typeclass_instances.
+    rewrite <- Extract_GeneralizeVar by auto with wf typeclass_instances.
+    eapply @Interp_EvalWithBound; eauto with wf typeclass_instances.
   Qed.
 
   Lemma Interp_PartialEvaluateWithListInfoFromBounds
@@ -1513,6 +1524,7 @@ Module Compilers.
 
   Theorem CheckedPartialEvaluateWithBounds_Correct
           (relax_zrange : zrange -> option zrange)
+          (assume_cast_truncates : bool)
           (skip_annotations_under : forall t, ident t -> bool)
           (strip_preexisting_annotations : bool)
           (Hrelax : forall r r' z, is_tighter_than_bool z r = true
@@ -1523,7 +1535,7 @@ Module Compilers.
           (Ht : type.is_not_higher_order t = true)
           (b_in : type.for_each_lhs_of_arrow ZRange.type.option.interp t)
           (b_out : ZRange.type.base.option.interp (type.final_codomain t))
-          rv (Hrv : CheckedPartialEvaluateWithBounds relax_zrange skip_annotations_under strip_preexisting_annotations E b_in b_out = inl rv)
+          rv (Hrv : CheckedPartialEvaluateWithBounds relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations E b_in b_out = inl rv)
     : (forall arg1 arg2
               (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
               (Harg1 : type.andb_bool_for_each_lhs_of_arrow (@ZRange.type.option.is_bounded_by) b_in arg1 = true),

--- a/src/AbstractInterpretation/Wf.v
+++ b/src/AbstractInterpretation/Wf.v
@@ -1086,9 +1086,9 @@ Module Compilers.
           : expr.wf G (@strip_all_annotations strip_annotations_under var1 t e1) (@strip_all_annotations strip_annotations_under var2 t e2).
         Proof using Type. revert Hwf; apply ident.wf_strip_all_annotations, @wf_annotation_to_cast. Qed.
 
-        Lemma wf_eval_with_bound {relax_zrange skip_annotations_under strip_preexisting_annotations t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
+        Lemma wf_eval_with_bound {relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
               (HGG' : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> wf_value_with_lets G' v1 v2)
-          : expr.wf G' (@eval_with_bound relax_zrange skip_annotations_under strip_preexisting_annotations var1 t e1 st1) (@eval_with_bound relax_zrange skip_annotations_under strip_preexisting_annotations var2 t e2 st2).
+          : expr.wf G' (@eval_with_bound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations var1 t e1 st1) (@eval_with_bound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations var2 t e2 st2).
         Proof.
           eapply ident.wf_eval_with_bound;
             solve [ eassumption
@@ -1101,9 +1101,9 @@ Module Compilers.
                   | apply is_annotated_for_Proper ].
         Qed.
 
-        Lemma wf_strip_annotations {t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
+        Lemma wf_strip_annotations {assume_cast_truncates} {t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
               (HGG' : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> wf_value_with_lets G' v1 v2)
-          : expr.wf G' (@strip_annotations var1 t e1 st1) (@strip_annotations var2 t e2 st2).
+          : expr.wf G' (@strip_annotations assume_cast_truncates var1 t e1 st1) (@strip_annotations assume_cast_truncates var2 t e2 st2).
         Proof.
           eapply ident.wf_eval_with_bound;
             solve [ eassumption
@@ -1140,14 +1140,14 @@ Module Compilers.
         intros ??; eapply wf_eval with (G:=nil); cbn [List.In]; try apply Hwf; tauto.
       Qed.
 
-      Lemma Wf_EvalWithBound {relax_zrange skip_annotations_under strip_preexisting_annotations t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
-        : Wf (EvalWithBound relax_zrange skip_annotations_under strip_preexisting_annotations e bound).
+      Lemma Wf_EvalWithBound {relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
+        : Wf (EvalWithBound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e bound).
       Proof.
         intros ??; eapply wf_eval_with_bound with (G:=nil); cbn [List.In]; try apply Hwf; tauto.
       Qed.
 
-      Lemma Wf_StripAnnotations {t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
-        : Wf (StripAnnotations e bound).
+      Lemma Wf_StripAnnotations {assume_cast_truncates} {t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
+        : Wf (StripAnnotations assume_cast_truncates e bound).
       Proof.
         intros ??; eapply wf_strip_annotations with (G:=nil); cbn [List.In]; try tauto; apply GeneralizeVar.Wf_GeneralizeVar, Hwf.
       Qed.
@@ -1191,11 +1191,11 @@ Module Compilers.
   Hint Opaque PartialEvaluateWithListInfoFromBounds : wf interp rewrite.
 
   Lemma Wf_PartialEvaluateWithBounds
-        {relax_zrange} {skip_annotations_under : forall t, ident t -> bool} {strip_preexisting_annotations : bool} {t} (E : Expr t)
+        {relax_zrange} {assume_cast_truncates : bool} {skip_annotations_under : forall t, ident t -> bool} {strip_preexisting_annotations : bool} {t} (E : Expr t)
         (b_in : type.for_each_lhs_of_arrow ZRange.type.option.interp t)
         (Hwf : Wf E)
         {b_in_Proper : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R base.type ZRange.type.base.option.interp (fun t0 : base.type => eq))) b_in}
-    : Wf (PartialEvaluateWithBounds relax_zrange skip_annotations_under strip_preexisting_annotations E b_in).
+    : Wf (PartialEvaluateWithBounds relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations E b_in).
   Proof. cbv [PartialEvaluateWithBounds]; eauto with wf. Qed.
   Hint Resolve Wf_PartialEvaluateWithBounds : wf.
   Hint Opaque PartialEvaluateWithBounds : wf interp rewrite.

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -485,6 +485,7 @@ Module Pipeline.
              out_bounds
   : ErrorT (Expr t)
     := (*let E := expr.Uncurry E in*)
+      let assume_cast_truncates := false in
       let opts := opts_of_method in
       dlet E := PreBoundsPipeline (* with_dead_code_elimination *) with_subst01 with_let_bind_return translate_to_fancy E arg_bounds in
       (** We first do bounds analysis with no relaxation so that we
@@ -492,7 +493,7 @@ Module Pipeline.
           way, we do bounds analysis again to relax the bounds. *)
       (** To get better error messages, we don't check bounds until
           after doing some extra rewriting *)
-      let E' := CheckedPartialEvaluateWithBounds (fun _ => None) (@ident.is_comment) false E arg_bounds ZRange.type.base.option.None in
+      let E' := CheckedPartialEvaluateWithBounds (fun _ => None) assume_cast_truncates (@ident.is_comment) false E arg_bounds ZRange.type.base.option.None in
       let E'
           := match E' with
              | inl E
@@ -502,12 +503,12 @@ Module Pipeline.
                   (** to give good error messages, we first look at
                       the version of the syntax tree annotated with
                       unrelaxed ranges *)
-                  let E' := CheckedPartialEvaluateWithBounds (fun _ => None) (@ident.is_comment) true (* strip pre-existing casts *) E arg_bounds out_bounds in
+                  let E' := CheckedPartialEvaluateWithBounds (fun _ => None) assume_cast_truncates (@ident.is_comment) true (* strip pre-existing casts *) E arg_bounds out_bounds in
                   match E' with
                   | inl E
                     => dlet_nd e := ToFlat E in
                        let E := FromFlat e in
-                       let E' := CheckedPartialEvaluateWithBounds relax_zrange (@ident.is_comment) true (* strip pre-existing casts *) E arg_bounds out_bounds in
+                       let E' := CheckedPartialEvaluateWithBounds relax_zrange assume_cast_truncates (@ident.is_comment) true (* strip pre-existing casts *) E arg_bounds out_bounds in
                        E'
                   | inr v => inr v
                   end

--- a/src/CompilersTestCases.v
+++ b/src/CompilersTestCases.v
@@ -61,7 +61,7 @@ Module testrewrite.
                           ((\ x , expr_let y := ##5 in $y + ($y + (#ident.fst @ $x + #ident.snd @ $x)))
                              @ (##1, ##7))%expr).
 
-  Redirect "log" Eval cbv in partial.eval_with_bound partial.default_relax_zrange (@ident.is_comment) false
+  Redirect "log" Eval cbv in partial.eval_with_bound partial.default_relax_zrange false (@ident.is_comment) false
                                       (RewriteRules.RewriteNBE RewriteRules.default_opts (fun var =>
                 (\z , ((\ x , expr_let y := ##5 in $y + ($z + (#ident.fst @ $x + #ident.snd @ $x)))
                          @ (##1, ##7)))%expr) _)
@@ -87,7 +87,7 @@ Module testpartial.
 
   Redirect "log" Eval cbv in partial.eval_with_bound
                 partial.default_relax_zrange
-                (@ident.is_comment) false
+                false (@ident.is_comment) false
                 (\z , ((\ x , expr_let y := ##5 in $y + ($z + (#ident.fst @ $x + #ident.snd @ $x)))
                          @ (##1, ##7)))%expr
                 (Datatypes.Some r[0~>100]%zrange, Datatypes.tt).
@@ -113,7 +113,7 @@ Module test2.
               expr_let x1 := ($x0 * $x0) in
               ($x1, $x1))%expr) => idtac
     end.
-    pose (partial.EvalWithBound partial.default_relax_zrange (@ident.is_comment) false E' (Some r[0~>10]%zrange, tt)) as E''.
+    pose (partial.EvalWithBound partial.default_relax_zrange false (@ident.is_comment) false E' (Some r[0~>10]%zrange, tt)) as E''.
     lazy in E''.
      lazymatch (eval cbv delta [E''] in E'') with
      | (fun var : type -> Type =>
@@ -149,7 +149,7 @@ Module test3.
               $x3 * $x3)%expr)
       => idtac
     end.
-    pose (partial.EvalWithBound partial.default_relax_zrange (@ident.is_comment) false E' (Some r[0~>10]%zrange, tt)) as E'''.
+    pose (partial.EvalWithBound partial.default_relax_zrange false (@ident.is_comment) false E' (Some r[0~>10]%zrange, tt)) as E'''.
     lazy in E'''.
     lazymatch (eval cbv delta [E'''] in E''') with
     | (fun var : type -> Type =>
@@ -170,7 +170,7 @@ Module test3point5.
     let v := Reify (fun y : (list Z) => List.nth_default (-1) y 0) in
     pose v as E.
     vm_compute in E.
-    pose (partial.EvalWithBound partial.default_relax_zrange (@ident.is_comment) false E (Some [Some r[0~>10]%zrange], tt)) as E'.
+    pose (partial.EvalWithBound partial.default_relax_zrange false (@ident.is_comment) false E (Some [Some r[0~>10]%zrange], tt)) as E'.
     lazy in E'.
     clear E.
     lazymatch (eval cbv delta [E'] in E') with
@@ -201,7 +201,7 @@ Module test4.
     clear E'.
     pose (PartialEvaluate RewriteRules.default_opts E'') as E'''.
     lazy in E'''.
-    pose (partial.EvalWithBound partial.default_relax_zrange (@ident.is_comment) false E''' bound) as E''''.
+    pose (partial.EvalWithBound partial.default_relax_zrange false (@ident.is_comment) false E''' bound) as E''''.
     lazy in E''''.
     clear E'' E'''.
     lazymatch (eval cbv delta [E''''] in E'''') with
@@ -437,7 +437,7 @@ Module test14.
     lazy in E''.
     pose (PartialEvaluate RewriteRules.default_opts E'') as E'''.
     vm_compute in E'''.
-    pose (partial.EvalWithBound partial.default_relax_zrange (@ident.is_comment) true E''' (Some r[0~>1]%zrange, tt)) as E''''.
+    pose (partial.EvalWithBound partial.default_relax_zrange false (@ident.is_comment) true E''' (Some r[0~>1]%zrange, tt)) as E''''.
     lazy in E''''.
     unify E E''.
     unify E'' E'''.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -39,6 +39,89 @@ Local Coercion Z.pos : positive >-> Z.
 Local Existing Instance default_low_level_rewriter_method.
 Local Instance : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.
 
+Module debugging_21271_from_bytes.
+  Import Crypto.PushButtonSynthesis.UnsaturatedSolinas.
+  Import Stringification.C.
+  Import Stringification.C.Compilers.
+  Import Stringification.C.Compilers.ToString.
+  Section __.
+    Local Existing Instance C.OutputCAPI.
+    Local Instance static : static_opt := false.
+    Local Instance : internal_static_opt := true.
+    Local Instance : emit_primitives_opt := false.
+    Local Instance : use_mul_for_cmovznz_opt := false.
+    Local Instance : widen_carry_opt := false.
+    Local Instance : widen_bytes_opt := false.
+    Local Instance : only_signed_opt := false.
+    Local Instance : no_select_opt := false.
+    Local Instance : should_split_mul_opt := false.
+    Local Instance : should_split_multiret_opt :=false.
+
+    Definition n := 3%nat (*5%nat*).
+    Definition s := 2^127 (* 255*).
+    Definition c := [(1, 1(*9*))].
+    Definition machine_wordsize := 64.
+
+    Import IR.Compilers.ToString.
+
+    Goal True.
+      pose (sfrom_bytes n s c machine_wordsize "1271") as v.
+      cbv [sfrom_bytes] in v.
+      set (k := from_bytes _ _ _ _) in (value of v).
+      clear v.
+      cbv [from_bytes] in k.
+      cbv [Pipeline.BoundsPipeline] in k.
+      set (k' := Pipeline.PreBoundsPipeline _ _ _ _ _) in (value of k).
+      vm_compute in k'.
+      cbv [Rewriter.Util.LetIn.Let_In] in k.
+      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
+      vm_compute in k''.
+      lazymatch (eval cbv [k''] in k'') with
+      | @inl ?A ?B ?v => pose v as V; change k'' with (@inl A B V) in (value of k)
+      end.
+      cbv beta iota zeta in k.
+      clear k''.
+      set (e := GeneralizeVar.FromFlat _) in (value of k).
+      vm_compute in e.
+      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
+      cbv [CheckedPartialEvaluateWithBounds] in k''.
+      clear -k''.
+      cbv [Rewriter.Util.LetIn.Let_In] in k''.
+      set (e' := (GeneralizeVar.FromFlat (GeneralizeVar.ToFlat e))) in (value of k'').
+      vm_compute in e'; clear e; rename e' into e.
+      set (b := (partial.Extract _ _ _)) in (value of k'').
+      clear -b.
+      cbv [partial.Extract partial.ident.extract partial.extract_gen type.app_curried partial.extract'] in b.
+      subst e.
+      cbv beta iota zeta in b.
+      Import Rewriter.Util.LetIn.
+      cbn [partial.abstract_interp_ident] in b.
+      cbv [partial.abstract_interp_ident] in b.
+      cbv [ZRange.ident.option.interp] in b.
+      cbv [ZRange.ident.option.of_literal] in b.
+      cbn [ZRange.ident.option.interp_Z_cast option_map] in b.
+      cbv [partial.abstract_domain ZRange.type.base.option.interp type.interp ZRange.type.base.interp] in b.
+      cbn [fst snd] in b.
+      (do 54 try (lazymatch (eval cbv [b] in b) with
+                  | dlet x := ?v in _ => let v' := (eval vm_compute in v) in change v with v' in (value of b)
+                  end;
+                  unfold Let_In at 1 in (value of b));
+          try lazymatch (eval cbv [b] in b) with
+              | dlet x := ?v in _ => let v' := (eval vm_compute in v) in change v with v' in (value of b)
+              end).
+      (*
+      unfold Let_In at 1 in (value of b).
+      lazymatch (eval cbv [b] in b) with
+      | context[Crypto.Util.Option.bind ?v _] => let v' := (eval vm_compute in v) in change v with v' in (value of b)
+      end.
+      cbn [Crypto.Util.Option.bind] in b.
+      set (k' := Operations.ZRange.land_bounds _ _) in (value of b).
+      cbv [Operations.ZRange.land_bounds] in k'.
+      clear -k'.*)
+    Abort.
+  End __.
+End debugging_21271_from_bytes.
+
 Module debugging_sat_solinas_25519.
   Section __.
     Import Crypto.PushButtonSynthesis.WordByWordMontgomery.
@@ -356,7 +439,7 @@ Module debugging_p256_mul_bedrock2.
       cbv [mul] in k.
       cbv -[Pipeline.BoundsPipeline WordByWordMontgomeryReificationCache.WordByWordMontgomery.reified_mul_gen] in k.
       cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline Rewriter.Util.LetIn.Let_In] in k.
-      set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
+      set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'; cbv beta iota zeta in k.
       cbv [Pipeline.RewriteAndEliminateDeadAndInline] in k.
@@ -373,7 +456,7 @@ Module debugging_p256_mul_bedrock2.
       set (k' := ArithWithCasts.Compilers.RewriteRules.RewriteArithWithCasts _ _ _) in (value of k).
       vm_compute in k'.
       subst k'; cbv beta iota zeta in k.
-      set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
+      set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'; cbv beta iota zeta in k.
       set (k' := MulSplit.Compilers.RewriteRules.RewriteMulSplit _ _ _ _) in (value of k) at 1.
@@ -426,7 +509,7 @@ Module debugging_25519_to_bytes_bedrock2.
       set (k' := Arith.Compilers.RewriteRules.RewriteArith _ _ _) in (value of k).
       vm_compute in k'.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
-      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
+      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in k''.
       set (uint64 := r[0 ~> 18446744073709551615]%zrange) in (value of k'').
       subst k''.
@@ -435,7 +518,7 @@ Module debugging_25519_to_bytes_bedrock2.
       vm_compute in k''.
       Compute Z.log2 9223372036854775808.
       clear -k''.
-      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
+      set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in k''.
       subst k''.
       cbv beta iota zeta in k.
@@ -1048,7 +1131,7 @@ Module debugging_p256_uint1.
       cbv [split_multiret_to should_split_multiret should_split_multiret_opt_instance_0] in k.
       vm_compute ZRange.type.base.option.is_tighter_than in k.
       cbv beta iota zeta in k.
-      set (k' := PartialEvaluateWithBounds _ _ _ _ _) in (value of k) at 1.
+      set (k' := PartialEvaluateWithBounds _ _ _ _ _ _) in (value of k) at 1.
       vm_compute in k'.
     Abort.
   End __.
@@ -1200,7 +1283,7 @@ Module debugging_go_build.
       vm_compute in k'.
       subst k'.
       cbv beta iota in k.
-      set (k' := partial.Extract _ _) in (value of k).
+      set (k' := partial.Extract _ _ _) in (value of k).
       vm_compute in k'.
       subst k'.
       set (k' := ZRange.type.base.option.is_tighter_than _ _) in (value of k).
@@ -1209,7 +1292,7 @@ Module debugging_go_build.
       cbv [split_mul_to] in k.
       cbv [should_split_mul] in k.
       cbv [should_split_mul_opt_instance_0] in k.
-      set (k' := PartialEvaluateWithBounds _ _ _ _ _) in (value of k).
+      set (k' := PartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'.
       vm_compute in k.
@@ -2907,7 +2990,7 @@ Module debugging_remove_mul_split2.
       Import WordByWordMontgomeryReificationCache.
       cbv -[Pipeline.BoundsPipeline reified_mul_gen] in k.
       cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline LetIn.Let_In] in k.
-      set (v := CheckedPartialEvaluateWithBounds _ _ _ _ _ _) in (value of k).
+      set (v := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       Notation INL := (inl _).
       vm_compute in v.
       Notation IDD := (id _).


### PR DESCRIPTION
It's now possible to pass in an argument at a higher level specifying
whether or not casts are assumed to truncate.

This should help with
https://github.com/mit-plv/fiat-crypto/issues/833#issuecomment-655088557