### PR TITLE
Generalized sub/opp balance for unsaturated solinas

### DIFF
--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -117,8 +117,9 @@ Section __.
   Local Notation balance := (balance n s c).
 
   Definition m : Z := s - Associational.eval c.
-  Definition m_enc : list Z
-    := encode (weight (Qnum limbwidth) (Qden limbwidth)) n s c m.
+  Definition m_enc : list Z :=
+    let M := encode (weight (Qnum limbwidth) (Qden limbwidth)) n s c m in
+    distribute_balance n s c M.
 
   (* We include [0], so that even after bounds relaxation, we can
        notice where the constant 0s are, and remove them. *)
@@ -156,6 +157,13 @@ Section __.
   Lemma length_saturated_bounds_list : List.length saturated_bounds_list = n.
   Proof using Type. cbv [saturated_bounds_list]; now autorewrite with distr_length. Qed.
   Hint Rewrite length_saturated_bounds_list : distr_length.
+  Lemma length_m_enc : List.length m_enc = n.
+  Proof using Type.
+    cbv [m_enc distribute_balance distribute_balance_step].
+    apply fold_right_invariant; intros;
+      break_innermost_match; now autorewrite with distr_length.
+  Qed.
+  Hint Rewrite length_m_enc : distr_length.
 
   (** Note: If you change the name or type signature of this
         function, you will need to update the code in CLI.v *)

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -117,9 +117,22 @@ Section __.
   Local Notation balance := (balance n s c).
 
   Definition m : Z := s - Associational.eval c.
+  (* m_enc needs to be such that, if x is bounded by tight bounds:
+
+     -2*fw[i] <= x[i] - m_enc[i] <= fw[i]
+
+     ...so as to obey the bounds for the sub-with-borrow in freeze. fw[i] here
+     is shorthand for (weight (S i) / weight i). To obey the upper bound, we
+     need to redistribute m_enc such that:
+
+     tight_upperbounds[i] - fw[i] <= m_enc[i] *)
+  Definition m_enc_min : list Z :=
+    let wt := weight (Qnum limbwidth) (Qden limbwidth) in
+    let fw := map (fun i => wt (S i) / wt i) (seq 0 n) in
+    map2 Z.sub tight_upperbounds fw.
   Definition m_enc : list Z :=
     let M := encode (weight (Qnum limbwidth) (Qden limbwidth)) n s c m in
-    distribute_balance n s c M.
+    distribute_balance n s c m_enc_min M.
 
   (* We include [0], so that even after bounds relaxation, we can
        notice where the constant 0s are, and remove them. *)

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -144,6 +144,9 @@ Section __.
   Lemma length_tight_bounds : List.length tight_bounds = n.
   Proof using Type. cbv [tight_bounds]; now autorewrite with distr_length. Qed.
   Hint Rewrite length_tight_bounds : distr_length.
+  Lemma length_balance : List.length balance = n.
+  Proof using Type. now rewrite balance_length. Qed.
+  Hint Rewrite length_balance : distr_length.
   Lemma length_loose_bounds : List.length loose_bounds = n.
   Proof using Type. cbv [loose_bounds]; now autorewrite with distr_length natsimplify. Qed.
   Hint Rewrite length_loose_bounds : distr_length.

--- a/src/UnsaturatedSolinasHeuristics.v
+++ b/src/UnsaturatedSolinasHeuristics.v
@@ -128,8 +128,6 @@ else:
       let zero := [(weight i, x * fw); (weight (S i), -x)] in
       let Ba := to_associational weight n B ++ zero in
       let B := from_associational weight n Ba in
-      (* let B := update_nth i (Z.add (x * fw)) B in
-         let B := update_nth (S i) (fun y => y - x) B in *)
       B
     else B.
 

--- a/src/UnsaturatedSolinasHeuristics.v
+++ b/src/UnsaturatedSolinasHeuristics.v
@@ -134,7 +134,7 @@ else:
     else B.
 
   Definition distribute_balance minvalues B :=
-    fold_right (distribute_balance_step minvalues) B (seq 0 (n-1)).
+    fold_right (distribute_balance_step minvalues) B (rev (seq 0 (n-1))).
 
   (* distribute balance such that for all limbs i,
      tight_upperbounds[i] <= balance[i] *)

--- a/src/UnsaturatedSolinasHeuristics.v
+++ b/src/UnsaturatedSolinasHeuristics.v
@@ -106,23 +106,17 @@ else:
 
   (** Constraints: tight_upperbounds[i] <= balance[i] <= loose_upperbounds[i]
       Algorithm:
-        start with coef = 1
-
         B = encode (s - c)
         B = map(Z.mul coef, B)
         for i from 0 .. nlimbs-2:
             if B[i] < tight_upperbounds[i]:
                // need to find the lowest number we can add, confined to highest bits only
-               x = ((tight_upperbounds[i] / fw[i]) + 1)
+               x = tight_upperbounds[i] / fw[i]
+               if tight_upperbounds[i] mod fw[i] != 0:
+                  x += 1 // round up
                B[i] += x * fw[i]
                B[i+1] -= x
-
-        if B[-1] < tight_upperbounds[-1]:
-           B *= 2
-           coef *= 2
-           restart
    *)
-
   Definition distribute_balance_step (i : nat) (B : list Z) :=
     let Bi := nth_default 0 B i in
     let ti := nth_default 0 tight_upperbounds i in
@@ -271,32 +265,3 @@ Section ___.
        | Auto idx => nth_error get_possible_limbs idx
        end.
 End ___.
-
-(*
-Definition check_balance (balance : list Z) (loose_upperbounds : list Z)
-  := forallb (fun x => fst x <=? snd x)
-             (List.combine balance loose_upperbounds).
-
-About balance.
-Print balance.
-Require Import Crypto.Util.Strings.Show.
-Require Import Coq.Strings.String.
-Open Scope string_scope.
-(* Existing Instance PowersOfTwo.show_Z. *)
-(* Or: *)
-Existing Instance Hex.show_Z.
-
-Definition bal224 := (@balance default_tight_upperbound_fraction 4 (2^224) [(2^96,1);(1,-1)]).
-Definition lb224 := (@loose_upperbounds default_tight_upperbound_fraction 4 (2^224) [(2^96,1);(1,-1)]).
-
-Compute show false bal224.
-Compute show false lb224.
-Compute (check_balance bal224 lb224).
-
-Definition bal25519 := (@balance default_tight_upperbound_fraction 10 (2^255) [(1,19)]).
-Definition lb25519 := (@loose_upperbounds default_tight_upperbound_fraction 10 (2^255) [(1,19)]).
-
-Compute show false bal25519.
-Compute show false lb25519.
-Compute (check_balance bal224 lb224).
-*)

--- a/src/UnsaturatedSolinasHeuristics.v
+++ b/src/UnsaturatedSolinasHeuristics.v
@@ -111,8 +111,9 @@ else:
         for i from 0 .. nlimbs-2:
             if B[i] < tight_upperbounds[i]:
                // need to find the lowest number we can add, confined to highest bits only
-               x = tight_upperbounds[i] / fw[i]
-               if tight_upperbounds[i] mod fw[i] != 0:
+               d = tight_upperbounds[i] - B[i]
+               x = d / fw[i]
+               if d mod fw[i] != 0:
                   x += 1 // round up
                B[i] += x * fw[i]
                B[i+1] -= x
@@ -124,7 +125,7 @@ else:
     then
       let weight := weight (Qnum limbwidth) (Qden limbwidth) in
       let fw := weight (S i) / weight i in
-      let x := (ti / fw) + Z.b2z (negb (ti mod fw =? 0)) in
+      let x := ((ti - Bi) / fw) + Z.b2z (negb ((ti - Bi) mod fw =? 0)) in
       let zero := [(weight i, x * fw); (weight (S i), -x)] in
       let Ba := to_associational weight n B ++ zero in
       let B := from_associational weight n Ba in


### PR DESCRIPTION
See discussion in #554 

This PR generalizes the formula for computing sub/opp balance so that it works on primes with very low limbs (e.g. p224, whose lowest limb in base 2^56 is 1). The key idea is to borrow from higher limbs so that each limb of the balance is higher than the `tight_upperbounds` -- a strategy borrowed from the unsaturated-solinas p224 implementation in OpenSSL. We still can't synthesize unsaturated solinas code for p224 because we would need balance for reduce, and that comes with further complications (see #554).

Also included in the PR is a tweak to make `to_bytes` work for p224 (and other primes with low limbs) and unsaturated solinas -- using the same function we use to distribute sub/opp balance nicely across limbs, we distribute the encoding of the prime so that it doesn't cause problems in `to_bytes`.