### PR TITLE
Assume that cast truncates more pervasively

### DIFF
--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -485,7 +485,7 @@ Module Pipeline.
              out_bounds
   : ErrorT (Expr t)
     := (*let E := expr.Uncurry E in*)
-      let assume_cast_truncates := false in
+      let assume_cast_truncates := true in
       let opts := opts_of_method in
       dlet E := PreBoundsPipeline (* with_dead_code_elimination *) with_subst01 with_let_bind_return translate_to_fancy E arg_bounds in
       (** We first do bounds analysis with no relaxation so that we


### PR DESCRIPTION
This should fix the issue with `None` in the output bounds in #833

Reviews requested for the conceptual change (that we are now ~always working under the assumption that `cast` truncates its input, rather than being agnostic about how `cast` behaves when things are out of range).

On top of #836.  Closes #836.